### PR TITLE
fix: update stale custody group metric name in summary dashboard

### DIFF
--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -574,7 +574,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "beacon_target_custody_group_count",
+          "expr": "beacon_custody_groups",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,


### PR DESCRIPTION
## Problem

The peerdas metrics fix (`8e34c756`, PR #8920) renamed `beacon_target_custody_group_count` → `beacon_custody_groups` but only updated `lodestar_peerdas.json`. The summary dashboard (`lodestar_summary.json`) still referenced the old metric name, causing the **Custody Group Count** stat panel to show no data.

## Fix

Update the PromQL expression in the summary dashboard to use the new metric name.

## Changes

- `dashboards/lodestar_summary.json`: `beacon_target_custody_group_count` → `beacon_custody_groups`

## Verification

Searched all dashboards and source files for all four removed metric names from the peerdas commit:
- `beacon_target_custody_group_count` — **found in lodestar_summary.json** (this fix)
- `lodestar_import_columns_by_source_total` — not referenced anywhere
- `lodestar_recover_data_column_sidecar_recovered_columns_total` — not referenced anywhere
- `lodestar_recover_data_column_sidecar_recover_time_seconds` — not referenced anywhere

Only the summary dashboard had a stale reference.