### PR TITLE
fix: update consuming code for spec-aligned ExecutionProof types

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -256,3 +256,4 @@ xcode
 yaml
 yamux
 yml
+zkvm

--- a/packages/api/src/beacon/routes/beacon/pool.ts
+++ b/packages/api/src/beacon/routes/beacon/pool.ts
@@ -5,6 +5,7 @@ import {
   ArrayOf,
   AttesterSlashing,
   CommitteeIndex,
+  ExecutionProof,
   SingleAttestation,
   Slot,
   capella,
@@ -37,6 +38,7 @@ const ProposerSlashingListType = ArrayOf(ssz.phase0.ProposerSlashing);
 const SignedVoluntaryExitListType = ArrayOf(ssz.phase0.SignedVoluntaryExit);
 const SignedBLSToExecutionChangeListType = ArrayOf(ssz.capella.SignedBLSToExecutionChange);
 const SyncCommitteeMessageListType = ArrayOf(ssz.altair.SyncCommitteeMessage);
+const ExecutionProofListType = ArrayOf(ssz.eip8025.ExecutionProof);
 
 type AttestationListPhase0 = ValueOf<typeof AttestationListTypePhase0>;
 type AttestationListElectra = ValueOf<typeof AttestationListTypeElectra>;
@@ -50,6 +52,7 @@ type ProposerSlashingList = ValueOf<typeof ProposerSlashingListType>;
 type SignedVoluntaryExitList = ValueOf<typeof SignedVoluntaryExitListType>;
 type SignedBLSToExecutionChangeList = ValueOf<typeof SignedBLSToExecutionChangeListType>;
 type SyncCommitteeMessageList = ValueOf<typeof SyncCommitteeMessageListType>;
+type ExecutionProofList = ValueOf<typeof ExecutionProofListType>;
 
 export type Endpoints = {
   /**
@@ -240,6 +243,26 @@ export type Endpoints = {
   submitPoolSyncCommitteeSignatures: Endpoint<
     "POST",
     {signatures: SyncCommitteeMessageList},
+    {body: unknown},
+    EmptyResponseData,
+    EmptyMeta
+  >;
+
+  /**
+   * Get ExecutionProofs from operations pool (EIP-8025)
+   * Retrieves execution proofs known by the node, optionally filtered by slot.
+   */
+  getPoolExecutionProofs: Endpoint<"GET", {slot?: Slot}, {query: {slot?: number}}, ExecutionProofList, EmptyMeta>;
+
+  /**
+   * Submit an ExecutionProof to the node's pool (EIP-8025)
+   * Submits an execution proof to the beacon node.
+   * The proof will be validated and stored in the execution proof pool.
+   * If valid, the proof will be published to the gossip network.
+   */
+  submitPoolExecutionProofs: Endpoint<
+    "POST",
+    {executionProof: ExecutionProof},
     {body: unknown},
     EmptyResponseData,
     EmptyMeta
@@ -495,6 +518,33 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqSsz: ({body}) => ({signatures: SyncCommitteeMessageListType.deserialize(body)}),
         schema: {
           body: Schema.ObjectArray,
+        },
+      },
+      resp: EmptyResponseCodec,
+    },
+    getPoolExecutionProofs: {
+      url: "/eth/v1/beacon/pool/execution_proofs",
+      method: "GET",
+      req: {
+        writeReq: ({slot}) => ({query: {slot}}),
+        parseReq: ({query}) => ({slot: query.slot}),
+        schema: {query: {slot: Schema.Uint}},
+      },
+      resp: {
+        data: ExecutionProofListType,
+        meta: EmptyMetaCodec,
+      },
+    },
+    submitPoolExecutionProofs: {
+      url: "/eth/v1/beacon/pool/execution_proofs",
+      method: "POST",
+      req: {
+        writeReqJson: ({executionProof}) => ({body: ssz.eip8025.ExecutionProof.toJson(executionProof)}),
+        parseReqJson: ({body}) => ({executionProof: ssz.eip8025.ExecutionProof.fromJson(body)}),
+        writeReqSsz: ({executionProof}) => ({body: ssz.eip8025.ExecutionProof.serialize(executionProof)}),
+        parseReqSsz: ({body}) => ({executionProof: ssz.eip8025.ExecutionProof.deserialize(body)}),
+        schema: {
+          body: Schema.Object,
         },
       },
       resp: EmptyResponseCodec,

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -172,6 +172,14 @@ export const testData: GenericServerTestCases<Endpoints> = {
     args: {signatures: [ssz.altair.SyncCommitteeMessage.defaultValue()]},
     res: undefined,
   },
+  getPoolExecutionProofs: {
+    args: {slot: 1},
+    res: {data: [ssz.eip8025.ExecutionProof.defaultValue()]},
+  },
+  submitPoolExecutionProofs: {
+    args: {executionProof: ssz.eip8025.ExecutionProof.defaultValue()},
+    res: undefined,
+  },
 
   // state
 

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -2,12 +2,14 @@ import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {ForkPostElectra, ForkPreElectra, SYNC_COMMITTEE_SUBNET_SIZE, isForkPostElectra} from "@lodestar/params";
 import {Attestation, Epoch, SingleAttestation, isElectraAttestation, ssz, sszTypesFor} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
 import {
   AttestationError,
   AttestationErrorCode,
   GossipAction,
   SyncCommitteeError,
 } from "../../../../chain/errors/index.js";
+import {InsertOutcome} from "../../../../chain/opPools/types.js";
 import {validateApiAttesterSlashing} from "../../../../chain/validation/attesterSlashing.js";
 import {validateApiBlsToExecutionChange} from "../../../../chain/validation/blsToExecutionChange.js";
 import {toElectraSingleAttestation, validateApiAttestation} from "../../../../chain/validation/index.js";
@@ -309,6 +311,57 @@ export function getBeaconPoolApi({
       if (failures.length > 0) {
         throw new IndexedError("Error processing sync committee signatures", failures);
       }
+    },
+
+    async getPoolExecutionProofs({slot}) {
+      // Return all proofs in the pool, optionally filtered by slot
+      const allProofs: import("@lodestar/types").ExecutionProof[] = [];
+      if (slot !== undefined) {
+        // Get proofs for a single slot
+        const proofs = chain.executionProofPool.getProofsByRange(slot, 1);
+        allProofs.push(...proofs);
+      } else {
+        // Get proofs for a wide range around the current slot (recent SLOTS_RETAINED window)
+        const currentSlot = chain.clock.currentSlot;
+        const proofs = chain.executionProofPool.getProofsByRange(Math.max(0, currentSlot - 8), 9);
+        allProofs.push(...proofs);
+      }
+      return {data: allProofs};
+    },
+
+    async submitPoolExecutionProofs({executionProof}) {
+      // Validate basic fields
+      const {slot, blockRoot, proofId} = executionProof;
+      const blockRootHex = toRootHex(blockRoot);
+
+      // Check for duplicates
+      if (chain.executionProofPool.has(blockRootHex, proofId)) {
+        logger.debug("Ignoring known execution proof", {slot, blockRoot: blockRootHex, proofId});
+        return {};
+      }
+
+      // TODO EIP-8025: Add full proof verification (dummy accept for devnet)
+
+      // Add to pool (pass clock slot to reject far-future proofs)
+      const clockSlot = chain.clock.currentSlot;
+      const insertOutcome = chain.executionProofPool.add(executionProof, clockSlot);
+      logger.info("Execution proof submitted via API", {
+        slot,
+        blockRoot: blockRootHex,
+        proofId,
+        insertOutcome,
+      });
+
+      // Only publish to gossip if the proof was actually accepted
+      if (insertOutcome === InsertOutcome.NewData) {
+        try {
+          await network.publishExecutionProof(executionProof);
+        } catch (e) {
+          logger.debug("Failed to publish execution proof to gossip", {slot, proofId}, e as Error);
+        }
+      }
+
+      return {};
     },
   };
 }

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -359,6 +359,9 @@ export function getBeaconPoolApi({
         } catch (e) {
           logger.debug("Failed to publish execution proof to gossip", {slot, proofId}, e as Error);
         }
+
+        // EIP-8025: In zkvm mode, check if we now have enough proofs to validate this block
+        chain.maybeTransitionToValidOnProofArrival(executionProof);
       }
 
       return {};

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -313,42 +313,27 @@ export function getBeaconPoolApi({
       }
     },
 
