### PR TITLE
test: fix updateHead benchmark broken by missing Gloas fields on genesis

### DIFF
--- a/packages/fork-choice/test/perf/forkChoice/util.ts
+++ b/packages/fork-choice/test/perf/forkChoice/util.ts
@@ -38,6 +38,9 @@ export function initializeForkChoice(opts: Opts): ForkChoice {
       executionPayloadBlockHash: null,
       executionStatus: ExecutionStatus.PreMerge,
       dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+
+      parentBlockHash: null,
+      payloadStatus: PayloadStatus.FULL,
     } as Omit<ProtoBlock, "targetRoot">,
     genesisSlot
   );


### PR DESCRIPTION
## Summary

The `updateHead` fork-choice benchmark has been broken since the Gloas/ePBS changes. The genesis block in the benchmark utility (`util.ts`) was missing the new `parentBlockHash` and `payloadStatus` fields.

At runtime, `parentBlockHash` was `undefined` (not `null`), so `isGloasBlock()` (`block.parentBlockHash !== null`) incorrectly treated genesis as a Gloas block — creating PENDING+EMPTY variants instead of a single FULL node. This broke parent lookups for all subsequent pre-Gloas blocks, causing `updateHead` to fail with `blockRoot vote1 == vote2`.

### Changes:
- **`util.ts`**: Add `parentBlockHash: null` and `payloadStatus: PayloadStatus.FULL` to the genesis block passed to `ProtoArray.initialize`

## Test plan
- [ ] Run `yarn benchmark --grep "forkchoice updateHead"` — should complete without errors