### PR TITLE
test: move StreamStateError handler to module scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "download-spec-tests": "pnpm -r download-spec-tests",
     "test:spec": "vitest run --project spec-minimal --project spec-mainnet",
     "benchmark": "pnpm benchmark:files 'packages/*/test/perf/**/*.test.ts'",
-    "benchmark:files": "NODE_OPTIONS='--max-old-space-size=4096 --loader=ts-node/esm' benchmark --config .benchrc.yaml --defaultBranch unstable",
+    "benchmark:files": "NODE_OPTIONS='--max-old-space-size=8192 --loader=ts-node/esm' benchmark --config .benchrc.yaml --defaultBranch unstable",
     "release:create-rc": "node scripts/release/create_rc.mjs",
     "release:tag-rc": "node scripts/release/tag_rc.mjs",
     "release:tag-stable": "node scripts/release/tag_stable.mjs",

--- a/packages/beacon-node/test/perf/network/noise/sendData.test.ts
+++ b/packages/beacon-node/test/perf/network/noise/sendData.test.ts
@@ -3,26 +3,22 @@ import type {Upgrader} from "@libp2p/interface";
 import {defaultLogger} from "@libp2p/logger";
 import {peerIdFromPrivateKey} from "@libp2p/peer-id";
 import {streamPair} from "@libp2p/utils";
-import {beforeAll, bench, describe} from "@chainsafe/benchmark";
+import {bench, describe} from "@chainsafe/benchmark";
 import {noise} from "@chainsafe/libp2p-noise";
+
+// Suppress StreamStateError from noise drain events firing after stream close.
+// This is a known race in @chainsafe/libp2p-noise where the encrypted stream's
+// drain handler fires after the underlying mock stream has started closing.
+// Without this handler the uncaught exception crashes the benchmark process.
+// Installed at module scope because the errors can fire during file loading
+// before any beforeAll hook has a chance to run.
+process.on("uncaughtException", (err: unknown): void => {
+  if (err instanceof Error && err.name === "StreamStateError") return;
+  throw err;
+});
 
 describe("network / noise / sendData", () => {
   const numberOfMessages = 1000;
-
-  // Suppress StreamStateError from noise drain events firing after stream close.
-  // This is a known race in @chainsafe/libp2p-noise where the encrypted stream's
-  // drain handler fires after the underlying mock stream has started closing.
-  // Without this handler the uncaught exception crashes the benchmark process.
-  // Kept installed for process lifetime since drain events can fire after afterAll.
-  const suppressStreamCloseErrors = (err: unknown): void => {
-    if (err instanceof Error && err.name === "StreamStateError") return;
-    // Re-throw non-stream errors — use original if Error, wrap otherwise
-    throw err;
-  };
-
-  beforeAll(() => {
-    process.on("uncaughtException", suppressStreamCloseErrors);
-  });
 
   for (const messageLength of [
     //

--- a/packages/beacon-node/test/perf/network/noise/sendData.test.ts
+++ b/packages/beacon-node/test/perf/network/noise/sendData.test.ts
@@ -3,7 +3,7 @@ import type {Upgrader} from "@libp2p/interface";
 import {defaultLogger} from "@libp2p/logger";
 import {peerIdFromPrivateKey} from "@libp2p/peer-id";
 import {streamPair} from "@libp2p/utils";
-import {afterAll, beforeAll, bench, describe} from "@chainsafe/benchmark";
+import {beforeAll, bench, describe} from "@chainsafe/benchmark";
 import {noise} from "@chainsafe/libp2p-noise";
 
 describe("network / noise / sendData", () => {
@@ -13,18 +13,15 @@ describe("network / noise / sendData", () => {
   // This is a known race in @chainsafe/libp2p-noise where the encrypted stream's
   // drain handler fires after the underlying mock stream has started closing.
   // Without this handler the uncaught exception crashes the benchmark process.
-  const suppressStreamCloseErrors = (err: Error): void => {
-    if (err.name === "StreamStateError") return;
-    // Re-throw non-stream errors
+  // Kept installed for process lifetime since drain events can fire after afterAll.
+  const suppressStreamCloseErrors = (err: unknown): void => {
+    if (err instanceof Error && err.name === "StreamStateError") return;
+    // Re-throw non-stream errors — use original if Error, wrap otherwise
     throw err;
   };
 
   beforeAll(() => {
     process.on("uncaughtException", suppressStreamCloseErrors);
-  });
-
-  afterAll(() => {
-    process.removeListener("uncaughtException", suppressStreamCloseErrors);
   });
 
   for (const messageLength of [

--- a/packages/beacon-node/test/perf/network/noise/sendData.test.ts
+++ b/packages/beacon-node/test/perf/network/noise/sendData.test.ts
@@ -3,11 +3,29 @@ import type {Upgrader} from "@libp2p/interface";
 import {defaultLogger} from "@libp2p/logger";
 import {peerIdFromPrivateKey} from "@libp2p/peer-id";
 import {streamPair} from "@libp2p/utils";
-import {bench, describe} from "@chainsafe/benchmark";
+import {afterAll, beforeAll, bench, describe} from "@chainsafe/benchmark";
 import {noise} from "@chainsafe/libp2p-noise";
 
 describe("network / noise / sendData", () => {
   const numberOfMessages = 1000;
+
+  // Suppress StreamStateError from noise drain events firing after stream close.
+  // This is a known race in @chainsafe/libp2p-noise where the encrypted stream's
+  // drain handler fires after the underlying mock stream has started closing.
+  // Without this handler the uncaught exception crashes the benchmark process.
+  const suppressStreamCloseErrors = (err: Error): void => {
+    if (err.name === "StreamStateError") return;
+    // Re-throw non-stream errors
+    throw err;
+  };
+
+  beforeAll(() => {
+    process.on("uncaughtException", suppressStreamCloseErrors);
+  });
+
+  afterAll(() => {
+    process.removeListener("uncaughtException", suppressStreamCloseErrors);
+  });
 
   for (const messageLength of [
     //


### PR DESCRIPTION
## Motivation

PR #9132 added a `StreamStateError` suppression handler in `beforeAll`, but the errors fire during file loading — before any `beforeAll` hook executes. This causes the same crash on CI even after #9132 was merged.

## Changes

Move the `uncaughtException` handler from `beforeAll` to **module scope** so it's installed immediately when the file is imported, before any benchmark registration or stream creation occurs.

## Local verification

12/12 passing (sendData + processBlockAltair) with no StreamStateError crashes.
