### PR TITLE
test: scope clearPerfStateCache to loadState only to fix benchmark flakiness

### DIFF
--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -1,4 +1,4 @@
-import {afterAll, beforeAll, bench, describe} from "@chainsafe/benchmark";
+import {beforeAll, bench, describe} from "@chainsafe/benchmark";
 import {BitArray, toHexString} from "@chainsafe/ssz";
 import {ExecutionStatus, ForkChoice, IForkChoiceStore, PayloadStatus, ProtoArray} from "@lodestar/fork-choice";
 import {HISTORICAL_ROOTS_LIMIT, MAX_COMMITTEES_PER_SLOT, SLOTS_PER_EPOCH} from "@lodestar/params";
@@ -12,7 +12,7 @@ import {
   getBlockRootAtSlot,
   newFilledArray,
 } from "@lodestar/state-transition";
-import {clearPerfStateCache, generatePerfTestCachedStateElectra} from "@lodestar/state-transition/test-utils";
+import {generatePerfTestCachedStateElectra} from "@lodestar/state-transition/test-utils";
 import {electra, ssz} from "@lodestar/types";
 import {AggregatedAttestationPool} from "../../../../src/chain/opPools/aggregatedAttestationPool.js";
 import {ShufflingCache} from "../../../../src/chain/shufflingCache.js";
