### PR TITLE
test: move StreamStateError handler to module scope

### DIFF
--- a/packages/beacon-node/test/perf/network/noise/sendData.test.ts
+++ b/packages/beacon-node/test/perf/network/noise/sendData.test.ts
@@ -3,26 +3,22 @@ import type {Upgrader} from "@libp2p/interface";
 import {defaultLogger} from "@libp2p/logger";
 import {peerIdFromPrivateKey} from "@libp2p/peer-id";
 import {streamPair} from "@libp2p/utils";
-import {beforeAll, bench, describe} from "@chainsafe/benchmark";
+import {bench, describe} from "@chainsafe/benchmark";
 import {noise} from "@chainsafe/libp2p-noise";
+
+// Suppress StreamStateError from noise drain events firing after stream close.
+// This is a known race in @chainsafe/libp2p-noise where the encrypted stream's
+// drain handler fires after the underlying mock stream has started closing.
+// Without this handler the uncaught exception crashes the benchmark process.
+// Installed at module scope because the errors can fire during file loading
+// before any beforeAll hook has a chance to run.
+process.on("uncaughtException", (err: unknown): void => {
+  if (err instanceof Error && err.name === "StreamStateError") return;
+  throw err;
+});
 
 describe("network / noise / sendData", () => {
   const numberOfMessages = 1000;
-
-  // Suppress StreamStateError from noise drain events firing after stream close.
-  // This is a known race in @chainsafe/libp2p-noise where the encrypted stream's
-  // drain handler fires after the underlying mock stream has started closing.
-  // Without this handler the uncaught exception crashes the benchmark process.
-  // Kept installed for process lifetime since drain events can fire after afterAll.
-  const suppressStreamCloseErrors = (err: unknown): void => {
-    if (err instanceof Error && err.name === "StreamStateError") return;
-    // Re-throw non-stream errors — use original if Error, wrap otherwise
-    throw err;
-  };
-
-  beforeAll(() => {
-    process.on("uncaughtException", suppressStreamCloseErrors);
-  });
 
   for (const messageLength of [
     //


### PR DESCRIPTION
## Motivation

PR #9132 added a `StreamStateError` suppression handler inside `beforeAll`, but the errors fire during **file loading** — before any `beforeAll` hook executes. This causes the same crash on CI even after #9132 was merged:
- https://github.com/ChainSafe/lodestar/actions/runs/23767926571/job/69252027538

## Changes

Move the `uncaughtException` handler from `beforeAll` to **module scope** so it's installed immediately when the file is imported. Also:
- Type `err` as `unknown` with `instanceof Error` guard (addresses Gemini feedback from #9132)
- Remove `afterAll` cleanup since drain events can outlive the benchmark suite

## Local verification

12/12 passing (sendData + processBlockAltair) with no StreamStateError crashes.
