### PR TITLE
fix: process payload attestations before payload envelope import

### DIFF
--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -185,8 +185,8 @@ export class NetworkProcessor {
   // we may not receive the block for messages like Attestation and SignedAggregateAndProof messages, in that case PendingGossipsubMessage needs
   // to be stored in this Map and reprocessed once the block comes
   private readonly awaitingMessagesByBlockRoot: MapDef<RootHex, Set<PendingGossipsubMessage>>;
-  // we may not receive the payload for messages like payload_attestation_message messages, in that case PendingGossipsubMessage needs
-  // to be stored in this Map and reprocessed once the payload comes
+  // we may not receive the payload for messages that require the FULL payload variant to be processed,
+  // in that case PendingGossipsubMessage needs to be stored in this Map and reprocessed once the payload comes
   private readonly awaitingMessagesByPayloadBlockRoot: MapDef<RootHex, Set<PendingGossipsubMessage>>;
   private unknownBlocksBySlot = new MapDef<Slot, Set<RootHex>>(() => new Set());
   private unknownEnvelopesBySlot = new MapDef<Slot, Set<RootHex>>(() => new Set());
@@ -417,12 +417,14 @@ export class NetworkProcessor {
           if (root == null) break;
           const payloadPresent = getPayloadPresentFromPayloadAttestationMessageSerialized(message.msg.data);
           if (payloadPresent && !this.chain.forkChoice.hasPayloadHexUnsafe(root)) {
+            // payload attestation votes that the payload is available but it is not yet known
             this.searchUnknownEnvelope(
               {slot, root},
               BlockInputSource.network_processor,
               message.propagationSource.toString()
             );
-            preprocessResult = {action: PreprocessAction.AwaitEnvelope, root};
+            // do not await the envelope, payload attestation processing only requires that the block is known
+            // also do not reset preprocessResult, we may already await for the block
           }
           break;
         }


### PR DESCRIPTION
Follow up to https://github.com/ChainSafe/lodestar/pull/9025, there is no need to delay processing payload attestations until the payload envelope is fully imported, the gossip validation and fork choice only require beacon block to be known.

This is mostly problematic because PTC members will cast their vote based on the fact that the payload and all data is available, but not that the payload is valid (as per execution layer) and fully imported.

This timing discrepancy means that it's very likely we receive `payload_attestation_message` on gossip before we have fully imported the corresponding payload and currently this means we would delay re-gossiping and importing these messages for no good reason.