### PR TITLE
test: fix benchmark perf state poisoning

### DIFF
--- a/packages/beacon-node/test/perf/network/noise/sendData.test.ts
+++ b/packages/beacon-node/test/perf/network/noise/sendData.test.ts
@@ -3,26 +3,22 @@ import type {Upgrader} from "@libp2p/interface";
 import {defaultLogger} from "@libp2p/logger";
 import {peerIdFromPrivateKey} from "@libp2p/peer-id";
 import {streamPair} from "@libp2p/utils";
-import {beforeAll, bench, describe} from "@chainsafe/benchmark";
+import {bench, describe} from "@chainsafe/benchmark";
 import {noise} from "@chainsafe/libp2p-noise";
+
+// Suppress StreamStateError from noise drain events firing after stream close.
+// This is a known race in @chainsafe/libp2p-noise where the encrypted stream's
+// drain handler fires after the underlying mock stream has started closing.
+// Without this handler the uncaught exception crashes the benchmark process.
+// Installed at module scope because the errors can fire during file loading
+// before any beforeAll hook has a chance to run.
+process.on("uncaughtException", (err: unknown): void => {
+  if (err instanceof Error && err.name === "StreamStateError") return;
+  throw err;
+});
 
 describe("network / noise / sendData", () => {
   const numberOfMessages = 1000;
-
-  // Suppress StreamStateError from noise drain events firing after stream close.
-  // This is a known race in @chainsafe/libp2p-noise where the encrypted stream's
-  // drain handler fires after the underlying mock stream has started closing.
-  // Without this handler the uncaught exception crashes the benchmark process.
-  // Kept installed for process lifetime since drain events can fire after afterAll.
-  const suppressStreamCloseErrors = (err: unknown): void => {
-    if (err instanceof Error && err.name === "StreamStateError") return;
-    // Re-throw non-stream errors — use original if Error, wrap otherwise
-    throw err;
-  };
-
-  beforeAll(() => {
-    process.on("uncaughtException", suppressStreamCloseErrors);
-  });
 
   for (const messageLength of [
     //

--- a/packages/state-transition/src/testUtils/util.ts
+++ b/packages/state-transition/src/testUtils/util.ts
@@ -89,10 +89,10 @@ export function getSecretKeyFromIndexCached(validatorIndex: number): SecretKey {
   return sk;
 }
 
-function getPubkeyCaches({pubkeysMod}: ReturnType<typeof getPubkeys>) {
+function getPubkeyCaches({pubkeysMod}: ReturnType<typeof getPubkeys>, vc = numValidators) {
   // Manually sync pubkeys to prevent doing BLS opts 110_000 times
   const pubkeyCache = createPubkeyCache();
-  for (let i = 0; i < numValidators; i++) {
+  for (let i = 0; i < vc; i++) {
     const pubkey = pubkeysMod[i % keypairsMod];
     pubkeyCache.set(i, pubkey);
   }
@@ -214,7 +214,7 @@ export function generatePerfTestCachedStateAltair(opts?: {
 }): CachedBeaconStateAltair {
   const vc = opts?.vc ?? numValidators;
   const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys(vc);
-  const {pubkeyCache} = getPubkeyCaches({pubkeys, pubkeysMod, pubkeysModObj});
+  const {pubkeyCache} = getPubkeyCaches({pubkeys, pubkeysMod, pubkeysModObj}, vc);
 
   const altairConfig = createChainForkConfig({ALTAIR_FORK_EPOCH: 0});
 
@@ -257,7 +257,7 @@ export function generatePerfTestCachedStateElectra(opts?: {
 }): CachedBeaconStateElectra {
   const vc = opts?.vc ?? numValidators;
   const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys(vc);
-  const {pubkeyCache} = getPubkeyCaches({pubkeys, pubkeysMod, pubkeysModObj});
+  const {pubkeyCache} = getPubkeyCaches({pubkeys, pubkeysMod, pubkeysModObj}, vc);
 
   const electraConfig = createChainForkConfig({
     ALTAIR_FORK_EPOCH: 0,

--- a/packages/state-transition/src/testUtils/util.ts
+++ b/packages/state-transition/src/testUtils/util.ts
@@ -40,12 +40,12 @@ let phase0State: BeaconStatePhase0 | null = null;
 let phase0CachedState23637: CachedBeaconStatePhase0 | null = null;
 let phase0CachedState23638: CachedBeaconStatePhase0 | null = null;
 let phase0SignedBlock: phase0.SignedBeaconBlock | null = null;
-let altairState: BeaconStateAltair | null = null;
-let altairCachedState23637: CachedBeaconStateAltair | null = null;
-let altairCachedState23638: CachedBeaconStateAltair | null = null;
-let electraState: BeaconStateElectra | null = null;
-let electraCachedState23637: CachedBeaconStateElectra | null = null;
-let electraCachedState23638: CachedBeaconStateElectra | null = null;
+const altairStateByVc = new Map<number, BeaconStateAltair>();
+const altairCachedState23637ByVc = new Map<number, CachedBeaconStateAltair>();
+const altairCachedState23638ByVc = new Map<number, CachedBeaconStateAltair>();
+const electraStateByVc = new Map<number, BeaconStateElectra>();
+const electraCachedState23637ByVc = new Map<number, CachedBeaconStateElectra>();
+const electraCachedState23638ByVc = new Map<number, CachedBeaconStateElectra>();
 
 /**
  * Number of validators in prater is 210000 as of May 2021
@@ -189,7 +189,8 @@ export function generatePerfTestCachedStatePhase0(opts?: {goBackOneSlot: boolean
   }
   const resultingState = opts?.goBackOneSlot ? phase0CachedState23637 : phase0CachedState23638;
 
-  return resultingState.clone();
+  // Use dontTransferCache to preserve the global cache for subsequent callers
+  return resultingState.clone(true);
 }
 
 export function cachedStateAltairPopulateCaches(state: CachedBeaconStateAltair): void {
@@ -211,31 +212,39 @@ export function generatePerfTestCachedStateAltair(opts?: {
   goBackOneSlot: boolean;
   vc?: number;
 }): CachedBeaconStateAltair {
-  const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys(opts?.vc);
+  const vc = opts?.vc ?? numValidators;
+  const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys(vc);
   const {pubkeyCache} = getPubkeyCaches({pubkeys, pubkeysMod, pubkeysModObj});
 
   const altairConfig = createChainForkConfig({ALTAIR_FORK_EPOCH: 0});
 
   const origState = generatePerformanceStateAltair(pubkeys);
 
+  let altairCachedState23637 = altairCachedState23637ByVc.get(vc);
   if (!altairCachedState23637) {
-    const state = origState.clone();
+    const state = origState.clone(true);
     state.slot -= 1;
     altairCachedState23637 = createCachedBeaconState(state, {
       config: createBeaconConfig(altairConfig, state.genesisValidatorsRoot),
       pubkeyCache,
     });
+    altairCachedState23637ByVc.set(vc, altairCachedState23637);
   }
+
+  let altairCachedState23638 = altairCachedState23638ByVc.get(vc);
   if (!altairCachedState23638) {
     altairCachedState23638 = processSlots(
       altairCachedState23637,
       altairCachedState23637.slot + 1
     ) as CachedBeaconStateAltair;
     altairCachedState23638.slot += 1;
+    altairCachedState23638ByVc.set(vc, altairCachedState23638);
   }
+
   const resultingState = opts?.goBackOneSlot ? altairCachedState23637 : altairCachedState23638;
 
-  return resultingState.clone();
+  // Use dontTransferCache to preserve the global cache for subsequent callers
+  return resultingState.clone(true);
 }
 
 /**
@@ -246,7 +255,8 @@ export function generatePerfTestCachedStateElectra(opts?: {
   goBackOneSlot: boolean;
   vc?: number;
 }): CachedBeaconStateElectra {
-  const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys(opts?.vc);
+  const vc = opts?.vc ?? numValidators;
+  const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys(vc);
   const {pubkeyCache} = getPubkeyCaches({pubkeys, pubkeysMod, pubkeysModObj});
 
   const electraConfig = createChainForkConfig({
@@ -259,32 +269,39 @@ export function generatePerfTestCachedStateElectra(opts?: {
 
   const origState = generatePerformanceStateElectra(pubkeys);
 
+  let electraCachedState23637 = electraCachedState23637ByVc.get(vc);
   if (!electraCachedState23637) {
-    const state = origState.clone();
+    const state = origState.clone(true);
     state.slot -= 1;
     electraCachedState23637 = createCachedBeaconState(state, {
       config: createBeaconConfig(electraConfig, state.genesisValidatorsRoot),
       pubkeyCache,
     });
+    electraCachedState23637ByVc.set(vc, electraCachedState23637);
   }
+  let electraCachedState23638 = electraCachedState23638ByVc.get(vc);
   if (!electraCachedState23638) {
     electraCachedState23638 = processSlots(
       electraCachedState23637,
       electraCachedState23637.slot + 1
     ) as CachedBeaconStateElectra;
     electraCachedState23638.slot += 1;
+    electraCachedState23638ByVc.set(vc, electraCachedState23638);
   }
   const resultingState = opts?.goBackOneSlot ? electraCachedState23637 : electraCachedState23638;
 
-  return resultingState.clone();
+  // Use dontTransferCache to preserve the global cache for subsequent callers
+  return resultingState.clone(true);
 }
 
 /**
  * This is generated from Medalla state 756416
  */
 export function generatePerformanceStateAltair(pubkeysArg?: Uint8Array[]): BeaconStateAltair {
+  const pubkeys = pubkeysArg || getPubkeys().pubkeys;
+  const vc = pubkeys.length;
+  let altairState = altairStateByVc.get(vc);
   if (!altairState) {
-    const pubkeys = pubkeysArg || getPubkeys().pubkeys;
     const statePhase0 = buildPerformanceStatePhase0(pubkeys);
     const state = statePhase0 as BeaconState as BeaconState<ForkName.altair>;
 
@@ -316,16 +333,20 @@ export function generatePerformanceStateAltair(pubkeysArg?: Uint8Array[]): Beaco
     altairState = ssz.altair.BeaconState.toViewDU(state);
     // cache roots
     altairState.hashTreeRoot();
+    altairStateByVc.set(vc, altairState);
   }
-  return altairState.clone();
+  // Use dontTransferCache to preserve the global cache for subsequent callers
+  return altairState.clone(true);
 }
 
 /**
  * This is generated from the same performance state as Altair, upgraded to Electra fields.
  */
 export function generatePerformanceStateElectra(pubkeysArg?: Uint8Array[]): BeaconStateElectra {
+  const pubkeys = pubkeysArg || getPubkeys().pubkeys;
+  const vc = pubkeys.length;
+  let electraState = electraStateByVc.get(vc);
   if (!electraState) {
-    const pubkeys = pubkeysArg || getPubkeys().pubkeys;
     const electraConfig = createChainForkConfig({
       ALTAIR_FORK_EPOCH: 0,
       BELLATRIX_FORK_EPOCH: 0,
@@ -364,8 +385,10 @@ export function generatePerformanceStateElectra(pubkeysArg?: Uint8Array[]): Beac
 
     electraState = ssz.electra.BeaconState.toViewDU(state);
     electraState.hashTreeRoot();
+    electraStateByVc.set(vc, electraState);
   }
-  return electraState.clone();
+  // Use dontTransferCache to preserve the global cache for subsequent callers
+  return electraState.clone(true);
 }
 
 /**

--- a/packages/state-transition/test/unit/sanityCheck.test.ts
+++ b/packages/state-transition/test/unit/sanityCheck.test.ts
@@ -3,6 +3,7 @@ import {ACTIVE_PRESET, EFFECTIVE_BALANCE_INCREMENT, PresetName} from "@lodestar/
 import {beforeProcessEpoch} from "../../src/index.js";
 import {
   generatePerfTestCachedStateAltair,
+  generatePerfTestCachedStateElectra,
   generatePerfTestCachedStatePhase0,
   perfStateId,
 } from "../../src/testUtils/util.js";
@@ -30,6 +31,28 @@ describe("Perf test sanity check", () => {
   it("altairState validator count is the same", () => {
     const altairState = generatePerfTestCachedStateAltair();
     expect(altairState.validators.length).toEqualWithMessage(numValidators, "altairState validator count has changed");
+  });
+
+  it("altair perf states are cached independently per validator count", () => {
+    const smallState = generatePerfTestCachedStateAltair({vc: 1000, goBackOneSlot: false});
+    expect(smallState.validators.length).toEqual(1000);
+
+    const defaultState = generatePerfTestCachedStateAltair();
+    expect(defaultState.validators.length).toEqualWithMessage(
+      numValidators,
+      "default altair perf state was poisoned by a custom vc"
+    );
+  });
+
+  it("electra perf states are cached independently per validator count", () => {
+    const smallState = generatePerfTestCachedStateElectra({vc: 1000, goBackOneSlot: false});
+    expect(smallState.validators.length).toEqual(1000);
+
+    const defaultState = generatePerfTestCachedStateElectra();
+    expect(defaultState.validators.length).toEqualWithMessage(
+      numValidators,
+      "default electra perf state was poisoned by a custom vc"
+    );
   });
 
   it("targetStake is in the same range", () => {


### PR DESCRIPTION
## Motivation

Two benchmark failure modes were still present on `unstable`:

1. `sendData.test.ts` could still crash the benchmark process with `StreamStateError` because the suppression handler was installed in `beforeAll`, which runs too late when the error can fire during file loading.
2. `processBlockAltair` worstcase benchmarks could fail in the full suite with:
   - `TypeError: Cannot read properties of undefined (reading 'slashed')`

The deeper root cause for (2) was that the perf-state helpers cached Altair/Electra states in **global singletons that ignored custom validator counts (`vc`)**. During benchmark collection, files like `seed.test.ts` and `serializeState.test.ts` instantiate smaller custom-vc states. Because the cache was not keyed by `vc`, those collect-time calls could poison the default 250k-validator state later used by `processBlockAltair`, which then generated proposer slashings against validator indices far beyond the real state size.

## Changes

- move the `StreamStateError` suppression handler in `sendData.test.ts` to **module scope**
- key Altair/Electra perf-state caches by validator count instead of using a single global singleton
- use `clone(true)` for perf-state clones so callers do not strip cache state from the shared cached instances
- add regression coverage in `sanityCheck.test.ts` to ensure custom-vc Altair/Electra perf states do not poison the default cache

## Validation

- `pnpm lint` ✅ (repo has existing warnings only)
- `cd packages/state-transition && pnpm test:unit test/unit/sanityCheck.test.ts` ✅
- `LODESTAR_PRESET=mainnet pnpm benchmark:files packages/state-transition/test/perf/block/processBlockAltair.test.ts packages/state-transition/test/perf/util/seed.test.ts packages/state-transition/test/perf/util/serializeState.test.ts` ✅ (`8 passing / 0 failed / 13 pending`)
- `LODESTAR_PRESET=mainnet pnpm benchmark` ✅ (`298 passing / 0 failed / 138 pending`)

## Notes

This supersedes the partial `sendData`-only follow-up by also fixing the perf-state cache poisoning that only shows up in the full collected benchmark suite.
