### PR TITLE
chore: correct testCachePath after move from test/ to src/testUtils/

### DIFF
--- a/packages/state-transition/src/testUtils/cache.ts
+++ b/packages/state-transition/src/testUtils/cache.ts
@@ -5,4 +5,4 @@ import {fileURLToPath} from "node:url";
 // Solutions: https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export const testCachePath = path.join(__dirname, "../../test/test-cache");
+export const testCachePath = path.join(__dirname, "../../test-cache");


### PR DESCRIPTION
## Summary

PR #8990 moved `cache.ts` from `test/cache.ts` to `src/testUtils/cache.ts` but did not update the relative path for `testCachePath`.

**Before the move** (`test/cache.ts`):
- `__dirname` = `packages/state-transition/test/`
- `../test-cache` → `packages/state-transition/test-cache/` ✅

**After the move** (`src/testUtils/cache.ts`):
- `__dirname` = `packages/state-transition/src/testUtils/`
- `../../test/test-cache` → `packages/state-transition/test/test-cache/` ❌

This caused `interop-pubkeys.json` to be regenerated into a new directory on every test run, which then kept getting accidentally committed in unrelated PRs (removed and re-added multiple times in git history).

## Fix

Update the relative path to `../../test-cache` so it resolves back to the tracked `packages/state-transition/test-cache/` directory.

## Testing

- All 239 state-transition unit tests pass
- Verified cache file is read from / written to the correct `test-cache/` path
- Verified no file is generated at the broken `test/test-cache/` path
