### PR TITLE
feat: enable quic transport by default

### DIFF
--- a/docs/pages/run/beacon-management/networking.md
+++ b/docs/pages/run/beacon-management/networking.md
@@ -90,7 +90,7 @@ Lodestar supports [QUIC](https://datatracker.ietf.org/doc/html/rfc9000) as a tra
 
 #### Port Configuration
 
-With QUIC enabled by default, the node listens on an additional UDP port and advertises QUIC support in its ENR. Lodestar uses three ports for P2P networking:
+Lodestar uses three ports for P2P networking:
 
 | Port              | Protocol | Default                 | Purpose                   |
 | ----------------- | -------- | ----------------------- | ------------------------- |

--- a/docs/pages/run/beacon-management/networking.md
+++ b/docs/pages/run/beacon-management/networking.md
@@ -86,21 +86,23 @@ Libp2p operates at the lower levels of the OSI model, particularly at the Transp
 
 ### QUIC Transport
 
-Lodestar supports [QUIC](https://datatracker.ietf.org/doc/html/rfc9000) as a transport alongside TCP. QUIC is a UDP-based transport that provides built-in encryption (TLS 1.3), multiplexed streams, and faster connection establishment compared to TCP. QUIC is disabled by default and can be enabled with the `--quic` flag. When enabled, Lodestar will prefer QUIC when dialing peers that advertise QUIC support.
+Lodestar supports [QUIC](https://datatracker.ietf.org/doc/html/rfc9000) as a transport alongside TCP. QUIC is a UDP-based transport that provides built-in encryption (TLS 1.3), multiplexed streams, and faster connection establishment compared to TCP. QUIC is enabled by default. Lodestar will prefer QUIC when dialing peers that advertise QUIC support.
 
-#### Enabling QUIC
+#### Disabling QUIC
 
-To enable QUIC transport:
+To disable QUIC transport:
 
 ```bash
-lodestar beacon --quic
+lodestar beacon --quic=false
 ```
 
-When QUIC is enabled, the node will listen on an additional UDP port and advertise QUIC support in its ENR.
+You can also use `lodestar beacon --no-quic`.
+
+With the default QUIC-enabled configuration, the node listens on an additional UDP port and advertises QUIC support in its ENR.
 
 #### Port Configuration
 
-With QUIC enabled, Lodestar uses three ports for P2P networking:
+With QUIC enabled by default, Lodestar uses three ports for P2P networking:
 
 | Port              | Protocol | Default                 | Purpose                   |
 | ----------------- | -------- | ----------------------- | ------------------------- |
@@ -114,7 +116,7 @@ For IPv6 dual-stack, equivalent flags are available: `--port6`, `--discoveryPort
 
 #### ENR Advertisement
 
-When QUIC is enabled, the node's ENR automatically includes QUIC port information so that other nodes can discover and connect via QUIC. The ENR fields can be overridden with `--enr.quic` and `--enr.quic6`.
+When QUIC is enabled, the node's ENR automatically includes QUIC port information so that other nodes can discover and connect via QUIC. The ENR fields can be overridden with `--enr.quic` and `--enr.quic6`. If QUIC is disabled, those ENR fields are omitted.
 
 ## Firewall Management
 
@@ -124,7 +126,7 @@ Ports that must be opened:
 
 - 30303/TCP+UDP - Execution layer P2P communication port
 - 9000/TCP+UDP - Beacon node P2P communication (TCP transport + discv5 discovery)
-- 9001/UDP - Beacon node QUIC transport (only if `--quic` is enabled)
+- 9001/UDP - Beacon node QUIC transport (open by default; not needed if QUIC is disabled)
 
 Ports that must be protected:
 

--- a/docs/pages/run/beacon-management/networking.md
+++ b/docs/pages/run/beacon-management/networking.md
@@ -86,7 +86,7 @@ Libp2p operates at the lower levels of the OSI model, particularly at the Transp
 
 ### QUIC Transport
 
-Lodestar supports [QUIC](https://datatracker.ietf.org/doc/html/rfc9000) as a transport alongside TCP. QUIC is a UDP-based transport that provides built-in encryption (TLS 1.3), multiplexed streams, and faster connection establishment compared to TCP. QUIC is enabled by default and Lodestar will prefer QUIC when dialing peers that advertise QUIC support. The node's ENR automatically includes QUIC port information so other nodes can discover and connect via QUIC (overridable with `--enr.quic` and `--enr.quic6`).
+Lodestar supports [QUIC](https://datatracker.ietf.org/doc/html/rfc9000) as a transport alongside TCP. QUIC is a UDP-based transport that provides built-in encryption (TLS 1.3), multiplexed streams, and faster connection establishment compared to TCP. QUIC is enabled by default and Lodestar will prefer QUIC when dialing peers that advertise QUIC support. The node's ENR automatically includes QUIC port information so other nodes can discover and connect via QUIC. The ENR fields can be overridden with `--enr.quic` and `--enr.quic6`.
 
 ## Port Configuration
 

--- a/docs/pages/run/beacon-management/networking.md
+++ b/docs/pages/run/beacon-management/networking.md
@@ -88,21 +88,9 @@ Libp2p operates at the lower levels of the OSI model, particularly at the Transp
 
 Lodestar supports [QUIC](https://datatracker.ietf.org/doc/html/rfc9000) as a transport alongside TCP. QUIC is a UDP-based transport that provides built-in encryption (TLS 1.3), multiplexed streams, and faster connection establishment compared to TCP. QUIC is enabled by default. Lodestar will prefer QUIC when dialing peers that advertise QUIC support.
 
-#### Disabling QUIC
-
-To disable QUIC transport:
-
-```bash
-lodestar beacon --quic=false
-```
-
-You can also use `lodestar beacon --no-quic`.
-
-With the default QUIC-enabled configuration, the node listens on an additional UDP port and advertises QUIC support in its ENR.
-
 #### Port Configuration
 
-With QUIC enabled by default, Lodestar uses three ports for P2P networking:
+With QUIC enabled by default, the node listens on an additional UDP port and advertises QUIC support in its ENR. Lodestar uses three ports for P2P networking:
 
 | Port              | Protocol | Default                 | Purpose                   |
 | ----------------- | -------- | ----------------------- | ------------------------- |
@@ -116,7 +104,7 @@ For IPv6 dual-stack, equivalent flags are available: `--port6`, `--discoveryPort
 
 #### ENR Advertisement
 
-When QUIC is enabled, the node's ENR automatically includes QUIC port information so that other nodes can discover and connect via QUIC. The ENR fields can be overridden with `--enr.quic` and `--enr.quic6`. If QUIC is disabled, those ENR fields are omitted.
+The node's ENR automatically includes QUIC port information so that other nodes can discover and connect via QUIC. The ENR fields can be overridden with `--enr.quic` and `--enr.quic6`.
 
 ## Firewall Management
 
@@ -126,7 +114,7 @@ Ports that must be opened:
 
 - 30303/TCP+UDP - Execution layer P2P communication port
 - 9000/TCP+UDP - Beacon node P2P communication (TCP transport + discv5 discovery)
-- 9001/UDP - Beacon node QUIC transport (open by default; not needed if QUIC is disabled)
+- 9001/UDP - Beacon node QUIC transport
 
 Ports that must be protected:
 

--- a/docs/pages/run/beacon-management/networking.md
+++ b/docs/pages/run/beacon-management/networking.md
@@ -86,9 +86,9 @@ Libp2p operates at the lower levels of the OSI model, particularly at the Transp
 
 ### QUIC Transport
 
-Lodestar supports [QUIC](https://datatracker.ietf.org/doc/html/rfc9000) as a transport alongside TCP. QUIC is a UDP-based transport that provides built-in encryption (TLS 1.3), multiplexed streams, and faster connection establishment compared to TCP. QUIC is enabled by default. Lodestar will prefer QUIC when dialing peers that advertise QUIC support.
+Lodestar supports [QUIC](https://datatracker.ietf.org/doc/html/rfc9000) as a transport alongside TCP. QUIC is a UDP-based transport that provides built-in encryption (TLS 1.3), multiplexed streams, and faster connection establishment compared to TCP. QUIC is enabled by default and Lodestar will prefer QUIC when dialing peers that advertise QUIC support. The node's ENR automatically includes QUIC port information so other nodes can discover and connect via QUIC (overridable with `--enr.quic` and `--enr.quic6`).
 
-#### Port Configuration
+## Port Configuration
 
 Lodestar uses three ports for P2P networking:
 
@@ -101,10 +101,6 @@ Lodestar uses three ports for P2P networking:
 Note that `--discoveryPort` and `--quicPort` are both UDP but must use different ports. Lodestar will error on startup if they collide.
 
 For IPv6 dual-stack, equivalent flags are available: `--port6`, `--discoveryPort6`, and `--quicPort6`.
-
-#### ENR Advertisement
-
-The node's ENR automatically includes QUIC port information so that other nodes can discover and connect via QUIC. The ENR fields can be overridden with `--enr.quic` and `--enr.quic6`.
 
 ## Firewall Management
 

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -22,10 +22,7 @@ export type NodeJsLibp2pOpts = {
   metricsRegistry?: Registry;
 };
 
-export async function getDiscv5Multiaddrs(
-  bootEnrs: string[],
-  quicEnabled = defaultNetworkOptions.quic
-): Promise<string[]> {
+export async function getDiscv5Multiaddrs(bootEnrs: string[], quicEnabled: boolean): Promise<string[]> {
   const bootMultiaddrs = [];
   for (const enrStr of bootEnrs) {
     const enr = ENR.decodeTxt(enrStr);

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -10,6 +10,7 @@ import {Registry} from "prom-client";
 import {ENR} from "@chainsafe/enr";
 import {noise} from "@chainsafe/libp2p-noise";
 import {asCrypto, defaultCrypto} from "@chainsafe/libp2p-noise/crypto";
+import {quic} from "@chainsafe/libp2p-quic";
 import {Libp2p, LodestarComponents} from "../interface.js";
 import {NetworkOptions, defaultNetworkOptions} from "../options.js";
 import {Eth2PeerDataStore} from "../peers/datastore.js";
@@ -92,7 +93,6 @@ export async function createNodeJsLibp2p(
     );
   }
   if (quicEnabled) {
-    const {quic} = await import("@chainsafe/libp2p-quic");
     const quicMultiaddrs = localMultiaddrs.filter((ma) => ma.includes("/quic-v1"));
     const hasIpv4Quic = quicMultiaddrs.some((ma) => ma.includes("/ip4/"));
     const hasIpv6Quic = quicMultiaddrs.some((ma) => ma.includes("/ip6/"));

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -45,7 +45,7 @@ export async function createNodeJsLibp2p(
   const localMultiaddrs = networkOpts.localMultiaddrs || defaultNetworkOptions.localMultiaddrs;
   const disconnectThreshold = networkOpts.disconnectThreshold ?? defaultNetworkOptions.disconnectThreshold;
   const tcpEnabled = networkOpts.tcp ?? defaultNetworkOptions.tcp;
-  const quicEnabled = networkOpts.quic ?? defaultNetworkOptions.quic ?? false;
+  const quicEnabled = networkOpts.quic ?? defaultNetworkOptions.quic;
   const {peerStoreDir, disablePeerDiscovery} = nodeJsLibp2pOpts;
 
   let datastore: undefined | Eth2PeerDataStore = undefined;

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -45,7 +45,7 @@ export async function createNodeJsLibp2p(
   const localMultiaddrs = networkOpts.localMultiaddrs || defaultNetworkOptions.localMultiaddrs;
   const disconnectThreshold = networkOpts.disconnectThreshold ?? defaultNetworkOptions.disconnectThreshold;
   const tcpEnabled = networkOpts.tcp ?? defaultNetworkOptions.tcp;
-  const quicEnabled = networkOpts.quic ?? defaultNetworkOptions.quic;
+  const quicEnabled = networkOpts.quic ?? defaultNetworkOptions.quic ?? false;
   const {peerStoreDir, disablePeerDiscovery} = nodeJsLibp2pOpts;
 
   let datastore: undefined | Eth2PeerDataStore = undefined;

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -22,7 +22,7 @@ export type NodeJsLibp2pOpts = {
   metricsRegistry?: Registry;
 };
 
-export async function getDiscv5Multiaddrs(bootEnrs: string[], quicEnabled: boolean): Promise<string[]> {
+export async function getDiscv5Multiaddrs(bootEnrs: string[], quicEnabled?: boolean): Promise<string[]> {
   const bootMultiaddrs = [];
   for (const enrStr of bootEnrs) {
     const enr = ENR.decodeTxt(enrStr);
@@ -44,8 +44,8 @@ export async function createNodeJsLibp2p(
 ): Promise<Libp2p> {
   const localMultiaddrs = networkOpts.localMultiaddrs || defaultNetworkOptions.localMultiaddrs;
   const disconnectThreshold = networkOpts.disconnectThreshold ?? defaultNetworkOptions.disconnectThreshold;
-  const tcpEnabled = networkOpts.tcp ?? defaultNetworkOptions.tcp ?? true;
-  const quicEnabled = networkOpts.quic ?? defaultNetworkOptions.quic ?? true;
+  const tcpEnabled = networkOpts.tcp ?? defaultNetworkOptions.tcp;
+  const quicEnabled = networkOpts.quic ?? defaultNetworkOptions.quic;
   const {peerStoreDir, disablePeerDiscovery} = nodeJsLibp2pOpts;
 
   let datastore: undefined | Eth2PeerDataStore = undefined;

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -93,18 +93,22 @@ export async function createNodeJsLibp2p(
     const quicMultiaddrs = localMultiaddrs.filter((ma) => ma.includes("/quic-v1"));
     const hasIpv4Quic = quicMultiaddrs.some((ma) => ma.includes("/ip4/"));
     const hasIpv6Quic = quicMultiaddrs.some((ma) => ma.includes("/ip6/"));
-    transports.unshift(
-      quic({
-        handshakeTimeout: 5_000,
-        maxIdleTimeout: 10_000,
-        keepAliveInterval: 5_000,
-        maxConcurrentStreamLimit: 256,
-        maxStreamData: 10_000_000,
-        maxConnectionData: 15_000_000,
-        ipv4: hasIpv4Quic,
-        ipv6: hasIpv6Quic,
-      })
-    );
+    // Only add QUIC transport if at least one QUIC listen address is configured,
+    // otherwise the transport constructor will throw
+    if (hasIpv4Quic || hasIpv6Quic) {
+      transports.unshift(
+        quic({
+          handshakeTimeout: 5_000,
+          maxIdleTimeout: 10_000,
+          keepAliveInterval: 5_000,
+          maxConcurrentStreamLimit: 256,
+          maxStreamData: 10_000_000,
+          maxConnectionData: 15_000_000,
+          ipv4: hasIpv4Quic,
+          ipv6: hasIpv6Quic,
+        })
+      );
+    }
   }
 
   const noiseCrypto = {

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -22,7 +22,7 @@ export type NodeJsLibp2pOpts = {
   metricsRegistry?: Registry;
 };
 
-export async function getDiscv5Multiaddrs(bootEnrs: string[], quicEnabled?: boolean): Promise<string[]> {
+export async function getDiscv5Multiaddrs(bootEnrs: string[], quicEnabled: boolean): Promise<string[]> {
   const bootMultiaddrs = [];
   for (const enrStr of bootEnrs) {
     const enr = ENR.decodeTxt(enrStr);
@@ -44,8 +44,8 @@ export async function createNodeJsLibp2p(
 ): Promise<Libp2p> {
   const localMultiaddrs = networkOpts.localMultiaddrs || defaultNetworkOptions.localMultiaddrs;
   const disconnectThreshold = networkOpts.disconnectThreshold ?? defaultNetworkOptions.disconnectThreshold;
-  const tcpEnabled = networkOpts.tcp ?? defaultNetworkOptions.tcp;
-  const quicEnabled = networkOpts.quic ?? defaultNetworkOptions.quic;
+  const tcpEnabled = networkOpts.tcp ?? defaultNetworkOptions.tcp ?? true;
+  const quicEnabled = networkOpts.quic ?? defaultNetworkOptions.quic ?? true;
   const {peerStoreDir, disablePeerDiscovery} = nodeJsLibp2pOpts;
 
   let datastore: undefined | Eth2PeerDataStore = undefined;

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -22,7 +22,7 @@ export type NodeJsLibp2pOpts = {
   metricsRegistry?: Registry;
 };
 
-export async function getDiscv5Multiaddrs(bootEnrs: string[], quicEnabled: boolean): Promise<string[]> {
+export async function getDiscv5Multiaddrs(bootEnrs: string[], quicEnabled?: boolean): Promise<string[]> {
   const bootMultiaddrs = [];
   for (const enrStr of bootEnrs) {
     const enr = ENR.decodeTxt(enrStr);
@@ -45,7 +45,7 @@ export async function createNodeJsLibp2p(
   const localMultiaddrs = networkOpts.localMultiaddrs || defaultNetworkOptions.localMultiaddrs;
   const disconnectThreshold = networkOpts.disconnectThreshold ?? defaultNetworkOptions.disconnectThreshold;
   const tcpEnabled = networkOpts.tcp ?? defaultNetworkOptions.tcp;
-  const quicEnabled = networkOpts.quic ?? defaultNetworkOptions.quic ?? false;
+  const quicEnabled = networkOpts.quic ?? defaultNetworkOptions.quic;
   const {peerStoreDir, disablePeerDiscovery} = nodeJsLibp2pOpts;
 
   let datastore: undefined | Eth2PeerDataStore = undefined;

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -10,7 +10,6 @@ import {Registry} from "prom-client";
 import {ENR} from "@chainsafe/enr";
 import {noise} from "@chainsafe/libp2p-noise";
 import {asCrypto, defaultCrypto} from "@chainsafe/libp2p-noise/crypto";
-import {quic} from "@chainsafe/libp2p-quic";
 import {Libp2p, LodestarComponents} from "../interface.js";
 import {NetworkOptions, defaultNetworkOptions} from "../options.js";
 import {Eth2PeerDataStore} from "../peers/datastore.js";
@@ -22,7 +21,10 @@ export type NodeJsLibp2pOpts = {
   metricsRegistry?: Registry;
 };
 
-export async function getDiscv5Multiaddrs(bootEnrs: string[], quicEnabled?: boolean): Promise<string[]> {
+export async function getDiscv5Multiaddrs(
+  bootEnrs: string[],
+  quicEnabled = defaultNetworkOptions.quic
+): Promise<string[]> {
   const bootMultiaddrs = [];
   for (const enrStr of bootEnrs) {
     const enr = ENR.decodeTxt(enrStr);
@@ -44,6 +46,8 @@ export async function createNodeJsLibp2p(
 ): Promise<Libp2p> {
   const localMultiaddrs = networkOpts.localMultiaddrs || defaultNetworkOptions.localMultiaddrs;
   const disconnectThreshold = networkOpts.disconnectThreshold ?? defaultNetworkOptions.disconnectThreshold;
+  const tcpEnabled = networkOpts.tcp ?? defaultNetworkOptions.tcp;
+  const quicEnabled = networkOpts.quic ?? defaultNetworkOptions.quic;
   const {peerStoreDir, disablePeerDiscovery} = nodeJsLibp2pOpts;
 
   let datastore: undefined | Eth2PeerDataStore = undefined;
@@ -58,7 +62,7 @@ export async function createNodeJsLibp2p(
       ...(networkOpts.bootMultiaddrs ?? defaultNetworkOptions.bootMultiaddrs ?? []),
       // Append discv5.bootEnrs to bootMultiaddrs if requested
       ...(networkOpts.connectToDiscv5Bootnodes
-        ? await getDiscv5Multiaddrs(networkOpts.discv5?.bootEnrs ?? [], networkOpts.quic)
+        ? await getDiscv5Multiaddrs(networkOpts.discv5?.bootEnrs ?? [], quicEnabled)
         : []),
     ];
 
@@ -71,7 +75,7 @@ export async function createNodeJsLibp2p(
     }
   }
   const transports: Libp2pInit["transports"] = [];
-  if (networkOpts.tcp ?? true) {
+  if (tcpEnabled) {
     transports.unshift(
       tcp({
         // Reject connections when the server's connection count gets high
@@ -87,7 +91,8 @@ export async function createNodeJsLibp2p(
       })
     );
   }
-  if (networkOpts.quic) {
+  if (quicEnabled) {
+    const {quic} = await import("@chainsafe/libp2p-quic");
     const quicMultiaddrs = localMultiaddrs.filter((ma) => ma.includes("/quic-v1"));
     const hasIpv4Quic = quicMultiaddrs.some((ma) => ma.includes("/ip4/"));
     const hasIpv6Quic = quicMultiaddrs.some((ma) => ma.includes("/ip6/"));

--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -55,7 +55,12 @@ export const defaultNetworkOptions: NetworkOptions = {
   maxPeers: 210, // Allow some room above targetPeers for new inbound peers
   targetPeers: 200,
   // In CLI usage this is typically overridden; when unset it serves as a fallback default (e.g. programmatic usage/tests)
-  localMultiaddrs: ["/ip4/0.0.0.0/tcp/9000", "/ip6/::/tcp/9000"],
+  localMultiaddrs: [
+    "/ip4/0.0.0.0/udp/9001/quic-v1",
+    "/ip6/::/udp/9001/quic-v1",
+    "/ip4/0.0.0.0/tcp/9000",
+    "/ip6/::/tcp/9000",
+  ],
   bootMultiaddrs: [],
   /** disabled by default */
   discv5: null,
@@ -69,7 +74,7 @@ export const defaultNetworkOptions: NetworkOptions = {
   slotsToSubscribeBeforeAggregatorDuty: 2,
   // This will enable the light client server by default
   disableLightClientServer: false,
-  quic: false,
+  quic: true,
   tcp: true,
   // specific option for fulu
   //   - this is the same to TARGET_SUBNET_PEERS

--- a/packages/beacon-node/test/e2e/network/mdns.test.ts
+++ b/packages/beacon-node/test/e2e/network/mdns.test.ts
@@ -14,12 +14,12 @@ import {NetworkOptions, defaultNetworkOptions} from "../../../src/network/option
 import {getMockedBeaconChain} from "../../mocks/mockedBeaconChain.js";
 import {getMockedBeaconDb} from "../../mocks/mockedBeaconDb.js";
 import {memoOnce} from "../../utils/cache.js";
-import {createNetworkModules, onPeerConnect, tcpToQuicMultiaddr} from "../../utils/network.js";
+import {createNetworkModules, onPeerConnect} from "../../utils/network.js";
 import {generateState, zeroProtoBlock} from "../../utils/state.js";
 
 let port = 9000;
 const tcpMu = "/ip4/127.0.0.1/tcp/0";
-const quicMu = tcpToQuicMultiaddr(tcpMu);
+const quicMu = tcpMu.replace(/\/tcp\/(\d+)/, "/udp/$1/quic-v1");
 
 // https://github.com/ChainSafe/lodestar/issues/5967
 describe.skip("mdns", () => {

--- a/packages/beacon-node/test/e2e/network/mdns.test.ts
+++ b/packages/beacon-node/test/e2e/network/mdns.test.ts
@@ -14,11 +14,12 @@ import {NetworkOptions, defaultNetworkOptions} from "../../../src/network/option
 import {getMockedBeaconChain} from "../../mocks/mockedBeaconChain.js";
 import {getMockedBeaconDb} from "../../mocks/mockedBeaconDb.js";
 import {memoOnce} from "../../utils/cache.js";
-import {createNetworkModules, onPeerConnect} from "../../utils/network.js";
+import {createNetworkModules, onPeerConnect, tcpToQuicMultiaddr} from "../../utils/network.js";
 import {generateState, zeroProtoBlock} from "../../utils/state.js";
 
 let port = 9000;
-const mu = "/ip4/127.0.0.1/tcp/0";
+const tcpMu = "/ip4/127.0.0.1/tcp/0";
+const quicMu = tcpToQuicMultiaddr(tcpMu);
 
 // https://github.com/ChainSafe/lodestar/issues/5967
 describe.skip("mdns", () => {
@@ -97,7 +98,11 @@ describe.skip("mdns", () => {
 
     const network = await Network.init({
       ...modules,
-      ...(await createNetworkModules(mu, privateKey, {...opts, mdns: true})),
+      ...(await createNetworkModules(tcpMu, privateKey, {
+        ...opts,
+        mdns: true,
+        localMultiaddrs: [quicMu, tcpMu],
+      })),
       logger,
     });
 

--- a/packages/beacon-node/test/e2e/network/mdns.test.ts
+++ b/packages/beacon-node/test/e2e/network/mdns.test.ts
@@ -19,7 +19,7 @@ import {generateState, zeroProtoBlock} from "../../utils/state.js";
 
 let port = 9000;
 const tcpMu = "/ip4/127.0.0.1/tcp/0";
-const quicMu = tcpMu.replace(/\/tcp\/(\d+)/, "/udp/$1/quic-v1");
+const quicMu = "/ip4/127.0.0.1/udp/0/quic-v1";
 
 // https://github.com/ChainSafe/lodestar/issues/5967
 describe.skip("mdns", () => {
@@ -98,10 +98,9 @@ describe.skip("mdns", () => {
 
     const network = await Network.init({
       ...modules,
-      ...(await createNetworkModules(tcpMu, privateKey, {
+      ...(await createNetworkModules([quicMu, tcpMu], privateKey, {
         ...opts,
         mdns: true,
-        localMultiaddrs: [quicMu, tcpMu],
       })),
       logger,
     });

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -59,7 +59,7 @@ describe("network / peers / PeerManager", () => {
     const status = ssz.phase0.Status.defaultValue();
     const statusCache = new LocalStatusCache(status);
     const privateKey = await generateKeyPair("secp256k1");
-    const libp2p = await createNode("/ip4/127.0.0.1/tcp/0", privateKey);
+    const libp2p = await createNode(["/ip4/127.0.0.1/udp/0/quic-v1", "/ip4/127.0.0.1/tcp/0"], privateKey);
 
     afterEachCallbacks.push(async () => {
       controller.abort();

--- a/packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts
+++ b/packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts
@@ -68,4 +68,21 @@ describe("network / libp2p / createNodeJsLibp2p", () => {
     );
     expect(createLibp2pMock).toHaveBeenCalledOnce();
   });
+
+  it("should skip QUIC transport when no QUIC listen addresses are configured", async () => {
+    const privateKey = await generateKeyPair("secp256k1");
+
+    await createNodeJsLibp2p(
+      privateKey,
+      {
+        tcp: true,
+        quic: true,
+        localMultiaddrs: ["/ip4/127.0.0.1/tcp/0"],
+      },
+      {disablePeerDiscovery: true}
+    );
+
+    expect(quicMock).not.toHaveBeenCalled();
+    expect(createLibp2pMock).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts
+++ b/packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts
@@ -14,8 +14,10 @@ vi.mock("libp2p", async (importActual) => {
   };
 });
 
-vi.mock("@chainsafe/libp2p-quic", () => {
+vi.mock("@chainsafe/libp2p-quic", async (importActual) => {
+  const mod = await importActual<typeof import("@chainsafe/libp2p-quic")>();
   return {
+    ...mod,
     quic: quicMock,
   };
 });

--- a/packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts
+++ b/packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts
@@ -14,10 +14,8 @@ vi.mock("libp2p", async (importActual) => {
   };
 });
 
-vi.mock("@chainsafe/libp2p-quic", async (importActual) => {
-  const mod = await importActual<typeof import("@chainsafe/libp2p-quic")>();
+vi.mock("@chainsafe/libp2p-quic", () => {
   return {
-    ...mod,
     quic: quicMock,
   };
 });

--- a/packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts
+++ b/packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts
@@ -69,7 +69,7 @@ describe("network / libp2p / createNodeJsLibp2p", () => {
     expect(createLibp2pMock).toHaveBeenCalledOnce();
   });
 
-  it("should skip QUIC transport when no QUIC listen addresses are configured", async () => {
+  it("should configure QUIC transport when both QUIC and TCP listen addresses are configured", async () => {
     const privateKey = await generateKeyPair("secp256k1");
 
     await createNodeJsLibp2p(
@@ -77,12 +77,18 @@ describe("network / libp2p / createNodeJsLibp2p", () => {
       {
         tcp: true,
         quic: true,
-        localMultiaddrs: ["/ip4/127.0.0.1/tcp/0"],
+        localMultiaddrs: ["/ip4/127.0.0.1/udp/0/quic-v1", "/ip4/127.0.0.1/tcp/0"],
       },
       {disablePeerDiscovery: true}
     );
 
-    expect(quicMock).not.toHaveBeenCalled();
+    expect(quicMock).toHaveBeenCalledOnce();
+    expect(quicMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipv4: true,
+        ipv6: false,
+      })
+    );
     expect(createLibp2pMock).toHaveBeenCalledOnce();
   });
 });

--- a/packages/beacon-node/test/unit/network/libp2p/getDiscv5Multiaddrs.test.ts
+++ b/packages/beacon-node/test/unit/network/libp2p/getDiscv5Multiaddrs.test.ts
@@ -25,12 +25,12 @@ describe("network / libp2p / getDiscv5Multiaddrs", () => {
     expect(result[0]).not.toContain("/tcp/");
   });
 
-  it("should return tcp by default (quic disabled)", async () => {
+  it("should prefer quic by default when available", async () => {
     const enrTxt = await createEnrTxt({tcp: true, quic: true});
     const result = await getDiscv5Multiaddrs([enrTxt]);
     expect(result).toHaveLength(1);
-    expect(result[0]).toContain("/tcp/");
-    expect(result[0]).not.toContain("/quic-v1");
+    expect(result[0]).toContain("/quic-v1");
+    expect(result[0]).not.toContain("/tcp/");
   });
 
   it("should return tcp when quic is explicitly disabled", async () => {

--- a/packages/beacon-node/test/unit/network/libp2p/getDiscv5Multiaddrs.test.ts
+++ b/packages/beacon-node/test/unit/network/libp2p/getDiscv5Multiaddrs.test.ts
@@ -27,7 +27,7 @@ describe("network / libp2p / getDiscv5Multiaddrs", () => {
 
   it("should prefer quic by default when available", async () => {
     const enrTxt = await createEnrTxt({tcp: true, quic: true});
-    const result = await getDiscv5Multiaddrs([enrTxt]);
+    const result = await getDiscv5Multiaddrs([enrTxt], true);
     expect(result).toHaveLength(1);
     expect(result[0]).toContain("/quic-v1");
     expect(result[0]).not.toContain("/tcp/");
@@ -43,7 +43,7 @@ describe("network / libp2p / getDiscv5Multiaddrs", () => {
 
   it("should skip ENRs with no transport at all", async () => {
     const enrTxt = await createEnrTxt({});
-    const result = await getDiscv5Multiaddrs([enrTxt]);
+    const result = await getDiscv5Multiaddrs([enrTxt], true);
     expect(result).toHaveLength(0);
   });
 

--- a/packages/beacon-node/test/unit/network/util.test.ts
+++ b/packages/beacon-node/test/unit/network/util.test.ts
@@ -38,7 +38,7 @@ describe("getDiscv5Multiaddrs", () => {
     const enrWithTcp = [
       "enr:-LK4QDiPGwNomqUqNDaM3iHYvtdX7M5qngson6Qb2xGIg1LwC8-Nic0aQwO0rVbJt5xp32sRE3S1YqvVrWO7OgVNv0kBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpA7CIeVAAAgCf__________gmlkgnY0gmlwhBKNA4qJc2VjcDI1NmsxoQKbBS4ROQ_sldJm5tMgi36qm5I5exKJFb4C8dDVS_otAoN0Y3CCIyiDdWRwgiMo",
     ];
-    const bootMultiaddrs = await getDiscv5Multiaddrs(enrWithTcp);
+    const bootMultiaddrs = await getDiscv5Multiaddrs(enrWithTcp, false);
     expect(bootMultiaddrs.length).toBe(1);
     expect(bootMultiaddrs[0]).toBe(
       "/ip4/18.141.3.138/tcp/9000/p2p/16Uiu2HAm5rokhpCBU7yBJHhMKXZ1xSVWwUcPMrzGKvU5Y7iBkmuK"
@@ -49,7 +49,7 @@ describe("getDiscv5Multiaddrs", () => {
     const enrWithoutTcp = [
       "enr:-Ku4QCFQW96tEDYPjtaueW3WIh1CB0cJnvw_ibx5qIFZGqfLLj-QajMX6XwVs2d4offuspwgH3NkIMpWtCjCytVdlywGh2F0dG5ldHOIEAIAAgABAUyEZXRoMpCi7FS9AQAAAAAiAQAAAAAAgmlkgnY0gmlwhFA4VK6Jc2VjcDI1NmsxoQNGH1sJJS86-0x9T7qQewz9Wn9zlp6bYxqqrR38JQ49yIN1ZHCCIyg",
     ];
-    const bootMultiaddrs = await getDiscv5Multiaddrs(enrWithoutTcp);
+    const bootMultiaddrs = await getDiscv5Multiaddrs(enrWithoutTcp, false);
     expect(bootMultiaddrs.length).toBe(0);
   });
 });

--- a/packages/beacon-node/test/utils/network.ts
+++ b/packages/beacon-node/test/utils/network.ts
@@ -10,22 +10,20 @@ import {createNodeJsLibp2p} from "../../src/network/libp2p/index.js";
 import {NetworkOptions, defaultNetworkOptions} from "../../src/network/options.js";
 import {PeerIdStr} from "../../src/util/peerId.js";
 
-export async function createNode(multiaddr: string, privateKey?: PrivateKey): Promise<Libp2p> {
+export async function createNode(multiaddrs: string[], privateKey?: PrivateKey): Promise<Libp2p> {
   return createNodeJsLibp2p(privateKey ?? (await generateKeyPair("secp256k1")), {
-    localMultiaddrs: [multiaddr.replace(/\/tcp\/(\d+)/, "/udp/$1/quic-v1"), multiaddr],
+    localMultiaddrs: multiaddrs,
   });
 }
 
 export async function createNetworkModules(
-  multiaddr: string,
+  multiaddrs: string[],
   privateKey?: PrivateKey,
   opts?: Partial<NetworkOptions>
 ): Promise<{opts: NetworkOptions; privateKey: PrivateKey}> {
-  const localMultiaddrs = opts?.localMultiaddrs ?? [multiaddr.replace(/\/tcp\/(\d+)/, "/udp/$1/quic-v1"), multiaddr];
-
   return {
     privateKey: privateKey ?? (await generateKeyPair("secp256k1")),
-    opts: {...defaultNetworkOptions, ...opts, localMultiaddrs},
+    opts: {...defaultNetworkOptions, ...opts, localMultiaddrs: opts?.localMultiaddrs ?? multiaddrs},
   };
 }
 

--- a/packages/beacon-node/test/utils/network.ts
+++ b/packages/beacon-node/test/utils/network.ts
@@ -10,8 +10,14 @@ import {createNodeJsLibp2p} from "../../src/network/libp2p/index.js";
 import {NetworkOptions, defaultNetworkOptions} from "../../src/network/options.js";
 import {PeerIdStr} from "../../src/util/peerId.js";
 
+export function tcpToQuicMultiaddr(tcpMu: string): string {
+  return tcpMu.replace(/\/tcp\/(\d+)/, "/udp/$1/quic-v1");
+}
+
 export async function createNode(multiaddr: string, privateKey?: PrivateKey): Promise<Libp2p> {
-  return createNodeJsLibp2p(privateKey ?? (await generateKeyPair("secp256k1")), {localMultiaddrs: [multiaddr]});
+  return createNodeJsLibp2p(privateKey ?? (await generateKeyPair("secp256k1")), {
+    localMultiaddrs: [tcpToQuicMultiaddr(multiaddr), multiaddr],
+  });
 }
 
 export async function createNetworkModules(
@@ -19,9 +25,11 @@ export async function createNetworkModules(
   privateKey?: PrivateKey,
   opts?: Partial<NetworkOptions>
 ): Promise<{opts: NetworkOptions; privateKey: PrivateKey}> {
+  const localMultiaddrs = opts?.localMultiaddrs ?? [tcpToQuicMultiaddr(multiaddr), multiaddr];
+
   return {
     privateKey: privateKey ?? (await generateKeyPair("secp256k1")),
-    opts: {...defaultNetworkOptions, ...opts, localMultiaddrs: [multiaddr]},
+    opts: {...defaultNetworkOptions, ...opts, localMultiaddrs},
   };
 }
 

--- a/packages/beacon-node/test/utils/network.ts
+++ b/packages/beacon-node/test/utils/network.ts
@@ -10,13 +10,9 @@ import {createNodeJsLibp2p} from "../../src/network/libp2p/index.js";
 import {NetworkOptions, defaultNetworkOptions} from "../../src/network/options.js";
 import {PeerIdStr} from "../../src/util/peerId.js";
 
-export function tcpToQuicMultiaddr(tcpMu: string): string {
-  return tcpMu.replace(/\/tcp\/(\d+)/, "/udp/$1/quic-v1");
-}
-
 export async function createNode(multiaddr: string, privateKey?: PrivateKey): Promise<Libp2p> {
   return createNodeJsLibp2p(privateKey ?? (await generateKeyPair("secp256k1")), {
-    localMultiaddrs: [tcpToQuicMultiaddr(multiaddr), multiaddr],
+    localMultiaddrs: [multiaddr.replace(/\/tcp\/(\d+)/, "/udp/$1/quic-v1"), multiaddr],
   });
 }
 
@@ -25,7 +21,7 @@ export async function createNetworkModules(
   privateKey?: PrivateKey,
   opts?: Partial<NetworkOptions>
 ): Promise<{opts: NetworkOptions; privateKey: PrivateKey}> {
-  const localMultiaddrs = opts?.localMultiaddrs ?? [tcpToQuicMultiaddr(multiaddr), multiaddr];
+  const localMultiaddrs = opts?.localMultiaddrs ?? [multiaddr.replace(/\/tcp\/(\d+)/, "/udp/$1/quic-v1"), multiaddr];
 
   return {
     privateKey: privateKey ?? (await generateKeyPair("secp256k1")),

--- a/packages/beacon-node/test/utils/networkWithMockDb.ts
+++ b/packages/beacon-node/test/utils/networkWithMockDb.ts
@@ -12,7 +12,6 @@ import {NetworkOptions, defaultNetworkOptions} from "../../src/network/options.j
 import {GetReqRespHandlerFn} from "../../src/network/reqresp/types.js";
 import {getMockedBeaconDb} from "../mocks/mockedBeaconDb.js";
 import {ClockStatic} from "./clock.js";
-import {tcpToQuicMultiaddr} from "./network.js";
 import {generateState} from "./state.js";
 
 export type NetworkForTestOpts = {
@@ -108,7 +107,7 @@ export async function getNetworkForTest(
       maxPeers: 10,
       targetPeers: 1,
       bootMultiaddrs: [],
-      localMultiaddrs: [tcpToQuicMultiaddr("/ip4/0.0.0.0/tcp/0"), "/ip4/0.0.0.0/tcp/0"],
+      localMultiaddrs: ["/ip4/0.0.0.0/udp/0/quic-v1", "/ip4/0.0.0.0/tcp/0"],
       discv5FirstQueryDelayMs: 0,
       discv5: null,
       skipParamsLog: true,

--- a/packages/beacon-node/test/utils/networkWithMockDb.ts
+++ b/packages/beacon-node/test/utils/networkWithMockDb.ts
@@ -12,6 +12,7 @@ import {NetworkOptions, defaultNetworkOptions} from "../../src/network/options.j
 import {GetReqRespHandlerFn} from "../../src/network/reqresp/types.js";
 import {getMockedBeaconDb} from "../mocks/mockedBeaconDb.js";
 import {ClockStatic} from "./clock.js";
+import {tcpToQuicMultiaddr} from "./network.js";
 import {generateState} from "./state.js";
 
 export type NetworkForTestOpts = {
@@ -107,7 +108,7 @@ export async function getNetworkForTest(
       maxPeers: 10,
       targetPeers: 1,
       bootMultiaddrs: [],
-      localMultiaddrs: ["/ip4/0.0.0.0/tcp/0"],
+      localMultiaddrs: [tcpToQuicMultiaddr("/ip4/0.0.0.0/tcp/0"), "/ip4/0.0.0.0/tcp/0"],
       discv5FirstQueryDelayMs: 0,
       discv5: null,
       skipParamsLog: true,

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -28,6 +28,7 @@ import {defaultNetworkOptions} from "../../../src/network/options.js";
 import {IBeaconNodeOptions, defaultOptions} from "../../../src/node/options.js";
 import {InteropStateOpts} from "../../../src/node/utils/interop/state.js";
 import {initDevState} from "../../../src/node/utils/state.js";
+import {tcpToQuicMultiaddr} from "../network.js";
 
 export async function getDevBeaconNode(
   opts: {
@@ -108,7 +109,10 @@ export async function getDevBeaconNode(
         metrics: {enabled: false},
         network: {
           discv5: null,
-          localMultiaddrs: options.network?.localMultiaddrs || ["/ip4/127.0.0.1/tcp/0"],
+          localMultiaddrs: options.network?.localMultiaddrs || [
+            tcpToQuicMultiaddr("/ip4/127.0.0.1/tcp/0"),
+            "/ip4/127.0.0.1/tcp/0",
+          ],
           // Increase of following value is just to circumvent the following error in e2e tests
           // > libp2p:mplex rate limit hit when receiving messages
           disconnectThreshold: 255,

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -28,7 +28,6 @@ import {defaultNetworkOptions} from "../../../src/network/options.js";
 import {IBeaconNodeOptions, defaultOptions} from "../../../src/node/options.js";
 import {InteropStateOpts} from "../../../src/node/utils/interop/state.js";
 import {initDevState} from "../../../src/node/utils/state.js";
-import {tcpToQuicMultiaddr} from "../network.js";
 
 export async function getDevBeaconNode(
   opts: {
@@ -109,10 +108,7 @@ export async function getDevBeaconNode(
         metrics: {enabled: false},
         network: {
           discv5: null,
-          localMultiaddrs: options.network?.localMultiaddrs || [
-            tcpToQuicMultiaddr("/ip4/127.0.0.1/tcp/0"),
-            "/ip4/127.0.0.1/tcp/0",
-          ],
+          localMultiaddrs: options.network?.localMultiaddrs || ["/ip4/127.0.0.1/udp/0/quic-v1", "/ip4/127.0.0.1/tcp/0"],
           // Increase of following value is just to circumvent the following error in e2e tests
           // > libp2p:mplex rate limit hit when receiving messages
           disconnectThreshold: 255,

--- a/packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts
+++ b/packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts
@@ -6,6 +6,7 @@ import type {PrivateKey} from "@libp2p/interface";
 import {peerIdFromPrivateKey} from "@libp2p/peer-id";
 import {Multiaddr} from "@multiformats/multiaddr";
 import {SignableENR} from "@chainsafe/enr";
+import {defaultOptions} from "@lodestar/beacon-node";
 import {Logger} from "@lodestar/utils";
 import {exportToJSON, readPrivateKey} from "../../config/index.js";
 import {parseListenArgs} from "../../options/beaconNodeOptions/network.js";
@@ -67,8 +68,8 @@ export function overwriteEnrWithCliArgs(
 ): void {
   const preSeq = enr.seq;
   const {port, discoveryPort, quicPort, port6, discoveryPort6, quicPort6} = parseListenArgs(args);
-  const tcp = args.tcp ?? true;
-  const quic = args.quic ?? true;
+  const tcp = args.tcp ?? defaultOptions.network.tcp;
+  const quic = args.quic ?? defaultOptions.network.quic;
   maybeUpdateEnr(enr, "ip", args["enr.ip"] ?? enr.ip);
   maybeUpdateEnr(enr, "ip6", args["enr.ip6"] ?? enr.ip6);
   maybeUpdateEnr(enr, "udp", args["enr.udp"] ?? discoveryPort ?? enr.udp);

--- a/packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts
+++ b/packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts
@@ -68,7 +68,7 @@ export function overwriteEnrWithCliArgs(
   const preSeq = enr.seq;
   const {port, discoveryPort, quicPort, port6, discoveryPort6, quicPort6} = parseListenArgs(args);
   const tcp = args.tcp ?? true;
-  const quic = args.quic ?? false;
+  const quic = args.quic ?? true;
   maybeUpdateEnr(enr, "ip", args["enr.ip"] ?? enr.ip);
   maybeUpdateEnr(enr, "ip6", args["enr.ip6"] ?? enr.ip6);
   maybeUpdateEnr(enr, "udp", args["enr.udp"] ?? discoveryPort ?? enr.udp);

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -87,7 +87,7 @@ export function parseListenArgs(args: NetworkArgs) {
 export function parseArgs(args: NetworkArgs): IBeaconNodeOptions["network"] {
   const {listenAddress, port, discoveryPort, quicPort, listenAddress6, port6, discoveryPort6, quicPort6} =
     parseListenArgs(args);
-  const quic = args.quic ?? false;
+  const quic = args.quic ?? true;
   const tcp = args.tcp ?? true;
 
   if (!quic && !tcp) {
@@ -313,8 +313,8 @@ export const options: CliCommandOptions<NetworkArgs> = {
 
   quic: {
     type: "boolean",
-    description: "Enable QUIC transport",
-    default: false,
+    description: "Enable QUIC transport (enabled by default)",
+    default: true,
     group: "network",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -313,7 +313,7 @@ export const options: CliCommandOptions<NetworkArgs> = {
 
   quic: {
     type: "boolean",
-    description: "Enable QUIC transport (enabled by default)",
+    description: "Enable QUIC transport",
     default: true,
     group: "network",
   },

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -87,7 +87,7 @@ export function parseListenArgs(args: NetworkArgs) {
 export function parseArgs(args: NetworkArgs): IBeaconNodeOptions["network"] {
   const {listenAddress, port, discoveryPort, quicPort, listenAddress6, port6, discoveryPort6, quicPort6} =
     parseListenArgs(args);
-  const quic = args.quic ?? true;
+  const quic = args.quic ?? defaultOptions.network.quic;
   const tcp = args.tcp ?? true;
 
   if (!quic && !tcp) {

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -314,7 +314,7 @@ export const options: CliCommandOptions<NetworkArgs> = {
   quic: {
     type: "boolean",
     description: "Enable QUIC transport",
-    default: true,
+    defaultDescription: String(defaultOptions.network.quic),
     group: "network",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -88,7 +88,7 @@ export function parseArgs(args: NetworkArgs): IBeaconNodeOptions["network"] {
   const {listenAddress, port, discoveryPort, quicPort, listenAddress6, port6, discoveryPort6, quicPort6} =
     parseListenArgs(args);
   const quic = args.quic ?? defaultOptions.network.quic;
-  const tcp = args.tcp ?? true;
+  const tcp = args.tcp ?? defaultOptions.network.tcp;
 
   if (!quic && !tcp) {
     throw new YargsError("Cannot disable both TCP and QUIC transports");
@@ -322,7 +322,7 @@ export const options: CliCommandOptions<NetworkArgs> = {
     hidden: true,
     type: "boolean",
     description: "Enable TCP transport",
-    default: true,
+    defaultDescription: String(defaultOptions.network.tcp),
     group: "network",
   },
 

--- a/packages/cli/test/unit/cmds/initPeerIdAndEnr.test.ts
+++ b/packages/cli/test/unit/cmds/initPeerIdAndEnr.test.ts
@@ -9,7 +9,7 @@ import {BeaconArgs} from "../../../src/cmds/beacon/options.js";
 import {testLogger} from "../../utils.js";
 
 describe("overwriteEnrWithCliArgs", () => {
-  it("should set tcp but not quic fields by default", async () => {
+  it("should set tcp and quic fields by default", async () => {
     const privateKey = await generateKeyPair("secp256k1");
     const enr = SignableENR.createFromPrivateKey(privateKey);
     const logger = testLogger();
@@ -17,7 +17,7 @@ describe("overwriteEnrWithCliArgs", () => {
     overwriteEnrWithCliArgs(enr, {listenAddress: "0.0.0.0", port: 9000, nat: true} as unknown as BeaconArgs, logger);
 
     expect(enr.tcp).toBe(9000);
-    expect(enr.quic).toBeUndefined();
+    expect(enr.quic).toBe(9001);
   });
 
   it("should set both tcp and quic fields when quic is true", async () => {

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -181,7 +181,7 @@ describe("options / beaconNodeOptions", () => {
         },
         maxPeers: 30,
         targetPeers: 25,
-        localMultiaddrs: ["/ip4/127.0.0.1/tcp/9001"],
+        localMultiaddrs: ["/ip4/127.0.0.1/udp/9003/quic-v1", "/ip4/127.0.0.1/tcp/9001"],
         subscribeAllSubnets: true,
         slotsToSubscribeBeforeAggregatorDuty: 1,
         disablePeerScoring: true,
@@ -194,7 +194,7 @@ describe("options / beaconNodeOptions", () => {
         gossipsubDHigh: 6,
         gossipsubAwaitHandler: true,
         mdns: false,
-        quic: false,
+        quic: true,
         rateLimitMultiplier: 1,
         maxGossipTopicConcurrency: 64,
         useWorker: true,
@@ -218,13 +218,13 @@ describe("options / beaconNodeOptions", () => {
 });
 
 describe("options / network / tcp and quic flags", () => {
-  it("should include only tcp multiaddrs by default", () => {
+  it("should include both tcp and quic multiaddrs by default", () => {
     const result = parseNetworkArgs({listenAddress: "0.0.0.0", port: 9000} as NetworkArgs);
     expect(result.localMultiaddrs).toContain("/ip4/0.0.0.0/tcp/9000");
-    expect(result.localMultiaddrs).not.toContain("/ip4/0.0.0.0/udp/9001/quic-v1");
+    expect(result.localMultiaddrs).toContain("/ip4/0.0.0.0/udp/9001/quic-v1");
   });
 
-  it("should include both tcp and quic multiaddrs when quic is true", () => {
+  it("should include both tcp and quic multiaddrs when quic is explicitly true", () => {
     const result = parseNetworkArgs({listenAddress: "0.0.0.0", port: 9000, quic: true} as NetworkArgs);
     expect(result.localMultiaddrs).toContain("/ip4/0.0.0.0/tcp/9000");
     expect(result.localMultiaddrs).toContain("/ip4/0.0.0.0/udp/9001/quic-v1");


### PR DESCRIPTION
## Description

Enable QUIC transport by default. QUIC provides built-in TLS 1.3 encryption, multiplexed streams, and faster connection establishment compared to TCP. With the IPv6 crash fix already merged (#9101), QUIC is now safe to enable on all systems including IPv4-only hosts.

## Changes

### Defaults
- `packages/beacon-node/src/network/options.ts`: `quic: false` → `quic: true`, added QUIC multiaddrs to `defaultNetworkOptions.localMultiaddrs`
- `packages/cli/src/options/beaconNodeOptions/network.ts`: CLI `--quic` default `false` → `true`, updated fallback in `parseArgs`
- `packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts`: ENR initialization fallback `false` → `true`

### libp2p setup
- `packages/beacon-node/src/network/libp2p/index.ts`: Changed `@chainsafe/libp2p-quic` from static import to dynamic `await import()` (only loaded when QUIC is enabled), updated `getDiscv5Multiaddrs` default parameter to match new default

### Documentation
- `docs/pages/run/beacon-management/networking.md`: Updated QUIC section — "disabled by default" → "enabled by default", section renamed "Enabling QUIC" → "Disabling QUIC" with `--quic=false` / `--no-quic` instructions, firewall ports updated

### Tests
- `packages/cli/test/unit/cmds/initPeerIdAndEnr.test.ts`: Default ENR now includes QUIC port
- `packages/cli/test/unit/options/beaconNodeOptions.test.ts`: Default multiaddrs include QUIC, default `quic: true`
- `packages/beacon-node/test/unit/network/libp2p/getDiscv5Multiaddrs.test.ts`: Default behavior now prefers QUIC over TCP
- `packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts`: Removed unused static import

## How to disable QUIC

```bash
lodestar beacon --quic=false
# or
lodestar beacon --no-quic
```

## Motivation

QUIC is already supported by all major consensus clients (Lighthouse, Prysm, Teku, Nimbus). Enabling it by default improves connection establishment speed and reduces handshake overhead for Lodestar nodes.

<!-- readthedocs:preview -->
