### PR TITLE
fix: only prefer QUIC bootnodes when QUIC transport is active

### DIFF
--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -46,6 +46,8 @@ export async function createNodeJsLibp2p(
   const disconnectThreshold = networkOpts.disconnectThreshold ?? defaultNetworkOptions.disconnectThreshold;
   const tcpEnabled = networkOpts.tcp ?? defaultNetworkOptions.tcp;
   const quicEnabled = networkOpts.quic ?? defaultNetworkOptions.quic;
+  // Check if QUIC transport will actually be active: flag enabled AND at least one QUIC listen address
+  const hasQuicTransport = quicEnabled && localMultiaddrs.some((ma) => ma.includes("/quic-v1"));
   const {peerStoreDir, disablePeerDiscovery} = nodeJsLibp2pOpts;
 
   let datastore: undefined | Eth2PeerDataStore = undefined;
@@ -60,7 +62,7 @@ export async function createNodeJsLibp2p(
       ...(networkOpts.bootMultiaddrs ?? defaultNetworkOptions.bootMultiaddrs ?? []),
       // Append discv5.bootEnrs to bootMultiaddrs if requested
       ...(networkOpts.connectToDiscv5Bootnodes
-        ? await getDiscv5Multiaddrs(networkOpts.discv5?.bootEnrs ?? [], quicEnabled)
+        ? await getDiscv5Multiaddrs(networkOpts.discv5?.bootEnrs ?? [], hasQuicTransport)
         : []),
     ];
 


### PR DESCRIPTION
## Description

When `quic=true` (now the default after #9133) but no QUIC listen addresses are configured in `localMultiaddrs`, the QUIC transport is not installed (the constructor would throw). However, `getDiscv5Multiaddrs` was still called with `quicEnabled=true`, causing it to prefer QUIC bootnode multiaddrs that the node cannot actually dial.

This could cause bootstrap failures when `connectToDiscv5Bootnodes` is enabled and bootnodes advertise both TCP and QUIC — the node would only get `/quic-v1` multiaddrs it has no transport for, skipping the TCP addresses that would have worked.

### Fix

Compute `hasQuicTransport` by checking both the config flag (`quic=true`) AND the presence of at least one `/quic-v1` listen address in `localMultiaddrs`. Pass this to `getDiscv5Multiaddrs` instead of the raw config flag.

### Changes

- `packages/beacon-node/src/network/libp2p/index.ts`: Add `hasQuicTransport` guard, pass to `getDiscv5Multiaddrs`

---

_This PR was authored by Lodekeeper 🌟, an AI contributor to Lodestar, with assistance from Claude._