### PR TITLE
fix: handle genesis block in gloas fork choice and genesis state init

### DIFF
--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -220,6 +220,11 @@ export class ProtoArray {
       return PayloadStatus.FULL;
     }
 
+    // Genesis block has no parent (parentRoot is zero hash), treat as FULL
+    if (block.parentRoot === HEX_ZERO_HASH) {
+      return PayloadStatus.FULL;
+    }
+
     const parentVariants = this.indices.get(block.parentRoot);
     if (parentVariants === undefined) {
       throw new ProtoArrayError({

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -292,36 +292,44 @@ export function initializeBeaconStateFromEth1(
     const stateBellatrix = state as CompositeViewDU<typeof ssz.bellatrix.BeaconState>;
     stateBellatrix.fork.previousVersion = config.BELLATRIX_FORK_VERSION;
     stateBellatrix.fork.currentVersion = config.BELLATRIX_FORK_VERSION;
-    stateBellatrix.latestExecutionPayloadHeader =
-      (executionPayloadHeader as CompositeViewDU<typeof ssz.bellatrix.ExecutionPayloadHeader>) ??
-      ssz.bellatrix.ExecutionPayloadHeader.defaultViewDU();
+    if (fork < ForkSeq.gloas) {
+      stateBellatrix.latestExecutionPayloadHeader =
+        (executionPayloadHeader as CompositeViewDU<typeof ssz.bellatrix.ExecutionPayloadHeader>) ??
+        ssz.bellatrix.ExecutionPayloadHeader.defaultViewDU();
+    }
   }
 
   if (fork >= ForkSeq.capella) {
     const stateCapella = state as CompositeViewDU<typeof ssz.capella.BeaconState>;
     stateCapella.fork.previousVersion = config.CAPELLA_FORK_VERSION;
     stateCapella.fork.currentVersion = config.CAPELLA_FORK_VERSION;
-    stateCapella.latestExecutionPayloadHeader =
-      (executionPayloadHeader as CompositeViewDU<typeof ssz.capella.ExecutionPayloadHeader>) ??
-      ssz.capella.ExecutionPayloadHeader.defaultViewDU();
+    if (fork < ForkSeq.gloas) {
+      stateCapella.latestExecutionPayloadHeader =
+        (executionPayloadHeader as CompositeViewDU<typeof ssz.capella.ExecutionPayloadHeader>) ??
+        ssz.capella.ExecutionPayloadHeader.defaultViewDU();
+    }
   }
 
   if (fork >= ForkSeq.deneb) {
     const stateDeneb = state as CompositeViewDU<typeof ssz.deneb.BeaconState>;
     stateDeneb.fork.previousVersion = config.DENEB_FORK_VERSION;
     stateDeneb.fork.currentVersion = config.DENEB_FORK_VERSION;
-    stateDeneb.latestExecutionPayloadHeader =
-      (executionPayloadHeader as CompositeViewDU<typeof ssz.deneb.ExecutionPayloadHeader>) ??
-      ssz.deneb.ExecutionPayloadHeader.defaultViewDU();
+    if (fork < ForkSeq.gloas) {
+      stateDeneb.latestExecutionPayloadHeader =
+        (executionPayloadHeader as CompositeViewDU<typeof ssz.deneb.ExecutionPayloadHeader>) ??
+        ssz.deneb.ExecutionPayloadHeader.defaultViewDU();
+    }
   }
 
   if (fork >= ForkSeq.electra) {
     const stateElectra = state as CompositeViewDU<typeof ssz.electra.BeaconState>;
     stateElectra.fork.previousVersion = config.ELECTRA_FORK_VERSION;
     stateElectra.fork.currentVersion = config.ELECTRA_FORK_VERSION;
-    stateElectra.latestExecutionPayloadHeader =
-      (executionPayloadHeader as CompositeViewDU<typeof ssz.electra.ExecutionPayloadHeader>) ??
-      ssz.electra.ExecutionPayloadHeader.defaultViewDU();
+    if (fork < ForkSeq.gloas) {
+      stateElectra.latestExecutionPayloadHeader =
+        (executionPayloadHeader as CompositeViewDU<typeof ssz.electra.ExecutionPayloadHeader>) ??
+        ssz.electra.ExecutionPayloadHeader.defaultViewDU();
+    }
     stateElectra.depositRequestsStartIndex = UNSET_DEPOSIT_REQUESTS_START_INDEX;
   }
 
@@ -329,9 +337,11 @@ export function initializeBeaconStateFromEth1(
     const stateFulu = state as CompositeViewDU<typeof ssz.fulu.BeaconState>;
     stateFulu.fork.previousVersion = config.FULU_FORK_VERSION;
     stateFulu.fork.currentVersion = config.FULU_FORK_VERSION;
-    stateFulu.latestExecutionPayloadHeader =
-      (executionPayloadHeader as CompositeViewDU<typeof ssz.fulu.ExecutionPayloadHeader>) ??
-      ssz.fulu.ExecutionPayloadHeader.defaultViewDU();
+    if (fork < ForkSeq.gloas) {
+      stateFulu.latestExecutionPayloadHeader =
+        (executionPayloadHeader as CompositeViewDU<typeof ssz.fulu.ExecutionPayloadHeader>) ??
+        ssz.fulu.ExecutionPayloadHeader.defaultViewDU();
+    }
   }
 
   if (fork >= ForkSeq.gloas) {


### PR DESCRIPTION
## Summary

- **Fork choice fix**: Handle genesis block's all-zeros `parentRoot` in `getParentPayloadStatus()` — returns `PayloadStatus.FULL` instead of throwing `PROTO_ARRAY_ERROR_UNKNOWN_PARENT_BLOCK`. This fixes the mainnet preset crash at block production time.
- **Genesis init fix**: Guard `latestExecutionPayloadHeader` assignments in `initializeBeaconStateFromEth1()` with `fork < ForkSeq.gloas` since this field was removed in gloas (EIP-7732), replaced by `latestExecutionPayloadBid`.

### Note on minimal preset SSZ crash

The minimal preset crash (`First offset must equal to fixedEnd 109509 != 11589`) is a genesis generator issue, not Lodestar. The difference of 97920 bytes exactly matches `ptcWindow` size with mainnet `PTC_SIZE=512` vs minimal `PTC_SIZE=2` — the genesis generator (`ethpandaops/ethereum-genesis-generator:gloas-genesis`) appears to use mainnet's `PTC_SIZE` when generating minimal preset states.

## Test plan

- [x] All fork-choice unit tests pass (104/104)
- [x] Beacon-node fork choice tests pass
- [x] Type check passes
- [x] Lint passes
- [ ] Test with Kurtosis devnet using mainnet preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)