### PR TITLE
fix: restore seen root dedupe for column created block inputs

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -505,7 +505,7 @@ export class BeaconChain implements IBeaconChain {
   }
 
   seenBlock(blockRoot: RootHex): boolean {
-    return this.seenBlockInputCache.hasBlock(blockRoot) || this.forkChoice.hasBlockHexUnsafe(blockRoot);
+    return this.seenBlockInputCache.has(blockRoot) || this.forkChoice.hasBlockHexUnsafe(blockRoot);
   }
 
   seenPayloadEnvelope(blockRoot: RootHex): boolean {

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -153,6 +153,10 @@ export class SeenBlockInput {
     return this.blockInputs.get(rootHex)?.hasBlock() ?? false;
   }
 
+  has(rootHex: RootHex): boolean {
+    return this.blockInputs.has(rootHex);
+  }
+
   get(rootHex: RootHex): IBlockInput | undefined {
     return this.blockInputs.get(rootHex);
   }

--- a/packages/beacon-node/test/unit/chain/seenCache/seenBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenBlockInput.test.ts
@@ -23,6 +23,7 @@ import {
   config,
   generateBlock,
   generateBlockWithBlobSidecars,
+  generateBlockWithColumnSidecars,
   generateChainOfBlocks,
 } from "../../../utils/blocksAndData.js";
 
@@ -80,6 +81,22 @@ describe("SeenBlockInputCache", async () => {
       blockRoot[1] = (blockRoot[1] + 1) % 255;
       blockRoot[2] = (blockRoot[2] + 1) % 255;
       expect(cache.hasBlock(toRootHex(blockRoot))).toBeFalsy();
+    });
+  });
+
+  describe("has()", () => {
+    it("should return true for a cached fulu column-only BlockInput", () => {
+      const {columnSidecars, rootHex} = generateBlockWithColumnSidecars({forkName: ForkName.fulu});
+
+      cache.getByColumn({
+        columnSidecar: columnSidecars[0],
+        blockRootHex: rootHex,
+        source: BlockInputSource.gossip,
+        seenTimestampSec: Date.now() / 1000,
+      });
+
+      expect(cache.has(rootHex)).toBeTruthy();
+      expect(cache.hasBlock(rootHex)).toBeFalsy();
     });
   });
 


### PR DESCRIPTION
Fulu can cache a `BlockInput` from data columns before the full beacon block is available.

PR #9025 narrowed `seenBlock()` to only treat roots with a cached block as seen, which caused the network processor to start `unknownBlockRoot` sync for roots that were already being assembled locally from columns.

Restore the broader seen root check for `BlockInput` cache entries while keeping `hasBlock()` available for the narrower "full block present" query. Add a regression test covering a Fulu column first cache entry.