@@ -27,35 +27,25 @@ const vc = 1_500_000;
  *   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      23.86144 ops/s    41.90862 ms/op        -         18 runs   34.1 s
  */
 describe(`getAttestationsForBlock vc=${vc}`, () => {
-  let originalState: CachedBeaconStateElectra | undefined;
-  let protoArray: ProtoArray | undefined;
-  let forkchoice: ForkChoice | undefined;
-
-  const requireOriginalState = (): CachedBeaconStateElectra => {
-    if (!originalState) throw Error("originalState not initialized");
-    return originalState;
-  };
-
-  const requireForkchoice = (): ForkChoice => {
-    if (!forkchoice) throw Error("forkchoice not initialized");
-    return forkchoice;
-  };
+  let originalState: CachedBeaconStateElectra;
+  let protoArray: ProtoArray;
+  let forkchoice: ForkChoice;
 
   beforeAll(
     () => {
       originalState = generatePerfTestCachedStateElectra({goBackOneSlot: true, vc});
 
-      const {blockHeader, checkpoint} = computeAnchorCheckpoint(requireOriginalState().config, requireOriginalState());
+      const {blockHeader, checkpoint} = computeAnchorCheckpoint(originalState.config, originalState);
       // TODO figure out why getBlockRootAtSlot(originalState, justifiedSlot) is not the same to justifiedCheckpoint.root
-      const finalizedEpoch = requireOriginalState().finalizedCheckpoint.epoch;
+      const finalizedEpoch = originalState.finalizedCheckpoint.epoch;
       const finalizedCheckpoint = {
         epoch: finalizedEpoch,
-        root: getBlockRootAtSlot(requireOriginalState(), computeStartSlotAtEpoch(finalizedEpoch)),
+        root: getBlockRootAtSlot(originalState, computeStartSlotAtEpoch(finalizedEpoch)),
       };
-      const justifiedEpoch = requireOriginalState().currentJustifiedCheckpoint.epoch;
+      const justifiedEpoch = originalState.currentJustifiedCheckpoint.epoch;
       const justifiedCheckpoint = {
         epoch: justifiedEpoch,
-        root: getBlockRootAtSlot(requireOriginalState(), computeStartSlotAtEpoch(justifiedEpoch)),
+        root: getBlockRootAtSlot(originalState, computeStartSlotAtEpoch(justifiedEpoch)),
       };
 
       protoArray = ProtoArray.initialize(
@@ -82,18 +72,18 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
           parentBlockHash: null,
           payloadStatus: 2, // PayloadStatus.FULL
         },
-        requireOriginalState().slot
+        originalState.slot
       );
 
-      for (let slot = computeStartSlotAtEpoch(finalizedCheckpoint.epoch); slot < requireOriginalState().slot; slot++) {
+      for (let slot = computeStartSlotAtEpoch(finalizedCheckpoint.epoch); slot < originalState.slot; slot++) {
         const epoch = computeEpochAtSlot(slot);
         protoArray.onBlock(
           {
             slot,
-            blockRoot: toHexString(getBlockRootAtSlot(requireOriginalState(), slot)),
-            parentRoot: toHexString(getBlockRootAtSlot(requireOriginalState(), slot - 1)),
-            stateRoot: toHexString(requireOriginalState().stateRoots.get(slot % HISTORICAL_ROOTS_LIMIT)),
-            targetRoot: toHexString(getBlockRootAtSlot(requireOriginalState(), computeStartSlotAtEpoch(epoch))),
+            blockRoot: toHexString(getBlockRootAtSlot(originalState, slot)),
+            parentRoot: toHexString(getBlockRootAtSlot(originalState, slot - 1)),
+            stateRoot: toHexString(originalState.stateRoots.get(slot % HISTORICAL_ROOTS_LIMIT)),
+            targetRoot: toHexString(getBlockRootAtSlot(originalState, computeStartSlotAtEpoch(epoch))),
             justifiedEpoch: justifiedCheckpoint.epoch,
             justifiedRoot: toHexString(justifiedCheckpoint.root),
             finalizedEpoch: finalizedCheckpoint.epoch,
@@ -116,19 +106,19 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
       }
 
       let totalBalance = 0;
-      for (let i = 0; i < requireOriginalState().epochCtx.effectiveBalanceIncrements.length; i++) {
-        totalBalance += requireOriginalState().epochCtx.effectiveBalanceIncrements[i];
+      for (let i = 0; i < originalState.epochCtx.effectiveBalanceIncrements.length; i++) {
+        totalBalance += originalState.epochCtx.effectiveBalanceIncrements[i];
       }
 
       const fcStore: IForkChoiceStore = {
-        currentSlot: requireOriginalState().slot,
+        currentSlot: originalState.slot,
         justified: {
           checkpoint: {
             ...justifiedCheckpoint,
             rootHex: toHexString(justifiedCheckpoint.root),
             payloadStatus: PayloadStatus.FULL,
           },
-          balances: requireOriginalState().epochCtx.effectiveBalanceIncrements,
+          balances: originalState.epochCtx.effectiveBalanceIncrements,
           totalBalance,
         },
         unrealizedJustified: {
@@ -137,7 +127,7 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
             rootHex: toHexString(justifiedCheckpoint.root),
             payloadStatus: PayloadStatus.FULL,
           },
-          balances: requireOriginalState().epochCtx.effectiveBalanceIncrements,
+          balances: originalState.epochCtx.effectiveBalanceIncrements,
         },
         finalizedCheckpoint: {
           ...finalizedCheckpoint,
@@ -149,26 +139,13 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
           rootHex: toHexString(finalizedCheckpoint.root),
           payloadStatus: PayloadStatus.FULL,
         },
-        justifiedBalancesGetter: () => requireOriginalState().epochCtx.effectiveBalanceIncrements,
+        justifiedBalancesGetter: () => originalState.epochCtx.effectiveBalanceIncrements,
         equivocatingIndices: new Set(),
       };
-      forkchoice = new ForkChoice(
-        requireOriginalState().config,
-        fcStore,
-        protoArray,
-        requireOriginalState().validators.length,
-        null
-      );
+      forkchoice = new ForkChoice(originalState.config, fcStore, protoArray, originalState.validators.length, null);
     },
     5 * 60 * 1000
   );
-
-  afterAll(() => {
-    originalState = undefined;
-    protoArray = undefined;
-    forkchoice = undefined;
-    clearPerfStateCache();
-  });
 
   // notSeenSlots should be >=1
   for (const [notSeenSlots, numMissedVotes, numBadVotes] of [
@@ -180,7 +157,7 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
     bench({
       id: `notSeenSlots=${notSeenSlots} numMissedVotes=${numMissedVotes} numBadVotes=${numBadVotes}`,
       before: () => {
-        const state = requireOriginalState().clone();
+        const state = originalState.clone();
         // by default make all validators have full participation
         const previousParticipation = newFilledArray(vc, 0b111);
         // origState is at slot 0 of epoch so there is no currentParticipation
@@ -216,10 +193,10 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
         );
         const shufflingCache = new ShufflingCache();
         shufflingCache.processState(state);
-        return {state, pool, shufflingCache, forkchoice: requireForkchoice(), config: requireOriginalState().config};
+        return {state, pool, shufflingCache};
       },
-      fn: ({state, pool, shufflingCache, forkchoice, config}) => {
-        pool.getAttestationsForBlock(config.getForkName(state.slot), forkchoice, shufflingCache, state);
+      fn: ({state, pool, shufflingCache}) => {
+        pool.getAttestationsForBlock(originalState.config.getForkName(state.slot), forkchoice, shufflingCache, state);
       },
     });
   }

--- a/packages/beacon-node/test/perf/chain/opPools/opPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/opPool.test.ts
@@ -1,4 +1,4 @@
-import {afterAll, beforeAll, bench, describe} from "@chainsafe/benchmark";
+import {beforeAll, bench, describe} from "@chainsafe/benchmark";
 import {createBeaconConfig} from "@lodestar/config";
 import {chainConfig as chainConfigDef} from "@lodestar/config/default";
 import {
@@ -9,7 +9,7 @@ import {
   MAX_VOLUNTARY_EXITS,
 } from "@lodestar/params";
 import {BeaconStateView, CachedBeaconStateAltair, PubkeyCache} from "@lodestar/state-transition";
-import {clearPerfStateCache, generatePerfTestCachedStateAltair} from "@lodestar/state-transition/test-utils";
+import {generatePerfTestCachedStateAltair} from "@lodestar/state-transition/test-utils";
 import {ssz} from "@lodestar/types";
 import {BlockType} from "../../../../src/chain/interface.js";
 import {OpPool} from "../../../../src/chain/opPools/opPool.js";
@@ -21,13 +21,8 @@ import {
 } from "../../../fixtures/phase0.js";
 
 describe("opPool", () => {
-  let originalState: BeaconStateView | undefined;
+  let originalState: BeaconStateView;
   const config = createBeaconConfig(chainConfigDef, Buffer.alloc(32, 0xaa));
-
-  const requireOriginalState = (): BeaconStateView => {
-    if (!originalState) throw Error("originalState not initialized");
-    return originalState;
-  };
 
   beforeAll(
     () => {
@@ -36,26 +31,21 @@ describe("opPool", () => {
     2 * 60 * 1000 // Generating the states for the first time is very slow
   );
 
-  afterAll(() => {
-    originalState = undefined;
-    clearPerfStateCache();
-  });
-
   bench({
     id: "getSlashingsAndExits - default max",
     beforeEach: () => {
       const pool = new OpPool(config);
-      const beaconState = requireOriginalState().cachedState as CachedBeaconStateAltair;
+      const beaconState = originalState.cachedState as CachedBeaconStateAltair;
       fillAttesterSlashing(pool, beaconState, MAX_ATTESTER_SLASHINGS);
       fillProposerSlashing(pool, beaconState, MAX_PROPOSER_SLASHINGS);
       fillVoluntaryExits(pool, beaconState, MAX_VOLUNTARY_EXITS);
       // TODO: feed pubkeyCache separately instead of getting from originalState
       fillBlsToExecutionChanges(beaconState.epochCtx.pubkeyCache, pool, beaconState, MAX_BLS_TO_EXECUTION_CHANGES);
 
-      return {pool, state: requireOriginalState()};
+      return pool;
     },
-    fn: ({pool, state}) => {
-      pool.getSlashingsAndExits(state, BlockType.Full, null);
+    fn: (pool) => {
+      pool.getSlashingsAndExits(originalState, BlockType.Full, null);
     },
   });
 
@@ -64,17 +54,17 @@ describe("opPool", () => {
     beforeEach: () => {
       const pool = new OpPool(config);
       const maxItemsInPool = 2_000;
-      const beaconState = requireOriginalState().cachedState as CachedBeaconStateAltair;
+      const beaconState = originalState.cachedState as CachedBeaconStateAltair;
       fillAttesterSlashing(pool, beaconState, maxItemsInPool);
       fillProposerSlashing(pool, beaconState, maxItemsInPool);
       fillVoluntaryExits(pool, beaconState, maxItemsInPool);
       // TODO: feed pubkeyCache separately instead of getting from originalState
       fillBlsToExecutionChanges(beaconState.epochCtx.pubkeyCache, pool, beaconState, maxItemsInPool);
 
-      return {pool, state: requireOriginalState()};
+      return pool;
     },
-    fn: ({pool, state}) => {
-      pool.getSlashingsAndExits(state, BlockType.Full, null);
+    fn: (pool) => {
+      pool.getSlashingsAndExits(originalState, BlockType.Full, null);
     },
   });
 });

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -3,7 +3,7 @@ import {afterAll, beforeAll, bench, describe} from "@chainsafe/benchmark";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {BeaconStateView, CachedBeaconStateElectra} from "@lodestar/state-transition";
-import {clearPerfStateCache, generatePerfTestCachedStateElectra} from "@lodestar/state-transition/test-utils";
+import {generatePerfTestCachedStateElectra} from "@lodestar/state-transition/test-utils";
 import {toRootHex} from "@lodestar/utils";
 import {defaultOptions as defaultValidatorOptions} from "@lodestar/validator";
 import {BeaconChain} from "../../../../src/chain/index.js";
@@ -19,26 +19,15 @@ import {ArchiveMode, BeaconDb} from "../../../../src/index.js";
 const logger = testLogger();
 
 describe("produceBlockBody", () => {
-  let stateOg: CachedBeaconStateElectra | undefined;
+  const stateOg = generatePerfTestCachedStateElectra({goBackOneSlot: false});
 
-  let db: BeaconDb | undefined;
-  let chain: BeaconChain | undefined;
-  let state: CachedBeaconStateElectra | undefined;
-
-  const requireChain = (): BeaconChain => {
-    if (!chain) throw Error("chain not initialized");
-    return chain;
-  };
-
-  const requireState = (): CachedBeaconStateElectra => {
-    if (!state) throw Error("state not initialized");
-    return state;
-  };
+  let db: BeaconDb;
+  let chain: BeaconChain;
+  let state: CachedBeaconStateElectra;
 
   const controller = new AbortController();
 
   beforeAll(async () => {
-    stateOg = generatePerfTestCachedStateElectra({goBackOneSlot: false});
     state = stateOg.clone();
 
     const executionEngineBackend = new ExecutionEngineMockBackend({
@@ -84,13 +73,9 @@ describe("produceBlockBody", () => {
 
   afterAll(async () => {
     controller.abort();
+    // If before blocks fail, db won't be declared
     if (db !== undefined) await db.close();
     if (chain !== undefined) await chain.close();
-    db = undefined;
-    chain = undefined;
-    state = undefined;
-    stateOg = undefined;
-    clearPerfStateCache();
   });
 
   bench({
@@ -99,12 +84,11 @@ describe("produceBlockBody", () => {
     maxMs: Infinity,
     timeoutBench: 60 * 1000,
     beforeEach: async () => {
-      const head = requireChain().forkChoice.getHead();
-      const currentState = requireState();
-      const proposerIndex = currentState.epochCtx.getBeaconProposer(currentState.slot);
-      const proposerPubKey = currentState.epochCtx.pubkeyCache.getOrThrow(proposerIndex).toBytes();
+      const head = chain.forkChoice.getHead();
+      const proposerIndex = state.epochCtx.getBeaconProposer(state.slot);
+      const proposerPubKey = state.epochCtx.pubkeyCache.getOrThrow(proposerIndex).toBytes();
 
-      return {chain: requireChain(), state: new BeaconStateView(currentState), head, proposerIndex, proposerPubKey};
+      return {chain, state: new BeaconStateView(state), head, proposerIndex, proposerPubKey};
     },
     fn: async ({chain, state, head, proposerIndex, proposerPubKey}) => {
       const slot = state.slot;

--- a/packages/state-transition/src/testUtils/util.ts
+++ b/packages/state-transition/src/testUtils/util.ts
@@ -544,8 +544,12 @@ export function generateTestCachedBeaconStateOnlyValidators({
 
 /**
  * Release all cached perf states to free memory.
- * Call this before memory-intensive benchmarks (e.g. loadState with 1.5M validators)
- * to avoid OOM from accumulated singletons.
+ * Only call this before memory-intensive benchmarks that need to allocate
+ * very large states (e.g. loadState with 1.5M validators) where the
+ * accumulated singletons would cause OOM.
+ *
+ * WARNING: Do NOT call this in epoch/block benchmark afterAll blocks —
+ * destroying singletons mid-suite causes GC storms that corrupt measurements.
  */
 export function clearPerfStateCache(): void {
   phase0State = null;

--- a/packages/state-transition/test/perf/epoch/epochAltair.test.ts
+++ b/packages/state-transition/test/perf/epoch/epochAltair.test.ts
@@ -21,7 +21,6 @@ import {
 } from "../../../src/index.js";
 import {altairState} from "../../../src/testUtils/params.js";
 import {getNetworkCachedState} from "../../../src/testUtils/testFileCache.js";
-import {clearPerfStateCache} from "../../../src/testUtils/util.js";
 import {LazyValue, beforeValue} from "../../utils/beforeValueBenchmark.js";
 import {StateEpoch} from "../types.js";
 
@@ -35,7 +34,6 @@ describe(`altair processEpoch - ${stateId}`, () => {
   });
 
   const stateOg = beforeValue(async () => {
-    clearPerfStateCache();
     const state = await getNetworkCachedState(altairState.network, slot, 300_000);
     state.hashTreeRoot();
     return state;

--- a/packages/state-transition/test/perf/epoch/epochCapella.test.ts
+++ b/packages/state-transition/test/perf/epoch/epochCapella.test.ts
@@ -21,7 +21,6 @@ import {
 } from "../../../src/index.js";
 import {capellaState} from "../../../src/testUtils/params.js";
 import {getNetworkCachedState} from "../../../src/testUtils/testFileCache.js";
-import {clearPerfStateCache} from "../../../src/testUtils/util.js";
 import {LazyValue, beforeValue} from "../../utils/beforeValueBenchmark.js";
 import {StateEpoch} from "../types.js";
 
@@ -35,7 +34,6 @@ describe(`capella processEpoch - ${stateId}`, () => {
   });
 
   const stateOg = beforeValue(async () => {
-    clearPerfStateCache();
     const state = await getNetworkCachedState(capellaState.network, slot, 300_000);
     state.hashTreeRoot();
     return state;

--- a/packages/state-transition/test/perf/epoch/epochPhase0.test.ts
+++ b/packages/state-transition/test/perf/epoch/epochPhase0.test.ts
@@ -19,7 +19,6 @@ import {
 } from "../../../src/index.js";
 import {phase0State} from "../../../src/testUtils/params.js";
 import {getNetworkCachedState} from "../../../src/testUtils/testFileCache.js";
-import {clearPerfStateCache} from "../../../src/testUtils/util.js";
 import {LazyValue, beforeValue} from "../../utils/beforeValueBenchmark.js";
 import {StateEpoch} from "../types.js";
 
@@ -33,7 +32,6 @@ describe(`phase0 processEpoch - ${stateId}`, () => {
   });
 
   const stateOg = beforeValue(async () => {
-    clearPerfStateCache();
     const state = await getNetworkCachedState(phase0State.network, slot, 300_000);
     state.hashTreeRoot();
     return state;


### PR DESCRIPTION
## Motivation

PR #9140 added `clearPerfStateCache()` calls in `afterAll` blocks and `beforeValue` callbacks across epoch and beacon-node benchmark files to prevent OOM. While the OOM fix worked, clearing ~2.5GB of singletons mid-suite caused severe performance regressions (100-400x) due to GC storms corrupting subsequent measurements.

### Root cause

The `@chainsafe/benchmark` runner processes all files in a single Node.js process. Module-level state singletons (phase0 ×4, altair ×3, electra ×3 = ~2.5GB) are shared across files. When `clearPerfStateCache()` runs in an `afterAll` block, it:

1. Destroys all 10 singletons at once
2. Triggers a major GC event to reclaim ~2.5GB
3. Corrupts measurements of downstream benchmarks that depend on those singletons

The only benchmark that genuinely needs `clearPerfStateCache()` is `loadState.test.ts` — it allocates a 1.5M validator state (6x the standard 250k) and needs to free accumulated singletons first to fit within the 8GB heap.

## Changes

Scope `clearPerfStateCache()` to the one call site that needs it:

### Removed (from #9140):
- `clearPerfStateCache()` calls from epoch benchmarks (phase0, altair, capella)
- `afterAll` cleanup blocks + typed `require*()` helpers from beacon-node benchmarks (aggregatedAttestationPool, opPool, produceBlockBody)
- Updated `clearPerfStateCache()` jsdoc with warning against mid-suite use

### Kept (unchanged from unstable):
- `clearPerfStateCache()` function definition in `testUtils/util.ts`
- `clearPerfStateCache()` call in `loadState.test.ts` `before()` block (pre-measurement, not mid-suite)
- `beforeValue` `afterAll` teardown (releases lazy fixtures between suites)

## Verification

### Full suite (`--max-old-space-size=8192`)

```
298 passing
  0 failed
138 pending
```

No OOM, no FATAL errors. `loadState` completed successfully (1.5M validators).

### Same-hardware A/B comparison (targeted files, sequential runs)

| Benchmark | Original ([`04e52d1`](https://github.com/ChainSafe/lodestar/commit/04e52d1), 4GB) | Fix ([`7fd1028`](https://github.com/ChainSafe/lodestar/commit/7fd10283f7), 8GB) | Ratio |
|---|---|---|---|
| setStatus 1/6 | 323 µs/op | 151 µs/op | 0.47x ✅ |
| processAttestation normalcase | 2.62 ms/op | 3.18 ms/op | 1.21x ✅ |
| altair processEpoch | 351 ms/op | 297 ms/op | 0.85x ✅ |
| processInactivityUpdates normal | 16.7 ms/op | 16.9 ms/op | 1.01x ✅ |
| processRewardsAndPenalties normal | 16.5 ms/op | 23.7 ms/op | 1.43x ✅ |

All benchmarks within normal variance range. No 100-400x regression. The `processRewardsAndPenalties` variance (16.5→23.7ms) is consistent with run-to-run noise on shared hardware — the same benchmark measured 20.3 ms/op in the full suite run.