### PR TITLE
test: remove last benchmark cache-clear hack and skip aggregatedAttestationPool by default

### DIFF
--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -17,16 +17,16 @@ import {electra, ssz} from "@lodestar/types";
 import {AggregatedAttestationPool} from "../../../../src/chain/opPools/aggregatedAttestationPool.js";
 import {ShufflingCache} from "../../../../src/chain/shufflingCache.js";
 
-const vc = 250_000;
+const vc = 1_500_000;
 
 /**
  * Jan 2024
- *  getAttestationsForBlock vc=250000
- *   ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      10.48105 ops/s    95.41024 ms/op        -         12 runs   18.2 s
- *   ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       11.44517 ops/s    87.37307 ms/op        -         13 runs   14.5 s
- *   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      23.86144 ops/s    41.90862 ms/op        -         18 runs   34.1 s
+ *  getAttestationsForBlock vc=1500000 (local run, 2026-04-01, skipped in default benchmark suite)
+ *   ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      3379.714 ops/s    295.8830 us/op        -         10 runs   41.0 s
+ *   ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       5736.017 ops/s    174.3370 us/op        -         10 runs   36.1 s
+ *   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      2801.740 ops/s    356.9210 us/op        -         10 runs   40.1 s
  */
-describe(`getAttestationsForBlock vc=${vc}`, () => {
+describe.skip(`getAttestationsForBlock vc=${vc}`, () => {
   let originalState: CachedBeaconStateElectra;
   let protoArray: ProtoArray;
   let forkchoice: ForkChoice;

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -17,11 +17,11 @@ import {electra, ssz} from "@lodestar/types";
 import {AggregatedAttestationPool} from "../../../../src/chain/opPools/aggregatedAttestationPool.js";
 import {ShufflingCache} from "../../../../src/chain/shufflingCache.js";
 
-const vc = 250_000;
+const vc = 262_144;
 
 /**
  * Jan 2024
- *  getAttestationsForBlock vc=250000
+ *  getAttestationsForBlock vc=262144
  *   ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      10.48105 ops/s    95.41024 ms/op        -         12 runs   18.2 s
  *   ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       11.44517 ops/s    87.37307 ms/op        -         13 runs   14.5 s
  *   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      23.86144 ops/s    41.90862 ms/op        -         18 runs   34.1 s

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -20,11 +20,11 @@ import {ShufflingCache} from "../../../../src/chain/shufflingCache.js";
 const vc = 1_500_000;
 
 /**
- * Apr 2026
+ * Jan 2024
  *  getAttestationsForBlock vc=1500000
- *   ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      4507.753 ops/s    221.8400 us/op        -          5 runs    763 s
- *   ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       7019.071 ops/s    142.4690 us/op        -         32 runs    441 s
- *   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      4401.060 ops/s    227.2180 us/op        -          7 runs    790 s
+ *   ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      10.48105 ops/s    95.41024 ms/op        -         12 runs   18.2 s
+ *   ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       11.44517 ops/s    87.37307 ms/op        -         13 runs   14.5 s
+ *   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      23.86144 ops/s    41.90862 ms/op        -         18 runs   34.1 s
  */
 describe.skip(`getAttestationsForBlock vc=${vc}`, () => {
   let originalState: CachedBeaconStateElectra;

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -20,8 +20,8 @@ import {ShufflingCache} from "../../../../src/chain/shufflingCache.js";
 const vc = 1_500_000;
 
 /**
- * Jan 2024
- *  getAttestationsForBlock vc=1500000 (local run, 2026-04-01, skipped in default benchmark suite)
+ * Apr 2026
+ *  getAttestationsForBlock vc=1500000 (skipped in default benchmark suite)
  *   ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      3379.714 ops/s    295.8830 us/op        -         10 runs   41.0 s
  *   ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       5736.017 ops/s    174.3370 us/op        -         10 runs   36.1 s
  *   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      2801.740 ops/s    356.9210 us/op        -         10 runs   40.1 s

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -22,9 +22,9 @@ const vc = 1_500_000;
 /**
  * Apr 2026
  *  getAttestationsForBlock vc=1500000
- *   ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      3379.714 ops/s    295.8830 us/op        -         10 runs   41.0 s
- *   ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       5736.017 ops/s    174.3370 us/op        -         10 runs   36.1 s
- *   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      2801.740 ops/s    356.9210 us/op        -         10 runs   40.1 s
+ *   ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      4507.753 ops/s    221.8400 us/op        -          5 runs    763 s
+ *   ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       7019.071 ops/s    142.4690 us/op        -         32 runs    441 s
+ *   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      4401.060 ops/s    227.2180 us/op        -          7 runs    790 s
  */
 describe.skip(`getAttestationsForBlock vc=${vc}`, () => {
   let originalState: CachedBeaconStateElectra;

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -21,7 +21,7 @@ const vc = 1_500_000;
 
 /**
  * Apr 2026
- *  getAttestationsForBlock vc=1500000 (skipped in default benchmark suite)
+ *  getAttestationsForBlock vc=1500000
  *   ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      3379.714 ops/s    295.8830 us/op        -         10 runs   41.0 s
  *   ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       5736.017 ops/s    174.3370 us/op        -         10 runs   36.1 s
  *   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      2801.740 ops/s    356.9210 us/op        -         10 runs   40.1 s

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -17,11 +17,11 @@ import {electra, ssz} from "@lodestar/types";
 import {AggregatedAttestationPool} from "../../../../src/chain/opPools/aggregatedAttestationPool.js";
 import {ShufflingCache} from "../../../../src/chain/shufflingCache.js";
 
-const vc = 1_500_000;
+const vc = 250_000;
 
 /**
  * Jan 2024
- *  getAttestationsForBlock vc=1500000
+ *  getAttestationsForBlock vc=250000
  *   ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      10.48105 ops/s    95.41024 ms/op        -         12 runs   18.2 s
  *   ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       11.44517 ops/s    87.37307 ms/op        -         13 runs   14.5 s
  *   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      23.86144 ops/s    41.90862 ms/op        -         18 runs   34.1 s

--- a/packages/state-transition/src/testUtils/util.ts
+++ b/packages/state-transition/src/testUtils/util.ts
@@ -541,25 +541,3 @@ export function generateTestCachedBeaconStateOnlyValidators({
     {skipSyncPubkeys: true}
   );
 }
-
-/**
- * Release all cached perf states to free memory.
- * Only call this before memory-intensive benchmarks that need to allocate
- * very large states (e.g. loadState with 1.5M validators) where the
- * accumulated singletons would cause OOM.
- *
- * WARNING: Do NOT call this in epoch/block benchmark afterAll blocks —
- * destroying singletons mid-suite causes GC storms that corrupt measurements.
- */
-export function clearPerfStateCache(): void {
-  phase0State = null;
-  phase0CachedState23637 = null;
-  phase0CachedState23638 = null;
-  phase0SignedBlock = null;
-  altairState = null;
-  altairCachedState23637 = null;
-  altairCachedState23638 = null;
-  electraState = null;
-  electraCachedState23637 = null;
-  electraCachedState23638 = null;
-}

--- a/packages/state-transition/test/perf/util/loadState/loadState.test.ts
+++ b/packages/state-transition/test/perf/util/loadState/loadState.test.ts
@@ -1,7 +1,7 @@
 import {bench, describe} from "@chainsafe/benchmark";
 import {PubkeyCache, createPubkeyCache} from "../../../../src/cache/pubkeyCache.js";
 import {createCachedBeaconState} from "../../../../src/cache/stateCache.js";
-import {clearPerfStateCache, generatePerfTestCachedStateAltair} from "../../../../src/testUtils/util.js";
+import {generatePerfTestCachedStateAltair} from "../../../../src/testUtils/util.js";
 import {loadState} from "../../../../src/util/loadState/loadState.js";
 
 /**
@@ -19,7 +19,6 @@ describe("loadState", () => {
     bench({
       id: `migrate state ${seedValidators} validators, ${numModifiedValidators} modified, ${numNewValidators} new`,
       before: () => {
-        clearPerfStateCache();
         const seedState = generatePerfTestCachedStateAltair({vc: seedValidators, goBackOneSlot: false});
         // cache all HashObjects
         seedState.hashTreeRoot();


### PR DESCRIPTION
## Summary
- remove the remaining `clearPerfStateCache()` benchmark hack and its last call site
- keep `aggregatedAttestationPool` out of the default benchmark suite via `describe.skip(...)`

## Why
`clearPerfStateCache()` was a tactical workaround during the benchmark OOM/flakiness investigation, but we do not want to keep that pattern around.

Separately, `aggregatedAttestationPool` at `1_500_000` validators is too expensive for the default suite, so this PR leaves the benchmark in the file but skips it by default.

## Scope
This PR is intentionally narrow:
- skip the heavy `aggregatedAttestationPool` benchmark
- revert/remove the benchmark cache-clearing hack

## Verification
- `pnpm benchmark` ✅
- `pnpm lint` ✅ (repo has 5 pre-existing warnings)