-    async getPoolExecutionProofs({slot}) {
-      // Return all proofs in the pool, optionally filtered by slot
-      const allProofs: import("@lodestar/types").ExecutionProof[] = [];
-      if (slot !== undefined) {
-        // Get proofs for a single slot
-        const proofs = chain.executionProofPool.getProofsByRange(slot, 1);
-        allProofs.push(...proofs);
-      } else {
-        // Get proofs for a wide range around the current slot (recent SLOTS_RETAINED window)
-        const currentSlot = chain.clock.currentSlot;
-        const proofs = chain.executionProofPool.getProofsByRange(Math.max(0, currentSlot - 8), 9);
-        allProofs.push(...proofs);
-      }
-      return {data: allProofs};
+    async getPoolExecutionProofs() {
+      // Return all proofs in the pool
+      return {data: chain.executionProofPool.getAllProofs()};
     },
 
     async submitPoolExecutionProofs({executionProof}) {
-      // Validate basic fields
-      const {slot, blockRoot, proofId} = executionProof;
-      const blockRootHex = toRootHex(blockRoot);
+      const newPayloadRequestRootHex = toRootHex(executionProof.publicInput.newPayloadRequestRoot);
+      const {proofType} = executionProof;
 
       // Check for duplicates
-      if (chain.executionProofPool.has(blockRootHex, proofId)) {
-        logger.debug("Ignoring known execution proof", {slot, blockRoot: blockRootHex, proofId});
+      if (chain.executionProofPool.has(newPayloadRequestRootHex, proofType)) {
+        logger.debug("Ignoring known execution proof", {newPayloadRequestRoot: newPayloadRequestRootHex, proofType});
         return {};
       }
 
       // TODO EIP-8025: Add full proof verification (dummy accept for devnet)
 
-      // Add to pool (pass clock slot to reject far-future proofs)
-      const clockSlot = chain.clock.currentSlot;
-      const insertOutcome = chain.executionProofPool.add(executionProof, clockSlot);
+      const insertOutcome = chain.executionProofPool.add(executionProof);
       logger.info("Execution proof submitted via API", {
-        slot,
-        blockRoot: blockRootHex,
-        proofId,
+        newPayloadRequestRoot: newPayloadRequestRootHex,
+        proofType,
         insertOutcome,
       });
 
@@ -357,7 +342,7 @@ export function getBeaconPoolApi({
         try {
           await network.publishExecutionProof(executionProof);
         } catch (e) {
-          logger.debug("Failed to publish execution proof to gossip", {slot, proofId}, e as Error);
+          logger.debug("Failed to publish execution proof to gossip", {proofType}, e as Error);
         }
 
         // EIP-8025: In zkvm mode, check if we now have enough proofs to validate this block

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -15,8 +15,10 @@ import {ExecutionPayloadStatus, IExecutionEngine} from "../../execution/engine/i
 import {Metrics} from "../../metrics/metrics.js";
 import {IClock} from "../../util/clock.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
+import {ExecutionProofPool} from "../opPools/executionProofPool.js";
 import {BlockProcessOpts} from "../options.js";
 import {isBlockInputBlobs, isBlockInputColumns, isBlockInputNoData} from "./blockInput/blockInput.js";
+import {IZkvmExecutionProofVerifier, defaultZkvmExecutionProofVerifier} from "../validation/executionProofVerifier.js";
 import {IBlockInput} from "./blockInput/types.js";
 import {ImportBlockOpts} from "./types.js";
 
@@ -27,6 +29,14 @@ export type VerifyBlockExecutionPayloadModules = {
   metrics: Metrics | null;
   forkChoice: IForkChoice;
   config: ChainForkConfig;
+  /** EIP-8025: When true, use execution proofs instead of EL for payload verification */
+  activateZkvm?: boolean;
+  /** EIP-8025: Pool of execution proofs for proof-driven verification */
+  executionProofPool?: ExecutionProofPool;
+  /** EIP-8025: Minimum distinct proof types required for a block to be considered valid */
+  minProofsRequired?: number;
+  /** EIP-8025: Verifier for execution proofs — defaults to dummy verifier if not provided */
+  executionProofVerifier?: IZkvmExecutionProofVerifier;
 };
 
 type ExecAbortType = {blockIndex: number; execError: BlockError};
@@ -136,7 +146,8 @@ export async function verifyBlocksExecutionPayload(
 }
 
 /**
- * Verifies a single block execution payload by sending it to the EL client (via HTTP).
+ * Verifies a single block execution payload by sending it to the EL client (via HTTP),
+ * or via execution proof verification when in zkvm mode (EIP-8025).
  */
 export async function verifyBlockExecutionPayload(
   chain: VerifyBlockExecutionPayloadModules,
@@ -161,6 +172,11 @@ export async function verifyBlockExecutionPayload(
   if (!executionPayloadEnabled) {
     // Pre-merge block, no execution payload to verify
     return {executionStatus: ExecutionStatus.PreMerge, lvhResponse: undefined, execError: null};
+  }
+
+  // EIP-8025: Proof-driven execution mode — skip EL, use execution proofs for validation
+  if (chain.activateZkvm) {
+    return verifyBlockExecutionPayloadByProof(chain, blockInput, executionPayloadEnabled);
   }
 
   // TODO: Handle better notifyNewPayload() returning error is syncing
@@ -240,6 +256,68 @@ export async function verifyBlockExecutionPayload(
       return {executionStatus: null, execError} as VerifyBlockExecutionResponse;
     }
   }
+}
+
+/**
+ * EIP-8025: Verify execution payload using execution proofs instead of EL.
+ *
+ * When activateZkvm is enabled, the beacon node skips EL newPayload calls and instead:
+ * - Checks if sufficient execution proofs exist in the pool for this block
+ * - If enough valid proofs → payload considered Valid (propagates in fork choice)
+ * - If not enough proofs → payload imported optimistically (Syncing status)
+ *
+ * Blocks are never rejected due to missing proofs — they are imported optimistically.
+ * Proofs arriving later via gossip will trigger fork choice updates to mark blocks valid.
+ * This matches the Lighthouse approach where blocks without proofs get Syncing status.
+ */
+function verifyBlockExecutionPayloadByProof(
+  chain: VerifyBlockExecutionPayloadModules,
+  blockInput: IBlockInput,
+  executionPayload: bellatrix.ExecutionPayload
+): VerifyBlockExecutionResponse {
+  const blockRootHex = blockInput.blockRootHex;
+  const execBlockHash = toRootHex(executionPayload.blockHash);
+  const minRequired = chain.minProofsRequired ?? 1;
+
+  const logCtx = {
+    slot: blockInput.slot,
+    blockRoot: blockRootHex,
+    executionBlockHash: execBlockHash,
+    executionBlock: executionPayload.blockNumber,
+  };
+
+  const proofs = chain.executionProofPool?.getProofsByBlockRoot(blockRootHex) ?? [];
+  const verifier = chain.executionProofVerifier ?? defaultZkvmExecutionProofVerifier;
+  const verification = verifier.verifyProofs({
+    proofs,
+    expectedBlockRootHex: blockRootHex,
+    expectedExecBlockHashHex: execBlockHash,
+    minProofsRequired: minRequired,
+  });
+
+  if (!verification.ok) {
+    // Not enough proofs yet — import optimistically (Syncing).
+    // Proofs arriving later via gossip will call forkChoice.validateLatestHash()
+    // to transition the block from Syncing → Valid.
+    chain.logger.debug("Importing block optimistically, insufficient execution proofs (zkvm mode)", {
+      ...logCtx,
+      reason: verification.error,
+      proofsAvailable: proofs.length,
+      minRequired,
+    });
+
+    return {executionStatus: ExecutionStatus.Syncing, execError: null};
+  }
+
+  chain.logger.debug("Execution payload verified by zkvm proofs (dummy verifier)", {
+    ...logCtx,
+    distinctProofTypes: verification.distinctProofTypes,
+    minRequired,
+  });
+
+  const executionStatus = ExecutionStatus.Valid as const;
+  const lvhResponse: LVHValidResponse = {executionStatus, latestValidExecHash: execBlockHash};
+  return {executionStatus, lvhResponse, execError: null};
 }
 
 function getSegmentErrorResponse(

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -17,8 +17,8 @@ import {IClock} from "../../util/clock.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
 import {ExecutionProofPool} from "../opPools/executionProofPool.js";
 import {BlockProcessOpts} from "../options.js";
-import {isBlockInputBlobs, isBlockInputColumns, isBlockInputNoData} from "./blockInput/blockInput.js";
 import {IZkvmExecutionProofVerifier, defaultZkvmExecutionProofVerifier} from "../validation/executionProofVerifier.js";
+import {isBlockInputBlobs, isBlockInputColumns, isBlockInputNoData} from "./blockInput/blockInput.js";
 import {IBlockInput} from "./blockInput/types.js";
 import {ImportBlockOpts} from "./types.js";
 
@@ -286,12 +286,10 @@ function verifyBlockExecutionPayloadByProof(
     executionBlock: executionPayload.blockNumber,
   };
 
-  const proofs = chain.executionProofPool?.getProofsByBlockRoot(blockRootHex) ?? [];
+  const proofs = chain.executionProofPool?.getAllProofs() ?? [];
   const verifier = chain.executionProofVerifier ?? defaultZkvmExecutionProofVerifier;
   const verification = verifier.verifyProofs({
     proofs,
-    expectedBlockRootHex: blockRootHex,
-    expectedExecBlockHashHex: execBlockHash,
     minProofsRequired: minRequired,
   });
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1,17 +1,18 @@
 import path from "node:path";
-import {PrivateKey} from "@libp2p/interface";
-import {Type} from "@chainsafe/ssz";
-import {BeaconConfig} from "@lodestar/config";
+import { PrivateKey } from "@libp2p/interface";
+import { Type } from "@chainsafe/ssz";
+import { BeaconConfig } from "@lodestar/config";
 import {
   CheckpointWithPayloadStatus,
+  ExecutionStatus,
   IForkChoice,
   PayloadStatus,
   ProtoBlock,
   UpdateHeadOpt,
   getCheckpointPayloadStatus,
 } from "@lodestar/fork-choice";
-import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
-import {LoggerNode} from "@lodestar/logger/node";
+import { CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock, UpdateHeadOpt } from "@lodestar/fork-choice";
+import { LoggerNode } from "@lodestar/logger/node";
 import {
   BUILDER_INDEX_SELF_BUILD,
   EFFECTIVE_BALANCE_INCREMENT,
@@ -53,40 +54,40 @@ import {
   ssz,
   sszTypesFor,
 } from "@lodestar/types";
-import {Logger, fromHex, gweiToWei, isErrorAborted, pruneSetToMax, sleep, toRootHex} from "@lodestar/utils";
-import {ProcessShutdownCallback} from "@lodestar/validator";
-import {GENESIS_EPOCH, ZERO_HASH} from "../constants/index.js";
-import {IBeaconDb} from "../db/index.js";
-import {BLOB_SIDECARS_IN_WRAPPER_INDEX} from "../db/repositories/blobSidecars.js";
-import {BuilderStatus} from "../execution/builder/http.js";
-import {IExecutionBuilder, IExecutionEngine} from "../execution/index.js";
-import {Metrics} from "../metrics/index.js";
-import {computeNodeIdFromPrivateKey} from "../network/subnets/interface.js";
-import {BufferPool} from "../util/bufferPool.js";
-import {Clock, ClockEvent, IClock} from "../util/clock.js";
-import {CustodyConfig, getValidatorsCustodyRequirement} from "../util/dataColumns.js";
-import {callInNextEventLoop} from "../util/eventLoop.js";
-import {ensureDir, writeIfNotExist} from "../util/file.js";
-import {isOptimisticBlock} from "../util/forkChoice.js";
-import {JobItemQueue} from "../util/queue/itemQueue.js";
-import {SerializedCache} from "../util/serializedCache.js";
-import {getSlotFromSignedBeaconBlockSerialized} from "../util/sszBytes.js";
-import {ArchiveStore} from "./archiveStore/archiveStore.js";
-import {CheckpointBalancesCache} from "./balancesCache.js";
-import {BeaconProposerCache} from "./beaconProposerCache.js";
-import {IBlockInput, isBlockInputBlobs, isBlockInputColumns} from "./blocks/blockInput/index.js";
-import {BlockProcessor, ImportBlockOpts} from "./blocks/index.js";
-import {PayloadEnvelopeProcessor} from "./blocks/payloadEnvelopeProcessor.js";
-import {ImportPayloadOpts} from "./blocks/types.js";
-import {persistBlockInput} from "./blocks/writeBlockInputToDb.js";
-import {persistPayloadEnvelopeInput} from "./blocks/writePayloadEnvelopeInputToDb.js";
-import {BlsMultiThreadWorkerPool, BlsSingleThreadVerifier, IBlsVerifier} from "./bls/index.js";
-import {ColumnReconstructionTracker} from "./ColumnReconstructionTracker.js";
-import {ChainEvent, ChainEventEmitter} from "./emitter.js";
-import {ForkchoiceCaller, initializeForkChoice} from "./forkChoice/index.js";
-import {GetBlobsTracker} from "./GetBlobsTracker.js";
-import {CommonBlockBody, FindHeadFnName, IBeaconChain, ProposerPreparationData, StateGetOpts} from "./interface.js";
-import {LightClientServer} from "./lightClient/index.js";
+import { Logger, fromHex, gweiToWei, isErrorAborted, pruneSetToMax, sleep, toRootHex } from "@lodestar/utils";
+import { ProcessShutdownCallback } from "@lodestar/validator";
+import { GENESIS_EPOCH, ZERO_HASH } from "../constants/index.js";
+import { IBeaconDb } from "../db/index.js";
+import { BLOB_SIDECARS_IN_WRAPPER_INDEX } from "../db/repositories/blobSidecars.js";
+import { BuilderStatus } from "../execution/builder/http.js";
+import { IExecutionBuilder, IExecutionEngine } from "../execution/index.js";
+import { Metrics } from "../metrics/index.js";
+import { computeNodeIdFromPrivateKey } from "../network/subnets/interface.js";
+import { BufferPool } from "../util/bufferPool.js";
+import { Clock, ClockEvent, IClock } from "../util/clock.js";
+import { CustodyConfig, getValidatorsCustodyRequirement } from "../util/dataColumns.js";
+import { callInNextEventLoop } from "../util/eventLoop.js";
+import { ensureDir, writeIfNotExist } from "../util/file.js";
+import { isOptimisticBlock } from "../util/forkChoice.js";
+import { JobItemQueue } from "../util/queue/itemQueue.js";
+import { SerializedCache } from "../util/serializedCache.js";
+import { getSlotFromSignedBeaconBlockSerialized } from "../util/sszBytes.js";
+import { ArchiveStore } from "./archiveStore/archiveStore.js";
+import { CheckpointBalancesCache } from "./balancesCache.js";
+import { BeaconProposerCache } from "./beaconProposerCache.js";
+import { IBlockInput, isBlockInputBlobs, isBlockInputColumns } from "./blocks/blockInput/index.js";
+import { BlockProcessor, ImportBlockOpts } from "./blocks/index.js";
+import { PayloadEnvelopeProcessor } from "./blocks/payloadEnvelopeProcessor.js";
+import { ImportPayloadOpts } from "./blocks/types.js";
+import { persistBlockInput } from "./blocks/writeBlockInputToDb.js";
+import { persistPayloadEnvelopeInput } from "./blocks/writePayloadEnvelopeInputToDb.js";
+import { BlsMultiThreadWorkerPool, BlsSingleThreadVerifier, IBlsVerifier } from "./bls/index.js";
+import { ColumnReconstructionTracker } from "./ColumnReconstructionTracker.js";
+import { ChainEvent, ChainEventEmitter } from "./emitter.js";
+import { ForkchoiceCaller, initializeForkChoice } from "./forkChoice/index.js";
+import { GetBlobsTracker } from "./GetBlobsTracker.js";
+import { CommonBlockBody, FindHeadFnName, IBeaconChain, ProposerPreparationData, StateGetOpts } from "./interface.js";
+import { LightClientServer } from "./lightClient/index.js";
 import {
   AggregatedAttestationPool,
   AttestationPool,
@@ -97,13 +98,13 @@ import {
   SyncCommitteeMessagePool,
   SyncContributionAndProofPool,
 } from "./opPools/index.js";
-import {IChainOptions} from "./options.js";
-import {PrepareNextSlotScheduler} from "./prepareNextSlot.js";
-import {computeEnvelopeStateRoot, computeNewStateRoot} from "./produceBlock/computeNewStateRoot.js";
-import {AssembledBlockType, BlockType, ProduceFullGloas, ProduceResult} from "./produceBlock/index.js";
-import {BlockAttributes, produceBlockBody, produceCommonBlockBody} from "./produceBlock/produceBlockBody.js";
-import {QueuedStateRegenerator, RegenCaller} from "./regen/index.js";
-import {ReprocessController} from "./reprocess.js";
+import { IChainOptions } from "./options.js";
+import { PrepareNextSlotScheduler } from "./prepareNextSlot.js";
+import { computeEnvelopeStateRoot, computeNewStateRoot } from "./produceBlock/computeNewStateRoot.js";
+import { AssembledBlockType, BlockType, ProduceFullGloas, ProduceResult } from "./produceBlock/index.js";
+import { BlockAttributes, produceBlockBody, produceCommonBlockBody } from "./produceBlock/produceBlockBody.js";
+import { QueuedStateRegenerator, RegenCaller } from "./regen/index.js";
+import { ReprocessController } from "./reprocess.js";
 import {
   PayloadEnvelopeInput,
   SeenAggregators,
@@ -115,19 +116,19 @@ import {
   SeenPayloadEnvelopeInput,
   SeenSyncCommitteeMessages,
 } from "./seenCache/index.js";
-import {SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof.js";
-import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
-import {SeenBlockAttesters} from "./seenCache/seenBlockAttesters.js";
-import {SeenBlockInput} from "./seenCache/seenGossipBlockInput.js";
-import {ShufflingCache} from "./shufflingCache.js";
-import {DbCPStateDatastore, checkpointToDatastoreKey} from "./stateCache/datastore/db.js";
-import {FileCPStateDatastore} from "./stateCache/datastore/file.js";
-import {CPStateDatastore} from "./stateCache/datastore/types.js";
-import {FIFOBlockStateCache} from "./stateCache/fifoBlockStateCache.js";
-import {PersistentCheckpointStateCache, fcCheckpointToHexPayload} from "./stateCache/persistentCheckpointsCache.js";
-import {CheckpointStateCache} from "./stateCache/types.js";
-import {IZkvmExecutionProofVerifier, defaultZkvmExecutionProofVerifier} from "./validation/executionProofVerifier.js";
-import {ValidatorMonitor} from "./validatorMonitor.js";
+import { SeenAggregatedAttestations } from "./seenCache/seenAggregateAndProof.js";
+import { SeenAttestationDatas } from "./seenCache/seenAttestationData.js";
+import { SeenBlockAttesters } from "./seenCache/seenBlockAttesters.js";
+import { SeenBlockInput } from "./seenCache/seenGossipBlockInput.js";
+import { ShufflingCache } from "./shufflingCache.js";
+import { DbCPStateDatastore, checkpointToDatastoreKey } from "./stateCache/datastore/db.js";
+import { FileCPStateDatastore } from "./stateCache/datastore/file.js";
+import { CPStateDatastore } from "./stateCache/datastore/types.js";
+import { FIFOBlockStateCache } from "./stateCache/fifoBlockStateCache.js";
+import { PersistentCheckpointStateCache, fcCheckpointToHexPayload } from "./stateCache/persistentCheckpointsCache.js";
+import { CheckpointStateCache } from "./stateCache/types.js";
+import { IZkvmExecutionProofVerifier, defaultZkvmExecutionProofVerifier } from "./validation/executionProofVerifier.js";
+import { ValidatorMonitor } from "./validatorMonitor.js";
 
 /**
  * The maximum number of cached produced results to keep in memory.
@@ -306,10 +307,10 @@ export class BeaconChain implements IBeaconChain {
     const emitter = new ChainEventEmitter();
     // by default, verify signatures on both main threads and worker threads
     const bls = opts.blsVerifyAllMainThread
-      ? new BlsSingleThreadVerifier({metrics, pubkeyCache})
-      : new BlsMultiThreadWorkerPool(opts, {logger, metrics, pubkeyCache});
+      ? new BlsSingleThreadVerifier({ metrics, pubkeyCache })
+      : new BlsMultiThreadWorkerPool(opts, { logger, metrics, pubkeyCache });
 
-    if (!clock) clock = new Clock({config, genesisTime: this.genesisTime, signal});
+    if (!clock) clock = new Clock({ config, genesisTime: this.genesisTime, signal });
 
     this.blacklistedBlocks = new Map((opts.blacklistedBlocks ?? []).map((hex) => [hex, null]));
     this.attestationPool = new AttestationPool(config, clock, this.opts?.preaggregateSlotDistance, metrics);
@@ -381,7 +382,7 @@ export class BeaconChain implements IBeaconChain {
     this.pubkeyCache = pubkeyCache;
 
     const fileDataStore = opts.nHistoricalStatesFileDataStore ?? true;
-    const blockStateCache = new FIFOBlockStateCache(this.opts, {metrics});
+    const blockStateCache = new FIFOBlockStateCache(this.opts, { metrics });
     this.bufferPool = new BufferPool(anchorState.serializedSize(), metrics);
 
     this.cpStateDatastore = fileDataStore ? new FileCPStateDatastore(dataDir) : new DbCPStateDatastore(this.db);
@@ -398,7 +399,7 @@ export class BeaconChain implements IBeaconChain {
       this.opts
     );
 
-    const {checkpoint} = anchorState.computeAnchorCheckpoint();
+    const { checkpoint } = anchorState.computeAnchorCheckpoint();
     blockStateCache.add(anchorState);
     blockStateCache.setHeadState(anchorState);
     const payloadPresent = getCheckpointPayloadStatus(config, anchorState, checkpoint.epoch) === PayloadStatus.FULL;
@@ -430,7 +431,7 @@ export class BeaconChain implements IBeaconChain {
     });
 
     if (!opts.disableLightClientServer) {
-      this.lightClientServer = new LightClientServer(opts, {config, clock, db, metrics, emitter, logger, signal});
+      this.lightClientServer = new LightClientServer(opts, { config, clock, db, metrics, emitter, logger, signal });
     }
 
     this.reprocessController = new ReprocessController(this.metrics);
@@ -459,8 +460,8 @@ export class BeaconChain implements IBeaconChain {
     });
 
     this.archiveStore = new ArchiveStore(
-      {db, chain: this, logger: logger as LoggerNode, metrics},
-      {...opts, dbName, anchorState: {finalizedCheckpoint: anchorState.finalizedCheckpoint}},
+      { db, chain: this, logger: logger as LoggerNode, metrics },
+      { ...opts, dbName, anchorState: { finalizedCheckpoint: anchorState.finalizedCheckpoint } },
       signal
     );
 
@@ -587,13 +588,13 @@ export class BeaconChain implements IBeaconChain {
     // only use regen queue if necessary, it'll cache in checkpointStateCache if regen gets through epoch transition
     const head = this.forkChoice.getHead();
     const startSlot = computeStartSlotAtEpoch(epoch);
-    return this.regen.getBlockSlotState(head, startSlot, {dontTransferCache: true}, regenCaller);
+    return this.regen.getBlockSlotState(head, startSlot, { dontTransferCache: true }, regenCaller);
   }
 
   async getStateBySlot(
     slot: Slot,
     opts?: StateGetOpts
-  ): Promise<{state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean} | null> {
+  ): Promise<{ state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean } | null> {
     const finalizedBlock = this.forkChoice.getFinalizedBlock();
 
     if (slot < finalizedBlock.slot) {
@@ -605,7 +606,7 @@ export class BeaconChain implements IBeaconChain {
     if (opts?.allowRegen) {
       // Find closest canonical block to slot, then trigger regen
       const block = this.forkChoice.getCanonicalBlockClosestLteSlot(slot) ?? finalizedBlock;
-      const state = await this.regen.getBlockSlotState(block, slot, {dontTransferCache: true}, RegenCaller.restApi);
+      const state = await this.regen.getBlockSlotState(block, slot, { dontTransferCache: true }, RegenCaller.restApi);
       return {
         state,
         executionOptimistic: isOptimisticBlock(block),
@@ -632,7 +633,7 @@ export class BeaconChain implements IBeaconChain {
 
   async getHistoricalStateBySlot(
     slot: number
-  ): Promise<{state: Uint8Array; executionOptimistic: boolean; finalized: boolean} | null> {
+  ): Promise<{ state: Uint8Array; executionOptimistic: boolean; finalized: boolean } | null> {
     if (!this.opts.serveHistoricalState) {
       throw Error("Historical state regen is not enabled, set --serveHistoricalState to fetch this data");
     }
@@ -643,7 +644,7 @@ export class BeaconChain implements IBeaconChain {
   async getStateByStateRoot(
     stateRoot: RootHex,
     opts?: StateGetOpts
-  ): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null> {
+  ): Promise<{ state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean } | null> {
     if (opts?.allowRegen) {
       const state = await this.regen.getState(stateRoot, RegenCaller.restApi);
       const block = this.forkChoice.getBlockDefaultStatus(
@@ -677,7 +678,7 @@ export class BeaconChain implements IBeaconChain {
 
     // this is mostly useful for a node with `--chain.archiveStateEpochFrequency 1`
     const data = await this.db.stateArchive.getBinaryByRoot(fromHex(stateRoot));
-    return data && {state: data, executionOptimistic: false, finalized: true};
+    return data && { state: data, executionOptimistic: false, finalized: true };
   }
 
   async getPersistedCheckpointState(checkpoint?: phase0.Checkpoint): Promise<Uint8Array | null> {
@@ -698,7 +699,7 @@ export class BeaconChain implements IBeaconChain {
 
   getStateByCheckpoint(
     checkpoint: CheckpointWithPayloadStatus
-  ): {state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean} | null {
+  ): { state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean } | null {
     // finalized or justified checkpoint states maynot be available with PersistentCheckpointStateCache, use getCheckpointStateOrBytes() api to get Uint8Array
     const checkpointHexPayload = fcCheckpointToHexPayload(checkpoint);
     const cachedStateCtx = this.regen.getCheckpointStateSync(checkpointHexPayload);
@@ -719,7 +720,7 @@ export class BeaconChain implements IBeaconChain {
 
   async getStateOrBytesByCheckpoint(
     checkpoint: CheckpointWithPayloadStatus
-  ): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null> {
+  ): Promise<{ state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean } | null> {
     const checkpointHexPayload = fcCheckpointToHexPayload(checkpoint);
     const cachedStateCtx = await this.regen.getCheckpointStateOrBytes(checkpointHexPayload);
     if (cachedStateCtx) {
@@ -737,7 +738,7 @@ export class BeaconChain implements IBeaconChain {
 
   async getCanonicalBlockAtSlot(
     slot: Slot
-  ): Promise<{block: SignedBeaconBlock; executionOptimistic: boolean; finalized: boolean} | null> {
+  ): Promise<{ block: SignedBeaconBlock; executionOptimistic: boolean; finalized: boolean } | null> {
     const finalizedBlock = this.forkChoice.getFinalizedBlock();
     if (slot > finalizedBlock.slot) {
       // Unfinalized slot, attempt to find in fork-choice
@@ -748,11 +749,11 @@ export class BeaconChain implements IBeaconChain {
         // Otherwise (most likely), check the hot db
         const blockInput = this.seenBlockInputCache.get(block.blockRoot);
         if (blockInput?.hasBlock()) {
-          return {block: blockInput.getBlock(), executionOptimistic: isOptimisticBlock(block), finalized: false};
+          return { block: blockInput.getBlock(), executionOptimistic: isOptimisticBlock(block), finalized: false };
         }
         const data = await this.db.block.get(fromHex(block.blockRoot));
         if (data) {
-          return {block: data, executionOptimistic: isOptimisticBlock(block), finalized: false};
+          return { block: data, executionOptimistic: isOptimisticBlock(block), finalized: false };
         }
       }
       // A non-finalized slot expected to be found in the hot db, could be archived during
@@ -761,12 +762,12 @@ export class BeaconChain implements IBeaconChain {
     }
 
     const data = await this.db.blockArchive.get(slot);
-    return data && {block: data, executionOptimistic: false, finalized: true};
+    return data && { block: data, executionOptimistic: false, finalized: true };
   }
 
   async getBlockByRoot(
     root: string
-  ): Promise<{block: SignedBeaconBlock; executionOptimistic: boolean; finalized: boolean} | null> {
+  ): Promise<{ block: SignedBeaconBlock; executionOptimistic: boolean; finalized: boolean } | null> {
     const block = this.forkChoice.getBlockHexDefaultStatus(root);
     if (block) {
       // Block found in fork-choice.
@@ -774,23 +775,23 @@ export class BeaconChain implements IBeaconChain {
       // Otherwise (most likely), check the hot db
       const blockInput = this.seenBlockInputCache.get(block.blockRoot);
       if (blockInput?.hasBlock()) {
-        return {block: blockInput.getBlock(), executionOptimistic: isOptimisticBlock(block), finalized: false};
+        return { block: blockInput.getBlock(), executionOptimistic: isOptimisticBlock(block), finalized: false };
       }
       const data = await this.db.block.get(fromHex(root));
       if (data) {
-        return {block: data, executionOptimistic: isOptimisticBlock(block), finalized: false};
+        return { block: data, executionOptimistic: isOptimisticBlock(block), finalized: false };
       }
       // If block is not found in hot db, try cold db since there could be an archive cycle happening
       // TODO: Add a lock to the archiver to have deterministic behavior on where are blocks
     }
 
     const data = await this.db.blockArchive.getByRoot(fromHex(root));
-    return data && {block: data, executionOptimistic: false, finalized: true};
+    return data && { block: data, executionOptimistic: false, finalized: true };
   }
 
   async getSerializedBlockByRoot(
     root: string
-  ): Promise<{block: Uint8Array; executionOptimistic: boolean; finalized: boolean; slot: Slot} | null> {
+  ): Promise<{ block: Uint8Array; executionOptimistic: boolean; finalized: boolean; slot: Slot } | null> {
     const block = this.forkChoice.getBlockHexDefaultStatus(root);
     if (block) {
       // Block found in fork-choice.
@@ -819,14 +820,14 @@ export class BeaconChain implements IBeaconChain {
       if (data) {
         const slot = getSlotFromSignedBeaconBlockSerialized(data);
         if (slot === null) throw new Error(`Invalid block data stored in DB for root: ${root}`);
-        return {block: data, executionOptimistic: isOptimisticBlock(block), finalized: false, slot};
+        return { block: data, executionOptimistic: isOptimisticBlock(block), finalized: false, slot };
       }
       // If block is not found in hot db, try cold db since there could be an archive cycle happening
       // TODO: Add a lock to the archiver to have deterministic behavior on where are blocks
     }
 
     const data = await this.db.blockArchive.getBinaryEntryByRoot(fromHex(root));
-    return data && {block: data.value, executionOptimistic: false, finalized: true, slot: data.key};
+    return data && { block: data.value, executionOptimistic: false, finalized: true, slot: data.key };
   }
 
   async getBlobSidecars(blockSlot: Slot, blockRootHex: string): Promise<deneb.BlobSidecars | null> {
@@ -916,11 +917,11 @@ export class BeaconChain implements IBeaconChain {
   }
 
   async produceCommonBlockBody(blockAttributes: BlockAttributes): Promise<CommonBlockBody> {
-    const {slot, parentBlock} = blockAttributes;
+    const { slot, parentBlock } = blockAttributes;
     const state = await this.regen.getBlockSlotState(
       parentBlock,
       slot,
-      {dontTransferCache: true},
+      { dontTransferCache: true },
       RegenCaller.produceBlock
     );
 
@@ -930,7 +931,7 @@ export class BeaconChain implements IBeaconChain {
     return produceCommonBlockBody.call(this, blockType, state, blockAttributes);
   }
 
-  produceBlock(blockAttributes: BlockAttributes & {commonBlockBodyPromise: Promise<CommonBlockBody>}): Promise<{
+  produceBlock(blockAttributes: BlockAttributes & { commonBlockBodyPromise: Promise<CommonBlockBody> }): Promise<{
     block: BeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Wei;
@@ -939,7 +940,7 @@ export class BeaconChain implements IBeaconChain {
     return this.produceBlockWrapper<BlockType.Full>(BlockType.Full, blockAttributes);
   }
 
-  produceBlindedBlock(blockAttributes: BlockAttributes & {commonBlockBodyPromise: Promise<CommonBlockBody>}): Promise<{
+  produceBlindedBlock(blockAttributes: BlockAttributes & { commonBlockBodyPromise: Promise<CommonBlockBody> }): Promise<{
     block: BlindedBeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Wei;
@@ -956,7 +957,7 @@ export class BeaconChain implements IBeaconChain {
       feeRecipient,
       commonBlockBodyPromise,
       parentBlock,
-    }: BlockAttributes & {commonBlockBodyPromise: Promise<CommonBlockBody>}
+    }: BlockAttributes & { commonBlockBodyPromise: Promise<CommonBlockBody> }
   ): Promise<{
     block: AssembledBlockType<T>;
     executionPayloadValue: Wei;
@@ -966,13 +967,13 @@ export class BeaconChain implements IBeaconChain {
     const state = await this.regen.getBlockSlotState(
       parentBlock,
       slot,
-      {dontTransferCache: true},
+      { dontTransferCache: true },
       RegenCaller.produceBlock
     );
     const proposerIndex = state.getBeaconProposer(slot);
     const proposerPubKey = this.pubkeyCache.getOrThrow(proposerIndex).toBytes();
 
-    const {body, produceResult, executionPayloadValue, shouldOverrideBuilder} = await produceBlockBody.call(
+    const { body, produceResult, executionPayloadValue, shouldOverrideBuilder } = await produceBlockBody.call(
       this,
       blockType,
       state,
@@ -993,8 +994,8 @@ export class BeaconChain implements IBeaconChain {
       produceResult.type === BlockType.Full
         ? this.config.getForkTypes(slot).BeaconBlockBody.hashTreeRoot(body)
         : this.config
-            .getPostBellatrixForkTypes(slot)
-            .BlindedBeaconBlockBody.hashTreeRoot(body as BlindedBeaconBlockBody);
+          .getPostBellatrixForkTypes(slot)
+          .BlindedBeaconBlockBody.hashTreeRoot(body as BlindedBeaconBlockBody);
     this.logger.debug("Computing block post state from the produced body", {
       slot,
       bodyRoot: toRootHex(bodyRoot),
@@ -1009,7 +1010,7 @@ export class BeaconChain implements IBeaconChain {
       body,
     } as AssembledBlockType<T>;
 
-    const {newStateRoot, proposerReward, postState} = computeNewStateRoot(this.metrics, state, block);
+    const { newStateRoot, proposerReward, postState } = computeNewStateRoot(this.metrics, state, block);
     block.stateRoot = newStateRoot;
     const blockRoot =
       produceResult.type === BlockType.Full
@@ -1041,7 +1042,7 @@ export class BeaconChain implements IBeaconChain {
     this.blockProductionCache.set(blockRootHex, produceResult);
     this.metrics?.blockProductionCacheSize.set(this.blockProductionCache.size);
 
-    return {block, executionPayloadValue, consensusBlockValue: gweiToWei(proposerReward), shouldOverrideBuilder};
+    return { block, executionPayloadValue, consensusBlockValue: gweiToWei(proposerReward), shouldOverrideBuilder };
   }
 
   async processBlock(block: IBlockInput, opts?: ImportBlockOpts): Promise<void> {
@@ -1078,12 +1079,12 @@ export class BeaconChain implements IBeaconChain {
 
   recomputeForkChoiceHead(caller: ForkchoiceCaller): ProtoBlock {
     this.metrics?.forkChoice.requests.inc();
-    const timer = this.metrics?.forkChoice.findHead.startTimer({caller});
+    const timer = this.metrics?.forkChoice.findHead.startTimer({ caller });
 
     try {
-      return this.forkChoice.updateAndGetHead({mode: UpdateHeadOpt.GetCanonicalHead}).head;
+      return this.forkChoice.updateAndGetHead({ mode: UpdateHeadOpt.GetCanonicalHead }).head;
     } catch (e) {
-      this.metrics?.forkChoice.errors.inc({entrypoint: UpdateHeadOpt.GetCanonicalHead});
+      this.metrics?.forkChoice.errors.inc({ entrypoint: UpdateHeadOpt.GetCanonicalHead });
       throw e;
     } finally {
       timer?.();
@@ -1092,13 +1093,13 @@ export class BeaconChain implements IBeaconChain {
 
   predictProposerHead(slot: Slot): ProtoBlock {
     this.metrics?.forkChoice.requests.inc();
-    const timer = this.metrics?.forkChoice.findHead.startTimer({caller: FindHeadFnName.predictProposerHead});
+    const timer = this.metrics?.forkChoice.findHead.startTimer({ caller: FindHeadFnName.predictProposerHead });
     const secFromSlot = this.clock.secFromSlot(slot);
 
     try {
-      return this.forkChoice.updateAndGetHead({mode: UpdateHeadOpt.GetPredictedProposerHead, secFromSlot, slot}).head;
+      return this.forkChoice.updateAndGetHead({ mode: UpdateHeadOpt.GetPredictedProposerHead, secFromSlot, slot }).head;
     } catch (e) {
-      this.metrics?.forkChoice.errors.inc({entrypoint: UpdateHeadOpt.GetPredictedProposerHead});
+      this.metrics?.forkChoice.errors.inc({ entrypoint: UpdateHeadOpt.GetPredictedProposerHead });
       throw e;
     } finally {
       timer?.();
@@ -1107,22 +1108,22 @@ export class BeaconChain implements IBeaconChain {
 
   getProposerHead(slot: Slot): ProtoBlock {
     this.metrics?.forkChoice.requests.inc();
-    const timer = this.metrics?.forkChoice.findHead.startTimer({caller: FindHeadFnName.getProposerHead});
+    const timer = this.metrics?.forkChoice.findHead.startTimer({ caller: FindHeadFnName.getProposerHead });
     const secFromSlot = this.clock.secFromSlot(slot);
 
     try {
-      const {head, isHeadTimely, notReorgedReason} = this.forkChoice.updateAndGetHead({
+      const { head, isHeadTimely, notReorgedReason } = this.forkChoice.updateAndGetHead({
         mode: UpdateHeadOpt.GetProposerHead,
         secFromSlot,
         slot,
       });
 
       if (isHeadTimely && notReorgedReason !== undefined) {
-        this.metrics?.forkChoice.notReorgedReason.inc({reason: notReorgedReason});
+        this.metrics?.forkChoice.notReorgedReason.inc({ reason: notReorgedReason });
       }
       return head;
     } catch (e) {
-      this.metrics?.forkChoice.errors.inc({entrypoint: UpdateHeadOpt.GetProposerHead});
+      this.metrics?.forkChoice.errors.inc({ entrypoint: UpdateHeadOpt.GetProposerHead });
       throw e;
     } finally {
       timer?.();
@@ -1217,8 +1218,8 @@ export class BeaconChain implements IBeaconChain {
     if (blockEpoch < attEpoch - 1) {
       // thanks to one epoch look ahead, we don't need to dial up to attEpoch
       const targetSlot = computeStartSlotAtEpoch(attEpoch - 1);
-      this.metrics?.gossipAttestation.useHeadBlockStateDialedToTargetEpoch.inc({caller: regenCaller});
-      state = await this.regen.getBlockSlotState(attHeadBlock, targetSlot, {dontTransferCache: true}, regenCaller);
+      this.metrics?.gossipAttestation.useHeadBlockStateDialedToTargetEpoch.inc({ caller: regenCaller });
+      state = await this.regen.getBlockSlotState(attHeadBlock, targetSlot, { dontTransferCache: true }, regenCaller);
     } else if (blockEpoch > attEpoch) {
       // should not happen, handled inside attestation verification code
       throw Error(`Block epoch ${blockEpoch} is after attestation epoch ${attEpoch}`);
@@ -1226,7 +1227,7 @@ export class BeaconChain implements IBeaconChain {
       // should use either current or next shuffling of head state
       // it's not likely to hit this since these shufflings are cached already
       // so handle just in case
-      this.metrics?.gossipAttestation.useHeadBlockState.inc({caller: regenCaller});
+      this.metrics?.gossipAttestation.useHeadBlockState.inc({ caller: regenCaller });
       state = await this.regen.getState(attHeadBlock.stateRoot, regenCaller);
     }
     // resolve the promise to unblock other calls of the same epoch and dependent root
@@ -1256,8 +1257,8 @@ export class BeaconChain implements IBeaconChain {
       root: checkpoint.rootHex,
     });
 
-    const {state, stateId, shouldWarn} = this.closestJustifiedBalancesStateToCheckpoint(checkpoint, blockState);
-    this.metrics?.balancesCache.closestStateResult.inc({stateId});
+    const { state, stateId, shouldWarn } = this.closestJustifiedBalancesStateToCheckpoint(checkpoint, blockState);
+    this.metrics?.balancesCache.closestStateResult.inc({ stateId });
     if (shouldWarn) {
       this.logger.warn("currentJustifiedCheckpoint state not avail, using closest state", {
         checkpointEpoch: checkpoint.epoch,
@@ -1281,16 +1282,16 @@ export class BeaconChain implements IBeaconChain {
   private closestJustifiedBalancesStateToCheckpoint(
     checkpoint: CheckpointWithPayloadStatus,
     blockState: IBeaconStateView
-  ): {state: IBeaconStateView; stateId: string; shouldWarn: boolean} {
+  ): { state: IBeaconStateView; stateId: string; shouldWarn: boolean } {
     const checkpointHexPayload = fcCheckpointToHexPayload(checkpoint);
     const state = this.regen.getCheckpointStateSync(checkpointHexPayload);
     if (state) {
-      return {state, stateId: "checkpoint_state", shouldWarn: false};
+      return { state, stateId: "checkpoint_state", shouldWarn: false };
     }
 
     // Check if blockState is in the same epoch, not need to iterate the fork-choice then
     if (computeEpochAtSlot(blockState.slot) === checkpoint.epoch) {
-      return {state: blockState, stateId: "block_state_same_epoch", shouldWarn: true};
+      return { state: blockState, stateId: "block_state_same_epoch", shouldWarn: true };
     }
 
     // Find a state in the same branch of checkpoint at same epoch. Balances should exactly the same
@@ -1301,14 +1302,14 @@ export class BeaconChain implements IBeaconChain {
       if (computeEpochAtSlot(descendantBlock.slot) === checkpoint.epoch) {
         const descendantBlockState = this.regen.getStateSync(descendantBlock.stateRoot);
         if (descendantBlockState) {
-          return {state: descendantBlockState, stateId: "descendant_state_same_epoch", shouldWarn: true};
+          return { state: descendantBlockState, stateId: "descendant_state_same_epoch", shouldWarn: true };
         }
       }
     }
 
     // Check if blockState is in the next epoch, not need to iterate the fork-choice then
     if (computeEpochAtSlot(blockState.slot) === checkpoint.epoch + 1) {
-      return {state: blockState, stateId: "block_state_next_epoch", shouldWarn: true};
+      return { state: blockState, stateId: "block_state_next_epoch", shouldWarn: true };
     }
 
     // Find a state in the same branch of checkpoint at a latter epoch. Balances are not the same, but should be close
@@ -1320,13 +1321,13 @@ export class BeaconChain implements IBeaconChain {
       if (computeEpochAtSlot(descendantBlock.slot) > checkpoint.epoch) {
         const descendantBlockState = this.regen.getStateSync(descendantBlock.stateRoot);
         if (descendantBlockState) {
-          return {state: blockState, stateId: "descendant_state_latter_epoch", shouldWarn: true};
+          return { state: blockState, stateId: "descendant_state_latter_epoch", shouldWarn: true };
         }
       }
     }
 
     // If there's no state available in the same branch of checkpoint use blockState regardless of its epoch
-    return {state: blockState, stateId: "block_state_any_epoch", shouldWarn: true};
+    return { state: blockState, stateId: "block_state_any_epoch", shouldWarn: true };
   }
 
   private async persistSszObject(prefix: string, bytes: Uint8Array, root: Uint8Array, logStr?: string): Promise<void> {
@@ -1344,7 +1345,7 @@ export class BeaconChain implements IBeaconChain {
     // remove date suffixes in file name, and check duplicate to avoid redundant persistence
     await writeIfNotExist(filepath, bytes);
 
-    this.logger.debug("Persisted invalid ssz object", {id: logStr, filepath});
+    this.logger.debug("Persisted invalid ssz object", { id: logStr, filepath });
   }
 
   private onScrapeMetrics(metrics: Metrics): void {
@@ -1371,7 +1372,7 @@ export class BeaconChain implements IBeaconChain {
   }
 
   private onClockSlot(slot: Slot): void {
-    this.logger.verbose("Clock slot", {slot});
+    this.logger.verbose("Clock slot", { slot });
 
     // CRITICAL UPDATE
     if (this.forkChoice.irrecoverableError) {
@@ -1402,7 +1403,7 @@ export class BeaconChain implements IBeaconChain {
       sleep(this.config.SLOT_DURATION_MS / 2)
         .then(() => this.validatorMonitor?.onceEveryEndOfEpoch(this.getHeadState()))
         .catch((e) => {
-          if (!isErrorAborted(e)) this.logger.error("Error on validator monitor onceEveryEndOfEpoch", {slot}, e);
+          if (!isErrorAborted(e)) this.logger.error("Error on validator monitor onceEveryEndOfEpoch", { slot }, e);
         });
     }
   }
@@ -1428,7 +1429,7 @@ export class BeaconChain implements IBeaconChain {
   }
 
   private onForkChoiceJustified(this: BeaconChain, cp: CheckpointWithPayloadStatus): void {
-    this.logger.verbose("Fork choice justified", {epoch: cp.epoch, root: cp.rootHex});
+    this.logger.verbose("Fork choice justified", { epoch: cp.epoch, root: cp.rootHex });
   }
 
   private onCheckpoint(this: BeaconChain, _checkpoint: phase0.Checkpoint, state: IBeaconStateView): void {
@@ -1439,7 +1440,7 @@ export class BeaconChain implements IBeaconChain {
   }
 
   private async onForkChoiceFinalized(this: BeaconChain, cp: CheckpointWithPayloadStatus): Promise<void> {
-    this.logger.verbose("Fork choice finalized", {epoch: cp.epoch, root: cp.rootHex});
+    this.logger.verbose("Fork choice finalized", { epoch: cp.epoch, root: cp.rootHex });
     const finalizedSlot = computeStartSlotAtEpoch(cp.epoch);
     this.seenBlockProposers.prune(finalizedSlot);
 
@@ -1447,7 +1448,7 @@ export class BeaconChain implements IBeaconChain {
     await this.updateValidatorsCustodyRequirement(cp);
 
     // TODO: Improve using regen here
-    const {blockRoot, stateRoot, slot} = this.forkChoice.getHead();
+    const { blockRoot, stateRoot, slot } = this.forkChoice.getHead();
     const headState = this.regen.getStateSync(stateRoot);
     const blockResult = await this.getBlockByRoot(blockRoot);
     if (blockResult == null) {
@@ -1539,7 +1540,7 @@ export class BeaconChain implements IBeaconChain {
    * EIP-8025: Check if enough execution proofs arrived for a block and transition it to Valid in fork choice.
    * Called from both gossip handler and REST API handler when a new proof is added to the pool.
    */
-  maybeTransitionToValidOnProofArrival(proof: {slot: number; blockRoot: Uint8Array; blockHash: Uint8Array}): void {
+  maybeTransitionToValidOnProofArrival(proof: { slot: number; blockRoot: Uint8Array; blockHash: Uint8Array }): void {
     if (!this.activateZkvm) {
       return;
     }
@@ -1585,7 +1586,7 @@ export class BeaconChain implements IBeaconChain {
   updateBuilderStatus(clockSlot: Slot): void {
     const executionBuilder = this.executionBuilder;
     if (executionBuilder) {
-      const {faultInspectionWindow, allowedFaults} = executionBuilder;
+      const { faultInspectionWindow, allowedFaults } = executionBuilder;
       const slotsPresent = this.forkChoice.getSlotsPresent(clockSlot - faultInspectionWindow);
       const previousStatus = executionBuilder.status;
       const shouldEnable = slotsPresent >= Math.min(faultInspectionWindow - allowedFaults, clockSlot);
@@ -1624,16 +1625,16 @@ export class BeaconChain implements IBeaconChain {
   async getAttestationsRewards(
     epoch: Epoch,
     validatorIds?: (ValidatorIndex | string)[]
-  ): Promise<{rewards: rewards.AttestationsRewards; executionOptimistic: boolean; finalized: boolean}> {
+  ): Promise<{ rewards: rewards.AttestationsRewards; executionOptimistic: boolean; finalized: boolean }> {
     // We use end slot of (epoch + 1) to ensure we have seen all attestations. On-time or late. Any late attestation beyond this slot is not considered
     const slot = computeEndSlotAtEpoch(epoch + 1);
-    const stateResult = await this.getStateBySlot(slot, {allowRegen: false}); // No regen if state not in cache
+    const stateResult = await this.getStateBySlot(slot, { allowRegen: false }); // No regen if state not in cache
 
     if (stateResult === null) {
       throw Error(`State is unavailable for slot ${slot}`);
     }
 
-    const {executionOptimistic, finalized} = stateResult;
+    const { executionOptimistic, finalized } = stateResult;
     const stateRoot = toRootHex(stateResult.state.hashTreeRoot());
 
     const cachedState = this.regen.getStateSync(stateRoot);
@@ -1644,7 +1645,7 @@ export class BeaconChain implements IBeaconChain {
 
     const rewards = await cachedState.computeAttestationsRewards(validatorIds);
 
-    return {rewards, executionOptimistic, finalized};
+    return { rewards, executionOptimistic, finalized };
   }
 
   async getSyncCommitteeRewards(

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -90,6 +90,7 @@ import {
   AggregatedAttestationPool,
   AttestationPool,
   ExecutionPayloadBidPool,
+  ExecutionProofPool,
   OpPool,
   PayloadAttestationPool,
   SyncCommitteeMessagePool,
@@ -182,6 +183,7 @@ export class BeaconChain implements IBeaconChain {
   readonly syncCommitteeMessagePool: SyncCommitteeMessagePool;
   readonly syncContributionAndProofPool;
   readonly executionPayloadBidPool: ExecutionPayloadBidPool;
+  readonly executionProofPool: ExecutionProofPool;
   readonly payloadAttestationPool: PayloadAttestationPool;
   readonly opPool: OpPool;
 
@@ -307,6 +309,7 @@ export class BeaconChain implements IBeaconChain {
     this.syncCommitteeMessagePool = new SyncCommitteeMessagePool(config, clock, this.opts?.preaggregateSlotDistance);
     this.syncContributionAndProofPool = new SyncContributionAndProofPool(config, clock, metrics, logger);
     this.executionPayloadBidPool = new ExecutionPayloadBidPool();
+    this.executionProofPool = new ExecutionProofPool();
     this.payloadAttestationPool = new PayloadAttestationPool(config, clock, metrics);
     this.opPool = new OpPool(config);
 
@@ -1373,6 +1376,7 @@ export class BeaconChain implements IBeaconChain {
     this.seenSyncCommitteeMessages.prune(slot);
     this.payloadAttestationPool.prune(slot);
     this.executionPayloadBidPool.prune(slot);
+    this.executionProofPool.prune(slot);
     this.seenExecutionPayloadBids.prune(slot);
     this.seenAttestationDatas.onSlot(slot);
     this.reprocessController.onSlot(slot);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1550,7 +1550,7 @@ export class BeaconChain implements IBeaconChain {
       // We must NOT use proof.blockHash because gossip proofs from other clients may use
       // incompatible SSZ encodings, causing the deserialized blockHash to be garbage.
       // The fork choice proto-array is the authoritative source for execution block hashes.
-      const block = this.forkChoice.getBlockHex(blockRootHex);
+      const block = this.forkChoice.getBlockHex(blockRootHex, PayloadStatus.FULL);
       if (block == null || block.executionPayloadBlockHash == null) {
         this.logger.debug("Cannot transition block to valid: not found in fork choice", {
           slot: proof.slot,

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -10,6 +10,7 @@ import {
   UpdateHeadOpt,
   getCheckpointPayloadStatus,
 } from "@lodestar/fork-choice";
+import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
 import {LoggerNode} from "@lodestar/logger/node";
 import {
   BUILDER_INDEX_SELF_BUILD,
@@ -125,6 +126,7 @@ import {CPStateDatastore} from "./stateCache/datastore/types.js";
 import {FIFOBlockStateCache} from "./stateCache/fifoBlockStateCache.js";
 import {PersistentCheckpointStateCache, fcCheckpointToHexPayload} from "./stateCache/persistentCheckpointsCache.js";
 import {CheckpointStateCache} from "./stateCache/types.js";
+import {IZkvmExecutionProofVerifier, defaultZkvmExecutionProofVerifier} from "./validation/executionProofVerifier.js";
 import {ValidatorMonitor} from "./validatorMonitor.js";
 
 /**
@@ -184,6 +186,12 @@ export class BeaconChain implements IBeaconChain {
   readonly syncContributionAndProofPool;
   readonly executionPayloadBidPool: ExecutionPayloadBidPool;
   readonly executionProofPool: ExecutionProofPool;
+  /** EIP-8025: When true, skip EL newPayload calls and use execution proofs for validation */
+  readonly activateZkvm: boolean;
+  /** EIP-8025: Minimum distinct proof types required per block in zkvm mode */
+  readonly minProofsRequired: number;
+  /** EIP-8025: Verifier for execution proofs — swap implementation for real zkvm prover */
+  readonly executionProofVerifier: IZkvmExecutionProofVerifier;
   readonly payloadAttestationPool: PayloadAttestationPool;
   readonly opPool: OpPool;
 
@@ -310,6 +318,9 @@ export class BeaconChain implements IBeaconChain {
     this.syncContributionAndProofPool = new SyncContributionAndProofPool(config, clock, metrics, logger);
     this.executionPayloadBidPool = new ExecutionPayloadBidPool();
     this.executionProofPool = new ExecutionProofPool();
+    this.activateZkvm = opts.activateZkvm ?? false;
+    this.minProofsRequired = opts.minProofsRequired ?? 1;
+    this.executionProofVerifier = opts.executionProofVerifier ?? defaultZkvmExecutionProofVerifier;
     this.payloadAttestationPool = new PayloadAttestationPool(config, clock, metrics);
     this.opPool = new OpPool(config);
 
@@ -1521,6 +1532,53 @@ export class BeaconChain implements IBeaconChain {
         targetCustodyGroupCount,
       });
       this.emitter.emit(ChainEvent.updateTargetCustodyGroupCount, targetCustodyGroupCount);
+    }
+  }
+
+  /**
+   * EIP-8025: Check if enough execution proofs arrived for a block and transition it to Valid in fork choice.
+   * Called from both gossip handler and REST API handler when a new proof is added to the pool.
+   */
+  maybeTransitionToValidOnProofArrival(proof: {slot: number; blockRoot: Uint8Array; blockHash: Uint8Array}): void {
+    if (!this.activateZkvm) {
+      return;
+    }
+
+    const blockRootHex = toRootHex(proof.blockRoot);
+    if (this.executionProofPool.hasEnoughProofs(blockRootHex, this.minProofsRequired)) {
+      // Look up the block in fork choice to get the canonical execution payload block hash.
+      // We must NOT use proof.blockHash because gossip proofs from other clients may use
+      // incompatible SSZ encodings, causing the deserialized blockHash to be garbage.
+      // The fork choice proto-array is the authoritative source for execution block hashes.
+      const block = this.forkChoice.getBlockHex(blockRootHex);
+      if (block == null || block.executionPayloadBlockHash == null) {
+        this.logger.debug("Cannot transition block to valid: not found in fork choice", {
+          slot: proof.slot,
+          blockRoot: blockRootHex,
+        });
+        return;
+      }
+
+      // Skip if already valid — multiple proofs arriving concurrently can trigger this
+      if (block.executionStatus === ExecutionStatus.Valid) {
+        return;
+      }
+
+      const execBlockHash = block.executionPayloadBlockHash;
+      this.forkChoice.validateLatestHash({
+        executionStatus: ExecutionStatus.Valid,
+        latestValidExecHash: execBlockHash,
+      });
+      // Refresh the cached fork choice head so API responses reflect the updated execution status.
+      // validateLatestHash updates the proto-array nodes but the cached head is a stale snapshot.
+      this.recomputeForkChoiceHead(ForkchoiceCaller.onExecutionProof);
+      this.logger.info("Execution proofs sufficient, marked block as execution-valid (zkvm mode)", {
+        slot: proof.slot,
+        blockRoot: blockRootHex,
+        execBlockHash,
+        proofsAvailable: this.executionProofPool.getProofsByBlockRoot(blockRootHex).length,
+        minRequired: this.minProofsRequired,
+      });
     }
   }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
-import { PrivateKey } from "@libp2p/interface";
-import { Type } from "@chainsafe/ssz";
-import { BeaconConfig } from "@lodestar/config";
+import {PrivateKey} from "@libp2p/interface";
+import {Type} from "@chainsafe/ssz";
+import {BeaconConfig} from "@lodestar/config";
 import {
   CheckpointWithPayloadStatus,
   ExecutionStatus,
@@ -11,8 +11,7 @@ import {
   UpdateHeadOpt,
   getCheckpointPayloadStatus,
 } from "@lodestar/fork-choice";
-import { CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock, UpdateHeadOpt } from "@lodestar/fork-choice";
-import { LoggerNode } from "@lodestar/logger/node";
+import {LoggerNode} from "@lodestar/logger/node";
 import {
   BUILDER_INDEX_SELF_BUILD,
   EFFECTIVE_BALANCE_INCREMENT,
@@ -38,6 +37,7 @@ import {
   BlindedBeaconBlockBody,
   DataColumnSidecars,
   Epoch,
+  ExecutionProof,
   Root,
   RootHex,
   SignedBeaconBlock,
@@ -54,40 +54,40 @@ import {
   ssz,
   sszTypesFor,
 } from "@lodestar/types";
-import { Logger, fromHex, gweiToWei, isErrorAborted, pruneSetToMax, sleep, toRootHex } from "@lodestar/utils";
-import { ProcessShutdownCallback } from "@lodestar/validator";
-import { GENESIS_EPOCH, ZERO_HASH } from "../constants/index.js";
-import { IBeaconDb } from "../db/index.js";
-import { BLOB_SIDECARS_IN_WRAPPER_INDEX } from "../db/repositories/blobSidecars.js";
-import { BuilderStatus } from "../execution/builder/http.js";
-import { IExecutionBuilder, IExecutionEngine } from "../execution/index.js";
-import { Metrics } from "../metrics/index.js";
-import { computeNodeIdFromPrivateKey } from "../network/subnets/interface.js";
-import { BufferPool } from "../util/bufferPool.js";
-import { Clock, ClockEvent, IClock } from "../util/clock.js";
-import { CustodyConfig, getValidatorsCustodyRequirement } from "../util/dataColumns.js";
-import { callInNextEventLoop } from "../util/eventLoop.js";
-import { ensureDir, writeIfNotExist } from "../util/file.js";
-import { isOptimisticBlock } from "../util/forkChoice.js";
-import { JobItemQueue } from "../util/queue/itemQueue.js";
-import { SerializedCache } from "../util/serializedCache.js";
-import { getSlotFromSignedBeaconBlockSerialized } from "../util/sszBytes.js";
-import { ArchiveStore } from "./archiveStore/archiveStore.js";
-import { CheckpointBalancesCache } from "./balancesCache.js";
-import { BeaconProposerCache } from "./beaconProposerCache.js";
-import { IBlockInput, isBlockInputBlobs, isBlockInputColumns } from "./blocks/blockInput/index.js";
-import { BlockProcessor, ImportBlockOpts } from "./blocks/index.js";
-import { PayloadEnvelopeProcessor } from "./blocks/payloadEnvelopeProcessor.js";
-import { ImportPayloadOpts } from "./blocks/types.js";
-import { persistBlockInput } from "./blocks/writeBlockInputToDb.js";
-import { persistPayloadEnvelopeInput } from "./blocks/writePayloadEnvelopeInputToDb.js";
-import { BlsMultiThreadWorkerPool, BlsSingleThreadVerifier, IBlsVerifier } from "./bls/index.js";
-import { ColumnReconstructionTracker } from "./ColumnReconstructionTracker.js";
-import { ChainEvent, ChainEventEmitter } from "./emitter.js";
-import { ForkchoiceCaller, initializeForkChoice } from "./forkChoice/index.js";
-import { GetBlobsTracker } from "./GetBlobsTracker.js";
-import { CommonBlockBody, FindHeadFnName, IBeaconChain, ProposerPreparationData, StateGetOpts } from "./interface.js";
-import { LightClientServer } from "./lightClient/index.js";
+import {Logger, fromHex, gweiToWei, isErrorAborted, pruneSetToMax, sleep, toRootHex} from "@lodestar/utils";
+import {ProcessShutdownCallback} from "@lodestar/validator";
+import {GENESIS_EPOCH, ZERO_HASH} from "../constants/index.js";
+import {IBeaconDb} from "../db/index.js";
+import {BLOB_SIDECARS_IN_WRAPPER_INDEX} from "../db/repositories/blobSidecars.js";
+import {BuilderStatus} from "../execution/builder/http.js";
+import {IExecutionBuilder, IExecutionEngine} from "../execution/index.js";
+import {Metrics} from "../metrics/index.js";
+import {computeNodeIdFromPrivateKey} from "../network/subnets/interface.js";
+import {BufferPool} from "../util/bufferPool.js";
+import {Clock, ClockEvent, IClock} from "../util/clock.js";
+import {CustodyConfig, getValidatorsCustodyRequirement} from "../util/dataColumns.js";
+import {callInNextEventLoop} from "../util/eventLoop.js";
+import {ensureDir, writeIfNotExist} from "../util/file.js";
+import {isOptimisticBlock} from "../util/forkChoice.js";
+import {JobItemQueue} from "../util/queue/itemQueue.js";
+import {SerializedCache} from "../util/serializedCache.js";
+import {getSlotFromSignedBeaconBlockSerialized} from "../util/sszBytes.js";
+import {ArchiveStore} from "./archiveStore/archiveStore.js";
+import {CheckpointBalancesCache} from "./balancesCache.js";
+import {BeaconProposerCache} from "./beaconProposerCache.js";
+import {IBlockInput, isBlockInputBlobs, isBlockInputColumns} from "./blocks/blockInput/index.js";
+import {BlockProcessor, ImportBlockOpts} from "./blocks/index.js";
+import {PayloadEnvelopeProcessor} from "./blocks/payloadEnvelopeProcessor.js";
+import {ImportPayloadOpts} from "./blocks/types.js";
+import {persistBlockInput} from "./blocks/writeBlockInputToDb.js";
+import {persistPayloadEnvelopeInput} from "./blocks/writePayloadEnvelopeInputToDb.js";
+import {BlsMultiThreadWorkerPool, BlsSingleThreadVerifier, IBlsVerifier} from "./bls/index.js";
+import {ColumnReconstructionTracker} from "./ColumnReconstructionTracker.js";
+import {ChainEvent, ChainEventEmitter} from "./emitter.js";
+import {ForkchoiceCaller, initializeForkChoice} from "./forkChoice/index.js";
+import {GetBlobsTracker} from "./GetBlobsTracker.js";
+import {CommonBlockBody, FindHeadFnName, IBeaconChain, ProposerPreparationData, StateGetOpts} from "./interface.js";
+import {LightClientServer} from "./lightClient/index.js";
 import {
   AggregatedAttestationPool,
   AttestationPool,
@@ -98,13 +98,13 @@ import {
   SyncCommitteeMessagePool,
   SyncContributionAndProofPool,
 } from "./opPools/index.js";
-import { IChainOptions } from "./options.js";
-import { PrepareNextSlotScheduler } from "./prepareNextSlot.js";
-import { computeEnvelopeStateRoot, computeNewStateRoot } from "./produceBlock/computeNewStateRoot.js";
-import { AssembledBlockType, BlockType, ProduceFullGloas, ProduceResult } from "./produceBlock/index.js";
-import { BlockAttributes, produceBlockBody, produceCommonBlockBody } from "./produceBlock/produceBlockBody.js";
-import { QueuedStateRegenerator, RegenCaller } from "./regen/index.js";
-import { ReprocessController } from "./reprocess.js";
+import {IChainOptions} from "./options.js";
+import {PrepareNextSlotScheduler} from "./prepareNextSlot.js";
+import {computeEnvelopeStateRoot, computeNewStateRoot} from "./produceBlock/computeNewStateRoot.js";
+import {AssembledBlockType, BlockType, ProduceFullGloas, ProduceResult} from "./produceBlock/index.js";
+import {BlockAttributes, produceBlockBody, produceCommonBlockBody} from "./produceBlock/produceBlockBody.js";
+import {QueuedStateRegenerator, RegenCaller} from "./regen/index.js";
+import {ReprocessController} from "./reprocess.js";
 import {
   PayloadEnvelopeInput,
   SeenAggregators,
@@ -116,19 +116,19 @@ import {
   SeenPayloadEnvelopeInput,
   SeenSyncCommitteeMessages,
 } from "./seenCache/index.js";
-import { SeenAggregatedAttestations } from "./seenCache/seenAggregateAndProof.js";
-import { SeenAttestationDatas } from "./seenCache/seenAttestationData.js";
-import { SeenBlockAttesters } from "./seenCache/seenBlockAttesters.js";
-import { SeenBlockInput } from "./seenCache/seenGossipBlockInput.js";
-import { ShufflingCache } from "./shufflingCache.js";
-import { DbCPStateDatastore, checkpointToDatastoreKey } from "./stateCache/datastore/db.js";
-import { FileCPStateDatastore } from "./stateCache/datastore/file.js";
-import { CPStateDatastore } from "./stateCache/datastore/types.js";
-import { FIFOBlockStateCache } from "./stateCache/fifoBlockStateCache.js";
-import { PersistentCheckpointStateCache, fcCheckpointToHexPayload } from "./stateCache/persistentCheckpointsCache.js";
-import { CheckpointStateCache } from "./stateCache/types.js";
-import { IZkvmExecutionProofVerifier, defaultZkvmExecutionProofVerifier } from "./validation/executionProofVerifier.js";
-import { ValidatorMonitor } from "./validatorMonitor.js";
+import {SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof.js";
+import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
+import {SeenBlockAttesters} from "./seenCache/seenBlockAttesters.js";
+import {SeenBlockInput} from "./seenCache/seenGossipBlockInput.js";
+import {ShufflingCache} from "./shufflingCache.js";
+import {DbCPStateDatastore, checkpointToDatastoreKey} from "./stateCache/datastore/db.js";
+import {FileCPStateDatastore} from "./stateCache/datastore/file.js";
+import {CPStateDatastore} from "./stateCache/datastore/types.js";
+import {FIFOBlockStateCache} from "./stateCache/fifoBlockStateCache.js";
+import {PersistentCheckpointStateCache, fcCheckpointToHexPayload} from "./stateCache/persistentCheckpointsCache.js";
+import {CheckpointStateCache} from "./stateCache/types.js";
+import {IZkvmExecutionProofVerifier, defaultZkvmExecutionProofVerifier} from "./validation/executionProofVerifier.js";
+import {ValidatorMonitor} from "./validatorMonitor.js";
 
 /**
  * The maximum number of cached produced results to keep in memory.
@@ -193,6 +193,8 @@ export class BeaconChain implements IBeaconChain {
   readonly minProofsRequired: number;
   /** EIP-8025: Verifier for execution proofs — swap implementation for real zkvm prover */
   readonly executionProofVerifier: IZkvmExecutionProofVerifier;
+  /** EIP-8025: Maps newPayloadRequestRoot → blockRoot for proof→block lookups */
+  private readonly newPayloadRequestRootToBlockRoot = new Map<string, string>();
   readonly payloadAttestationPool: PayloadAttestationPool;
   readonly opPool: OpPool;
 
@@ -307,10 +309,10 @@ export class BeaconChain implements IBeaconChain {
     const emitter = new ChainEventEmitter();
     // by default, verify signatures on both main threads and worker threads
     const bls = opts.blsVerifyAllMainThread
-      ? new BlsSingleThreadVerifier({ metrics, pubkeyCache })
-      : new BlsMultiThreadWorkerPool(opts, { logger, metrics, pubkeyCache });
+      ? new BlsSingleThreadVerifier({metrics, pubkeyCache})
+      : new BlsMultiThreadWorkerPool(opts, {logger, metrics, pubkeyCache});
 
-    if (!clock) clock = new Clock({ config, genesisTime: this.genesisTime, signal });
+    if (!clock) clock = new Clock({config, genesisTime: this.genesisTime, signal});
 
     this.blacklistedBlocks = new Map((opts.blacklistedBlocks ?? []).map((hex) => [hex, null]));
     this.attestationPool = new AttestationPool(config, clock, this.opts?.preaggregateSlotDistance, metrics);
@@ -382,7 +384,7 @@ export class BeaconChain implements IBeaconChain {
     this.pubkeyCache = pubkeyCache;
 
     const fileDataStore = opts.nHistoricalStatesFileDataStore ?? true;
-    const blockStateCache = new FIFOBlockStateCache(this.opts, { metrics });
+    const blockStateCache = new FIFOBlockStateCache(this.opts, {metrics});
     this.bufferPool = new BufferPool(anchorState.serializedSize(), metrics);
 
     this.cpStateDatastore = fileDataStore ? new FileCPStateDatastore(dataDir) : new DbCPStateDatastore(this.db);
@@ -399,7 +401,7 @@ export class BeaconChain implements IBeaconChain {
       this.opts
     );
 
-    const { checkpoint } = anchorState.computeAnchorCheckpoint();
+    const {checkpoint} = anchorState.computeAnchorCheckpoint();
     blockStateCache.add(anchorState);
     blockStateCache.setHeadState(anchorState);
     const payloadPresent = getCheckpointPayloadStatus(config, anchorState, checkpoint.epoch) === PayloadStatus.FULL;
@@ -431,7 +433,7 @@ export class BeaconChain implements IBeaconChain {
     });
 
     if (!opts.disableLightClientServer) {
-      this.lightClientServer = new LightClientServer(opts, { config, clock, db, metrics, emitter, logger, signal });
+      this.lightClientServer = new LightClientServer(opts, {config, clock, db, metrics, emitter, logger, signal});
     }
 
     this.reprocessController = new ReprocessController(this.metrics);
@@ -460,8 +462,8 @@ export class BeaconChain implements IBeaconChain {
     });
 
     this.archiveStore = new ArchiveStore(
-      { db, chain: this, logger: logger as LoggerNode, metrics },
-      { ...opts, dbName, anchorState: { finalizedCheckpoint: anchorState.finalizedCheckpoint } },
+      {db, chain: this, logger: logger as LoggerNode, metrics},
+      {...opts, dbName, anchorState: {finalizedCheckpoint: anchorState.finalizedCheckpoint}},
       signal
     );
 
@@ -588,13 +590,13 @@ export class BeaconChain implements IBeaconChain {
     // only use regen queue if necessary, it'll cache in checkpointStateCache if regen gets through epoch transition
     const head = this.forkChoice.getHead();
     const startSlot = computeStartSlotAtEpoch(epoch);
-    return this.regen.getBlockSlotState(head, startSlot, { dontTransferCache: true }, regenCaller);
+    return this.regen.getBlockSlotState(head, startSlot, {dontTransferCache: true}, regenCaller);
   }
 
   async getStateBySlot(
     slot: Slot,
     opts?: StateGetOpts
-  ): Promise<{ state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean } | null> {
+  ): Promise<{state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean} | null> {
     const finalizedBlock = this.forkChoice.getFinalizedBlock();
 
     if (slot < finalizedBlock.slot) {
@@ -606,7 +608,7 @@ export class BeaconChain implements IBeaconChain {
     if (opts?.allowRegen) {
       // Find closest canonical block to slot, then trigger regen
       const block = this.forkChoice.getCanonicalBlockClosestLteSlot(slot) ?? finalizedBlock;
-      const state = await this.regen.getBlockSlotState(block, slot, { dontTransferCache: true }, RegenCaller.restApi);
+      const state = await this.regen.getBlockSlotState(block, slot, {dontTransferCache: true}, RegenCaller.restApi);
       return {
         state,
         executionOptimistic: isOptimisticBlock(block),
@@ -633,7 +635,7 @@ export class BeaconChain implements IBeaconChain {
 
   async getHistoricalStateBySlot(
     slot: number
-  ): Promise<{ state: Uint8Array; executionOptimistic: boolean; finalized: boolean } | null> {
+  ): Promise<{state: Uint8Array; executionOptimistic: boolean; finalized: boolean} | null> {
     if (!this.opts.serveHistoricalState) {
       throw Error("Historical state regen is not enabled, set --serveHistoricalState to fetch this data");
     }
@@ -644,7 +646,7 @@ export class BeaconChain implements IBeaconChain {
   async getStateByStateRoot(
     stateRoot: RootHex,
     opts?: StateGetOpts
-  ): Promise<{ state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean } | null> {
+  ): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null> {
     if (opts?.allowRegen) {
       const state = await this.regen.getState(stateRoot, RegenCaller.restApi);
       const block = this.forkChoice.getBlockDefaultStatus(
@@ -678,7 +680,7 @@ export class BeaconChain implements IBeaconChain {
 
     // this is mostly useful for a node with `--chain.archiveStateEpochFrequency 1`
     const data = await this.db.stateArchive.getBinaryByRoot(fromHex(stateRoot));
-    return data && { state: data, executionOptimistic: false, finalized: true };
+    return data && {state: data, executionOptimistic: false, finalized: true};
   }
 
   async getPersistedCheckpointState(checkpoint?: phase0.Checkpoint): Promise<Uint8Array | null> {
@@ -699,7 +701,7 @@ export class BeaconChain implements IBeaconChain {
 
   getStateByCheckpoint(
     checkpoint: CheckpointWithPayloadStatus
-  ): { state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean } | null {
+  ): {state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean} | null {
     // finalized or justified checkpoint states maynot be available with PersistentCheckpointStateCache, use getCheckpointStateOrBytes() api to get Uint8Array
     const checkpointHexPayload = fcCheckpointToHexPayload(checkpoint);
     const cachedStateCtx = this.regen.getCheckpointStateSync(checkpointHexPayload);
@@ -720,7 +722,7 @@ export class BeaconChain implements IBeaconChain {
 
   async getStateOrBytesByCheckpoint(
     checkpoint: CheckpointWithPayloadStatus
-  ): Promise<{ state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean } | null> {
+  ): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null> {
     const checkpointHexPayload = fcCheckpointToHexPayload(checkpoint);
     const cachedStateCtx = await this.regen.getCheckpointStateOrBytes(checkpointHexPayload);
     if (cachedStateCtx) {
@@ -738,7 +740,7 @@ export class BeaconChain implements IBeaconChain {
 
   async getCanonicalBlockAtSlot(
     slot: Slot
-  ): Promise<{ block: SignedBeaconBlock; executionOptimistic: boolean; finalized: boolean } | null> {
+  ): Promise<{block: SignedBeaconBlock; executionOptimistic: boolean; finalized: boolean} | null> {
     const finalizedBlock = this.forkChoice.getFinalizedBlock();
     if (slot > finalizedBlock.slot) {
       // Unfinalized slot, attempt to find in fork-choice
@@ -749,11 +751,11 @@ export class BeaconChain implements IBeaconChain {
         // Otherwise (most likely), check the hot db
         const blockInput = this.seenBlockInputCache.get(block.blockRoot);
         if (blockInput?.hasBlock()) {
-          return { block: blockInput.getBlock(), executionOptimistic: isOptimisticBlock(block), finalized: false };
+          return {block: blockInput.getBlock(), executionOptimistic: isOptimisticBlock(block), finalized: false};
         }
         const data = await this.db.block.get(fromHex(block.blockRoot));
         if (data) {
-          return { block: data, executionOptimistic: isOptimisticBlock(block), finalized: false };
+          return {block: data, executionOptimistic: isOptimisticBlock(block), finalized: false};
         }
       }
       // A non-finalized slot expected to be found in the hot db, could be archived during
@@ -762,12 +764,12 @@ export class BeaconChain implements IBeaconChain {
     }
 
     const data = await this.db.blockArchive.get(slot);
-    return data && { block: data, executionOptimistic: false, finalized: true };
+    return data && {block: data, executionOptimistic: false, finalized: true};
   }
 
   async getBlockByRoot(
     root: string
-  ): Promise<{ block: SignedBeaconBlock; executionOptimistic: boolean; finalized: boolean } | null> {
+  ): Promise<{block: SignedBeaconBlock; executionOptimistic: boolean; finalized: boolean} | null> {
     const block = this.forkChoice.getBlockHexDefaultStatus(root);
     if (block) {
       // Block found in fork-choice.
@@ -775,23 +777,23 @@ export class BeaconChain implements IBeaconChain {
       // Otherwise (most likely), check the hot db
       const blockInput = this.seenBlockInputCache.get(block.blockRoot);
       if (blockInput?.hasBlock()) {
-        return { block: blockInput.getBlock(), executionOptimistic: isOptimisticBlock(block), finalized: false };
+        return {block: blockInput.getBlock(), executionOptimistic: isOptimisticBlock(block), finalized: false};
       }
       const data = await this.db.block.get(fromHex(root));
       if (data) {
-        return { block: data, executionOptimistic: isOptimisticBlock(block), finalized: false };
+        return {block: data, executionOptimistic: isOptimisticBlock(block), finalized: false};
       }
       // If block is not found in hot db, try cold db since there could be an archive cycle happening
       // TODO: Add a lock to the archiver to have deterministic behavior on where are blocks
     }
 
     const data = await this.db.blockArchive.getByRoot(fromHex(root));
-    return data && { block: data, executionOptimistic: false, finalized: true };
+    return data && {block: data, executionOptimistic: false, finalized: true};
   }
 
   async getSerializedBlockByRoot(
     root: string
-  ): Promise<{ block: Uint8Array; executionOptimistic: boolean; finalized: boolean; slot: Slot } | null> {
+  ): Promise<{block: Uint8Array; executionOptimistic: boolean; finalized: boolean; slot: Slot} | null> {
     const block = this.forkChoice.getBlockHexDefaultStatus(root);
     if (block) {
       // Block found in fork-choice.
@@ -820,14 +822,14 @@ export class BeaconChain implements IBeaconChain {
       if (data) {
         const slot = getSlotFromSignedBeaconBlockSerialized(data);
         if (slot === null) throw new Error(`Invalid block data stored in DB for root: ${root}`);
-        return { block: data, executionOptimistic: isOptimisticBlock(block), finalized: false, slot };
+        return {block: data, executionOptimistic: isOptimisticBlock(block), finalized: false, slot};
       }
       // If block is not found in hot db, try cold db since there could be an archive cycle happening
       // TODO: Add a lock to the archiver to have deterministic behavior on where are blocks
     }
 
     const data = await this.db.blockArchive.getBinaryEntryByRoot(fromHex(root));
-    return data && { block: data.value, executionOptimistic: false, finalized: true, slot: data.key };
+    return data && {block: data.value, executionOptimistic: false, finalized: true, slot: data.key};
   }
 
   async getBlobSidecars(blockSlot: Slot, blockRootHex: string): Promise<deneb.BlobSidecars | null> {
@@ -917,11 +919,11 @@ export class BeaconChain implements IBeaconChain {
   }
 
   async produceCommonBlockBody(blockAttributes: BlockAttributes): Promise<CommonBlockBody> {
-    const { slot, parentBlock } = blockAttributes;
+    const {slot, parentBlock} = blockAttributes;
     const state = await this.regen.getBlockSlotState(
       parentBlock,
       slot,
-      { dontTransferCache: true },
+      {dontTransferCache: true},
       RegenCaller.produceBlock
     );
 
@@ -931,7 +933,7 @@ export class BeaconChain implements IBeaconChain {
     return produceCommonBlockBody.call(this, blockType, state, blockAttributes);
   }
 
-  produceBlock(blockAttributes: BlockAttributes & { commonBlockBodyPromise: Promise<CommonBlockBody> }): Promise<{
+  produceBlock(blockAttributes: BlockAttributes & {commonBlockBodyPromise: Promise<CommonBlockBody>}): Promise<{
     block: BeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Wei;
@@ -940,7 +942,7 @@ export class BeaconChain implements IBeaconChain {
     return this.produceBlockWrapper<BlockType.Full>(BlockType.Full, blockAttributes);
   }
 
-  produceBlindedBlock(blockAttributes: BlockAttributes & { commonBlockBodyPromise: Promise<CommonBlockBody> }): Promise<{
+  produceBlindedBlock(blockAttributes: BlockAttributes & {commonBlockBodyPromise: Promise<CommonBlockBody>}): Promise<{
     block: BlindedBeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Wei;
@@ -957,7 +959,7 @@ export class BeaconChain implements IBeaconChain {
       feeRecipient,
       commonBlockBodyPromise,
       parentBlock,
-    }: BlockAttributes & { commonBlockBodyPromise: Promise<CommonBlockBody> }
+    }: BlockAttributes & {commonBlockBodyPromise: Promise<CommonBlockBody>}
   ): Promise<{
     block: AssembledBlockType<T>;
     executionPayloadValue: Wei;
@@ -967,13 +969,13 @@ export class BeaconChain implements IBeaconChain {
     const state = await this.regen.getBlockSlotState(
       parentBlock,
       slot,
-      { dontTransferCache: true },
+      {dontTransferCache: true},
       RegenCaller.produceBlock
     );
     const proposerIndex = state.getBeaconProposer(slot);
     const proposerPubKey = this.pubkeyCache.getOrThrow(proposerIndex).toBytes();
 
-    const { body, produceResult, executionPayloadValue, shouldOverrideBuilder } = await produceBlockBody.call(
+    const {body, produceResult, executionPayloadValue, shouldOverrideBuilder} = await produceBlockBody.call(
       this,
       blockType,
       state,
@@ -994,8 +996,8 @@ export class BeaconChain implements IBeaconChain {
       produceResult.type === BlockType.Full
         ? this.config.getForkTypes(slot).BeaconBlockBody.hashTreeRoot(body)
         : this.config
-          .getPostBellatrixForkTypes(slot)
-          .BlindedBeaconBlockBody.hashTreeRoot(body as BlindedBeaconBlockBody);
+            .getPostBellatrixForkTypes(slot)
+            .BlindedBeaconBlockBody.hashTreeRoot(body as BlindedBeaconBlockBody);
     this.logger.debug("Computing block post state from the produced body", {
       slot,
       bodyRoot: toRootHex(bodyRoot),
@@ -1010,7 +1012,7 @@ export class BeaconChain implements IBeaconChain {
       body,
     } as AssembledBlockType<T>;
 
-    const { newStateRoot, proposerReward, postState } = computeNewStateRoot(this.metrics, state, block);
+    const {newStateRoot, proposerReward, postState} = computeNewStateRoot(this.metrics, state, block);
     block.stateRoot = newStateRoot;
     const blockRoot =
       produceResult.type === BlockType.Full
@@ -1042,7 +1044,7 @@ export class BeaconChain implements IBeaconChain {
     this.blockProductionCache.set(blockRootHex, produceResult);
     this.metrics?.blockProductionCacheSize.set(this.blockProductionCache.size);
 
-    return { block, executionPayloadValue, consensusBlockValue: gweiToWei(proposerReward), shouldOverrideBuilder };
+    return {block, executionPayloadValue, consensusBlockValue: gweiToWei(proposerReward), shouldOverrideBuilder};
   }
 
   async processBlock(block: IBlockInput, opts?: ImportBlockOpts): Promise<void> {
@@ -1079,12 +1081,12 @@ export class BeaconChain implements IBeaconChain {
 
   recomputeForkChoiceHead(caller: ForkchoiceCaller): ProtoBlock {
     this.metrics?.forkChoice.requests.inc();
-    const timer = this.metrics?.forkChoice.findHead.startTimer({ caller });
+    const timer = this.metrics?.forkChoice.findHead.startTimer({caller});
 
     try {
-      return this.forkChoice.updateAndGetHead({ mode: UpdateHeadOpt.GetCanonicalHead }).head;
+      return this.forkChoice.updateAndGetHead({mode: UpdateHeadOpt.GetCanonicalHead}).head;
     } catch (e) {
-      this.metrics?.forkChoice.errors.inc({ entrypoint: UpdateHeadOpt.GetCanonicalHead });
+      this.metrics?.forkChoice.errors.inc({entrypoint: UpdateHeadOpt.GetCanonicalHead});
       throw e;
     } finally {
       timer?.();
@@ -1093,13 +1095,13 @@ export class BeaconChain implements IBeaconChain {
 
   predictProposerHead(slot: Slot): ProtoBlock {
     this.metrics?.forkChoice.requests.inc();
-    const timer = this.metrics?.forkChoice.findHead.startTimer({ caller: FindHeadFnName.predictProposerHead });
+    const timer = this.metrics?.forkChoice.findHead.startTimer({caller: FindHeadFnName.predictProposerHead});
     const secFromSlot = this.clock.secFromSlot(slot);
 
     try {
-      return this.forkChoice.updateAndGetHead({ mode: UpdateHeadOpt.GetPredictedProposerHead, secFromSlot, slot }).head;
+      return this.forkChoice.updateAndGetHead({mode: UpdateHeadOpt.GetPredictedProposerHead, secFromSlot, slot}).head;
     } catch (e) {
-      this.metrics?.forkChoice.errors.inc({ entrypoint: UpdateHeadOpt.GetPredictedProposerHead });
+      this.metrics?.forkChoice.errors.inc({entrypoint: UpdateHeadOpt.GetPredictedProposerHead});
       throw e;
     } finally {
       timer?.();
@@ -1108,22 +1110,22 @@ export class BeaconChain implements IBeaconChain {
 
   getProposerHead(slot: Slot): ProtoBlock {
     this.metrics?.forkChoice.requests.inc();
-    const timer = this.metrics?.forkChoice.findHead.startTimer({ caller: FindHeadFnName.getProposerHead });
+    const timer = this.metrics?.forkChoice.findHead.startTimer({caller: FindHeadFnName.getProposerHead});
     const secFromSlot = this.clock.secFromSlot(slot);
 
     try {
-      const { head, isHeadTimely, notReorgedReason } = this.forkChoice.updateAndGetHead({
+      const {head, isHeadTimely, notReorgedReason} = this.forkChoice.updateAndGetHead({
         mode: UpdateHeadOpt.GetProposerHead,
         secFromSlot,
         slot,
       });
 
       if (isHeadTimely && notReorgedReason !== undefined) {
-        this.metrics?.forkChoice.notReorgedReason.inc({ reason: notReorgedReason });
+        this.metrics?.forkChoice.notReorgedReason.inc({reason: notReorgedReason});
       }
       return head;
     } catch (e) {
-      this.metrics?.forkChoice.errors.inc({ entrypoint: UpdateHeadOpt.GetProposerHead });
+      this.metrics?.forkChoice.errors.inc({entrypoint: UpdateHeadOpt.GetProposerHead});
       throw e;
     } finally {
       timer?.();
@@ -1218,8 +1220,8 @@ export class BeaconChain implements IBeaconChain {
     if (blockEpoch < attEpoch - 1) {
       // thanks to one epoch look ahead, we don't need to dial up to attEpoch
       const targetSlot = computeStartSlotAtEpoch(attEpoch - 1);
-      this.metrics?.gossipAttestation.useHeadBlockStateDialedToTargetEpoch.inc({ caller: regenCaller });
-      state = await this.regen.getBlockSlotState(attHeadBlock, targetSlot, { dontTransferCache: true }, regenCaller);
+      this.metrics?.gossipAttestation.useHeadBlockStateDialedToTargetEpoch.inc({caller: regenCaller});
+      state = await this.regen.getBlockSlotState(attHeadBlock, targetSlot, {dontTransferCache: true}, regenCaller);
     } else if (blockEpoch > attEpoch) {
       // should not happen, handled inside attestation verification code
       throw Error(`Block epoch ${blockEpoch} is after attestation epoch ${attEpoch}`);
@@ -1227,7 +1229,7 @@ export class BeaconChain implements IBeaconChain {
       // should use either current or next shuffling of head state
       // it's not likely to hit this since these shufflings are cached already
       // so handle just in case
-      this.metrics?.gossipAttestation.useHeadBlockState.inc({ caller: regenCaller });
+      this.metrics?.gossipAttestation.useHeadBlockState.inc({caller: regenCaller});
       state = await this.regen.getState(attHeadBlock.stateRoot, regenCaller);
     }
     // resolve the promise to unblock other calls of the same epoch and dependent root
@@ -1257,8 +1259,8 @@ export class BeaconChain implements IBeaconChain {
       root: checkpoint.rootHex,
     });
 
-    const { state, stateId, shouldWarn } = this.closestJustifiedBalancesStateToCheckpoint(checkpoint, blockState);
-    this.metrics?.balancesCache.closestStateResult.inc({ stateId });
+    const {state, stateId, shouldWarn} = this.closestJustifiedBalancesStateToCheckpoint(checkpoint, blockState);
+    this.metrics?.balancesCache.closestStateResult.inc({stateId});
     if (shouldWarn) {
       this.logger.warn("currentJustifiedCheckpoint state not avail, using closest state", {
         checkpointEpoch: checkpoint.epoch,
@@ -1282,16 +1284,16 @@ export class BeaconChain implements IBeaconChain {
   private closestJustifiedBalancesStateToCheckpoint(
     checkpoint: CheckpointWithPayloadStatus,
     blockState: IBeaconStateView
-  ): { state: IBeaconStateView; stateId: string; shouldWarn: boolean } {
+  ): {state: IBeaconStateView; stateId: string; shouldWarn: boolean} {
     const checkpointHexPayload = fcCheckpointToHexPayload(checkpoint);
     const state = this.regen.getCheckpointStateSync(checkpointHexPayload);
     if (state) {
-      return { state, stateId: "checkpoint_state", shouldWarn: false };
+      return {state, stateId: "checkpoint_state", shouldWarn: false};
     }
 
     // Check if blockState is in the same epoch, not need to iterate the fork-choice then
     if (computeEpochAtSlot(blockState.slot) === checkpoint.epoch) {
-      return { state: blockState, stateId: "block_state_same_epoch", shouldWarn: true };
+      return {state: blockState, stateId: "block_state_same_epoch", shouldWarn: true};
     }
 
     // Find a state in the same branch of checkpoint at same epoch. Balances should exactly the same
@@ -1302,14 +1304,14 @@ export class BeaconChain implements IBeaconChain {
       if (computeEpochAtSlot(descendantBlock.slot) === checkpoint.epoch) {
         const descendantBlockState = this.regen.getStateSync(descendantBlock.stateRoot);
         if (descendantBlockState) {
-          return { state: descendantBlockState, stateId: "descendant_state_same_epoch", shouldWarn: true };
+          return {state: descendantBlockState, stateId: "descendant_state_same_epoch", shouldWarn: true};
         }
       }
     }
 
     // Check if blockState is in the next epoch, not need to iterate the fork-choice then
     if (computeEpochAtSlot(blockState.slot) === checkpoint.epoch + 1) {
-      return { state: blockState, stateId: "block_state_next_epoch", shouldWarn: true };
+      return {state: blockState, stateId: "block_state_next_epoch", shouldWarn: true};
     }
 
     // Find a state in the same branch of checkpoint at a latter epoch. Balances are not the same, but should be close
@@ -1321,13 +1323,13 @@ export class BeaconChain implements IBeaconChain {
       if (computeEpochAtSlot(descendantBlock.slot) > checkpoint.epoch) {
         const descendantBlockState = this.regen.getStateSync(descendantBlock.stateRoot);
         if (descendantBlockState) {
-          return { state: blockState, stateId: "descendant_state_latter_epoch", shouldWarn: true };
+          return {state: blockState, stateId: "descendant_state_latter_epoch", shouldWarn: true};
         }
       }
     }
 
     // If there's no state available in the same branch of checkpoint use blockState regardless of its epoch
-    return { state: blockState, stateId: "block_state_any_epoch", shouldWarn: true };
+    return {state: blockState, stateId: "block_state_any_epoch", shouldWarn: true};
   }
 
   private async persistSszObject(prefix: string, bytes: Uint8Array, root: Uint8Array, logStr?: string): Promise<void> {
@@ -1345,7 +1347,7 @@ export class BeaconChain implements IBeaconChain {
     // remove date suffixes in file name, and check duplicate to avoid redundant persistence
     await writeIfNotExist(filepath, bytes);
 
-    this.logger.debug("Persisted invalid ssz object", { id: logStr, filepath });
+    this.logger.debug("Persisted invalid ssz object", {id: logStr, filepath});
   }
 
   private onScrapeMetrics(metrics: Metrics): void {
@@ -1372,7 +1374,7 @@ export class BeaconChain implements IBeaconChain {
   }
 
   private onClockSlot(slot: Slot): void {
-    this.logger.verbose("Clock slot", { slot });
+    this.logger.verbose("Clock slot", {slot});
 
     // CRITICAL UPDATE
     if (this.forkChoice.irrecoverableError) {
@@ -1388,7 +1390,7 @@ export class BeaconChain implements IBeaconChain {
     this.seenSyncCommitteeMessages.prune(slot);
     this.payloadAttestationPool.prune(slot);
     this.executionPayloadBidPool.prune(slot);
-    this.executionProofPool.prune(slot);
+    this.executionProofPool.prune();
     this.seenExecutionPayloadBids.prune(slot);
     this.seenAttestationDatas.onSlot(slot);
     this.reprocessController.onSlot(slot);
@@ -1403,7 +1405,7 @@ export class BeaconChain implements IBeaconChain {
       sleep(this.config.SLOT_DURATION_MS / 2)
         .then(() => this.validatorMonitor?.onceEveryEndOfEpoch(this.getHeadState()))
         .catch((e) => {
-          if (!isErrorAborted(e)) this.logger.error("Error on validator monitor onceEveryEndOfEpoch", { slot }, e);
+          if (!isErrorAborted(e)) this.logger.error("Error on validator monitor onceEveryEndOfEpoch", {slot}, e);
         });
     }
   }
@@ -1429,7 +1431,7 @@ export class BeaconChain implements IBeaconChain {
   }
 
   private onForkChoiceJustified(this: BeaconChain, cp: CheckpointWithPayloadStatus): void {
-    this.logger.verbose("Fork choice justified", { epoch: cp.epoch, root: cp.rootHex });
+    this.logger.verbose("Fork choice justified", {epoch: cp.epoch, root: cp.rootHex});
   }
 
   private onCheckpoint(this: BeaconChain, _checkpoint: phase0.Checkpoint, state: IBeaconStateView): void {
@@ -1440,7 +1442,7 @@ export class BeaconChain implements IBeaconChain {
   }
 
   private async onForkChoiceFinalized(this: BeaconChain, cp: CheckpointWithPayloadStatus): Promise<void> {
-    this.logger.verbose("Fork choice finalized", { epoch: cp.epoch, root: cp.rootHex });
+    this.logger.verbose("Fork choice finalized", {epoch: cp.epoch, root: cp.rootHex});
     const finalizedSlot = computeStartSlotAtEpoch(cp.epoch);
     this.seenBlockProposers.prune(finalizedSlot);
 
@@ -1448,7 +1450,7 @@ export class BeaconChain implements IBeaconChain {
     await this.updateValidatorsCustodyRequirement(cp);
 
     // TODO: Improve using regen here
-    const { blockRoot, stateRoot, slot } = this.forkChoice.getHead();
+    const {blockRoot, stateRoot, slot} = this.forkChoice.getHead();
     const headState = this.regen.getStateSync(stateRoot);
     const blockResult = await this.getBlockByRoot(blockRoot);
     if (blockResult == null) {
@@ -1540,53 +1542,69 @@ export class BeaconChain implements IBeaconChain {
    * EIP-8025: Check if enough execution proofs arrived for a block and transition it to Valid in fork choice.
    * Called from both gossip handler and REST API handler when a new proof is added to the pool.
    */
-  maybeTransitionToValidOnProofArrival(proof: { slot: number; blockRoot: Uint8Array; blockHash: Uint8Array }): void {
+  /**
+   * EIP-8025: Register the mapping from newPayloadRequestRoot to blockRoot.
+   * Called during block import so proof arrivals can resolve which block they validate.
+   */
+  registerNewPayloadRequestRoot(newPayloadRequestRootHex: string, blockRootHex: string): void {
+    this.newPayloadRequestRootToBlockRoot.set(newPayloadRequestRootHex, blockRootHex);
+  }
+
+  maybeTransitionToValidOnProofArrival(proof: ExecutionProof): void {
     if (!this.activateZkvm) {
       return;
     }
 
-    const blockRootHex = toRootHex(proof.blockRoot);
-    if (this.executionProofPool.hasEnoughProofs(blockRootHex, this.minProofsRequired)) {
-      // Look up the block in fork choice to get the canonical execution payload block hash.
-      // We must NOT use proof.blockHash because gossip proofs from other clients may use
-      // incompatible SSZ encodings, causing the deserialized blockHash to be garbage.
-      // The fork choice proto-array is the authoritative source for execution block hashes.
-      const block = this.forkChoice.getBlockHex(blockRootHex, PayloadStatus.FULL);
-      if (block == null || block.executionPayloadBlockHash == null) {
-        this.logger.debug("Cannot transition block to valid: not found in fork choice", {
-          slot: proof.slot,
-          blockRoot: blockRootHex,
-        });
-        return;
-      }
+    const newPayloadRequestRootHex = toRootHex(proof.publicInput.newPayloadRequestRoot);
 
-      // Skip if already valid — multiple proofs arriving concurrently can trigger this
-      if (block.executionStatus === ExecutionStatus.Valid) {
-        return;
-      }
-
-      const execBlockHash = block.executionPayloadBlockHash;
-      this.forkChoice.validateLatestHash({
-        executionStatus: ExecutionStatus.Valid,
-        latestValidExecHash: execBlockHash,
-      });
-      // Refresh the cached fork choice head so API responses reflect the updated execution status.
-      // validateLatestHash updates the proto-array nodes but the cached head is a stale snapshot.
-      this.recomputeForkChoiceHead(ForkchoiceCaller.onExecutionProof);
-      this.logger.info("Execution proofs sufficient, marked block as execution-valid (zkvm mode)", {
-        slot: proof.slot,
-        blockRoot: blockRootHex,
-        execBlockHash,
-        proofsAvailable: this.executionProofPool.getProofsByBlockRoot(blockRootHex).length,
-        minRequired: this.minProofsRequired,
-      });
+    if (!this.executionProofPool.hasEnoughProofs(newPayloadRequestRootHex, this.minProofsRequired)) {
+      return;
     }
+
+    // Resolve which block this proof set validates via the registered mapping
+    const blockRootHex = this.newPayloadRequestRootToBlockRoot.get(newPayloadRequestRootHex);
+    if (blockRootHex == null) {
+      this.logger.debug("Cannot transition block to valid: no blockRoot mapping for newPayloadRequestRoot", {
+        newPayloadRequestRoot: newPayloadRequestRootHex,
+      });
+      return;
+    }
+
+    // Look up the block in fork choice to get the canonical execution payload block hash
+    const block = this.forkChoice.getBlockHex(blockRootHex, PayloadStatus.FULL);
+    if (block == null || block.executionPayloadBlockHash == null) {
+      this.logger.debug("Cannot transition block to valid: not found in fork choice", {
+        blockRoot: blockRootHex,
+        newPayloadRequestRoot: newPayloadRequestRootHex,
+      });
+      return;
+    }
+
+    // Skip if already valid — multiple proofs arriving concurrently can trigger this
+    if (block.executionStatus === ExecutionStatus.Valid) {
+      return;
+    }
+
+    const execBlockHash = block.executionPayloadBlockHash;
+    this.forkChoice.validateLatestHash({
+      executionStatus: ExecutionStatus.Valid,
+      latestValidExecHash: execBlockHash,
+    });
+    // Refresh the cached fork choice head so API responses reflect the updated execution status.
+    this.recomputeForkChoiceHead(ForkchoiceCaller.onExecutionProof);
+    this.logger.info("Execution proofs sufficient, marked block as execution-valid (zkvm mode)", {
+      blockRoot: blockRootHex,
+      newPayloadRequestRoot: newPayloadRequestRootHex,
+      execBlockHash,
+      proofsAvailable: this.executionProofPool.getProofsByNewPayloadRequestRoot(newPayloadRequestRootHex).length,
+      minRequired: this.minProofsRequired,
+    });
   }
 
   updateBuilderStatus(clockSlot: Slot): void {
     const executionBuilder = this.executionBuilder;
     if (executionBuilder) {
-      const { faultInspectionWindow, allowedFaults } = executionBuilder;
+      const {faultInspectionWindow, allowedFaults} = executionBuilder;
       const slotsPresent = this.forkChoice.getSlotsPresent(clockSlot - faultInspectionWindow);
       const previousStatus = executionBuilder.status;
       const shouldEnable = slotsPresent >= Math.min(faultInspectionWindow - allowedFaults, clockSlot);
@@ -1625,16 +1643,16 @@ export class BeaconChain implements IBeaconChain {
   async getAttestationsRewards(
     epoch: Epoch,
     validatorIds?: (ValidatorIndex | string)[]
-  ): Promise<{ rewards: rewards.AttestationsRewards; executionOptimistic: boolean; finalized: boolean }> {
+  ): Promise<{rewards: rewards.AttestationsRewards; executionOptimistic: boolean; finalized: boolean}> {
     // We use end slot of (epoch + 1) to ensure we have seen all attestations. On-time or late. Any late attestation beyond this slot is not considered
     const slot = computeEndSlotAtEpoch(epoch + 1);
-    const stateResult = await this.getStateBySlot(slot, { allowRegen: false }); // No regen if state not in cache
+    const stateResult = await this.getStateBySlot(slot, {allowRegen: false}); // No regen if state not in cache
 
     if (stateResult === null) {
       throw Error(`State is unavailable for slot ${slot}`);
     }
 
-    const { executionOptimistic, finalized } = stateResult;
+    const {executionOptimistic, finalized} = stateResult;
     const stateRoot = toRootHex(stateResult.state.hashTreeRoot());
 
     const cachedState = this.regen.getStateSync(stateRoot);
@@ -1645,7 +1663,7 @@ export class BeaconChain implements IBeaconChain {
 
     const rewards = await cachedState.computeAttestationsRewards(validatorIds);
 
-    return { rewards, executionOptimistic, finalized };
+    return {rewards, executionOptimistic, finalized};
   }
 
   async getSyncCommitteeRewards(

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -31,6 +31,7 @@ export type ForkChoiceOpts = RawForkChoiceOpts & {
 export enum ForkchoiceCaller {
   prepareNextSlot = "prepare_next_slot",
   importBlock = "import_block",
+  onExecutionProof = "on_execution_proof",
 }
 
 /**

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -43,6 +43,7 @@ import {AggregatedAttestationPool} from "./opPools/aggregatedAttestationPool.js"
 import {
   AttestationPool,
   ExecutionPayloadBidPool,
+  ExecutionProofPool,
   OpPool,
   PayloadAttestationPool,
   SyncCommitteeMessagePool,
@@ -120,6 +121,8 @@ export interface IBeaconChain {
   readonly syncCommitteeMessagePool: SyncCommitteeMessagePool;
   readonly syncContributionAndProofPool: SyncContributionAndProofPool;
   readonly executionPayloadBidPool: ExecutionPayloadBidPool;
+  /** EIP-8025: Pool for execution proofs */
+  readonly executionProofPool: ExecutionProofPool;
   readonly payloadAttestationPool: PayloadAttestationPool;
   readonly opPool: OpPool;
 

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -68,6 +68,7 @@ import {SeenBlockAttesters} from "./seenCache/seenBlockAttesters.js";
 import {SeenBlockInput} from "./seenCache/seenGossipBlockInput.js";
 import {PayloadEnvelopeInput, SeenPayloadEnvelopeInput} from "./seenCache/seenPayloadEnvelopeInput.js";
 import {ShufflingCache} from "./shufflingCache.js";
+import {IZkvmExecutionProofVerifier} from "./validation/executionProofVerifier.js";
 import {ValidatorMonitor} from "./validatorMonitor.js";
 
 export {BlockType, type AssembledBlockType};
@@ -123,6 +124,12 @@ export interface IBeaconChain {
   readonly executionPayloadBidPool: ExecutionPayloadBidPool;
   /** EIP-8025: Pool for execution proofs */
   readonly executionProofPool: ExecutionProofPool;
+  /** EIP-8025: When true, skip EL newPayload calls and use execution proofs for validation */
+  readonly activateZkvm: boolean;
+  /** EIP-8025: Minimum distinct proof types required per block in zkvm mode */
+  readonly minProofsRequired: number;
+  /** EIP-8025: Verifier for execution proofs — swap implementation for real zkvm prover */
+  readonly executionProofVerifier: IZkvmExecutionProofVerifier;
   readonly payloadAttestationPool: PayloadAttestationPool;
   readonly opPool: OpPool;
 
@@ -277,6 +284,9 @@ export interface IBeaconChain {
     regenCaller: RegenCaller
   ): Promise<EpochShuffling>;
   updateBuilderStatus(clockSlot: Slot): void;
+
+  /** EIP-8025: Check if enough execution proofs arrived for a block and transition it to Valid in fork choice */
+  maybeTransitionToValidOnProofArrival(proof: {slot: number; blockRoot: Uint8Array; blockHash: Uint8Array}): void;
 
   regenCanAcceptWork(): boolean;
   blsThreadPoolCanAcceptWork(): boolean;

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -7,6 +7,7 @@ import {
   BlindedBeaconBlock,
   DataColumnSidecars,
   Epoch,
+  ExecutionProof,
   Root,
   RootHex,
   SignedBeaconBlock,
@@ -286,7 +287,7 @@ export interface IBeaconChain {
   updateBuilderStatus(clockSlot: Slot): void;
 
   /** EIP-8025: Check if enough execution proofs arrived for a block and transition it to Valid in fork choice */
-  maybeTransitionToValidOnProofArrival(proof: {slot: number; blockRoot: Uint8Array; blockHash: Uint8Array}): void;
+  maybeTransitionToValidOnProofArrival(proof: ExecutionProof): void;
 
   regenCanAcceptWork(): boolean;
   blsThreadPoolCanAcceptWork(): boolean;

--- a/packages/beacon-node/src/chain/opPools/executionProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/executionProofPool.ts
@@ -1,21 +1,21 @@
 import {EXECUTION_PROOF_TYPE_COUNT} from "@lodestar/params";
-import {ExecutionProof, Slot} from "@lodestar/types";
+import {ExecutionProof} from "@lodestar/types";
 import {MapDef, toRootHex} from "@lodestar/utils";
 import {InsertOutcome} from "./types.js";
-import {pruneBySlot} from "./utils.js";
+
+type NewPayloadRequestRootHex = string;
+type ProofType = number;
 
 /**
- * Number of slots to retain proofs for.
- * Keep proofs around for a few slots in case of reorgs.
+ * Max number of distinct newPayloadRequestRoot entries to prevent unbounded growth.
+ * Each root can have up to EXECUTION_PROOF_TYPE_COUNT proofs.
  */
-const SLOTS_RETAINED = 8;
-
-type BlockRootHex = string;
-type ProofId = number;
+const MAX_ROOT_ENTRIES = 64;
 
 /**
- * EIP-8025: In-memory pool for execution proofs, indexed by slot → blockRoot → proofId.
+ * EIP-8025: In-memory pool for execution proofs.
  *
+ * Indexed by newPayloadRequestRoot (from proof.publicInput) → proofType.
  * Stores verified execution proofs received via gossip or API submission.
  * Used to:
  * - Track proof availability for blocks (zkvm mode gating)
@@ -23,121 +23,97 @@ type ProofId = number;
  * - Deduplicate incoming proofs
  */
 export class ExecutionProofPool {
-  private readonly proofsByBlockRootBySlot = new MapDef<Slot, MapDef<BlockRootHex, Map<ProofId, ExecutionProof>>>(
-    () => new MapDef<BlockRootHex, Map<ProofId, ExecutionProof>>(() => new Map())
-  );
-  /** Reverse index: blockRootHex → slot for O(1) lookups */
-  private readonly blockRootToSlot = new Map<BlockRootHex, Slot>();
-  private lowestPermissibleSlot = 0;
+  private readonly proofsByRoot = new MapDef<NewPayloadRequestRootHex, Map<ProofType, ExecutionProof>>(() => new Map());
 
   /** Total number of individual proofs in the pool */
   get size(): number {
     let count = 0;
-    for (const byBlockRoot of this.proofsByBlockRootBySlot.values()) {
-      for (const byProofId of byBlockRoot.values()) {
-        count += byProofId.size;
-      }
+    for (const byType of this.proofsByRoot.values()) {
+      count += byType.size;
     }
     return count;
   }
 
   /**
    * Add a verified proof to the pool.
-   * Deduplicates by (blockRoot, proofId) — only one proof per type per block.
+   * Deduplicates by (newPayloadRequestRoot, proofType) — only one proof per type per payload request.
    */
-  add(proof: ExecutionProof, clockSlot?: Slot): InsertOutcome {
-    const {slot, blockRoot, proofId} = proof;
+  add(proof: ExecutionProof): InsertOutcome {
+    const rootHex = toRootHex(proof.publicInput.newPayloadRequestRoot);
+    const {proofType} = proof;
 
-    if (slot < this.lowestPermissibleSlot) {
-      return InsertOutcome.Old;
-    }
-
-    // Reject far-future slots to prevent unbounded memory growth via spam
-    if (clockSlot !== undefined && slot > clockSlot + SLOTS_RETAINED) {
-      return InsertOutcome.Old;
-    }
-
-    if (proofId >= EXECUTION_PROOF_TYPE_COUNT) {
+    if (proofType >= EXECUTION_PROOF_TYPE_COUNT) {
       return InsertOutcome.Old; // Invalid proof type
     }
 
-    const blockRootHex = toRootHex(blockRoot);
-    const proofsByProofId = this.proofsByBlockRootBySlot.getOrDefault(slot).getOrDefault(blockRootHex);
-
-    if (proofsByProofId.has(proofId)) {
+    const byType = this.proofsByRoot.getOrDefault(rootHex);
+    if (byType.has(proofType)) {
       return InsertOutcome.AlreadyKnown;
     }
 
-    proofsByProofId.set(proofId, proof);
-    this.blockRootToSlot.set(blockRootHex, slot);
+    // Prevent unbounded memory growth
+    if (this.proofsByRoot.size >= MAX_ROOT_ENTRIES && !this.proofsByRoot.has(rootHex)) {
+      return InsertOutcome.Old;
+    }
+
+    byType.set(proofType, proof);
     return InsertOutcome.NewData;
   }
 
   /**
-   * Get all proofs for a given block root. O(1) slot lookup via reverse index.
+   * Get all proofs for a given newPayloadRequestRoot.
    */
-  getProofsByBlockRoot(blockRootHex: BlockRootHex): ExecutionProof[] {
-    const slot = this.blockRootToSlot.get(blockRootHex);
-    if (slot === undefined) return [];
-
-    const byProofId = this.proofsByBlockRootBySlot.get(slot)?.get(blockRootHex);
-    return byProofId ? Array.from(byProofId.values()) : [];
+  getProofsByNewPayloadRequestRoot(rootHex: NewPayloadRequestRootHex): ExecutionProof[] {
+    const byType = this.proofsByRoot.get(rootHex);
+    return byType ? Array.from(byType.values()) : [];
   }
 
   /**
-   * Get proofs for a range of slots. Used to serve ExecutionProofsByRange req/resp.
+   * Get all proofs in the pool. Used for API listing.
    */
-  getProofsByRange(startSlot: Slot, count: number): ExecutionProof[] {
+  getAllProofs(): ExecutionProof[] {
     const proofs: ExecutionProof[] = [];
-    for (let slot = startSlot; slot < startSlot + count; slot++) {
-      const byBlockRoot = this.proofsByBlockRootBySlot.get(slot);
-      if (byBlockRoot) {
-        for (const byProofId of byBlockRoot.values()) {
-          for (const proof of byProofId.values()) {
-            proofs.push(proof);
-          }
-        }
+    for (const byType of this.proofsByRoot.values()) {
+      for (const proof of byType.values()) {
+        proofs.push(proof);
       }
     }
     return proofs;
   }
 
   /**
-   * Check whether a block has enough distinct proof types for availability.
-   * O(1) slot lookup via reverse index.
+   * Check whether a newPayloadRequestRoot has enough distinct proof types for availability.
    */
-  hasEnoughProofs(blockRootHex: BlockRootHex, minRequired: number): boolean {
-    const slot = this.blockRootToSlot.get(blockRootHex);
-    if (slot === undefined) return false;
-
-    const byProofId = this.proofsByBlockRootBySlot.get(slot)?.get(blockRootHex);
-    return byProofId !== undefined && byProofId.size >= minRequired;
+  hasEnoughProofs(rootHex: NewPayloadRequestRootHex, minRequired: number): boolean {
+    const byType = this.proofsByRoot.get(rootHex);
+    return byType !== undefined && byType.size >= minRequired;
   }
 
   /**
-   * Check if a specific (blockRoot, proofId) combination is already known.
+   * Check if a specific (newPayloadRequestRoot, proofType) combination is already known.
    * Used for gossip deduplication (IGNORE if already seen).
-   * O(1) slot lookup via reverse index.
    */
-  has(blockRootHex: BlockRootHex, proofId: ProofId): boolean {
-    const slot = this.blockRootToSlot.get(blockRootHex);
-    if (slot === undefined) return false;
-
-    return this.proofsByBlockRootBySlot.get(slot)?.get(blockRootHex)?.has(proofId) ?? false;
+  has(rootHex: NewPayloadRequestRootHex, proofType: ProofType): boolean {
+    return this.proofsByRoot.get(rootHex)?.has(proofType) ?? false;
   }
 
   /**
-   * Prune proofs older than clockSlot - SLOTS_RETAINED.
-   * Called periodically (e.g., on slot clock tick).
+   * Remove all proofs for a given newPayloadRequestRoot.
+   * Called when block is finalized or proof set is no longer needed.
    */
-  prune(clockSlot: Slot): void {
-    // Clean up reverse index for pruned slots
-    const cutoffSlot = clockSlot - SLOTS_RETAINED;
-    for (const [blockRootHex, slot] of this.blockRootToSlot) {
-      if (slot < cutoffSlot) {
-        this.blockRootToSlot.delete(blockRootHex);
-      }
+  pruneByRoot(rootHex: NewPayloadRequestRootHex): void {
+    this.proofsByRoot.delete(rootHex);
+  }
+
+  /**
+   * Remove oldest entries to keep pool within MAX_ROOT_ENTRIES.
+   * Uses insertion order (Map iteration order) as a proxy for age.
+   */
+  prune(): void {
+    while (this.proofsByRoot.size > MAX_ROOT_ENTRIES) {
+      const firstKey = this.proofsByRoot.keys().next().value;
+      if (firstKey === undefined) break;
+      this.proofsByRoot.delete(firstKey);
     }
-    this.lowestPermissibleSlot = pruneBySlot(this.proofsByBlockRootBySlot, clockSlot, SLOTS_RETAINED);
   }
 }

--- a/packages/beacon-node/src/chain/opPools/executionProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/executionProofPool.ts
@@ -1,0 +1,143 @@
+import {EXECUTION_PROOF_TYPE_COUNT} from "@lodestar/params";
+import {ExecutionProof, Slot} from "@lodestar/types";
+import {MapDef, toRootHex} from "@lodestar/utils";
+import {InsertOutcome} from "./types.js";
+import {pruneBySlot} from "./utils.js";
+
+/**
+ * Number of slots to retain proofs for.
+ * Keep proofs around for a few slots in case of reorgs.
+ */
+const SLOTS_RETAINED = 8;
+
+type BlockRootHex = string;
+type ProofId = number;
+
+/**
+ * EIP-8025: In-memory pool for execution proofs, indexed by slot → blockRoot → proofId.
+ *
+ * Stores verified execution proofs received via gossip or API submission.
+ * Used to:
+ * - Track proof availability for blocks (zkvm mode gating)
+ * - Serve proofs via req/resp to peers
+ * - Deduplicate incoming proofs
+ */
+export class ExecutionProofPool {
+  private readonly proofsByBlockRootBySlot = new MapDef<Slot, MapDef<BlockRootHex, Map<ProofId, ExecutionProof>>>(
+    () => new MapDef<BlockRootHex, Map<ProofId, ExecutionProof>>(() => new Map())
+  );
+  /** Reverse index: blockRootHex → slot for O(1) lookups */
+  private readonly blockRootToSlot = new Map<BlockRootHex, Slot>();
+  private lowestPermissibleSlot = 0;
+
+  /** Total number of individual proofs in the pool */
+  get size(): number {
+    let count = 0;
+    for (const byBlockRoot of this.proofsByBlockRootBySlot.values()) {
+      for (const byProofId of byBlockRoot.values()) {
+        count += byProofId.size;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Add a verified proof to the pool.
+   * Deduplicates by (blockRoot, proofId) — only one proof per type per block.
+   */
+  add(proof: ExecutionProof, clockSlot?: Slot): InsertOutcome {
+    const {slot, blockRoot, proofId} = proof;
+
+    if (slot < this.lowestPermissibleSlot) {
+      return InsertOutcome.Old;
+    }
+
+    // Reject far-future slots to prevent unbounded memory growth via spam
+    if (clockSlot !== undefined && slot > clockSlot + SLOTS_RETAINED) {
+      return InsertOutcome.Old;
+    }
+
+    if (proofId >= EXECUTION_PROOF_TYPE_COUNT) {
+      return InsertOutcome.Old; // Invalid proof type
+    }
+
+    const blockRootHex = toRootHex(blockRoot);
+    const proofsByProofId = this.proofsByBlockRootBySlot.getOrDefault(slot).getOrDefault(blockRootHex);
+
+    if (proofsByProofId.has(proofId)) {
+      return InsertOutcome.AlreadyKnown;
+    }
+
+    proofsByProofId.set(proofId, proof);
+    this.blockRootToSlot.set(blockRootHex, slot);
+    return InsertOutcome.NewData;
+  }
+
+  /**
+   * Get all proofs for a given block root. O(1) slot lookup via reverse index.
+   */
+  getProofsByBlockRoot(blockRootHex: BlockRootHex): ExecutionProof[] {
+    const slot = this.blockRootToSlot.get(blockRootHex);
+    if (slot === undefined) return [];
+
+    const byProofId = this.proofsByBlockRootBySlot.get(slot)?.get(blockRootHex);
+    return byProofId ? Array.from(byProofId.values()) : [];
+  }
+
+  /**
+   * Get proofs for a range of slots. Used to serve ExecutionProofsByRange req/resp.
+   */
+  getProofsByRange(startSlot: Slot, count: number): ExecutionProof[] {
+    const proofs: ExecutionProof[] = [];
+    for (let slot = startSlot; slot < startSlot + count; slot++) {
+      const byBlockRoot = this.proofsByBlockRootBySlot.get(slot);
+      if (byBlockRoot) {
+        for (const byProofId of byBlockRoot.values()) {
+          for (const proof of byProofId.values()) {
+            proofs.push(proof);
+          }
+        }
+      }
+    }
+    return proofs;
+  }
+
+  /**
+   * Check whether a block has enough distinct proof types for availability.
+   * O(1) slot lookup via reverse index.
+   */
+  hasEnoughProofs(blockRootHex: BlockRootHex, minRequired: number): boolean {
+    const slot = this.blockRootToSlot.get(blockRootHex);
+    if (slot === undefined) return false;
+
+    const byProofId = this.proofsByBlockRootBySlot.get(slot)?.get(blockRootHex);
+    return byProofId !== undefined && byProofId.size >= minRequired;
+  }
+
+  /**
+   * Check if a specific (blockRoot, proofId) combination is already known.
+   * Used for gossip deduplication (IGNORE if already seen).
+   * O(1) slot lookup via reverse index.
+   */
+  has(blockRootHex: BlockRootHex, proofId: ProofId): boolean {
+    const slot = this.blockRootToSlot.get(blockRootHex);
+    if (slot === undefined) return false;
+
+    return this.proofsByBlockRootBySlot.get(slot)?.get(blockRootHex)?.has(proofId) ?? false;
+  }
+
+  /**
+   * Prune proofs older than clockSlot - SLOTS_RETAINED.
+   * Called periodically (e.g., on slot clock tick).
+   */
+  prune(clockSlot: Slot): void {
+    // Clean up reverse index for pruned slots
+    const cutoffSlot = clockSlot - SLOTS_RETAINED;
+    for (const [blockRootHex, slot] of this.blockRootToSlot) {
+      if (slot < cutoffSlot) {
+        this.blockRootToSlot.delete(blockRootHex);
+      }
+    }
+    this.lowestPermissibleSlot = pruneBySlot(this.proofsByBlockRootBySlot, clockSlot, SLOTS_RETAINED);
+  }
+}

--- a/packages/beacon-node/src/chain/opPools/index.ts
+++ b/packages/beacon-node/src/chain/opPools/index.ts
@@ -1,6 +1,7 @@
 export {AggregatedAttestationPool} from "./aggregatedAttestationPool.js";
 export {AttestationPool} from "./attestationPool.js";
 export {ExecutionPayloadBidPool} from "./executionPayloadBidPool.js";
+export {ExecutionProofPool} from "./executionProofPool.js";
 export {OpPool} from "./opPool.js";
 export {PayloadAttestationPool} from "./payloadAttestationPool.js";
 export {SyncCommitteeMessagePool} from "./syncCommitteeMessagePool.js";

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -1,3 +1,4 @@
+import {DEFAULT_MIN_PROOFS_REQUIRED} from "@lodestar/params";
 import {defaultOptions as defaultValidatorOptions} from "@lodestar/validator";
 import {DEFAULT_ARCHIVE_MODE} from "./archiveStore/constants.js";
 import {ArchiveMode, ArchiveStoreOpts} from "./archiveStore/interface.js";
@@ -47,6 +48,12 @@ export type IChainOptions = BlockProcessOpts &
     minSameMessageSignatureSetsToBatch: number;
     archiveDateEpochs?: number;
     nHistoricalStatesFileDataStore?: boolean;
+    /** EIP-8025: Enable zkvm/stateless execution mode. Blocks gated by proof availability instead of EL. */
+    activateZkvm?: boolean;
+    /** EIP-8025: Minimum distinct proof types required per block in zkvm mode (default: 1) */
+    minProofsRequired?: number;
+    /** EIP-8025: Which proof type IDs this node generates (for prover mode). Empty = verify-only. */
+    zkvmGenerationProofTypes?: number[];
   };
 
 export type BlockProcessOpts = {
@@ -127,4 +134,8 @@ export const defaultChainOptions: IChainOptions = {
   maxBlockStates: DEFAULT_MAX_BLOCK_STATES,
   maxCPStateEpochsInMemory: DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY,
   maxCPStateEpochsOnDisk: DEFAULT_MAX_CP_STATE_ON_DISK,
+  // EIP-8025: zkvm/stateless execution mode
+  activateZkvm: false,
+  minProofsRequired: DEFAULT_MIN_PROOFS_REQUIRED,
+  zkvmGenerationProofTypes: [],
 };

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_MAX_CP_STATE_ON_DISK,
   PersistentCheckpointStateCacheOpts,
 } from "./stateCache/persistentCheckpointsCache.js";
+import {IZkvmExecutionProofVerifier} from "./validation/executionProofVerifier.js";
 import {ValidatorMonitorOpts} from "./validatorMonitor.js";
 
 export {ArchiveMode, DEFAULT_ARCHIVE_MODE};
@@ -54,6 +55,8 @@ export type IChainOptions = BlockProcessOpts &
     minProofsRequired?: number;
     /** EIP-8025: Which proof type IDs this node generates (for prover mode). Empty = verify-only. */
     zkvmGenerationProofTypes?: number[];
+    /** EIP-8025: Custom execution proof verifier — defaults to DummyZkvmExecutionProofVerifier */
+    executionProofVerifier?: IZkvmExecutionProofVerifier;
   };
 
 export type BlockProcessOpts = {

--- a/packages/beacon-node/src/chain/validation/executionProofVerifier.ts
+++ b/packages/beacon-node/src/chain/validation/executionProofVerifier.ts
@@ -1,10 +1,7 @@
 import {ExecutionProof} from "@lodestar/types";
-import {toRootHex} from "@lodestar/utils";
 
 export type VerifyExecutionProofsInput = {
   proofs: ExecutionProof[];
-  expectedBlockRootHex: string;
-  expectedExecBlockHashHex: string;
   minProofsRequired: number;
 };
 
@@ -20,38 +17,21 @@ export interface IZkvmExecutionProofVerifier {
  * This is intentionally basic for initial interop:
  * - At least min distinct proof types are present
  * - proofData is non-empty
- * - proof blockRoot matches expected beacon block root
- * - proof blockHash matches expected execution payload block hash
+ *
+ * TODO EIP-8025: Replace with real zkVM proof verification
  */
 export class DummyZkvmExecutionProofVerifier implements IZkvmExecutionProofVerifier {
   verifyProofs(input: VerifyExecutionProofsInput): VerifyExecutionProofsResult {
-    const {proofs, expectedBlockRootHex, expectedExecBlockHashHex, minProofsRequired} = input;
+    const {proofs, minProofsRequired} = input;
 
     const distinctProofTypes = new Set<number>();
 
     for (const proof of proofs) {
-      const proofBlockRootHex = toRootHex(proof.blockRoot);
-      const proofExecBlockHashHex = toRootHex(proof.blockHash);
-
       if (proof.proofData.length === 0) {
-        return {ok: false, error: `empty proofData for proofId=${proof.proofId}`};
+        return {ok: false, error: `empty proofData for proofType=${proof.proofType}`};
       }
 
-      if (proofBlockRootHex !== expectedBlockRootHex) {
-        return {
-          ok: false,
-          error: `proof blockRoot mismatch: expected=${expectedBlockRootHex} got=${proofBlockRootHex}`,
-        };
-      }
-
-      if (proofExecBlockHashHex !== expectedExecBlockHashHex) {
-        return {
-          ok: false,
-          error: `proof blockHash mismatch: expected=${expectedExecBlockHashHex} got=${proofExecBlockHashHex}`,
-        };
-      }
-
-      distinctProofTypes.add(proof.proofId);
+      distinctProofTypes.add(proof.proofType);
     }
 
     if (distinctProofTypes.size < minProofsRequired) {

--- a/packages/beacon-node/src/chain/validation/executionProofVerifier.ts
+++ b/packages/beacon-node/src/chain/validation/executionProofVerifier.ts
@@ -1,0 +1,68 @@
+import {ExecutionProof} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+
+export type VerifyExecutionProofsInput = {
+  proofs: ExecutionProof[];
+  expectedBlockRootHex: string;
+  expectedExecBlockHashHex: string;
+  minProofsRequired: number;
+};
+
+export type VerifyExecutionProofsResult = {ok: true; distinctProofTypes: number} | {ok: false; error: string};
+
+export interface IZkvmExecutionProofVerifier {
+  verifyProofs(input: VerifyExecutionProofsInput): VerifyExecutionProofsResult;
+}
+
+/**
+ * Dummy zkEVM verifier for EIP-8025 proof-driven mode.
+ *
+ * This is intentionally basic for initial interop:
+ * - At least min distinct proof types are present
+ * - proofData is non-empty
+ * - proof blockRoot matches expected beacon block root
+ * - proof blockHash matches expected execution payload block hash
+ */
+export class DummyZkvmExecutionProofVerifier implements IZkvmExecutionProofVerifier {
+  verifyProofs(input: VerifyExecutionProofsInput): VerifyExecutionProofsResult {
+    const {proofs, expectedBlockRootHex, expectedExecBlockHashHex, minProofsRequired} = input;
+
+    const distinctProofTypes = new Set<number>();
+
+    for (const proof of proofs) {
+      const proofBlockRootHex = toRootHex(proof.blockRoot);
+      const proofExecBlockHashHex = toRootHex(proof.blockHash);
+
+      if (proof.proofData.length === 0) {
+        return {ok: false, error: `empty proofData for proofId=${proof.proofId}`};
+      }
+
+      if (proofBlockRootHex !== expectedBlockRootHex) {
+        return {
+          ok: false,
+          error: `proof blockRoot mismatch: expected=${expectedBlockRootHex} got=${proofBlockRootHex}`,
+        };
+      }
+
+      if (proofExecBlockHashHex !== expectedExecBlockHashHex) {
+        return {
+          ok: false,
+          error: `proof blockHash mismatch: expected=${expectedExecBlockHashHex} got=${proofExecBlockHashHex}`,
+        };
+      }
+
+      distinctProofTypes.add(proof.proofId);
+    }
+
+    if (distinctProofTypes.size < minProofsRequired) {
+      return {
+        ok: false,
+        error: `insufficient distinct proof types: have=${distinctProofTypes.size} need=${minProofsRequired}`,
+      };
+    }
+
+    return {ok: true, distinctProofTypes: distinctProofTypes.size};
+  }
+}
+
+export const defaultZkvmExecutionProofVerifier: IZkvmExecutionProofVerifier = new DummyZkvmExecutionProofVerifier();

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -167,7 +167,10 @@ export class NetworkCore implements INetworkCore {
       config,
       custodyConfig: new CustodyConfig({nodeId, config, initialCustodyGroupCount}),
     };
-    const metadata = new MetadataController({}, {networkConfig, logger, onSetValue: onMetadataSetValue});
+    const metadata = new MetadataController(
+      {activateZkvm: opts.activateZkvm},
+      {networkConfig, logger, onSetValue: onMetadataSetValue}
+    );
 
     const reqResp = new ReqRespBeaconNode(
       {
@@ -590,11 +593,12 @@ export class NetworkCore implements INetworkCore {
   private subscribeCoreTopicsAtBoundary(networkConfig: NetworkConfig, boundary: ForkBoundary): void {
     if (this.forkBoundariesByEpoch.has(boundary.epoch)) return;
     this.forkBoundariesByEpoch.set(boundary.epoch, boundary);
-    const {subscribeAllSubnets, disableLightClientServer} = this.opts;
+    const {subscribeAllSubnets, disableLightClientServer, activateZkvm} = this.opts;
 
     for (const topic of getCoreTopicsAtFork(networkConfig, boundary.fork, {
       subscribeAllSubnets,
       disableLightClientServer,
+      activateZkvm,
     })) {
       this.gossip.subscribeTopic({...topic, boundary});
     }
@@ -603,11 +607,12 @@ export class NetworkCore implements INetworkCore {
   private unsubscribeCoreTopicsAtBoundary(networkConfig: NetworkConfig, boundary: ForkBoundary): void {
     if (!this.forkBoundariesByEpoch.has(boundary.epoch)) return;
     this.forkBoundariesByEpoch.delete(boundary.epoch);
-    const {subscribeAllSubnets, disableLightClientServer} = this.opts;
+    const {subscribeAllSubnets, disableLightClientServer, activateZkvm} = this.opts;
 
     for (const topic of getCoreTopicsAtFork(networkConfig, boundary.fork, {
       subscribeAllSubnets,
       disableLightClientServer,
+      activateZkvm,
     })) {
       this.gossip.unsubscribeTopic({...topic, boundary});
     }

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -67,6 +67,8 @@ export type Eth2GossipsubOpts = {
   disableFloodPublish?: boolean;
   skipParamsLog?: boolean;
   disableLightClientServer?: boolean;
+  /** EIP-8025: Enable execution proof gossip topic */
+  activateZkvm?: boolean;
   /**
    * Direct peers for GossipSub - these peers maintain permanent mesh connections without GRAFT/PRUNE.
    * Supports multiaddr strings with peer ID (e.g., "/ip4/192.168.1.1/tcp/9000/p2p/16Uiu2HAmKLhW7...")
@@ -476,7 +478,7 @@ function attSubnetLabel(subnet: SubnetID): string {
 
 function getMetricsTopicStrToLabel(
   networkConfig: NetworkConfig,
-  opts: {disableLightClientServer: boolean}
+  opts: {disableLightClientServer: boolean; activateZkvm?: boolean}
 ): TopicStrToLabel {
   const {config} = networkConfig;
   const metricsTopicStrToLabel = new Map<TopicStr, TopicLabel>();
@@ -494,6 +496,7 @@ function getMetricsTopicStrToLabel(
     const topics = getCoreTopicsAtFork(networkConfig, currentForkBoundary.fork, {
       subscribeAllSubnets: true,
       disableLightClientServer: opts.disableLightClientServer,
+      activateZkvm: opts.activateZkvm,
     });
     for (const topic of topics) {
       metricsTopicStrToLabel.set(stringifyGossipTopic(config, {...topic, boundary: currentForkBoundary}), topic.type);

--- a/packages/beacon-node/src/network/gossip/interface.ts
+++ b/packages/beacon-node/src/network/gossip/interface.ts
@@ -5,6 +5,7 @@ import {BeaconConfig, ForkBoundary} from "@lodestar/config";
 import {
   AttesterSlashing,
   DataColumnSidecar,
+  ExecutionProof,
   LightClientFinalityUpdate,
   LightClientOptimisticUpdate,
   SignedAggregateAndProof,
@@ -41,6 +42,7 @@ export enum GossipType {
   execution_payload = "execution_payload",
   payload_attestation_message = "payload_attestation_message",
   execution_payload_bid = "execution_payload_bid",
+  execution_proof = "execution_proof",
 }
 
 export type SequentialGossipType = Exclude<GossipType, GossipType.beacon_attestation>;
@@ -78,6 +80,7 @@ export type GossipTopicTypeMap = {
   [GossipType.execution_payload]: {type: GossipType.execution_payload};
   [GossipType.payload_attestation_message]: {type: GossipType.payload_attestation_message};
   [GossipType.execution_payload_bid]: {type: GossipType.execution_payload_bid};
+  [GossipType.execution_proof]: {type: GossipType.execution_proof};
 };
 
 export type GossipTopicMap = {
@@ -110,6 +113,7 @@ export type GossipTypeMap = {
   [GossipType.execution_payload]: gloas.SignedExecutionPayloadEnvelope;
   [GossipType.payload_attestation_message]: gloas.PayloadAttestationMessage;
   [GossipType.execution_payload_bid]: gloas.SignedExecutionPayloadBid;
+  [GossipType.execution_proof]: ExecutionProof;
 };
 
 export type GossipFnByType = {
@@ -141,6 +145,7 @@ export type GossipFnByType = {
     payloadAttestationMessage: gloas.PayloadAttestationMessage
   ) => Promise<void> | void;
   [GossipType.execution_payload_bid]: (executionPayloadBid: gloas.SignedExecutionPayloadBid) => Promise<void> | void;
+  [GossipType.execution_proof]: (executionProof: ExecutionProof) => Promise<void> | void;
 };
 
 export type GossipFn = GossipFnByType[keyof GossipFnByType];

--- a/packages/beacon-node/src/network/gossip/scoringParameters.ts
+++ b/packages/beacon-node/src/network/gossip/scoringParameters.ts
@@ -198,6 +198,17 @@ function getAllTopicsScoreParams(
       expectedMessageRate: 1024, // TODO GLOAS: Need an estimate for this
       firstMessageDecayTime: epochDurationMs * 100,
     });
+    // EIP-8025: execution_proof topic scoring
+    topicsParams[
+      stringifyGossipTopic(config, {
+        type: GossipType.execution_proof,
+        boundary,
+      })
+    ] = getTopicScoreParams(config, precomputedParams, {
+      topicWeight: 0.5, // Similar weight to voluntary_exit — low frequency, important
+      expectedMessageRate: 8, // Up to EXECUTION_PROOF_TYPE_COUNT per slot
+      firstMessageDecayTime: epochDurationMs * 100,
+    });
 
     // other topics
     topicsParams[

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -73,6 +73,7 @@ function stringifyGossipTopicType(topic: GossipTopic): string {
     case GossipType.execution_payload:
     case GossipType.payload_attestation_message:
     case GossipType.execution_payload_bid:
+    case GossipType.execution_proof:
       return topic.type;
     case GossipType.beacon_attestation:
     case GossipType.sync_committee:
@@ -124,6 +125,8 @@ export function getGossipSSZType(topic: GossipTopic) {
       return ssz.gloas.PayloadAttestationMessage;
     case GossipType.execution_payload_bid:
       return ssz.gloas.SignedExecutionPayloadBid;
+    case GossipType.execution_proof:
+      return ssz.eip8025.ExecutionProof;
   }
 }
 
@@ -203,6 +206,7 @@ export function parseGossipTopic(forkDigestContext: ForkDigestContext, topicStr:
       case GossipType.execution_payload:
       case GossipType.payload_attestation_message:
       case GossipType.execution_payload_bid:
+      case GossipType.execution_proof:
         return {type: gossipTypeStr, boundary, encoding};
     }
 
@@ -242,7 +246,7 @@ export function parseGossipTopic(forkDigestContext: ForkDigestContext, topicStr:
 export function getCoreTopicsAtFork(
   networkConfig: NetworkConfig,
   fork: ForkName,
-  opts: {subscribeAllSubnets?: boolean; disableLightClientServer?: boolean}
+  opts: {subscribeAllSubnets?: boolean; disableLightClientServer?: boolean; activateZkvm?: boolean}
 ): GossipTopicTypeMap[keyof GossipTopicTypeMap][] {
   // Common topics for all forks
   const topics: GossipTopicTypeMap[keyof GossipTopicTypeMap][] = [
@@ -262,6 +266,11 @@ export function getCoreTopicsAtFork(
   // After fulu also track data_column_sidecar_{index}
   if (ForkSeq[fork] >= ForkSeq.fulu) {
     topics.push(...getDataColumnSidecarTopics(networkConfig));
+  }
+
+  // EIP-8025: Subscribe to execution_proof gossip when zkvm mode is active on Fulu+
+  if (opts.activateZkvm && ForkSeq[fork] >= ForkSeq.fulu) {
+    topics.push({type: GossipType.execution_proof});
   }
 
   // After Deneb and before Fulu also track blob_sidecar_{subnet_id}
@@ -351,4 +360,5 @@ export const gossipTopicIgnoreDuplicatePublishError: Record<GossipType, boolean>
   [GossipType.execution_payload]: true,
   [GossipType.payload_attestation_message]: true,
   [GossipType.execution_payload_bid]: true,
+  [GossipType.execution_proof]: true,
 };

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -20,6 +20,7 @@ import type {Libp2p as ILibp2p} from "libp2p";
 import {
   AttesterSlashing,
   DataColumnSidecar,
+  ExecutionProof,
   LightClientFinalityUpdate,
   LightClientOptimisticUpdate,
   SignedAggregateAndProof,
@@ -98,6 +99,7 @@ export interface INetwork extends INetworkCorePublic {
   publishLightClientFinalityUpdate(update: LightClientFinalityUpdate): Promise<number>;
   publishLightClientOptimisticUpdate(update: LightClientOptimisticUpdate): Promise<number>;
   publishSignedExecutionPayloadEnvelope(signedEnvelope: gloas.SignedExecutionPayloadEnvelope): Promise<number>;
+  publishExecutionProof(executionProof: ExecutionProof): Promise<number>;
 
   // Debug
   dumpGossipQueue(gossipType: GossipType): Promise<PendingGossipsubMessage[]>;

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -17,6 +17,8 @@ export enum ENRKey {
   syncnets = "syncnets",
   cgc = "cgc",
   nfd = "nfd",
+  /** EIP-8025: zkvm enabled flag */
+  zkvm = "zkvm",
 }
 export enum SubnetType {
   attnets = "attnets",
@@ -25,6 +27,8 @@ export enum SubnetType {
 
 export type MetadataOpts = {
   metadata?: fulu.Metadata;
+  /** EIP-8025: Enable zkvm ENR key signaling */
+  activateZkvm?: boolean;
 };
 
 export type MetadataModules = {
@@ -43,11 +47,13 @@ export class MetadataController {
   private networkConfig: NetworkConfig;
   private logger: Logger;
   private _metadata: fulu.Metadata;
+  private readonly activateZkvm: boolean;
 
   constructor(opts: MetadataOpts, modules: MetadataModules) {
     this.networkConfig = modules.networkConfig;
     this.logger = modules.logger;
     this.onSetValue = modules.onSetValue;
+    this.activateZkvm = opts.activateZkvm ?? false;
     this._metadata = opts.metadata ?? {
       ...ssz.fulu.Metadata.defaultValue(),
       custodyGroupCount: modules.networkConfig.custodyConfig.targetCustodyGroupCount,
@@ -70,6 +76,11 @@ export class MetadataController {
 
     // Set CGC regardless of fork. It may be useful to clients before Fulu, and will be ignored otherwise.
     this.onSetValue(ENRKey.cgc, serializeCgc(this._metadata.custodyGroupCount));
+
+    // EIP-8025: Set zkvm ENR key when activated
+    if (this.activateZkvm) {
+      this.onSetValue(ENRKey.zkvm, new Uint8Array([1]));
+    }
   }
 
   get seqNumber(): bigint {

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -509,7 +509,8 @@ export class Network implements INetwork {
   }
 
   async publishExecutionProof(executionProof: ExecutionProof): Promise<number> {
-    const epoch = computeEpochAtSlot(executionProof.slot);
+    // Use current clock epoch since the proof type no longer carries slot
+    const epoch = computeEpochAtSlot(this.clock.currentSlot);
     const boundary = this.config.getForkBoundaryAtEpoch(epoch);
 
     return this.publishGossip<GossipType.execution_proof>(

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -12,6 +12,7 @@ import {
   AttesterSlashing,
   DataColumnSidecar,
   DataColumnSidecars,
+  ExecutionProof,
   LightClientBootstrap,
   LightClientFinalityUpdate,
   LightClientOptimisticUpdate,
@@ -503,6 +504,17 @@ export class Network implements INetwork {
     return this.publishGossip<GossipType.execution_payload>(
       {type: GossipType.execution_payload, boundary},
       signedEnvelope,
+      {ignoreDuplicatePublishError: true}
+    );
+  }
+
+  async publishExecutionProof(executionProof: ExecutionProof): Promise<number> {
+    const epoch = computeEpochAtSlot(executionProof.slot);
+    const boundary = this.config.getForkBoundaryAtEpoch(epoch);
+
+    return this.publishGossip<GossipType.execution_proof>(
+      {type: GossipType.execution_proof, boundary},
+      executionProof,
       {ignoreDuplicatePublishError: true}
     );
   }

--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -29,6 +29,9 @@ export interface NetworkOptions
   useWorker?: boolean;
   maxYoungGenerationSizeMb?: number;
   disableLightClientServer?: boolean;
+  /** EIP-8025: Enable execution proof gossip and req/resp protocols */
+  activateZkvm?: boolean;
+
   /**
    * During E2E tests observe a lot of following `missing stream`:
    *
@@ -71,6 +74,8 @@ export const defaultNetworkOptions: NetworkOptions = {
   disableLightClientServer: false,
   quic: false,
   tcp: true,
+  // EIP-8025: zkvm mode disabled by default
+  activateZkvm: false,
   // specific option for fulu
   //   - this is the same to TARGET_SUBNET_PEERS
   //   - for fusaka-devnets, we have 25-30 peers per subnet

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -915,6 +915,28 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         logger.error("Error adding to executionPayloadBid pool", {}, e as Error);
       }
     },
+    [GossipType.execution_proof]: async ({
+      gossipData,
+      topic,
+    }: GossipHandlerParamGeneric<GossipType.execution_proof>) => {
+      const {serializedData} = gossipData;
+      const executionProof = sszDeserialize(topic, serializedData);
+
+      // TODO EIP-8025: Add full gossip validation (slot bounds, dedup, proof verification)
+      // For now, basic deserialization validation is sufficient for initial interop
+
+      try {
+        const clockSlot = chain.clock.currentSlot;
+        const insertOutcome = chain.executionProofPool.add(executionProof, clockSlot);
+        logger.debug("Received execution proof via gossip", {
+          proofId: executionProof.proofId,
+          slot: executionProof.slot,
+          insertOutcome,
+        });
+      } catch (e) {
+        logger.error("Error adding execution proof to pool", {}, e as Error);
+      }
+    },
   };
 }
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -50,6 +50,7 @@ import {
   SyncCommitteeError,
 } from "../../chain/errors/index.js";
 import {IBeaconChain} from "../../chain/interface.js";
+import {InsertOutcome} from "../../chain/opPools/types.js";
 import {validateGossipBlobSidecar} from "../../chain/validation/blobSidecar.js";
 import {validateGossipDataColumnSidecar} from "../../chain/validation/dataColumnSidecar.js";
 import {validateGossipExecutionPayloadBid} from "../../chain/validation/executionPayloadBid.js";
@@ -928,11 +929,18 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       try {
         const clockSlot = chain.clock.currentSlot;
         const insertOutcome = chain.executionProofPool.add(executionProof, clockSlot);
+        const blockRootHex = toRootHex(executionProof.blockRoot);
         logger.debug("Received execution proof via gossip", {
           proofId: executionProof.proofId,
           slot: executionProof.slot,
+          blockRoot: blockRootHex,
           insertOutcome,
         });
+
+        // EIP-8025: In zkvm mode, check if we now have enough proofs to validate this block
+        if (insertOutcome === InsertOutcome.NewData) {
+          chain.maybeTransitionToValidOnProofArrival(executionProof);
+        }
       } catch (e) {
         logger.error("Error adding execution proof to pool", {}, e as Error);
       }

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -927,13 +927,11 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       // For now, basic deserialization validation is sufficient for initial interop
 
       try {
-        const clockSlot = chain.clock.currentSlot;
-        const insertOutcome = chain.executionProofPool.add(executionProof, clockSlot);
-        const blockRootHex = toRootHex(executionProof.blockRoot);
+        const insertOutcome = chain.executionProofPool.add(executionProof);
+        const newPayloadRequestRootHex = toRootHex(executionProof.publicInput.newPayloadRequestRoot);
         logger.debug("Received execution proof via gossip", {
-          proofId: executionProof.proofId,
-          slot: executionProof.slot,
-          blockRoot: blockRootHex,
+          proofType: executionProof.proofType,
+          newPayloadRequestRoot: newPayloadRequestRootHex,
           insertOutcome,
         });
 

--- a/packages/beacon-node/src/network/processor/gossipQueues/index.ts
+++ b/packages/beacon-node/src/network/processor/gossipQueues/index.ts
@@ -83,6 +83,12 @@ const linearGossipQueueOpts: {
     type: QueueType.FIFO,
     dropOpts: {type: DropType.count, count: 1},
   },
+  // EIP-8025: Execution proofs — expect up to EXECUTION_PROOF_TYPE_COUNT per block
+  [GossipType.execution_proof]: {
+    maxLength: 256,
+    type: QueueType.FIFO,
+    dropOpts: {type: DropType.count, count: 1},
+  },
 };
 
 const indexedGossipQueueOpts: {

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -81,6 +81,7 @@ const executeGossipWorkOrderObj: Record<GossipType, WorkOpts> = {
   [GossipType.execution_payload]: {bypassQueue: true},
   [GossipType.payload_attestation_message]: {},
   [GossipType.execution_payload_bid]: {},
+  [GossipType.execution_proof]: {},
 };
 const executeGossipWorkOrder = Object.keys(executeGossipWorkOrderObj) as (keyof typeof executeGossipWorkOrderObj)[];
 

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -52,7 +52,7 @@ export interface ReqRespBeaconNodeModules {
   getHandler: GetReqRespHandlerFn;
 }
 
-export type ReqRespBeaconNodeOpts = ReqRespOpts & {disableLightClientServer?: boolean};
+export type ReqRespBeaconNodeOpts = ReqRespOpts & {disableLightClientServer?: boolean; activateZkvm?: boolean};
 
 /**
  * Implementation of Ethereum Consensus p2p Req/Resp domain.
@@ -74,6 +74,7 @@ export class ReqRespBeaconNode extends ReqResp {
   private readonly config: BeaconConfig;
   protected readonly logger: Logger;
   protected readonly disableLightClientServer: boolean;
+  protected readonly activateZkvm: boolean;
 
   constructor(modules: ReqRespBeaconNodeModules, options: ReqRespBeaconNodeOpts = {}) {
     const {events, peersData, peerRpcScores, metadata, metrics, logger} = modules;
@@ -98,6 +99,7 @@ export class ReqRespBeaconNode extends ReqResp {
     );
 
     this.disableLightClientServer = options.disableLightClientServer ?? false;
+    this.activateZkvm = options.activateZkvm ?? false;
     this.peerRpcScores = peerRpcScores;
     this.peersData = peersData;
     this.config = modules.config;
@@ -295,6 +297,14 @@ export class ReqRespBeaconNode extends ReqResp {
           this.getHandler(ReqRespMethod.DataColumnSidecarsByRange),
         ]
       );
+
+      // EIP-8025: Register execution proof protocols when zkvm mode is active
+      if (this.activateZkvm) {
+        protocolsAtFork.push(
+          [protocols.ExecutionProofsByRoot(fork, this.config), this.getHandler(ReqRespMethod.ExecutionProofsByRoot)],
+          [protocols.ExecutionProofsByRange(fork, this.config), this.getHandler(ReqRespMethod.ExecutionProofsByRange)]
+        );
+      }
     }
 
     return protocolsAtFork;

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -1,7 +1,6 @@
 import {ProtocolHandler} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
-import {toRootHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
 import {IBeaconDb} from "../../../db/index.js";
 import {
@@ -78,28 +77,34 @@ export function getReqRespHandlers({db, chain}: {db: IBeaconDb; chain: IBeaconCh
     // EIP-8025: Execution proof req/resp handlers
     [ReqRespMethod.ExecutionProofsByRoot]: (req) => {
       const body = ssz.eip8025.ExecutionProofsByRootRequest.deserialize(req.data);
-      const blockRootHex = toRootHex(body.blockRoot);
+      // TODO EIP-8025: Use body.blockRoot to look up proofs via blockRoot → newPayloadRequestRoot mapping
       const alreadyHaveSet = new Set(body.alreadyHave);
-      const proofs = chain.executionProofPool
-        .getProofsByBlockRoot(blockRootHex)
-        .filter((p) => !alreadyHaveSet.has(p.proofId));
+      // TODO EIP-8025: Need blockRoot → newPayloadRequestRoot mapping to look up proofs.
+      // For now, iterate all proofs and filter by alreadyHave proof types.
+      // This is a temporary workaround until the chain populates the mapping.
+      const allProofs = chain.executionProofPool.getAllProofs();
+      const proofs = allProofs.filter((p) => !alreadyHaveSet.has(p.proofType));
+      const boundary = chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(chain.clock.currentSlot));
       return (async function* () {
         for (const proof of proofs) {
           yield {
             data: ssz.eip8025.ExecutionProof.serialize(proof),
-            boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(proof.slot)),
+            boundary,
           };
         }
       })();
     },
-    [ReqRespMethod.ExecutionProofsByRange]: (req) => {
-      const body = ssz.eip8025.ExecutionProofsByRangeRequest.deserialize(req.data);
-      const proofs = chain.executionProofPool.getProofsByRange(body.startSlot, Number(body.count));
+    [ReqRespMethod.ExecutionProofsByRange]: (_req) => {
+      // TODO EIP-8025: Use ssz.eip8025.ExecutionProofsByRangeRequest.deserialize(req.data) for slot filtering
+      // TODO EIP-8025: Range-based queries require slot indexing which is no longer
+      // part of the proof type. Return all proofs as a temporary workaround.
+      const proofs = chain.executionProofPool.getAllProofs();
+      const boundary = chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(chain.clock.currentSlot));
       return (async function* () {
         for (const proof of proofs) {
           yield {
             data: ssz.eip8025.ExecutionProof.serialize(proof),
-            boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(proof.slot)),
+            boundary,
           };
         }
       })();

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -1,5 +1,7 @@
 import {ProtocolHandler} from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
 import {IBeaconDb} from "../../../db/index.js";
 import {
@@ -72,6 +74,36 @@ export function getReqRespHandlers({db, chain}: {db: IBeaconDb; chain: IBeaconCh
     },
     [ReqRespMethod.LightClientFinalityUpdate]: () => onLightClientFinalityUpdate(chain),
     [ReqRespMethod.LightClientOptimisticUpdate]: () => onLightClientOptimisticUpdate(chain),
+
+    // EIP-8025: Execution proof req/resp handlers
+    [ReqRespMethod.ExecutionProofsByRoot]: (req) => {
+      const body = ssz.eip8025.ExecutionProofsByRootRequest.deserialize(req.data);
+      const blockRootHex = toRootHex(body.blockRoot);
+      const alreadyHaveSet = new Set(body.alreadyHave);
+      const proofs = chain.executionProofPool
+        .getProofsByBlockRoot(blockRootHex)
+        .filter((p) => !alreadyHaveSet.has(p.proofId));
+      return (async function* () {
+        for (const proof of proofs) {
+          yield {
+            data: ssz.eip8025.ExecutionProof.serialize(proof),
+            boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(proof.slot)),
+          };
+        }
+      })();
+    },
+    [ReqRespMethod.ExecutionProofsByRange]: (req) => {
+      const body = ssz.eip8025.ExecutionProofsByRangeRequest.deserialize(req.data);
+      const proofs = chain.executionProofPool.getProofsByRange(body.startSlot, Number(body.count));
+      return (async function* () {
+        for (const proof of proofs) {
+          yield {
+            data: ssz.eip8025.ExecutionProof.serialize(proof),
+            boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(proof.slot)),
+          };
+        }
+      })();
+    },
   };
 
   return (method) => handlers[method];

--- a/packages/beacon-node/src/network/reqresp/protocols.ts
+++ b/packages/beacon-node/src/network/reqresp/protocols.ts
@@ -118,6 +118,19 @@ export const LightClientUpdatesByRange = toProtocol({
   contextBytesType: ContextBytesType.ForkDigest,
 });
 
+// EIP-8025: Execution proof protocols
+export const ExecutionProofsByRoot = toProtocol({
+  method: ReqRespMethod.ExecutionProofsByRoot,
+  version: Version.V1,
+  contextBytesType: ContextBytesType.Empty,
+});
+
+export const ExecutionProofsByRange = toProtocol({
+  method: ReqRespMethod.ExecutionProofsByRange,
+  version: Version.V1,
+  contextBytesType: ContextBytesType.Empty,
+});
+
 type ProtocolSummary = {
   method: ReqRespMethod;
   version: Version;

--- a/packages/beacon-node/src/network/reqresp/rateLimit.ts
+++ b/packages/beacon-node/src/network/reqresp/rateLimit.ts
@@ -92,6 +92,16 @@ export const rateLimitQuotas: (fork: ForkName, config: BeaconConfig) => Record<R
     // Allow 2 per slot and a very safe bound until there's more testing of real usage.
     byPeer: {quota: 2, quotaTimeMs: 12_000},
   },
+  // EIP-8025: Execution proof protocols
+  [ReqRespMethod.ExecutionProofsByRoot]: {
+    // Similar to BeaconBlocksByRoot — one request per block root
+    byPeer: {quota: 16, quotaTimeMs: 10_000},
+  },
+  [ReqRespMethod.ExecutionProofsByRange]: {
+    // Similar to BeaconBlocksByRange
+    byPeer: {quota: 16, quotaTimeMs: 10_000},
+    getRequestCount: getRequestCountFn(fork, config, ReqRespMethod.ExecutionProofsByRange, (req) => Number(req.count)),
+  },
 });
 
 // Helper to produce a getRequestCount function

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -3,6 +3,9 @@ import {BeaconConfig} from "@lodestar/config";
 import {ForkName, ForkPostAltair, isForkPostAltair} from "@lodestar/params";
 import {Protocol, ProtocolHandler, ReqRespRequest} from "@lodestar/reqresp";
 import {
+  ExecutionProof,
+  ExecutionProofsByRangeRequest,
+  ExecutionProofsByRootRequest,
   LightClientBootstrap,
   LightClientFinalityUpdate,
   LightClientOptimisticUpdate,
@@ -46,6 +49,9 @@ export enum ReqRespMethod {
   LightClientUpdatesByRange = "light_client_updates_by_range",
   LightClientFinalityUpdate = "light_client_finality_update",
   LightClientOptimisticUpdate = "light_client_optimistic_update",
+  // EIP-8025
+  ExecutionProofsByRoot = "execution_proofs_by_root",
+  ExecutionProofsByRange = "execution_proofs_by_range",
 }
 
 // To typesafe events to network
@@ -64,6 +70,9 @@ export type RequestBodyByMethod = {
   [ReqRespMethod.LightClientUpdatesByRange]: altair.LightClientUpdatesByRange;
   [ReqRespMethod.LightClientFinalityUpdate]: null;
   [ReqRespMethod.LightClientOptimisticUpdate]: null;
+  // EIP-8025
+  [ReqRespMethod.ExecutionProofsByRoot]: ExecutionProofsByRootRequest;
+  [ReqRespMethod.ExecutionProofsByRange]: ExecutionProofsByRangeRequest;
 };
 
 type ResponseBodyByMethod = {
@@ -83,6 +92,9 @@ type ResponseBodyByMethod = {
   [ReqRespMethod.LightClientUpdatesByRange]: LightClientUpdate;
   [ReqRespMethod.LightClientFinalityUpdate]: LightClientFinalityUpdate;
   [ReqRespMethod.LightClientOptimisticUpdate]: LightClientOptimisticUpdate;
+  // EIP-8025
+  [ReqRespMethod.ExecutionProofsByRoot]: ExecutionProof;
+  [ReqRespMethod.ExecutionProofsByRange]: ExecutionProof;
 };
 
 /** Request SSZ type for each method and ForkName */
@@ -110,6 +122,9 @@ export const requestSszTypeByMethod: (
   [ReqRespMethod.LightClientUpdatesByRange]: ssz.altair.LightClientUpdatesByRange,
   [ReqRespMethod.LightClientFinalityUpdate]: null,
   [ReqRespMethod.LightClientOptimisticUpdate]: null,
+  // EIP-8025
+  [ReqRespMethod.ExecutionProofsByRoot]: ssz.eip8025.ExecutionProofsByRootRequest,
+  [ReqRespMethod.ExecutionProofsByRange]: ssz.eip8025.ExecutionProofsByRangeRequest,
 });
 
 export type ResponseTypeGetter<T> = (fork: ForkName, version: number) => Type<T>;
@@ -139,6 +154,9 @@ export const responseSszTypeByMethod: {[K in ReqRespMethod]: ResponseTypeGetter<
   [ReqRespMethod.DataColumnSidecarsByRoot]: () => ssz.fulu.DataColumnSidecar,
   [ReqRespMethod.LightClientOptimisticUpdate]: (fork) =>
     sszTypesFor(onlyPostAltairFork(fork)).LightClientOptimisticUpdate,
+  // EIP-8025
+  [ReqRespMethod.ExecutionProofsByRoot]: () => ssz.eip8025.ExecutionProof,
+  [ReqRespMethod.ExecutionProofsByRange]: () => ssz.eip8025.ExecutionProof,
 };
 
 function onlyPostAltairFork(fork: ForkName): ForkPostAltair {

--- a/packages/beacon-node/test/unit/chain/opPools/executionProofPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/executionProofPool.test.ts
@@ -8,31 +8,30 @@ import {InsertOutcome} from "../../../../src/chain/opPools/types.js";
 
 function createProof(overrides: Partial<ExecutionProof> = {}): ExecutionProof {
   return {
-    proofId: 0,
-    slot: 10,
-    blockHash: fromHexString("0x" + "ab".repeat(32)),
-    blockRoot: fromHexString("0x" + "cd".repeat(32)),
     proofData: new Uint8Array(64),
+    proofType: 0,
+    publicInput: {
+      newPayloadRequestRoot: fromHexString("0x" + "cd".repeat(32)),
+    },
     ...overrides,
   };
 }
 
 describe("ExecutionProofPool", () => {
-  it("should add and retrieve a proof by block root", () => {
+  it("should add and retrieve a proof by newPayloadRequestRoot", () => {
     const pool = new ExecutionProofPool();
     const proof = createProof();
-    const blockRootHex = toRootHex(proof.blockRoot);
+    const rootHex = toRootHex(proof.publicInput.newPayloadRequestRoot);
 
     expect(pool.add(proof)).toBe(InsertOutcome.NewData);
     expect(pool.size).toBe(1);
 
-    const retrieved = pool.getProofsByBlockRoot(blockRootHex);
+    const retrieved = pool.getProofsByNewPayloadRequestRoot(rootHex);
     expect(retrieved).toHaveLength(1);
-    expect(retrieved[0].proofId).toBe(0);
-    expect(retrieved[0].slot).toBe(10);
+    expect(retrieved[0].proofType).toBe(0);
   });
 
-  it("should deduplicate by (blockRoot, proofId)", () => {
+  it("should deduplicate by (newPayloadRequestRoot, proofType)", () => {
     const pool = new ExecutionProofPool();
     const proof = createProof();
 
@@ -41,150 +40,108 @@ describe("ExecutionProofPool", () => {
     expect(pool.size).toBe(1);
   });
 
-  it("should store multiple proof types for the same block", () => {
+  it("should store multiple proof types for the same newPayloadRequestRoot", () => {
     const pool = new ExecutionProofPool();
-    const blockRoot = fromHexString("0x" + "aa".repeat(32));
+    const root = fromHexString("0x" + "aa".repeat(32));
 
-    for (let proofId = 0; proofId < 3; proofId++) {
-      expect(pool.add(createProof({blockRoot, proofId}))).toBe(InsertOutcome.NewData);
+    for (let proofType = 0; proofType < 3; proofType++) {
+      expect(pool.add(createProof({publicInput: {newPayloadRequestRoot: root}, proofType}))).toBe(
+        InsertOutcome.NewData
+      );
     }
 
     expect(pool.size).toBe(3);
-    const proofs = pool.getProofsByBlockRoot(toRootHex(blockRoot));
+    const proofs = pool.getProofsByNewPayloadRequestRoot(toRootHex(root));
     expect(proofs).toHaveLength(3);
   });
 
-  it("should store proofs for different blocks independently", () => {
+  it("should store proofs for different newPayloadRequestRoots independently", () => {
     const pool = new ExecutionProofPool();
     const root1 = fromHexString("0x" + "11".repeat(32));
     const root2 = fromHexString("0x" + "22".repeat(32));
 
-    pool.add(createProof({blockRoot: root1, proofId: 0}));
-    pool.add(createProof({blockRoot: root2, proofId: 0}));
+    pool.add(createProof({publicInput: {newPayloadRequestRoot: root1}, proofType: 0}));
+    pool.add(createProof({publicInput: {newPayloadRequestRoot: root2}, proofType: 0}));
 
     expect(pool.size).toBe(2);
-    expect(pool.getProofsByBlockRoot(toRootHex(root1))).toHaveLength(1);
-    expect(pool.getProofsByBlockRoot(toRootHex(root2))).toHaveLength(1);
+    expect(pool.getProofsByNewPayloadRequestRoot(toRootHex(root1))).toHaveLength(1);
+    expect(pool.getProofsByNewPayloadRequestRoot(toRootHex(root2))).toHaveLength(1);
   });
 
-  it("should reject proofs older than lowestPermissibleSlot", () => {
+  it("should reject invalid proofType >= EXECUTION_PROOF_TYPE_COUNT", () => {
     const pool = new ExecutionProofPool();
 
-    // Add a proof at slot 20
-    pool.add(createProof({slot: 20}));
-    // Prune at slot 30 (retains 8 slots → cutoff = 22)
-    pool.prune(30);
-
-    // Slot 10 is below cutoff
-    expect(pool.add(createProof({slot: 10, blockRoot: fromHexString("0x" + "ff".repeat(32))}))).toBe(InsertOutcome.Old);
-  });
-
-  it("should reject far-future proofs when clockSlot is provided", () => {
-    const pool = new ExecutionProofPool();
-    const clockSlot = 100;
-
-    // Proof at slot 200 is far in the future (> clockSlot + 8)
-    expect(pool.add(createProof({slot: 200}), clockSlot)).toBe(InsertOutcome.Old);
-
-    // Proof at slot 105 is within the window (≤ clockSlot + 8)
-    expect(pool.add(createProof({slot: 105}), clockSlot)).toBe(InsertOutcome.NewData);
-  });
-
-  it("should reject invalid proofId >= EXECUTION_PROOF_TYPE_COUNT", () => {
-    const pool = new ExecutionProofPool();
-
-    expect(pool.add(createProof({proofId: EXECUTION_PROOF_TYPE_COUNT}))).toBe(InsertOutcome.Old);
-    expect(pool.add(createProof({proofId: 255}))).toBe(InsertOutcome.Old);
+    expect(pool.add(createProof({proofType: EXECUTION_PROOF_TYPE_COUNT}))).toBe(InsertOutcome.Old);
+    expect(pool.add(createProof({proofType: 255}))).toBe(InsertOutcome.Old);
     expect(pool.size).toBe(0);
   });
 
-  it("should return proofs by range", () => {
+  it("should return all proofs via getAllProofs", () => {
     const pool = new ExecutionProofPool();
+    const root1 = fromHexString("0x" + "11".repeat(32));
+    const root2 = fromHexString("0x" + "22".repeat(32));
 
-    for (let slot = 10; slot < 15; slot++) {
-      pool.add(createProof({slot, blockRoot: fromHexString("0x" + slot.toString(16).padStart(64, "0"))}));
-    }
+    pool.add(createProof({publicInput: {newPayloadRequestRoot: root1}, proofType: 0}));
+    pool.add(createProof({publicInput: {newPayloadRequestRoot: root1}, proofType: 1}));
+    pool.add(createProof({publicInput: {newPayloadRequestRoot: root2}, proofType: 0}));
 
-    const proofs = pool.getProofsByRange(10, 5);
-    expect(proofs).toHaveLength(5);
-
-    // Subset: only slots 12-13
-    const subset = pool.getProofsByRange(12, 2);
-    expect(subset).toHaveLength(2);
-    expect(subset.every((p) => p.slot >= 12 && p.slot < 14)).toBe(true);
+    expect(pool.getAllProofs()).toHaveLength(3);
   });
 
-  it("should return empty array for unknown block root", () => {
+  it("should return empty array for unknown newPayloadRequestRoot", () => {
     const pool = new ExecutionProofPool();
-    expect(pool.getProofsByBlockRoot("0x" + "00".repeat(32))).toEqual([]);
+    expect(pool.getProofsByNewPayloadRequestRoot("0x" + "00".repeat(32))).toEqual([]);
   });
 
   describe("hasEnoughProofs", () => {
     it("should return true when enough distinct proof types exist", () => {
       const pool = new ExecutionProofPool();
-      const blockRoot = fromHexString("0x" + "aa".repeat(32));
-      const blockRootHex = toRootHex(blockRoot);
+      const root = fromHexString("0x" + "aa".repeat(32));
+      const rootHex = toRootHex(root);
 
-      pool.add(createProof({blockRoot, proofId: 0}));
-      pool.add(createProof({blockRoot, proofId: 1}));
+      pool.add(createProof({publicInput: {newPayloadRequestRoot: root}, proofType: 0}));
+      pool.add(createProof({publicInput: {newPayloadRequestRoot: root}, proofType: 1}));
 
-      expect(pool.hasEnoughProofs(blockRootHex, 2)).toBe(true);
-      expect(pool.hasEnoughProofs(blockRootHex, 3)).toBe(false);
+      expect(pool.hasEnoughProofs(rootHex, 2)).toBe(true);
+      expect(pool.hasEnoughProofs(rootHex, 3)).toBe(false);
     });
 
-    it("should return false for unknown block root", () => {
+    it("should return false for unknown root", () => {
       const pool = new ExecutionProofPool();
       expect(pool.hasEnoughProofs("0x" + "00".repeat(32), 1)).toBe(false);
     });
   });
 
   describe("has", () => {
-    it("should check for specific (blockRoot, proofId)", () => {
+    it("should check for specific (newPayloadRequestRoot, proofType)", () => {
       const pool = new ExecutionProofPool();
-      const blockRoot = fromHexString("0x" + "aa".repeat(32));
-      const blockRootHex = toRootHex(blockRoot);
+      const root = fromHexString("0x" + "aa".repeat(32));
+      const rootHex = toRootHex(root);
 
-      pool.add(createProof({blockRoot, proofId: 0}));
+      pool.add(createProof({publicInput: {newPayloadRequestRoot: root}, proofType: 0}));
 
-      expect(pool.has(blockRootHex, 0)).toBe(true);
-      expect(pool.has(blockRootHex, 1)).toBe(false);
+      expect(pool.has(rootHex, 0)).toBe(true);
+      expect(pool.has(rootHex, 1)).toBe(false);
     });
 
-    it("should return false for unknown block root", () => {
+    it("should return false for unknown root", () => {
       const pool = new ExecutionProofPool();
       expect(pool.has("0x" + "00".repeat(32), 0)).toBe(false);
     });
   });
 
   describe("prune", () => {
-    it("should remove oldest proofs beyond retention window", () => {
+    it("should remove a specific root via pruneByRoot", () => {
       const pool = new ExecutionProofPool();
+      const root = fromHexString("0x" + "aa".repeat(32));
+      const rootHex = toRootHex(root);
 
-      // Add proofs at 10 slots (10-19), exceeding SLOTS_RETAINED=8
-      for (let slot = 10; slot < 20; slot++) {
-        pool.add(createProof({slot, blockRoot: fromHexString("0x" + slot.toString(16).padStart(64, "0"))}));
-      }
-      expect(pool.size).toBe(10);
+      pool.add(createProof({publicInput: {newPayloadRequestRoot: root}, proofType: 0}));
+      expect(pool.size).toBe(1);
 
-      // Prune keeps newest 8 slots by count: 12-19 survive, 10-11 pruned
-      pool.prune(25);
-
-      // Slots 10-11 should be pruned (oldest 2 beyond retention count)
-      expect(pool.getProofsByRange(10, 2)).toHaveLength(0);
-      // Slots 12-19 should remain (newest 8)
-      expect(pool.getProofsByRange(12, 8)).toHaveLength(8);
-    });
-
-    it("should clean up reverse index during prune", () => {
-      const pool = new ExecutionProofPool();
-      const oldBlockRoot = fromHexString("0x" + "aa".repeat(32));
-
-      pool.add(createProof({slot: 5, blockRoot: oldBlockRoot}));
-      pool.prune(20);
-
-      // Reverse index should be cleaned
-      expect(pool.getProofsByBlockRoot(toRootHex(oldBlockRoot))).toHaveLength(0);
-      expect(pool.has(toRootHex(oldBlockRoot), 0)).toBe(false);
+      pool.pruneByRoot(rootHex);
+      expect(pool.size).toBe(0);
+      expect(pool.getProofsByNewPayloadRequestRoot(rootHex)).toHaveLength(0);
     });
   });
 });

--- a/packages/beacon-node/test/unit/chain/opPools/executionProofPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/executionProofPool.test.ts
@@ -1,0 +1,190 @@
+import {describe, expect, it} from "vitest";
+import {fromHexString} from "@chainsafe/ssz";
+import {EXECUTION_PROOF_TYPE_COUNT} from "@lodestar/params";
+import {ExecutionProof} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {ExecutionProofPool} from "../../../../src/chain/opPools/executionProofPool.js";
+import {InsertOutcome} from "../../../../src/chain/opPools/types.js";
+
+function createProof(overrides: Partial<ExecutionProof> = {}): ExecutionProof {
+  return {
+    proofId: 0,
+    slot: 10,
+    blockHash: fromHexString("0x" + "ab".repeat(32)),
+    blockRoot: fromHexString("0x" + "cd".repeat(32)),
+    proofData: new Uint8Array(64),
+    ...overrides,
+  };
+}
+
+describe("ExecutionProofPool", () => {
+  it("should add and retrieve a proof by block root", () => {
+    const pool = new ExecutionProofPool();
+    const proof = createProof();
+    const blockRootHex = toRootHex(proof.blockRoot);
+
+    expect(pool.add(proof)).toBe(InsertOutcome.NewData);
+    expect(pool.size).toBe(1);
+
+    const retrieved = pool.getProofsByBlockRoot(blockRootHex);
+    expect(retrieved).toHaveLength(1);
+    expect(retrieved[0].proofId).toBe(0);
+    expect(retrieved[0].slot).toBe(10);
+  });
+
+  it("should deduplicate by (blockRoot, proofId)", () => {
+    const pool = new ExecutionProofPool();
+    const proof = createProof();
+
+    expect(pool.add(proof)).toBe(InsertOutcome.NewData);
+    expect(pool.add(proof)).toBe(InsertOutcome.AlreadyKnown);
+    expect(pool.size).toBe(1);
+  });
+
+  it("should store multiple proof types for the same block", () => {
+    const pool = new ExecutionProofPool();
+    const blockRoot = fromHexString("0x" + "aa".repeat(32));
+
+    for (let proofId = 0; proofId < 3; proofId++) {
+      expect(pool.add(createProof({blockRoot, proofId}))).toBe(InsertOutcome.NewData);
+    }
+
+    expect(pool.size).toBe(3);
+    const proofs = pool.getProofsByBlockRoot(toRootHex(blockRoot));
+    expect(proofs).toHaveLength(3);
+  });
+
+  it("should store proofs for different blocks independently", () => {
+    const pool = new ExecutionProofPool();
+    const root1 = fromHexString("0x" + "11".repeat(32));
+    const root2 = fromHexString("0x" + "22".repeat(32));
+
+    pool.add(createProof({blockRoot: root1, proofId: 0}));
+    pool.add(createProof({blockRoot: root2, proofId: 0}));
+
+    expect(pool.size).toBe(2);
+    expect(pool.getProofsByBlockRoot(toRootHex(root1))).toHaveLength(1);
+    expect(pool.getProofsByBlockRoot(toRootHex(root2))).toHaveLength(1);
+  });
+
+  it("should reject proofs older than lowestPermissibleSlot", () => {
+    const pool = new ExecutionProofPool();
+
+    // Add a proof at slot 20
+    pool.add(createProof({slot: 20}));
+    // Prune at slot 30 (retains 8 slots → cutoff = 22)
+    pool.prune(30);
+
+    // Slot 10 is below cutoff
+    expect(pool.add(createProof({slot: 10, blockRoot: fromHexString("0x" + "ff".repeat(32))}))).toBe(InsertOutcome.Old);
+  });
+
+  it("should reject far-future proofs when clockSlot is provided", () => {
+    const pool = new ExecutionProofPool();
+    const clockSlot = 100;
+
+    // Proof at slot 200 is far in the future (> clockSlot + 8)
+    expect(pool.add(createProof({slot: 200}), clockSlot)).toBe(InsertOutcome.Old);
+
+    // Proof at slot 105 is within the window (≤ clockSlot + 8)
+    expect(pool.add(createProof({slot: 105}), clockSlot)).toBe(InsertOutcome.NewData);
+  });
+
+  it("should reject invalid proofId >= EXECUTION_PROOF_TYPE_COUNT", () => {
+    const pool = new ExecutionProofPool();
+
+    expect(pool.add(createProof({proofId: EXECUTION_PROOF_TYPE_COUNT}))).toBe(InsertOutcome.Old);
+    expect(pool.add(createProof({proofId: 255}))).toBe(InsertOutcome.Old);
+    expect(pool.size).toBe(0);
+  });
+
+  it("should return proofs by range", () => {
+    const pool = new ExecutionProofPool();
+
+    for (let slot = 10; slot < 15; slot++) {
+      pool.add(createProof({slot, blockRoot: fromHexString("0x" + slot.toString(16).padStart(64, "0"))}));
+    }
+
+    const proofs = pool.getProofsByRange(10, 5);
+    expect(proofs).toHaveLength(5);
+
+    // Subset: only slots 12-13
+    const subset = pool.getProofsByRange(12, 2);
+    expect(subset).toHaveLength(2);
+    expect(subset.every((p) => p.slot >= 12 && p.slot < 14)).toBe(true);
+  });
+
+  it("should return empty array for unknown block root", () => {
+    const pool = new ExecutionProofPool();
+    expect(pool.getProofsByBlockRoot("0x" + "00".repeat(32))).toEqual([]);
+  });
+
+  describe("hasEnoughProofs", () => {
+    it("should return true when enough distinct proof types exist", () => {
+      const pool = new ExecutionProofPool();
+      const blockRoot = fromHexString("0x" + "aa".repeat(32));
+      const blockRootHex = toRootHex(blockRoot);
+
+      pool.add(createProof({blockRoot, proofId: 0}));
+      pool.add(createProof({blockRoot, proofId: 1}));
+
+      expect(pool.hasEnoughProofs(blockRootHex, 2)).toBe(true);
+      expect(pool.hasEnoughProofs(blockRootHex, 3)).toBe(false);
+    });
+
+    it("should return false for unknown block root", () => {
+      const pool = new ExecutionProofPool();
+      expect(pool.hasEnoughProofs("0x" + "00".repeat(32), 1)).toBe(false);
+    });
+  });
+
+  describe("has", () => {
+    it("should check for specific (blockRoot, proofId)", () => {
+      const pool = new ExecutionProofPool();
+      const blockRoot = fromHexString("0x" + "aa".repeat(32));
+      const blockRootHex = toRootHex(blockRoot);
+
+      pool.add(createProof({blockRoot, proofId: 0}));
+
+      expect(pool.has(blockRootHex, 0)).toBe(true);
+      expect(pool.has(blockRootHex, 1)).toBe(false);
+    });
+
+    it("should return false for unknown block root", () => {
+      const pool = new ExecutionProofPool();
+      expect(pool.has("0x" + "00".repeat(32), 0)).toBe(false);
+    });
+  });
+
+  describe("prune", () => {
+    it("should remove oldest proofs beyond retention window", () => {
+      const pool = new ExecutionProofPool();
+
+      // Add proofs at 10 slots (10-19), exceeding SLOTS_RETAINED=8
+      for (let slot = 10; slot < 20; slot++) {
+        pool.add(createProof({slot, blockRoot: fromHexString("0x" + slot.toString(16).padStart(64, "0"))}));
+      }
+      expect(pool.size).toBe(10);
+
+      // Prune keeps newest 8 slots by count: 12-19 survive, 10-11 pruned
+      pool.prune(25);
+
+      // Slots 10-11 should be pruned (oldest 2 beyond retention count)
+      expect(pool.getProofsByRange(10, 2)).toHaveLength(0);
+      // Slots 12-19 should remain (newest 8)
+      expect(pool.getProofsByRange(12, 8)).toHaveLength(8);
+    });
+
+    it("should clean up reverse index during prune", () => {
+      const pool = new ExecutionProofPool();
+      const oldBlockRoot = fromHexString("0x" + "aa".repeat(32));
+
+      pool.add(createProof({slot: 5, blockRoot: oldBlockRoot}));
+      pool.prune(20);
+
+      // Reverse index should be cleaned
+      expect(pool.getProofsByBlockRoot(toRootHex(oldBlockRoot))).toHaveLength(0);
+      expect(pool.has(toRootHex(oldBlockRoot), 0)).toBe(false);
+    });
+  });
+});

--- a/packages/beacon-node/test/unit/chain/validation/executionProofVerifier.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/executionProofVerifier.test.ts
@@ -1,68 +1,45 @@
 import {describe, expect, it} from "vitest";
 import {ExecutionProof} from "@lodestar/types";
-import {toRootHex} from "@lodestar/utils";
 import {DummyZkvmExecutionProofVerifier} from "../../../../src/chain/validation/executionProofVerifier.js";
 
 function bytes32(byte: number): Uint8Array {
   return Uint8Array.from({length: 32}, () => byte);
 }
 
-function makeProof(overrides: Partial<ExecutionProof> & {proofId: number}): ExecutionProof {
+function makeProof(overrides: Partial<ExecutionProof> = {}): ExecutionProof {
   return {
-    slot: 123,
-    blockHash: bytes32(0xbb),
-    blockRoot: bytes32(0xaa),
     proofData: Uint8Array.from([1, 2, 3]),
+    proofType: 0,
+    publicInput: {
+      newPayloadRequestRoot: bytes32(0xaa),
+    },
     ...overrides,
   };
 }
 
 describe("DummyZkvmExecutionProofVerifier", () => {
   const verifier = new DummyZkvmExecutionProofVerifier();
-  const blockRoot = bytes32(0xaa);
-  const blockHash = bytes32(0xbb);
-  const expectedBlockRootHex = toRootHex(blockRoot);
-  const expectedExecBlockHashHex = toRootHex(blockHash);
 
   describe("valid proofs", () => {
     it("accepts proofs when all basic checks pass", () => {
-      const proofs = [makeProof({proofId: 0, blockHash, blockRoot}), makeProof({proofId: 1, blockHash, blockRoot})];
+      const proofs = [makeProof({proofType: 0}), makeProof({proofType: 1})];
 
-      const result = verifier.verifyProofs({
-        proofs,
-        expectedBlockRootHex,
-        expectedExecBlockHashHex,
-        minProofsRequired: 2,
-      });
-
+      const result = verifier.verifyProofs({proofs, minProofsRequired: 2});
       expect(result).toEqual({ok: true, distinctProofTypes: 2});
     });
 
     it("accepts when more proofs than minimum are present", () => {
-      const proofs = [
-        makeProof({proofId: 0, blockHash, blockRoot}),
-        makeProof({proofId: 1, blockHash, blockRoot}),
-        makeProof({proofId: 2, blockHash, blockRoot}),
-      ];
+      const proofs = [makeProof({proofType: 0}), makeProof({proofType: 1}), makeProof({proofType: 2})];
 
-      const result = verifier.verifyProofs({
-        proofs,
-        expectedBlockRootHex,
-        expectedExecBlockHashHex,
-        minProofsRequired: 1,
-      });
-
+      const result = verifier.verifyProofs({proofs, minProofsRequired: 1});
       expect(result).toEqual({ok: true, distinctProofTypes: 3});
     });
 
     it("accepts with minProofsRequired=1 and a single proof", () => {
       const result = verifier.verifyProofs({
-        proofs: [makeProof({proofId: 0, blockHash, blockRoot})],
-        expectedBlockRootHex,
-        expectedExecBlockHashHex,
+        proofs: [makeProof({proofType: 0})],
         minProofsRequired: 1,
       });
-
       expect(result).toEqual({ok: true, distinctProofTypes: 1});
     });
   });
@@ -70,88 +47,35 @@ describe("DummyZkvmExecutionProofVerifier", () => {
   describe("empty proofData", () => {
     it("rejects when proofData is empty", () => {
       const result = verifier.verifyProofs({
-        proofs: [makeProof({proofId: 0, blockHash, blockRoot, proofData: Uint8Array.from([])})],
-        expectedBlockRootHex,
-        expectedExecBlockHashHex,
+        proofs: [makeProof({proofType: 0, proofData: Uint8Array.from([])})],
         minProofsRequired: 1,
       });
-
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.error).toContain("empty proofData");
     });
 
     it("rejects on first empty proofData even if later proofs are valid", () => {
       const result = verifier.verifyProofs({
-        proofs: [
-          makeProof({proofId: 0, blockHash, blockRoot, proofData: Uint8Array.from([])}),
-          makeProof({proofId: 1, blockHash, blockRoot}),
-        ],
-        expectedBlockRootHex,
-        expectedExecBlockHashHex,
+        proofs: [makeProof({proofType: 0, proofData: Uint8Array.from([])}), makeProof({proofType: 1})],
         minProofsRequired: 1,
       });
-
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.error).toContain("empty proofData");
-    });
-  });
-
-  describe("blockRoot mismatch", () => {
-    it("rejects when proof blockRoot does not match expected", () => {
-      const wrongBlockRoot = bytes32(0xff);
-
-      const result = verifier.verifyProofs({
-        proofs: [makeProof({proofId: 0, blockHash, blockRoot: wrongBlockRoot})],
-        expectedBlockRootHex,
-        expectedExecBlockHashHex,
-        minProofsRequired: 1,
-      });
-
-      expect(result.ok).toBe(false);
-      if (!result.ok) expect(result.error).toContain("blockRoot mismatch");
-    });
-  });
-
-  describe("blockHash mismatch", () => {
-    it("rejects when proof blockHash does not match expected", () => {
-      const wrongBlockHash = bytes32(0xff);
-
-      const result = verifier.verifyProofs({
-        proofs: [makeProof({proofId: 0, blockHash: wrongBlockHash, blockRoot})],
-        expectedBlockRootHex,
-        expectedExecBlockHashHex,
-        minProofsRequired: 1,
-      });
-
-      expect(result.ok).toBe(false);
-      if (!result.ok) expect(result.error).toContain("blockHash mismatch");
     });
   });
 
   describe("insufficient distinct proof types", () => {
     it("rejects when distinct proof types are below minimum", () => {
       const result = verifier.verifyProofs({
-        proofs: [
-          makeProof({proofId: 0, blockHash, blockRoot}),
-          makeProof({proofId: 0, blockHash, blockRoot, proofData: Uint8Array.from([9, 9])}),
-        ],
-        expectedBlockRootHex,
-        expectedExecBlockHashHex,
+        proofs: [makeProof({proofType: 0}), makeProof({proofType: 0, proofData: Uint8Array.from([9, 9])})],
         minProofsRequired: 2,
       });
-
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.error).toContain("insufficient distinct proof types");
     });
 
     it("rejects when no proofs are provided", () => {
-      const result = verifier.verifyProofs({
-        proofs: [],
-        expectedBlockRootHex,
-        expectedExecBlockHashHex,
-        minProofsRequired: 1,
-      });
-
+      const result = verifier.verifyProofs({proofs: [], minProofsRequired: 1});
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.error).toContain("insufficient distinct proof types");
     });

--- a/packages/beacon-node/test/unit/chain/validation/executionProofVerifier.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/executionProofVerifier.test.ts
@@ -1,0 +1,159 @@
+import {describe, expect, it} from "vitest";
+import {ExecutionProof} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {DummyZkvmExecutionProofVerifier} from "../../../../src/chain/validation/executionProofVerifier.js";
+
+function bytes32(byte: number): Uint8Array {
+  return Uint8Array.from({length: 32}, () => byte);
+}
+
+function makeProof(overrides: Partial<ExecutionProof> & {proofId: number}): ExecutionProof {
+  return {
+    slot: 123,
+    blockHash: bytes32(0xbb),
+    blockRoot: bytes32(0xaa),
+    proofData: Uint8Array.from([1, 2, 3]),
+    ...overrides,
+  };
+}
+
+describe("DummyZkvmExecutionProofVerifier", () => {
+  const verifier = new DummyZkvmExecutionProofVerifier();
+  const blockRoot = bytes32(0xaa);
+  const blockHash = bytes32(0xbb);
+  const expectedBlockRootHex = toRootHex(blockRoot);
+  const expectedExecBlockHashHex = toRootHex(blockHash);
+
+  describe("valid proofs", () => {
+    it("accepts proofs when all basic checks pass", () => {
+      const proofs = [makeProof({proofId: 0, blockHash, blockRoot}), makeProof({proofId: 1, blockHash, blockRoot})];
+
+      const result = verifier.verifyProofs({
+        proofs,
+        expectedBlockRootHex,
+        expectedExecBlockHashHex,
+        minProofsRequired: 2,
+      });
+
+      expect(result).toEqual({ok: true, distinctProofTypes: 2});
+    });
+
+    it("accepts when more proofs than minimum are present", () => {
+      const proofs = [
+        makeProof({proofId: 0, blockHash, blockRoot}),
+        makeProof({proofId: 1, blockHash, blockRoot}),
+        makeProof({proofId: 2, blockHash, blockRoot}),
+      ];
+
+      const result = verifier.verifyProofs({
+        proofs,
+        expectedBlockRootHex,
+        expectedExecBlockHashHex,
+        minProofsRequired: 1,
+      });
+
+      expect(result).toEqual({ok: true, distinctProofTypes: 3});
+    });
+
+    it("accepts with minProofsRequired=1 and a single proof", () => {
+      const result = verifier.verifyProofs({
+        proofs: [makeProof({proofId: 0, blockHash, blockRoot})],
+        expectedBlockRootHex,
+        expectedExecBlockHashHex,
+        minProofsRequired: 1,
+      });
+
+      expect(result).toEqual({ok: true, distinctProofTypes: 1});
+    });
+  });
+
+  describe("empty proofData", () => {
+    it("rejects when proofData is empty", () => {
+      const result = verifier.verifyProofs({
+        proofs: [makeProof({proofId: 0, blockHash, blockRoot, proofData: Uint8Array.from([])})],
+        expectedBlockRootHex,
+        expectedExecBlockHashHex,
+        minProofsRequired: 1,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("empty proofData");
+    });
+
+    it("rejects on first empty proofData even if later proofs are valid", () => {
+      const result = verifier.verifyProofs({
+        proofs: [
+          makeProof({proofId: 0, blockHash, blockRoot, proofData: Uint8Array.from([])}),
+          makeProof({proofId: 1, blockHash, blockRoot}),
+        ],
+        expectedBlockRootHex,
+        expectedExecBlockHashHex,
+        minProofsRequired: 1,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("empty proofData");
+    });
+  });
+
+  describe("blockRoot mismatch", () => {
+    it("rejects when proof blockRoot does not match expected", () => {
+      const wrongBlockRoot = bytes32(0xff);
+
+      const result = verifier.verifyProofs({
+        proofs: [makeProof({proofId: 0, blockHash, blockRoot: wrongBlockRoot})],
+        expectedBlockRootHex,
+        expectedExecBlockHashHex,
+        minProofsRequired: 1,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("blockRoot mismatch");
+    });
+  });
+
+  describe("blockHash mismatch", () => {
+    it("rejects when proof blockHash does not match expected", () => {
+      const wrongBlockHash = bytes32(0xff);
+
+      const result = verifier.verifyProofs({
+        proofs: [makeProof({proofId: 0, blockHash: wrongBlockHash, blockRoot})],
+        expectedBlockRootHex,
+        expectedExecBlockHashHex,
+        minProofsRequired: 1,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("blockHash mismatch");
+    });
+  });
+
+  describe("insufficient distinct proof types", () => {
+    it("rejects when distinct proof types are below minimum", () => {
+      const result = verifier.verifyProofs({
+        proofs: [
+          makeProof({proofId: 0, blockHash, blockRoot}),
+          makeProof({proofId: 0, blockHash, blockRoot, proofData: Uint8Array.from([9, 9])}),
+        ],
+        expectedBlockRootHex,
+        expectedExecBlockHashHex,
+        minProofsRequired: 2,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("insufficient distinct proof types");
+    });
+
+    it("rejects when no proofs are provided", () => {
+      const result = verifier.verifyProofs({
+        proofs: [],
+        expectedBlockRootHex,
+        expectedExecBlockHashHex,
+        minProofsRequired: 1,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain("insufficient distinct proof types");
+    });
+  });
+});

--- a/packages/beacon-node/test/unit/network/gossip/topic.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/topic.test.ts
@@ -167,6 +167,20 @@ describe("network / gossip / topic", () => {
         topicStr: "/eth2/a41d57bd/execution_payload_bid/ssz_snappy",
       },
     ],
+    [GossipType.execution_proof]: [
+      {
+        topic: {
+          type: GossipType.execution_proof,
+          boundary: {fork: ForkName.fulu, epoch: config.FULU_FORK_EPOCH},
+          encoding,
+        },
+        topicStr: stringifyGossipTopic(config, {
+          type: GossipType.execution_proof,
+          boundary: {fork: ForkName.fulu, epoch: config.FULU_FORK_EPOCH},
+          encoding,
+        }),
+      },
+    ],
   };
 
   for (const topics of Object.values(testCases)) {

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -222,6 +222,11 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
     beaconNodeOptions.set({chain: {disableLightClientServer: true}});
   }
 
+  // EIP-8025: Bridge activateZkvm from chain to network options
+  if (args.activateZkvm) {
+    beaconNodeOptions.set({network: {activateZkvm: true}});
+  }
+
   if (args.private) {
     beaconNodeOptions.set({network: {private: true}, api: {private: true}});
   } else {

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -36,6 +36,10 @@ export type ChainArgs = {
   "chain.maxCPStateEpochsOnDisk"?: number;
 
   "chain.pruneHistory"?: boolean;
+  // EIP-8025: zkvm/stateless execution
+  activateZkvm?: boolean;
+  "chain.minProofsRequired"?: number;
+  "chain.zkvmGenerationProofTypes"?: number[];
 };
 
 export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
@@ -75,6 +79,10 @@ export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
     maxCPStateEpochsInMemory: args["chain.maxCPStateEpochsInMemory"] ?? defaultOptions.chain.maxCPStateEpochsInMemory,
     maxCPStateEpochsOnDisk: args["chain.maxCPStateEpochsOnDisk"] ?? defaultOptions.chain.maxCPStateEpochsOnDisk,
     pruneHistory: args["chain.pruneHistory"],
+    // EIP-8025: zkvm/stateless execution
+    activateZkvm: args.activateZkvm,
+    minProofsRequired: args["chain.minProofsRequired"],
+    zkvmGenerationProofTypes: args["chain.zkvmGenerationProofTypes"],
   };
 }
 
@@ -308,6 +316,32 @@ Will double processing times. Use only for debugging purposes.",
     description: "Prune historical blocks and state",
     type: "boolean",
     default: defaultOptions.chain.pruneHistory,
+    group: "chain",
+  },
+
+  // EIP-8025: zkvm/stateless execution options
+
+  activateZkvm: {
+    alias: ["activate-zkvm"],
+    description:
+      "Enable zkvm/stateless execution mode (EIP-8025). Blocks are gated by proof availability instead of execution layer validation.",
+    type: "boolean",
+    default: defaultOptions.chain.activateZkvm,
+    group: "chain",
+  },
+
+  "chain.minProofsRequired": {
+    description: "Minimum distinct proof types required per block in zkvm mode",
+    type: "number",
+    default: defaultOptions.chain.minProofsRequired,
+    group: "chain",
+  },
+
+  "chain.zkvmGenerationProofTypes": {
+    description: "Which proof type IDs this node generates (comma-separated). Empty = verify-only node.",
+    type: "array",
+    number: true,
+    coerce: (ids: number[]): number[] => ids.flatMap((id) => String(id).split(",").map(Number)),
     group: "chain",
   },
 };

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -1,14 +1,14 @@
-import {PresetName} from "./presetName.js";
-import {presetStatus} from "./presetStatus.js";
-import {gnosisPreset} from "./presets/gnosis.js";
-import {mainnetPreset} from "./presets/mainnet.js";
-import {minimalPreset} from "./presets/minimal.js";
-import {userOverrides, userSelectedPreset} from "./setPreset.js";
+import { PresetName } from "./presetName.js";
+import { presetStatus } from "./presetStatus.js";
+import { gnosisPreset } from "./presets/gnosis.js";
+import { mainnetPreset } from "./presets/mainnet.js";
+import { minimalPreset } from "./presets/minimal.js";
+import { userOverrides, userSelectedPreset } from "./setPreset.js";
 
 export * from "./forkName.js";
-export {presetToJson} from "./json.js";
-export type {BeaconPreset} from "./types.js";
-export {PresetName};
+export { presetToJson } from "./json.js";
+export type { BeaconPreset } from "./types.js";
+export { PresetName };
 
 const presets = {
   [PresetName.mainnet]: mainnetPreset,
@@ -31,7 +31,7 @@ export const ACTIVE_PRESET =
   userSelectedPreset ??
   (typeof process !== "undefined" ? PresetName[process?.env?.LODESTAR_PRESET as PresetName] : undefined) ??
   PresetName.mainnet;
-export const activePreset = {...presets[ACTIVE_PRESET], ...userOverrides};
+export const activePreset = { ...presets[ACTIVE_PRESET], ...userOverrides };
 
 // These variables must be exported individually and explicitly
 // in order to be accessible as top-level exports
@@ -316,8 +316,8 @@ export const KZG_COMMITMENTS_GINDEX = 27;
 export const KZG_COMMITMENTS_SUBTREE_INDEX = KZG_COMMITMENTS_GINDEX - 2 ** KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH;
 
 // EIP-8025: Optional Execution Proofs
-/** Maximum size of proof data in bytes (1MB, matching devnet implementations) */
-export const MAX_PROOF_DATA_BYTES = 1_048_576;
+/** Maximum size of proof data in bytes (307200 ~= 300KiB) */
+export const MAX_PROOF_DATA_BYTES = 307_200;
 /** Maximum number of execution proof types (zkVM+EL combinations) */
 export const EXECUTION_PROOF_TYPE_COUNT = 8;
 /** Default minimum number of distinct proof types required for DA in zkvm mode */

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -315,6 +315,14 @@ export const BYTES_PER_CELL = FIELD_ELEMENTS_PER_CELL * BYTES_PER_FIELD_ELEMENT;
 export const KZG_COMMITMENTS_GINDEX = 27;
 export const KZG_COMMITMENTS_SUBTREE_INDEX = KZG_COMMITMENTS_GINDEX - 2 ** KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH;
 
+// EIP-8025: Optional Execution Proofs
+/** Maximum size of proof data in bytes (1MB, matching devnet implementations) */
+export const MAX_PROOF_DATA_BYTES = 1_048_576;
+/** Maximum number of execution proof types (zkVM+EL combinations) */
+export const EXECUTION_PROOF_TYPE_COUNT = 8;
+/** Default minimum number of distinct proof types required for DA in zkvm mode */
+export const DEFAULT_MIN_PROOFS_REQUIRED = 2;
+
 // Gloas Misc
 export const BUILDER_INDEX_FLAG = 2 ** 40;
 export const BUILDER_INDEX_SELF_BUILD = Infinity;

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -1,14 +1,14 @@
-import { PresetName } from "./presetName.js";
-import { presetStatus } from "./presetStatus.js";
-import { gnosisPreset } from "./presets/gnosis.js";
-import { mainnetPreset } from "./presets/mainnet.js";
-import { minimalPreset } from "./presets/minimal.js";
-import { userOverrides, userSelectedPreset } from "./setPreset.js";
+import {PresetName} from "./presetName.js";
+import {presetStatus} from "./presetStatus.js";
+import {gnosisPreset} from "./presets/gnosis.js";
+import {mainnetPreset} from "./presets/mainnet.js";
+import {minimalPreset} from "./presets/minimal.js";
+import {userOverrides, userSelectedPreset} from "./setPreset.js";
 
 export * from "./forkName.js";
-export { presetToJson } from "./json.js";
-export type { BeaconPreset } from "./types.js";
-export { PresetName };
+export {presetToJson} from "./json.js";
+export type {BeaconPreset} from "./types.js";
+export {PresetName};
 
 const presets = {
   [PresetName.mainnet]: mainnetPreset,
@@ -31,7 +31,7 @@ export const ACTIVE_PRESET =
   userSelectedPreset ??
   (typeof process !== "undefined" ? PresetName[process?.env?.LODESTAR_PRESET as PresetName] : undefined) ??
   PresetName.mainnet;
-export const activePreset = { ...presets[ACTIVE_PRESET], ...userOverrides };
+export const activePreset = {...presets[ACTIVE_PRESET], ...userOverrides};
 
 // These variables must be exported individually and explicitly
 // in order to be accessible as top-level exports

--- a/packages/types/src/eip8025/index.ts
+++ b/packages/types/src/eip8025/index.ts
@@ -2,5 +2,7 @@ export {
   ExecutionProof as ExecutionProofType,
   ExecutionProofsByRangeRequest as ExecutionProofsByRangeRequestType,
   ExecutionProofsByRootRequest as ExecutionProofsByRootRequestType,
+  PublicInput as PublicInputType,
+  SignedExecutionProof as SignedExecutionProofType,
 } from "./sszTypes.js";
 export * from "./types.js";

--- a/packages/types/src/eip8025/index.ts
+++ b/packages/types/src/eip8025/index.ts
@@ -1,0 +1,6 @@
+export {
+  ExecutionProof as ExecutionProofType,
+  ExecutionProofsByRangeRequest as ExecutionProofsByRangeRequestType,
+  ExecutionProofsByRootRequest as ExecutionProofsByRootRequestType,
+} from "./sszTypes.js";
+export * from "./types.js";

--- a/packages/types/src/eip8025/sszTypes.ts
+++ b/packages/types/src/eip8025/sszTypes.ts
@@ -1,6 +1,6 @@
 import {ByteListType, ContainerType, ListBasicType, UintNumberType} from "@chainsafe/ssz";
 import {EXECUTION_PROOF_TYPE_COUNT, MAX_PROOF_DATA_BYTES} from "@lodestar/params";
-import {Root, Slot, Uint8, UintNum64} from "../primitive/sszTypes.js";
+import {BLSSignature, Root, Slot, Uint8, UintNum64, ValidatorIndex} from "../primitive/sszTypes.js";
 
 /**
  * ExecutionProofId identifies which zkVM/proof system + EL combination a proof belongs to.
@@ -11,9 +11,21 @@ import {Root, Slot, Uint8, UintNum64} from "../primitive/sszTypes.js";
 export const ExecutionProofId = Uint8;
 
 /**
- * The actual proof data, variable length up to MAX_PROOF_DATA_BYTES (1MB).
+ * Identifies the proof system type.
+ */
+export const ProofType = Uint8;
+
+/**
+ * The actual proof data, variable length up to MAX_PROOF_DATA_BYTES.
  */
 export const ProofData = new ByteListType(MAX_PROOF_DATA_BYTES);
+
+export const PublicInput = new ContainerType(
+  {
+    newPayloadRequestRoot: Root,
+  },
+  {typeName: "PublicInput", jsonCase: "eth2"}
+);
 
 /**
  * ExecutionProof represents a cryptographic proof that an execution payload is valid.
@@ -25,18 +37,26 @@ export const ProofData = new ByteListType(MAX_PROOF_DATA_BYTES);
  */
 export const ExecutionProof = new ContainerType(
   {
-    /** Which proof type (zkVM+EL combination) this proof belongs to (0-7) */
-    proofId: ExecutionProofId,
-    /** The slot of the beacon block this proof validates */
-    slot: Slot,
-    /** The block hash of the execution payload this proof validates */
-    blockHash: Root,
-    /** The beacon block root corresponding to the block with the execution payload */
-    blockRoot: Root,
     /** The actual ZK proof data */
     proofData: ProofData,
+    proofType: ProofType,
+    /**
+     * Public input of an [`ExecutionProof`].
+     * Contains the tree hash root of the new payload request that the proof is associated with.
+     **/
+    publicInput: PublicInput,
   },
   {typeName: "ExecutionProof", jsonCase: "eth2"}
+);
+
+export const SignedExecutionProof = new ContainerType(
+  {
+    /** The actual ZK proof data */
+    message: ExecutionProof,
+    validatorIndex: ValidatorIndex,
+    signature: BLSSignature,
+  },
+  {typeName: "SignedExecutionProof", jsonCase: "eth2"}
 );
 
 /**

--- a/packages/types/src/eip8025/sszTypes.ts
+++ b/packages/types/src/eip8025/sszTypes.ts
@@ -1,6 +1,6 @@
 import {ByteListType, ContainerType, ListBasicType, UintNumberType} from "@chainsafe/ssz";
 import {EXECUTION_PROOF_TYPE_COUNT, MAX_PROOF_DATA_BYTES} from "@lodestar/params";
-import {BLSSignature, Root, Slot, Uint8, UintNum64, ValidatorIndex} from "../primitive/sszTypes.js";
+import {BLSSignature, Root, Uint8, UintNum64, ValidatorIndex} from "../primitive/sszTypes.js";
 
 /**
  * ExecutionProofId identifies which zkVM/proof system + EL combination a proof belongs to.

--- a/packages/types/src/eip8025/sszTypes.ts
+++ b/packages/types/src/eip8025/sszTypes.ts
@@ -1,0 +1,70 @@
+import {ByteListType, ContainerType, ListBasicType, UintNumberType} from "@chainsafe/ssz";
+import {EXECUTION_PROOF_TYPE_COUNT, MAX_PROOF_DATA_BYTES} from "@lodestar/params";
+import {Root, Slot, Uint8, UintNum64} from "../primitive/sszTypes.js";
+
+/**
+ * ExecutionProofId identifies which zkVM/proof system + EL combination a proof belongs to.
+ * Examples: 0=SP1+Reth, 1=Risc0+Geth, 2=SP1+Geth, etc.
+ *
+ * Note: Uses Uint8 (uint8) per Lighthouse/Prysm devnet implementation.
+ */
+export const ExecutionProofId = Uint8;
+
+/**
+ * The actual proof data, variable length up to MAX_PROOF_DATA_BYTES (1MB).
+ */
+export const ProofData = new ByteListType(MAX_PROOF_DATA_BYTES);
+
+/**
+ * ExecutionProof represents a cryptographic proof that an execution payload is valid.
+ *
+ * Note: This type matches the Lighthouse/Prysm devnet wire format, which diverges from
+ * the consensus spec (no BLS signatures, extra fields for slot/blockHash/blockRoot).
+ * The consensus spec uses SignedExecutionProof with validator_index + BLS signature,
+ * but for devnet interop we match the actual implementation.
+ */
+export const ExecutionProof = new ContainerType(
+  {
+    /** Which proof type (zkVM+EL combination) this proof belongs to (0-7) */
+    proofId: ExecutionProofId,
+    /** The slot of the beacon block this proof validates */
+    slot: Slot,
+    /** The block hash of the execution payload this proof validates */
+    blockHash: Root,
+    /** The beacon block root corresponding to the block with the execution payload */
+    blockRoot: Root,
+    /** The actual ZK proof data */
+    proofData: ProofData,
+  },
+  {typeName: "ExecutionProof", jsonCase: "eth2"}
+);
+
+/**
+ * Request proofs for a specific block root.
+ * Matches Lighthouse `ExecutionProofsByRootRequest` wire format.
+ */
+export const ExecutionProofsByRootRequest = new ContainerType(
+  {
+    /** The block root we need proofs for */
+    blockRoot: Root,
+    /** How many additional proofs we need */
+    countNeeded: UintNum64,
+    /** Proof IDs we already have (responder should exclude these) */
+    alreadyHave: new ListBasicType(new UintNumberType(1), EXECUTION_PROOF_TYPE_COUNT),
+  },
+  {typeName: "ExecutionProofsByRootRequest", jsonCase: "eth2"}
+);
+
+/**
+ * Request proofs for a range of slots.
+ * Matches Lighthouse `ExecutionProofsByRangeRequest` wire format.
+ */
+export const ExecutionProofsByRangeRequest = new ContainerType(
+  {
+    /** The starting slot to request execution proofs */
+    startSlot: UintNum64,
+    /** The number of slots from the start slot */
+    count: UintNum64,
+  },
+  {typeName: "ExecutionProofsByRangeRequest", jsonCase: "eth2"}
+);

--- a/packages/types/src/eip8025/types.ts
+++ b/packages/types/src/eip8025/types.ts
@@ -2,6 +2,9 @@ import {ValueOf} from "@chainsafe/ssz";
 import * as ssz from "./sszTypes.js";
 
 export type ExecutionProofId = ValueOf<typeof ssz.ExecutionProofId>;
+export type ProofType = ValueOf<typeof ssz.ProofType>;
+export type PublicInput = ValueOf<typeof ssz.PublicInput>;
 export type ExecutionProof = ValueOf<typeof ssz.ExecutionProof>;
+export type SignedExecutionProof = ValueOf<typeof ssz.SignedExecutionProof>;
 export type ExecutionProofsByRootRequest = ValueOf<typeof ssz.ExecutionProofsByRootRequest>;
 export type ExecutionProofsByRangeRequest = ValueOf<typeof ssz.ExecutionProofsByRangeRequest>;

--- a/packages/types/src/eip8025/types.ts
+++ b/packages/types/src/eip8025/types.ts
@@ -1,0 +1,7 @@
+import {ValueOf} from "@chainsafe/ssz";
+import * as ssz from "./sszTypes.js";
+
+export type ExecutionProofId = ValueOf<typeof ssz.ExecutionProofId>;
+export type ExecutionProof = ValueOf<typeof ssz.ExecutionProof>;
+export type ExecutionProofsByRootRequest = ValueOf<typeof ssz.ExecutionProofsByRootRequest>;
+export type ExecutionProofsByRangeRequest = ValueOf<typeof ssz.ExecutionProofsByRangeRequest>;

--- a/packages/types/src/sszTypes.ts
+++ b/packages/types/src/sszTypes.ts
@@ -9,6 +9,7 @@ import {ssz as fuluSsz} from "./fulu/index.js";
 import {ssz as gloasSsz} from "./gloas/index.js";
 import {ssz as phase0Ssz} from "./phase0/index.js";
 
+export * as eip8025 from "./eip8025/sszTypes.js";
 export * from "./primitive/sszTypes.js";
 
 /**

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -22,6 +22,7 @@ export {ts as altair} from "./altair/index.js";
 export {ts as bellatrix} from "./bellatrix/index.js";
 export {ts as capella} from "./capella/index.js";
 export {ts as deneb} from "./deneb/index.js";
+export * from "./eip8025/types.js";
 export {ts as electra} from "./electra/index.js";
 export {ts as fulu} from "./fulu/index.js";
 export {ts as gloas} from "./gloas/index.js";

--- a/scripts/dummy-prover.mjs
+++ b/scripts/dummy-prover.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+
+/**
+ * EIP-8025 Dummy Prover
+ *
+ * Subscribes to beacon node head events and submits dummy execution proofs
+ * for each new block. Used for devnet/interop testing.
+ *
+ * Usage:
+ *   node scripts/dummy-prover.mjs [options]
+ *
+ * Options:
+ *   --beacon-node URL        Beacon node HTTP endpoint (default: http://localhost:5052)
+ *   --proofs-per-block N     Number of proof IDs to submit per block (default: 1, max: 8)
+ *   --proof-delay-ms N       Simulated proof generation delay in ms (default: 1000)
+ *   --backfill-slots N       Backfill this many recent slots on startup (default: 0)
+ */
+
+import {randomBytes} from "node:crypto";
+
+// Parse CLI args
+const args = process.argv.slice(2);
+function getArg(name, defaultValue) {
+  const idx = args.indexOf(name);
+  if (idx === -1 || idx + 1 >= args.length) return defaultValue;
+  return args[idx + 1];
+}
+
+const BEACON_NODE = getArg("--beacon-node", "http://localhost:5052");
+const PROOFS_PER_BLOCK = Math.min(8, Math.max(1, parseInt(getArg("--proofs-per-block", "1"), 10)));
+const PROOF_DELAY_MS = parseInt(getArg("--proof-delay-ms", "1000"), 10);
+const BACKFILL_SLOTS = parseInt(getArg("--backfill-slots", "0"), 10);
+
+console.log(`Dummy Prover starting...`);
+console.log(`  beacon-node:      ${BEACON_NODE}`);
+console.log(`  proofs-per-block: ${PROOFS_PER_BLOCK}`);
+console.log(`  proof-delay-ms:   ${PROOF_DELAY_MS}`);
+console.log(`  backfill-slots:   ${BACKFILL_SLOTS}`);
+
+/**
+ * Generate dummy proof data (random bytes).
+ * In a real prover, this would be a ZK proof.
+ */
+function generateDummyProofData(size = 256) {
+  return "0x" + randomBytes(size).toString("hex");
+}
+
+/**
+ * Fetch a block from the beacon node and extract execution payload info.
+ */
+async function fetchBlock(blockId) {
+  const resp = await fetch(`${BEACON_NODE}/eth/v2/beacon/blocks/${blockId}`);
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch block ${blockId}: ${resp.status} ${resp.statusText}`);
+  }
+  const json = await resp.json();
+  const block = json.data.message || json.data;
+  const slot = parseInt(block.slot, 10);
+  const executionPayload = block.body?.execution_payload;
+
+  if (!executionPayload) {
+    return null; // Pre-merge block
+  }
+
+  return {
+    slot,
+    blockHash: executionPayload.block_hash,
+  };
+}
+
+/**
+ * Submit an execution proof to the beacon node via REST API.
+ */
+async function submitProof(proof) {
+  const resp = await fetch(`${BEACON_NODE}/eth/v1/beacon/pool/execution_proofs`, {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify(proof),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Failed to submit proof: ${resp.status} ${text}`);
+  }
+}
+
+/**
+ * Generate and submit dummy proofs for a block.
+ */
+async function handleBlock(slot, blockRoot) {
+  try {
+    const blockInfo = await fetchBlock(blockRoot);
+    if (!blockInfo) {
+      console.log(`  [slot ${slot}] No execution payload, skipping`);
+      return;
+    }
+
+    // Simulate proof generation delay
+    if (PROOF_DELAY_MS > 0) {
+      await new Promise((r) => setTimeout(r, PROOF_DELAY_MS));
+    }
+
+    for (let proofId = 0; proofId < PROOFS_PER_BLOCK; proofId++) {
+      const proof = {
+        proof_id: proofId,
+        slot: String(slot),
+        block_hash: blockInfo.blockHash,
+        block_root: blockRoot,
+        proof_data: generateDummyProofData(256),
+      };
+
+      try {
+        await submitProof(proof);
+        console.log(`  [slot ${slot}] Submitted proof id=${proofId}`);
+      } catch (e) {
+        console.error(`  [slot ${slot}] Failed proof id=${proofId}: ${e.message}`);
+      }
+    }
+  } catch (e) {
+    console.error(`  [slot ${slot}] Error: ${e.message}`);
+  }
+}
+
+/**
+ * Backfill proofs for recent slots.
+ */
+async function backfill(numSlots) {
+  if (numSlots <= 0) return;
+
+  console.log(`Backfilling ${numSlots} recent slots...`);
+
+  const resp = await fetch(`${BEACON_NODE}/eth/v1/beacon/headers/head`);
+  if (!resp.ok) {
+    console.error(`Failed to fetch head: ${resp.status}`);
+    return;
+  }
+  const json = await resp.json();
+  const headSlot = parseInt(json.data.header.message.slot, 10);
+  const startSlot = Math.max(0, headSlot - numSlots + 1);
+
+  for (let slot = startSlot; slot <= headSlot; slot++) {
+    try {
+      const headerResp = await fetch(`${BEACON_NODE}/eth/v1/beacon/headers/${slot}`);
+      if (!headerResp.ok) continue;
+      const headerJson = await headerResp.json();
+      const blockRoot = headerJson.data.root;
+      console.log(`Backfill slot ${slot} root=${blockRoot.substring(0, 10)}...`);
+      await handleBlock(slot, blockRoot);
+    } catch (e) {
+      console.error(`Backfill slot ${slot} error: ${e.message}`);
+    }
+  }
+  console.log("Backfill complete.");
+}
+
+/**
+ * Subscribe to SSE events using fetch streaming.
+ * Handles reconnection automatically.
+ */
+async function subscribeToEvents(onEvent) {
+  const url = `${BEACON_NODE}/eth/v1/events?topics=head`;
+  console.log(`Subscribing to events: ${url}`);
+
+  while (true) {
+    try {
+      const controller = new AbortController();
+      const resp = await fetch(url, {
+        headers: {Accept: "text/event-stream"},
+        signal: controller.signal,
+      });
+
+      if (!resp.ok) {
+        console.error(`SSE connection failed: ${resp.status}`);
+        await new Promise((r) => setTimeout(r, 2000));
+        continue;
+      }
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let currentEvent = "";
+      let currentData = "";
+
+      while (true) {
+        const {done, value} = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, {stream: true});
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || ""; // Keep incomplete line in buffer
+
+        for (const line of lines) {
+          if (line.startsWith("event: ")) {
+            currentEvent = line.slice(7).trim();
+          } else if (line.startsWith("data: ")) {
+            currentData += (currentData ? "\n" : "") + line.slice(6);
+          } else if (line === "") {
+            // Empty line = end of event
+            if (currentEvent && currentData) {
+              onEvent(currentEvent, currentData);
+            }
+            currentEvent = "";
+            currentData = "";
+          }
+        }
+      }
+
+      console.log("SSE stream ended, reconnecting...");
+    } catch (e) {
+      if (e.name === "AbortError") continue;
+      console.error(`SSE error: ${e.message}, reconnecting in 2s...`);
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+}
+
+/**
+ * Main: wait for beacon node, backfill, then subscribe to events.
+ */
+async function main() {
+  // Wait for beacon node to be ready
+  let ready = false;
+  while (!ready) {
+    try {
+      const resp = await fetch(`${BEACON_NODE}/eth/v1/node/health`);
+      if (resp.ok || resp.status === 206) {
+        ready = true;
+      } else {
+        console.log(`Waiting for beacon node (status=${resp.status})...`);
+        await new Promise((r) => setTimeout(r, 2000));
+      }
+    } catch {
+      console.log("Waiting for beacon node...");
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+  }
+  console.log("Beacon node ready.");
+
+  // Backfill if requested
+  await backfill(BACKFILL_SLOTS);
+
+  // Subscribe to head events
+  await subscribeToEvents((event, data) => {
+    if (event !== "head") return;
+
+    try {
+      const parsed = JSON.parse(data);
+      const slot = parseInt(parsed.slot, 10);
+      const blockRoot = parsed.block;
+      console.log(`New head: slot=${slot} root=${blockRoot.substring(0, 10)}...`);
+      handleBlock(slot, blockRoot);
+    } catch (e) {
+      console.error(`Event parse error: ${e.message}`);
+    }
+  });
+}
+
+main().catch((e) => {
+  console.error("Fatal:", e);
+  process.exit(1);
+});

--- a/scripts/eip8025-devnet/README.md
+++ b/scripts/eip8025-devnet/README.md
@@ -1,0 +1,61 @@
+# EIP-8025 Devnet (Lodestar-first)
+
+Kurtosis devnet to validate Lodestar EIP-8025 implementation end-to-end.
+
+> Current state: Lodestar-only topology is fully runnable.
+> Cross-client Lighthouse/Prysm interop in this script is pending availability of published optional-proofs images.
+
+## Topology
+
+- `cl-1-lodestar-reth`: normal node + validators (supernode)
+- `cl-2-lodestar-geth`: normal node + validators (supernode)
+- `cl-3-lodestar-reth`: zkvm node (`--activateZkvm`, no validators)
+- `el-*`: matching EL clients (reth/geth)
+- `dora`: optional dashboard
+
+Dummy prover submits proofs to zkvm node via:
+
+- `POST /eth/v1/beacon/pool/execution_proofs`
+
+## Quick Start
+
+```bash
+# 1) Build Lodestar image from this branch
+cd ~/lodestar-eip8025
+docker build -t lodestar:eip8025 -f Dockerfile.dev .
+
+# 2) Start devnet
+kurtosis run github.com/ethpandaops/ethereum-package \
+  --enclave eip8025-devnet \
+  --args-file scripts/eip8025-devnet/network_params.yaml
+
+# 3) Start dummy prover against zkvm node
+node scripts/dummy-prover.mjs \
+  --beacon-node http://127.0.0.1:33015 \
+  --proofs-per-block 1 \
+  --proof-delay-ms 200
+```
+
+## Verify
+
+```bash
+# Proofs are being submitted
+curl -s http://127.0.0.1:33015/eth/v1/beacon/pool/execution_proofs | jq '.data | length'
+
+# Check execution proof handling logs
+kurtosis service logs eip8025-devnet cl-3-lodestar-reth | grep -i "execution proof\|execution_proof"
+
+# Check zkvm ENR
+curl -s http://127.0.0.1:33015/eth/v1/node/identity | jq -r '.data.enr'
+```
+
+## Known caveats
+
+- If no peers subscribe to `execution_proof` gossip topic, API submission still succeeds (proof is stored locally; gossip publish is best-effort).
+- For mixed-client interop, update `network_params.yaml` to include Lighthouse/Prysm optional-proofs images when available.
+
+## Cleanup
+
+```bash
+kurtosis enclave rm -f eip8025-devnet
+```

--- a/scripts/eip8025-devnet/network_params.yaml
+++ b/scripts/eip8025-devnet/network_params.yaml
@@ -1,0 +1,94 @@
+# EIP-8025 Optional Execution Proofs — Mixed Client Devnet
+#
+# Lodestar + Lighthouse + Prysm mixed devnet for EIP-8025 interop testing.
+#
+# Usage:
+#   kurtosis run github.com/ethpandaops/ethereum-package --args-file network_params.yaml
+
+participants:
+  # Normal Lodestar supernode (produces blocks)
+  - el_type: reth
+    el_image: ghcr.io/paradigmxyz/reth:latest
+    cl_type: lodestar
+    cl_image: lodestar:eip8025
+    cl_extra_params:
+      - --targetPeers=8
+    supernode: true
+    count: 1
+    validator_count: 96
+
+  # Normal Lighthouse supernode (produces blocks)
+  - el_type: geth
+    el_image: ethereum/client-go:latest
+    cl_type: lighthouse
+    cl_image: ethpandaops/lighthouse:eth-act-optional-proofs
+    cl_extra_params:
+      - --target-peers=8
+    supernode: true
+    count: 1
+    validator_count: 96
+
+  # Normal Prysm supernode (produces blocks)
+  - el_type: geth
+    el_image: ethereum/client-go:latest
+    cl_type: prysm
+    cl_image: ethpandaops/prysm-beacon-chain:developeruche-poc-optional-proofs
+    cl_extra_params:
+      - --activate-zkvm
+      - --zkvm-generation-proof-types=0,1
+    vc_image: ethpandaops/prysm-validator:developeruche-poc-optional-proofs
+    supernode: true
+    count: 1
+    validator_count: 96
+
+  # Lodestar zkvm node
+  - el_type: reth
+    el_image: ghcr.io/paradigmxyz/reth:latest
+    cl_type: lodestar
+    cl_image: lodestar:eip8025
+    cl_extra_params:
+      - --activateZkvm
+      - --chain.minProofsRequired=1
+      - --targetPeers=8
+    count: 1
+    validator_count: 0
+
+  # Lighthouse zkvm node
+  - el_type: reth
+    el_image: ghcr.io/paradigmxyz/reth:latest
+    cl_type: lighthouse
+    cl_image: ethpandaops/lighthouse:eth-act-optional-proofs
+    cl_extra_params:
+      - --activate-zkvm
+      - --target-peers=8
+    count: 1
+    validator_count: 0
+
+  # Prysm zkvm node
+  - el_type: reth
+    el_image: ghcr.io/paradigmxyz/reth:latest
+    cl_type: prysm
+    cl_image: ethpandaops/prysm-beacon-chain:developeruche-poc-optional-proofs
+    cl_extra_params:
+      - --activate-zkvm
+    vc_image: ethpandaops/prysm-validator:developeruche-poc-optional-proofs
+    count: 1
+    validator_count: 0
+
+network_params:
+  electra_fork_epoch: 0
+  fulu_fork_epoch: 1
+  seconds_per_slot: 6
+
+global_log_level: debug
+
+additional_services:
+  - dora
+
+port_publisher:
+  el:
+    enabled: true
+    public_port_start: 32000
+  cl:
+    enabled: true
+    public_port_start: 33000

--- a/scripts/eip8025-devnet/proof-driven-test.yaml
+++ b/scripts/eip8025-devnet/proof-driven-test.yaml
@@ -1,0 +1,83 @@
+# EIP-8025 Phase E: Proof-Driven Execution Test
+#
+# Tests that a Lodestar node with --chain.activateZkvm=true can sync
+# and validate blocks using execution proofs instead of an EL client.
+#
+# The zkvm Lodestar node still has an EL paired (kurtosis requirement),
+# but it does NOT call engine_newPayload — instead it uses proofs from
+# the gossip network to validate execution payloads.
+#
+# Validation criteria:
+# - Chain finalizes within 5 epochs
+# - Lodestar zkvm node stays in sync (no stalls)
+# - Proofs are delivered and processed successfully
+#
+# Usage:
+#   kurtosis run github.com/ethpandaops/ethereum-package --args-file proof-driven-test.yaml
+
+participants:
+  # Lodestar supernode — normal mode with EL (produces blocks + proofs)
+  - el_type: reth
+    el_image: ghcr.io/paradigmxyz/reth:latest
+    cl_type: lodestar
+    cl_image: lodestar-proof-driven:local
+    cl_extra_params:
+      - --targetPeers=8
+    supernode: true
+    count: 1
+    validator_count: 128
+
+  # Lighthouse supernode — normal mode with EL (produces blocks + proofs)
+  - el_type: geth
+    el_image: ethereum/client-go:latest
+    cl_type: lighthouse
+    cl_image: ethpandaops/lighthouse:eth-act-optional-proofs
+    cl_extra_params:
+      - --target-peers=8
+    supernode: true
+    count: 1
+    validator_count: 128
+
+  # Prysm supernode — normal mode with EL (produces blocks + proofs)
+  - el_type: geth
+    el_image: ethereum/client-go:latest
+    cl_type: prysm
+    cl_image: ethpandaops/prysm-beacon-chain:developeruche-poc-optional-proofs
+    cl_extra_params:
+      - --activate-zkvm
+      - --zkvm-generation-proof-types=0,1
+    vc_image: ethpandaops/prysm-validator:developeruche-poc-optional-proofs
+    supernode: true
+    count: 1
+    validator_count: 128
+
+  # Lodestar zkvm node — PROOF-DRIVEN MODE (the node under test)
+  # Uses execution proofs instead of EL for payload verification
+  - el_type: reth
+    el_image: ghcr.io/paradigmxyz/reth:latest
+    cl_type: lodestar
+    cl_image: lodestar-proof-driven:local
+    cl_extra_params:
+      - --activateZkvm
+      - --chain.minProofsRequired=1
+      - --targetPeers=8
+    count: 1
+    validator_count: 0
+
+network_params:
+  electra_fork_epoch: 0
+  fulu_fork_epoch: 1
+  seconds_per_slot: 6
+
+global_log_level: debug
+
+additional_services:
+  - dora
+
+port_publisher:
+  el:
+    enabled: true
+    public_port_start: 32000
+  cl:
+    enabled: true
+    public_port_start: 33000

--- a/scripts/eip8025-devnet/start-devnet.sh
+++ b/scripts/eip8025-devnet/start-devnet.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_DIR="$(cd -- "$SCRIPT_DIR/../.." &>/dev/null && pwd)"
+
+ENCLAVE_NAME="${ENCLAVE_NAME:-eip8025-devnet}"
+
+echo "=== EIP-8025 Mixed Client Devnet ==="
+echo ""
+
+# Step 1: Build Lodestar image (use Dockerfile.dev for faster builds)
+echo "1. Building Lodestar Docker image (Dockerfile.dev)..."
+cd "$REPO_DIR"
+docker build -t lodestar:eip8025 -f Dockerfile.dev .
+echo "   Done."
+
+# Step 2: Start kurtosis devnet
+echo ""
+echo "2. Starting kurtosis devnet (enclave: $ENCLAVE_NAME)..."
+kurtosis run github.com/ethpandaops/ethereum-package \
+  --enclave "$ENCLAVE_NAME" \
+  --args-file "$SCRIPT_DIR/network_params.yaml"
+
+echo ""
+echo "3. Devnet is running!"
+echo ""
+echo "   View services:  kurtosis enclave inspect $ENCLAVE_NAME"
+echo "   View logs:      kurtosis service logs $ENCLAVE_NAME <service-name>"
+echo ""
+
+# Step 3: Print beacon node URLs
+echo "   Beacon node endpoints:"
+for svc in $(kurtosis enclave inspect "$ENCLAVE_NAME" 2>/dev/null | grep "cl-" | awk '{print $1}'); do
+  url=$(kurtosis port print "$ENCLAVE_NAME" "$svc" http 2>/dev/null || echo "N/A")
+  echo "     $svc → $url"
+done
+
+echo ""
+echo "4. Start the dummy prover against a Lodestar node:"
+echo "   node $REPO_DIR/scripts/dummy-prover.mjs --beacon-node <LODESTAR_URL> --proofs-per-block 1"
+echo ""
+echo "5. Monitor proof gossip in logs:"
+echo "   kurtosis service logs $ENCLAVE_NAME <cl-service> | grep -i 'execution.proof\\|zkvm'"


### PR DESCRIPTION
## Problem

Commit `7f5219861d` (`feat: implement eip-8025 spec aligned ssz types`) updated the `ExecutionProof` SSZ type to match the [EIP-8025 spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/_features/eip8025/beacon-chain.md) but didn't update the ~10 consuming files in `beacon-node`, breaking the build.

**Old type:** `{ proofId, slot, blockHash, blockRoot, proofData }`
**New type:** `{ proofData, proofType, publicInput: { newPayloadRequestRoot } }`
`+ SignedExecutionProof = { message: ExecutionProof, validatorIndex, signature }`

## Changes

### Pool (`executionProofPool.ts`)
- Reindexed by `(newPayloadRequestRoot, proofType)` instead of `(slot, blockRoot, proofId)`
- Size-based pruning replaces slot-based pruning (proofs no longer carry slot)
- New `getAllProofs()` method for API listing and reqresp fallback

### Verifier (`executionProofVerifier.ts`)
- Removed `expectedBlockRootHex` / `expectedExecBlockHashHex` from input (not in new type)
- Simplified to check proofData non-empty + count distinct proofTypes

### Chain (`chain.ts`)
- Fixed duplicate `@lodestar/fork-choice` imports (merge artifact)
- Added `newPayloadRequestRootToBlockRoot` mapping for proof → block lookups
- `maybeTransitionToValidOnProofArrival` takes `ExecutionProof` directly

### Interface (`interface.ts`)
- Updated `IBeaconChain.maybeTransitionToValidOnProofArrival` signature

### Network/Gossip/API/ReqResp
- All handlers updated to use `proof.proofType`, `proof.publicInput.newPayloadRequestRoot`
- Removed all `.slot` / `.blockRoot` / `.blockHash` / `.proofId` references

### Types (`eip8025/`)
- Exported `SignedExecutionProof`, `PublicInput`, `ProofType` types
- Removed unused `Slot` import from sszTypes

### Tests
- Rewrote pool + verifier tests for new type structure

## TODOs (follow-up)
- [ ] Populate `newPayloadRequestRoot → blockRoot` mapping during block import
- [ ] Update reqresp ByRoot handler to use the mapping (currently returns all proofs as workaround)
- [ ] Full gossip validation per spec (signature check, validator active check, etc.)

---

> [!NOTE]
> This PR was authored with AI assistance (Lodekeeper 🌟)