### PR TITLE
fix: checkpoint sync follow-head fixes for epbs-devnet-1

### DIFF
--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -187,7 +187,13 @@ export class BeaconSync implements IBeaconSync {
    */
   private addPeer = (data: NetworkEventData[NetworkEvent.peerConnected]): void => {
     const localStatus = this.chain.getStatus();
-    const syncType = getPeerSyncType(localStatus, data.status, this.chain.forkChoice, this.slotImportTolerance);
+    const syncType = getPeerSyncType(
+      localStatus,
+      data.status,
+      this.chain.forkChoice,
+      this.slotImportTolerance,
+      this.chain.clock.currentSlot
+    );
 
     // For metrics only
     this.peerSyncType.set(data.peer, syncType);

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -493,11 +493,27 @@ export class BlockInputSync {
           // case BlockErrorCode.GENESIS_BLOCK:
 
           case BlockErrorCode.PARENT_UNKNOWN:
-          case BlockErrorCode.PRESTATE_MISSING:
-            // Should not happen, mark as downloaded to try again latter
-            this.logger.debug("Attempted to process block but its parent was still unknown", errorData, res.err);
+          case BlockErrorCode.PRESTATE_MISSING: {
+            // For Gloas blocks: if the parent is missing its FULL variant (envelope not received),
+            // proactively fetch the parent's envelope via reqresp, then retry.
+            // This commonly happens after checkpoint sync + range sync where the head block's
+            // envelope was already gossipped before we connected to the network.
+            const retryCtx = this.getGloasInvalidStateRootRetryContext(pendingBlock);
+            if (retryCtx.shouldRetry && retryCtx.parentRoot) {
+              this.logger.debug("PRESTATE_MISSING due to missing parent FULL variant, resolving envelope", {
+                ...errorData,
+                ...retryCtx,
+              });
+              const parentBlock = this.chain.forkChoice.getBlockHexDefaultStatus(retryCtx.parentRoot);
+              if (parentBlock) {
+                await this.resolveEnvelopeForBlock(retryCtx.parentRoot, parentBlock.slot);
+              }
+            } else {
+              this.logger.debug("Attempted to process block but its parent was still unknown", errorData, res.err);
+            }
             pendingBlock.status = PendingBlockInputStatus.downloaded;
             break;
+          }
 
           case BlockErrorCode.EXECUTION_ENGINE_ERROR:
             // Removing the block(s) without penalizing the peers, hoping for EL to

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -500,13 +500,19 @@ export class BlockInputSync {
             // envelope was already gossipped before we connected to the network.
             const retryCtx = this.getGloasInvalidStateRootRetryContext(pendingBlock);
             if (retryCtx.shouldRetry && retryCtx.parentRoot) {
-              this.logger.debug("PRESTATE_MISSING due to missing parent FULL variant, resolving envelope", {
-                ...errorData,
-                ...retryCtx,
-              });
-              const parentBlock = this.chain.forkChoice.getBlockHexDefaultStatus(retryCtx.parentRoot);
-              if (parentBlock) {
-                await this.resolveEnvelopeForBlock(retryCtx.parentRoot, parentBlock.slot);
+              // Only fetch envelope if parent FULL variant is actually absent.
+              // getGloasInvalidStateRootRetryContext uses the default (PENDING) variant,
+              // so wantsFullParent can be true even when FULL already exists.
+              const parentFullBlock = this.chain.forkChoice.getBlockHex(retryCtx.parentRoot, PayloadStatus.FULL);
+              if (!parentFullBlock) {
+                this.logger.debug("PRESTATE_MISSING due to missing parent FULL variant, resolving envelope", {
+                  ...errorData,
+                  ...retryCtx,
+                });
+                const parentBlock = this.chain.forkChoice.getBlockHexDefaultStatus(retryCtx.parentRoot);
+                if (parentBlock) {
+                  await this.resolveEnvelopeForBlock(retryCtx.parentRoot, parentBlock.slot);
+                }
               }
             } else {
               this.logger.debug("Attempted to process block but its parent was still unknown", errorData, res.err);

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -498,6 +498,11 @@ export class BlockInputSync {
             // proactively fetch the parent's envelope via reqresp, then retry.
             // This commonly happens after checkpoint sync + range sync where the head block's
             // envelope was already gossipped before we connected to the network.
+            // Mark as downloaded before envelope resolution so that if the import
+            // triggers executionPayloadAvailable -> triggerUnknownBlockSearch, this
+            // block is already retryable instead of stuck in processing state.
+            pendingBlock.status = PendingBlockInputStatus.downloaded;
+
             const retryCtx = this.getGloasInvalidStateRootRetryContext(pendingBlock);
             if (retryCtx.shouldRetry && retryCtx.parentRoot) {
               // Only fetch envelope if parent FULL variant is actually absent.
@@ -517,7 +522,6 @@ export class BlockInputSync {
             } else {
               this.logger.debug("Attempted to process block but its parent was still unknown", errorData, res.err);
             }
-            pendingBlock.status = PendingBlockInputStatus.downloaded;
             break;
           }
 

--- a/packages/beacon-node/src/sync/utils/remoteSyncType.ts
+++ b/packages/beacon-node/src/sync/utils/remoteSyncType.ts
@@ -25,7 +25,8 @@ export function getPeerSyncType(
   local: Status,
   remote: Status,
   forkChoice: IForkChoice,
-  slotImportTolerance: number
+  slotImportTolerance: number,
+  currentSlot: Slot
 ): PeerSyncType {
   // Aux vars: Inclusive boundaries of the range to consider a peer's head synced to ours.
   const nearRangeStart = local.headSlot - slotImportTolerance;
@@ -51,12 +52,19 @@ export function getPeerSyncType(
   }
 
   if (remote.finalizedEpoch > local.finalizedEpoch) {
+    if (forkChoice.hasBlock(remote.headRoot)) {
+      return PeerSyncType.FullySynced;
+    }
+
+    const localIsBehindClock = currentSlot > local.headSlot + slotImportTolerance;
+    if (localIsBehindClock && remote.headSlot > local.headSlot) {
+      return PeerSyncType.Advanced;
+    }
+
     if (
       // Peer is in next epoch, and head is within range => SYNCED
-      (local.finalizedEpoch + 1 === remote.finalizedEpoch &&
-        withinRangeOf(remote.headSlot, local.headSlot, slotImportTolerance)) ||
-      // Peer's head is known => SYNCED
-      forkChoice.hasBlock(remote.headRoot)
+      local.finalizedEpoch + 1 === remote.finalizedEpoch &&
+      withinRangeOf(remote.headSlot, local.headSlot, slotImportTolerance)
     ) {
       return PeerSyncType.FullySynced;
     }

--- a/packages/beacon-node/test/unit/sync/utils/remoteSyncType.test.ts
+++ b/packages/beacon-node/test/unit/sync/utils/remoteSyncType.test.ts
@@ -27,6 +27,7 @@ describe("network / peers / remoteSyncType", () => {
       local: Partial<phase0.Status>;
       remote: Partial<phase0.Status>;
       blocks?: Root[];
+      currentSlot?: number;
       syncType: PeerSyncType;
     }[] = [
       {
@@ -61,6 +62,13 @@ describe("network / peers / remoteSyncType", () => {
         syncType: PeerSyncType.FullySynced,
       },
       {
+        id: "Remote has higher finalizedEpoch and close head but local is stalled behind clock",
+        local: {finalizedEpoch: 10, headSlot: 10},
+        remote: {finalizedEpoch: 10 + 1, headSlot: 10 + 1},
+        currentSlot: 10 + slotImportTolerance + 1,
+        syncType: PeerSyncType.Advanced,
+      },
+      {
         id: "Remote has higher finalizedEpoch",
         local: {finalizedEpoch: 10},
         remote: {finalizedEpoch: 10 + 5},
@@ -68,12 +76,14 @@ describe("network / peers / remoteSyncType", () => {
       },
     ];
 
-    for (const {id, local: localPartial, remote: remotePartial, blocks, syncType} of testCases) {
+    for (const {id, local: localPartial, remote: remotePartial, blocks, currentSlot, syncType} of testCases) {
       it(id, () => {
         const local = {...status, ...localPartial};
         const remote = {...status, ...remotePartial};
         const forkChoice = getMockForkChoice(blocks || []);
-        expect(getPeerSyncType(local, remote, forkChoice, slotImportTolerance)).toBe(syncType);
+        expect(getPeerSyncType(local, remote, forkChoice, slotImportTolerance, currentSlot ?? local.headSlot)).toBe(
+          syncType
+        );
       });
     }
   });

--- a/packages/beacon-node/test/unit/sync/utils/remoteSyncType.test.ts
+++ b/packages/beacon-node/test/unit/sync/utils/remoteSyncType.test.ts
@@ -69,6 +69,28 @@ describe("network / peers / remoteSyncType", () => {
         syncType: PeerSyncType.Advanced,
       },
       {
+        id: "Remote has higher finalizedEpoch and stalled local but known head root still returns FullySynced",
+        local: {finalizedEpoch: 10, headSlot: 10},
+        remote: {finalizedEpoch: 10 + 1, headSlot: 10 + 1, headRoot: knownRoot},
+        blocks: [knownRoot],
+        currentSlot: 10 + slotImportTolerance + 1,
+        syncType: PeerSyncType.FullySynced,
+      },
+      {
+        id: "Remote has higher finalizedEpoch but local stalled at exact tolerance boundary stays FullySynced",
+        local: {finalizedEpoch: 10, headSlot: 10},
+        remote: {finalizedEpoch: 10 + 1, headSlot: 10 + 1},
+        currentSlot: 10 + slotImportTolerance,
+        syncType: PeerSyncType.FullySynced,
+      },
+      {
+        id: "Remote has higher finalizedEpoch and local stalled but remote head not ahead stays FullySynced",
+        local: {finalizedEpoch: 10, headSlot: 10},
+        remote: {finalizedEpoch: 10 + 1, headSlot: 10},
+        currentSlot: 10 + slotImportTolerance + 1,
+        syncType: PeerSyncType.FullySynced,
+      },
+      {
         id: "Remote has higher finalizedEpoch",
         local: {finalizedEpoch: 10},
         remote: {finalizedEpoch: 10 + 5},


### PR DESCRIPTION
## Motivation

After checkpoint sync on epbs-devnet-1, Lodestar can fail to start finalized range sync and follow head due to two independent client-side bugs:

1. **Peer classification:** when the local node is stalled behind the wall clock, a peer with higher `finalizedEpoch` and higher `headSlot` can be incorrectly classified as `FullySynced` instead of `Advanced` if its head falls within the slot-import tolerance range. This prevents finalized range sync from starting.

2. **Missing parent envelope:** during unknown-block processing, `PRESTATE_MISSING` can occur because the parent block's FULL variant (execution payload envelope) is still absent. The existing sync path did not proactively resolve the missing parent envelope before retrying, leaving the block stuck in the download queue.

## Changes

### Peer sync classification fix (`remoteSyncType.ts`, `sync.ts`)

- Add `currentSlot` parameter to `getPeerSyncType`
- Before applying the close-in-range `FullySynced` shortcut when `remote.finalizedEpoch > local.finalizedEpoch`, check whether the local head is stalled behind the wall clock
- If local is behind the clock **and** remote has both higher finalized epoch and higher head slot, classify the peer as `Advanced` so range sync can begin
- Add regression test for this case

### Missing parent envelope recovery (`unknownBlock.ts`)

- On `PRESTATE_MISSING` error during block import, check whether the parent block's FULL variant is absent
- If absent, proactively fetch the parent's execution payload envelope via reqresp before retrying
- Gate the envelope fetch on explicit FULL absence to avoid unnecessary requests when the parent envelope already exists

## Evidence & Limitations

Live testing on epbs-devnet-1 showed that the classification fix causes Lodestar to correctly enter finalized range sync instead of staying in the fully-synced path. The misclassification was observed with a non-official peer (self-identifying as erigon/caplin) that connected to the network — the official epbs-devnet-1 network only runs Prysm and Lodestar CL clients.

That same session then hit a **separate** outgoing `beacon_blocks_by_range` V2 `INVALID_REQUEST` (`SSZ_SNAPPY_ERROR_UNDER_SSZ_MIN_SIZE`), which is **not addressed by this PR**. The direct-host repro window later became unstable (the same host anchor alternated between behind / peerless / refused states), so this PR does **not** claim a complete end-to-end live-devnet fix.

This PR is limited to the two client-side logic fixes that are currently best supported by the available evidence. The downstream req/resp interop failure with Caplin remains a separate follow-up investigation.

<!-- This PR was authored with AI assistance. -->