### PR TITLE
test: revert clone(true) to fix benchmark memory regression

### DIFF
--- a/packages/state-transition/src/testUtils/util.ts
+++ b/packages/state-transition/src/testUtils/util.ts
@@ -189,8 +189,7 @@ export function generatePerfTestCachedStatePhase0(opts?: {goBackOneSlot: boolean
   }
   const resultingState = opts?.goBackOneSlot ? phase0CachedState23637 : phase0CachedState23638;
 
-  // Use dontTransferCache to preserve the global cache for subsequent callers
-  return resultingState.clone(true);
+  return resultingState.clone();
 }
 
 export function cachedStateAltairPopulateCaches(state: CachedBeaconStateAltair): void {
@@ -224,7 +223,7 @@ export function generatePerfTestCachedStateAltair(opts?: {
   const isDefaultVc = vc === numValidators;
   let cachedState23637 = isDefaultVc ? altairCachedState23637 : null;
   if (!cachedState23637) {
-    const state = origState.clone(isDefaultVc);
+    const state = origState.clone();
     state.slot -= 1;
     cachedState23637 = createCachedBeaconState(state, {
       config: createBeaconConfig(altairConfig, state.genesisValidatorsRoot),
@@ -242,8 +241,7 @@ export function generatePerfTestCachedStateAltair(opts?: {
 
   const resultingState = opts?.goBackOneSlot ? cachedState23637 : cachedState23638;
 
-  // dontTransferCache only when preserving the singleton for subsequent callers
-  return resultingState.clone(isDefaultVc);
+  return resultingState.clone();
 }
 
 /**
@@ -272,7 +270,7 @@ export function generatePerfTestCachedStateElectra(opts?: {
   const isDefaultVc = vc === numValidators;
   let cachedState23637 = isDefaultVc ? electraCachedState23637 : null;
   if (!cachedState23637) {
-    const state = origState.clone(isDefaultVc);
+    const state = origState.clone();
     state.slot -= 1;
     cachedState23637 = createCachedBeaconState(state, {
       config: createBeaconConfig(electraConfig, state.genesisValidatorsRoot),
@@ -288,8 +286,7 @@ export function generatePerfTestCachedStateElectra(opts?: {
   }
   const resultingState = opts?.goBackOneSlot ? cachedState23637 : cachedState23638;
 
-  // dontTransferCache only when preserving the singleton for subsequent callers
-  return resultingState.clone(isDefaultVc);
+  return resultingState.clone();
 }
 
 /**
@@ -335,8 +332,7 @@ export function generatePerformanceStateAltair(pubkeysArg?: Uint8Array[]): Beaco
     cached.hashTreeRoot();
     if (isDefaultVc) altairState = cached;
   }
-  // dontTransferCache only when preserving the singleton for subsequent callers
-  return cached.clone(isDefaultVc);
+  return cached.clone();
 }
 
 /**
@@ -389,8 +385,7 @@ export function generatePerformanceStateElectra(pubkeysArg?: Uint8Array[]): Beac
     cached.hashTreeRoot();
     if (isDefaultVc) electraState = cached;
   }
-  // dontTransferCache only when preserving the singleton for subsequent callers
-  return cached.clone(isDefaultVc);
+  return cached.clone();
 }
 
 /**

--- a/packages/state-transition/src/testUtils/util.ts
+++ b/packages/state-transition/src/testUtils/util.ts
@@ -224,7 +224,7 @@ export function generatePerfTestCachedStateAltair(opts?: {
   const isDefaultVc = vc === numValidators;
   let cachedState23637 = isDefaultVc ? altairCachedState23637 : null;
   if (!cachedState23637) {
-    const state = origState.clone(true);
+    const state = origState.clone(isDefaultVc);
     state.slot -= 1;
     cachedState23637 = createCachedBeaconState(state, {
       config: createBeaconConfig(altairConfig, state.genesisValidatorsRoot),
@@ -242,8 +242,8 @@ export function generatePerfTestCachedStateAltair(opts?: {
 
   const resultingState = opts?.goBackOneSlot ? cachedState23637 : cachedState23638;
 
-  // Use dontTransferCache to preserve the global cache for subsequent callers
-  return resultingState.clone(true);
+  // dontTransferCache only when preserving the singleton for subsequent callers
+  return resultingState.clone(isDefaultVc);
 }
 
 /**
@@ -272,7 +272,7 @@ export function generatePerfTestCachedStateElectra(opts?: {
   const isDefaultVc = vc === numValidators;
   let cachedState23637 = isDefaultVc ? electraCachedState23637 : null;
   if (!cachedState23637) {
-    const state = origState.clone(true);
+    const state = origState.clone(isDefaultVc);
     state.slot -= 1;
     cachedState23637 = createCachedBeaconState(state, {
       config: createBeaconConfig(electraConfig, state.genesisValidatorsRoot),
@@ -288,8 +288,8 @@ export function generatePerfTestCachedStateElectra(opts?: {
   }
   const resultingState = opts?.goBackOneSlot ? cachedState23637 : cachedState23638;
 
-  // Use dontTransferCache to preserve the global cache for subsequent callers
-  return resultingState.clone(true);
+  // dontTransferCache only when preserving the singleton for subsequent callers
+  return resultingState.clone(isDefaultVc);
 }
 
 /**
@@ -335,8 +335,8 @@ export function generatePerformanceStateAltair(pubkeysArg?: Uint8Array[]): Beaco
     cached.hashTreeRoot();
     if (isDefaultVc) altairState = cached;
   }
-  // Use dontTransferCache to preserve the global cache for subsequent callers
-  return cached.clone(true);
+  // dontTransferCache only when preserving the singleton for subsequent callers
+  return cached.clone(isDefaultVc);
 }
 
 /**
@@ -389,8 +389,8 @@ export function generatePerformanceStateElectra(pubkeysArg?: Uint8Array[]): Beac
     cached.hashTreeRoot();
     if (isDefaultVc) electraState = cached;
   }
-  // Use dontTransferCache to preserve the global cache for subsequent callers
-  return cached.clone(true);
+  // dontTransferCache only when preserving the singleton for subsequent callers
+  return cached.clone(isDefaultVc);
 }
 
 /**


### PR DESCRIPTION
## Motivation

PR #9136 changed all `clone()` calls to `clone(true)` (`dontTransferCache`) to protect cached singletons. However, `clone(true)` keeps full tree caches on both source and clone, increasing retained memory across the benchmark process lifetime.

This caused OOM during the full benchmark suite — `epochCapella` (which downloads a real mainnet state) would crash at the heap limit.

## Changes

Revert all `clone(true)` back to plain `clone()`.

Anti-poisoning is preserved by the singleton write guards from PR #9137: custom-vc calls never write to module-level singletons, so the default 250k state can never be overwritten.

## Verification

- `pnpm lint` ✅
- `sanityCheck.test.ts` ✅ (all 5 tests including cache-poisoning regression tests)
- **Full `pnpm benchmark` passes locally** — 298 passing / 0 failed / 138 pending