### PR TITLE
docs: remove backticks from port defaultDescription to fix docs rendering

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -231,14 +231,14 @@ export const options: CliCommandOptions<NetworkArgs> = {
   discoveryPort: {
     description: "The UDP port that discovery will listen on. Defaults to `port`",
     type: "number",
-    defaultDescription: "`port`",
+    defaultDescription: "port",
     group: "network",
   },
 
   quicPort: {
     description: "The UDP port that QUIC will listen on. Defaults to `port` + 1",
     type: "number",
-    defaultDescription: "`port` + 1",
+    defaultDescription: "port + 1",
     group: "network",
   },
 
@@ -260,14 +260,14 @@ export const options: CliCommandOptions<NetworkArgs> = {
   discoveryPort6: {
     description: "The UDP port that discovery will listen on. Defaults to `port6`",
     type: "number",
-    defaultDescription: "`port6`",
+    defaultDescription: "port6",
     group: "network",
   },
 
   quicPort6: {
     description: "The UDP port that QUIC will listen on. Defaults to `port6` + 1",
     type: "number",
-    defaultDescription: "`port6` + 1",
+    defaultDescription: "port6 + 1",
     group: "network",
   },
 


### PR DESCRIPTION
## Description

The docs generator wraps default values in backticks when rendering CLI option pages. When the `defaultDescription` itself also contains backticks (e.g. `\`port\``), the rendered docs show double backticks or broken inline code formatting:

**Before (broken):**
```
default: ``port``
default: ``port` + 1`
```

**After (fixed):**
```
default: `port`
default: `port + 1`
```

## Changes

Remove backticks from `defaultDescription` for:
- `discoveryPort`: `\`port\`` → `port`
- `quicPort`: `\`port\` + 1` → `port + 1`
- `discoveryPort6`: `\`port6\`` → `port6`
- `quicPort6`: `\`port6\` + 1` → `port6 + 1`

---

*This PR was authored by an AI (@lodekeeper) with human oversight from @nflaig.*