### PR TITLE
fix: correct proposer boost logic and getParentNodeIndex for gloas

### DIFF
--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -354,9 +354,15 @@ export class ProtoArray {
         continue;
       }
 
-      const currentBoost = proposerBoost && proposerBoost.root === node.blockRoot ? proposerBoost.score : 0;
+      // For Gloas blocks, PENDING/EMPTY/FULL all share the same blockRoot.
+      // Only apply proposer boost to EMPTY (for Gloas) or FULL (for pre-Gloas) — the variant
+      // that validator votes target — to avoid a 2x boost from the boost being applied to
+      // each variant and then propagated up to PENDING via delta back-propagation.
+      const isBoostVariant = isGloasBlock(node) ? node.payloadStatus === PayloadStatus.EMPTY : true; // pre-Gloas has only FULL, always boost
+      const currentBoost =
+        proposerBoost && proposerBoost.root === node.blockRoot && isBoostVariant ? proposerBoost.score : 0;
       const previousBoost =
-        this.previousProposerBoost && this.previousProposerBoost.root === node.blockRoot
+        this.previousProposerBoost && this.previousProposerBoost.root === node.blockRoot && isBoostVariant
           ? this.previousProposerBoost.score
           : 0;
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -355,10 +355,10 @@ export class ProtoArray {
       }
 
       // For Gloas blocks, PENDING/EMPTY/FULL all share the same blockRoot.
-      // Only apply proposer boost to EMPTY (for Gloas) or FULL (for pre-Gloas) — the variant
-      // that validator votes target — to avoid a 2x boost from the boost being applied to
-      // each variant and then propagated up to PENDING via delta back-propagation.
-      const isBoostVariant = isGloasBlock(node) ? node.payloadStatus === PayloadStatus.EMPTY : true; // pre-Gloas has only FULL, always boost
+      // Only apply proposer boost to PENDING (for Gloas) or FULL (for pre-Gloas) — to avoid
+      // double-counting the boost across variants during delta back-propagation, and to keep
+      // the boost neutral with respect to EMPTY vs FULL selection.
+      const isBoostVariant = isGloasBlock(node) ? node.payloadStatus === PayloadStatus.PENDING : true; // pre-Gloas has only FULL, always boost
       const currentBoost =
         proposerBoost && proposerBoost.root === node.blockRoot && isBoostVariant ? proposerBoost.score : 0;
       const previousBoost =

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -1484,9 +1484,16 @@ export class ProtoArray {
    */
   private getParentNodeIndex(node: ProtoNode): number | undefined {
     if (isGloasBlock(node)) {
-      // Use getParentPayloadStatus for Gloas blocks to get correct EMPTY/FULL variant
-      const parentPayloadStatus = this.getParentPayloadStatus(node);
-      return this.getNodeIndexByRootAndStatus(node.parentRoot, parentPayloadStatus);
+      // Traversal may reach the finalized ProtoBlock, should not throw error in that case
+      try {
+        const parentPayloadStatus = this.getParentPayloadStatus(node);
+        return this.getNodeIndexByRootAndStatus(node.parentRoot, parentPayloadStatus);
+      } catch (e) {
+        if (e instanceof ProtoArrayError && e.type.code === ProtoArrayErrorCode.UNKNOWN_PARENT_BLOCK) {
+          return undefined;
+        }
+        throw e;
+      }
     }
     // Simple parent traversal for pre-Gloas blocks (includes fork transition)
     return node.parent;


### PR DESCRIPTION
**Motivation**

Two fork-choice bugs in the Gloas (ePBS) protoArray implementation:

1. **Proposer boost double-counting** — In Gloas, PENDING/EMPTY/FULL variants share the same blockRoot. The proposer boost was applied to every matching variant, causing a 2x boost that propagated up to PENDING via delta back-propagation.

2. **getParentNodeIndex() crash at finalized boundary** — getParentPayloadStatus() throws UNKNOWN_PARENT_BLOCK when traversal reaches the finalized ProtoBlock (whose parent has been pruned). This caused unexpected errors during score propagation and ancestor iteration.

**Description**

- Only apply proposer boost to the EMPTY variant (for Gloas) or FULL (for pre-Gloas) — the variant that validator votes target — to avoid double-counting.
- Catch UNKNOWN_PARENT_BLOCK in getParentNodeIndex() and return undefined (consistent with the method's number | undefined return type), re-throw all other errors.

**AI Assistance Disclosure**

Used Claude Code to assist with the PR creation.