### PR TITLE
fix: compute payload status for justified/finalized checkpoints

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -2,14 +2,7 @@ import path from "node:path";
 import {PrivateKey} from "@libp2p/interface";
 import {Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {
-  CheckpointWithPayloadStatus,
-  IForkChoice,
-  PayloadStatus,
-  ProtoBlock,
-  UpdateHeadOpt,
-  getCheckpointPayloadStatus,
-} from "@lodestar/fork-choice";
+import {CheckpointWithPayloadStatus, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
 import {LoggerNode} from "@lodestar/logger/node";
 import {
   BUILDER_INDEX_SELF_BUILD,
@@ -37,6 +30,7 @@ import {
   BlindedBeaconBlockBody,
   DataColumnSidecar,
   Epoch,
+  PayloadStatus,
   Root,
   RootHex,
   SignedBeaconBlock,
@@ -385,10 +379,10 @@ export class BeaconChain implements IBeaconChain {
       this.opts
     );
 
-    const {checkpoint} = anchorState.computeAnchorCheckpoint();
+    const {checkpoint, checkpointPayloadStatus} = anchorState.computeAnchorCheckpoint();
     blockStateCache.add(anchorState);
     blockStateCache.setHeadState(anchorState);
-    const payloadPresent = getCheckpointPayloadStatus(config, anchorState, checkpoint.epoch) === PayloadStatus.FULL;
+    const payloadPresent = checkpointPayloadStatus === PayloadStatus.FULL;
     checkpointStateCache.add(checkpoint, anchorState, payloadPresent);
 
     const forkChoice = initializeForkChoice(

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -8,7 +8,6 @@ import {
   ProtoArray,
   ProtoBlock,
   ForkChoiceOpts as RawForkChoiceOpts,
-  getCheckpointPayloadStatus,
 } from "@lodestar/fork-choice";
 import {ForkSeq, ZERO_HASH_HEX} from "@lodestar/params";
 import {
@@ -83,7 +82,7 @@ export function initializeForkChoiceFromFinalizedState(
   metrics: Metrics | null,
   logger?: Logger
 ): ForkChoice {
-  const {blockHeader, checkpoint} = state.computeAnchorCheckpoint();
+  const {blockHeader, checkpoint, checkpointPayloadStatus} = state.computeAnchorCheckpoint();
   const finalizedCheckpoint = {...checkpoint};
   const justifiedCheckpoint = {
     ...checkpoint,
@@ -102,11 +101,9 @@ export function initializeForkChoiceFromFinalizedState(
 
   const isForkPostGloas = computeEpochAtSlot(state.slot) >= config.GLOAS_FORK_EPOCH;
 
-  // Determine justified checkpoint payload status
-  const justifiedPayloadStatus = getCheckpointPayloadStatus(config, state, justifiedCheckpoint.epoch);
-
-  // Determine finalized checkpoint payload status
-  const finalizedPayloadStatus = getCheckpointPayloadStatus(config, state, finalizedCheckpoint.epoch);
+  // Both justified and finalized derive from the same anchor checkpoint
+  const justifiedPayloadStatus = checkpointPayloadStatus;
+  const finalizedPayloadStatus = checkpointPayloadStatus;
 
   return new forkchoiceConstructor(
     config,
@@ -200,10 +197,8 @@ export function initializeForkChoiceFromUnfinalizedState(
 
   const isForkPostGloas = computeEpochAtSlot(unfinalizedState.slot) >= config.GLOAS_FORK_EPOCH;
 
-  // For unfinalized state, use getCheckpointPayloadStatus to determine the correct status.
-  // It checks state.execution_payload_availability to determine EMPTY vs FULL.
-  const justifiedPayloadStatus = getCheckpointPayloadStatus(config, unfinalizedState, justifiedCheckpoint.epoch);
-  const finalizedPayloadStatus = getCheckpointPayloadStatus(config, unfinalizedState, finalizedCheckpoint.epoch);
+  const justifiedPayloadStatus = unfinalizedState.getCheckpointPayloadStatus(justifiedCheckpoint.epoch);
+  const finalizedPayloadStatus = unfinalizedState.getCheckpointPayloadStatus(finalizedCheckpoint.epoch);
 
   const store = new ForkChoiceStore(
     currentSlot,

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkSeq, SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
+import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
   DataAvailabilityStatus,
   EffectiveBalanceIncrements,
@@ -669,16 +669,18 @@ export class ForkChoice implements IForkChoice {
     }
 
     // Get justified checkpoint with payload status for Gloas
-    const justifiedPayloadStatus = getCheckpointPayloadStatus(
-      this.config,
-      state,
+    const justifiedPayloadStatus = this.getCheckpointPayloadStatusFromAncestor(
+      parentRootHex,
       state.currentJustifiedCheckpoint.epoch
     );
     const justifiedCheckpoint = toCheckpointWithPayload(state.currentJustifiedCheckpoint, justifiedPayloadStatus);
     const stateJustifiedEpoch = justifiedCheckpoint.epoch;
 
     // Get finalized checkpoint with payload status for Gloas
-    const finalizedPayloadStatus = getCheckpointPayloadStatus(this.config, state, state.finalizedCheckpoint.epoch);
+    const finalizedPayloadStatus = this.getCheckpointPayloadStatusFromAncestor(
+      parentRootHex,
+      state.finalizedCheckpoint.epoch
+    );
     const finalizedCheckpoint = toCheckpointWithPayload(state.finalizedCheckpoint, finalizedPayloadStatus);
 
     // Justified balances for `justifiedCheckpoint` are new to the fork-choice. Compute them on demand only if
@@ -709,10 +711,8 @@ export class ForkChoice implements IForkChoice {
         parentBlock.unrealizedFinalizedEpoch + 1 >= blockEpoch
       ) {
         // reuse from parent, happens at 1/3 last blocks of epoch as monitored in mainnet
-        // Get payload status for unrealized justified checkpoint
-        const unrealizedJustifiedPayloadStatus = getCheckpointPayloadStatus(
-          this.config,
-          state,
+        const unrealizedJustifiedPayloadStatus = this.getCheckpointPayloadStatusFromAncestor(
+          parentRootHex,
           parentBlock.unrealizedJustifiedEpoch
         );
         unrealizedJustifiedCheckpoint = {
@@ -721,10 +721,8 @@ export class ForkChoice implements IForkChoice {
           rootHex: parentBlock.unrealizedJustifiedRoot,
           payloadStatus: unrealizedJustifiedPayloadStatus,
         };
-        // Get payload status for unrealized finalized checkpoint
-        const unrealizedFinalizedPayloadStatus = getCheckpointPayloadStatus(
-          this.config,
-          state,
+        const unrealizedFinalizedPayloadStatus = this.getCheckpointPayloadStatusFromAncestor(
+          parentRootHex,
           parentBlock.unrealizedFinalizedEpoch
         );
         unrealizedFinalizedCheckpoint = {
@@ -736,20 +734,16 @@ export class ForkChoice implements IForkChoice {
       } else {
         // compute new, happens 2/3 first blocks of epoch as monitored in mainnet
         const unrealized = state.computeUnrealizedCheckpoints();
-        // Get payload status for unrealized justified checkpoint
-        const unrealizedJustifiedPayloadStatus = getCheckpointPayloadStatus(
-          this.config,
-          state,
+        const unrealizedJustifiedPayloadStatus = this.getCheckpointPayloadStatusFromAncestor(
+          parentRootHex,
           unrealized.justifiedCheckpoint.epoch
         );
         unrealizedJustifiedCheckpoint = toCheckpointWithPayload(
           unrealized.justifiedCheckpoint,
           unrealizedJustifiedPayloadStatus
         );
-        // Get payload status for unrealized finalized checkpoint
-        const unrealizedFinalizedPayloadStatus = getCheckpointPayloadStatus(
-          this.config,
-          state,
+        const unrealizedFinalizedPayloadStatus = this.getCheckpointPayloadStatusFromAncestor(
+          parentRootHex,
           unrealized.finalizedCheckpoint.epoch
         );
         unrealizedFinalizedCheckpoint = toCheckpointWithPayload(
@@ -1143,6 +1137,27 @@ export class ForkChoice implements IForkChoice {
   getFinalizedCheckpointSlot(): Slot {
     const finalizedEpoch = this.fcStore.finalizedCheckpoint.epoch;
     return computeStartSlotAtEpoch(finalizedEpoch);
+  }
+
+  /**
+   * Get checkpoint payload status using proto array ancestor lookup.
+   * For state-based lookup during initialization, see IBeaconStateView.getCheckpointPayloadStatus().
+   */
+  getCheckpointPayloadStatusFromAncestor(blockRoot: RootHex, checkpointEpoch: Epoch): PayloadStatus {
+    const checkpointSlot = computeStartSlotAtEpoch(checkpointEpoch);
+
+    if (this.config.getForkSeq(checkpointSlot) >= ForkSeq.gloas) {
+      const ancestorNode = this.getAncestor(blockRoot, checkpointSlot);
+      if (ancestorNode.slot === checkpointSlot) {
+        // Non-skipped: payload not arrived at the time block is processed
+        return PayloadStatus.EMPTY;
+      }
+      // Skipped: use proto node's status
+      return ancestorNode.payloadStatus;
+    }
+
+    // Pre-Gloas: always FULL
+    return PayloadStatus.FULL;
   }
 
   /**
@@ -1865,36 +1880,4 @@ export function getCommitteeFraction(
 ): number {
   const committeeWeight = Math.floor(justifiedTotalActiveBalanceByIncrement / config.slotsPerEpoch);
   return Math.floor((committeeWeight * config.committeePercent) / 100);
-}
-
-/**
- * Get the payload status for a checkpoint.
- *
- * Pre-Gloas: always FULL (payload embedded in block)
- * Gloas: determined by state.execution_payload_availability
- *
- * @param config - The chain fork config to determine fork at checkpoint slot
- * @param state - The state to check execution_payload_availability
- * @param checkpointEpoch - The epoch of the checkpoint
- */
-export function getCheckpointPayloadStatus(
-  config: ChainForkConfig,
-  state: IBeaconStateView,
-  checkpointEpoch: number
-): PayloadStatus {
-  // Compute checkpoint slot first to determine the correct fork
-  const checkpointSlot = computeStartSlotAtEpoch(checkpointEpoch);
-  const fork = config.getForkSeq(checkpointSlot);
-
-  // Pre-Gloas: always FULL
-  if (fork < ForkSeq.gloas) {
-    return PayloadStatus.FULL;
-  }
-
-  // For Gloas, check state.execution_payload_availability
-  // - For non-skipped slots at checkpoint: returns false (EMPTY) since payload hasn't arrived yet
-  // - For skipped slots at checkpoint: returns the actual availability status from state
-  const payloadAvailable = state.executionPayloadAvailability.get(checkpointSlot % SLOTS_PER_HISTORICAL_ROOT);
-
-  return payloadAvailable ? PayloadStatus.FULL : PayloadStatus.EMPTY;
 }

--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -6,12 +6,7 @@ export {
   type InvalidBlock,
   InvalidBlockCode,
 } from "./forkChoice/errors.js";
-export {
-  ForkChoice,
-  type ForkChoiceOpts,
-  UpdateHeadOpt,
-  getCheckpointPayloadStatus,
-} from "./forkChoice/forkChoice.js";
+export {ForkChoice, type ForkChoiceOpts, UpdateHeadOpt} from "./forkChoice/forkChoice.js";
 export {
   type AncestorResult,
   AncestorStatus,

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -1,5 +1,8 @@
 import {DataAvailabilityStatus} from "@lodestar/state-transition";
-import {Epoch, RootHex, Slot, UintNum64} from "@lodestar/types";
+import {Epoch, PayloadStatus, RootHex, Slot, UintNum64} from "@lodestar/types";
+
+// Re-export from @lodestar/types for backward compatibility
+export {PayloadStatus} from "@lodestar/types";
 
 // RootHex is a root as a hex string
 // Used for lightweight and easy comparison
@@ -34,16 +37,6 @@ export enum ExecutionStatus {
   PreMerge = "PreMerge",
   Invalid = "Invalid",
   PayloadSeparated = "PayloadSeparated",
-}
-
-/**
- * Payload status for ePBS (Gloas fork)
- * Spec: gloas/fork-choice.md#constants
- */
-export enum PayloadStatus {
-  PENDING = 0,
-  EMPTY = 1,
-  FULL = 2,
 }
 
 /**

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -11,6 +11,7 @@ import {
   Epoch,
   ExecutionPayloadBid,
   ExecutionPayloadHeader,
+  PayloadStatus,
   Root,
   RootHex,
   SignedBeaconBlock,
@@ -28,6 +29,7 @@ import {
   rewards,
 } from "@lodestar/types";
 import {Checkpoint, Fork} from "@lodestar/types/phase0";
+import {byteArrayEquals} from "@lodestar/utils";
 import {processExecutionPayloadEnvelope} from "../block/index.js";
 import {ProcessExecutionPayloadEnvelopeOpts} from "../block/processExecutionPayloadEnvelope.js";
 import {VoluntaryExitValidity, getVoluntaryExitValidity} from "../block/processVoluntaryExit.js";
@@ -463,8 +465,66 @@ export class BeaconStateView implements IBeaconStateView {
     return this.cachedState.epochCtx.getBeaconProposer(slot);
   }
 
-  computeAnchorCheckpoint(): {checkpoint: phase0.Checkpoint; blockHeader: phase0.BeaconBlockHeader} {
-    return computeAnchorCheckpoint(this.config, this.cachedState);
+  /**
+   * Compute anchor checkpoint and its payload status from state.
+   * For proto array-based lookup during block processing, see
+   * ForkChoice.getCheckpointPayloadStatusFromAncestor().
+   */
+  computeAnchorCheckpoint(): {
+    checkpoint: phase0.Checkpoint;
+    checkpointPayloadStatus: PayloadStatus;
+    blockHeader: phase0.BeaconBlockHeader;
+  } {
+    const result = computeAnchorCheckpoint(this.config, this.cachedState);
+
+    if (this.config.getForkSeq(this.cachedState.slot) >= ForkSeq.gloas) {
+      const blockSlot = this.cachedState.latestBlockHeader.slot;
+
+      // Non-skipped: payload not arrived at the time block is processed
+      if (this.cachedState.slot === blockSlot) {
+        return {...result, checkpointPayloadStatus: PayloadStatus.EMPTY};
+      }
+
+      // Skipped slot: check executionPayloadAvailability at actual block's slot
+      const payloadAvailable = this.executionPayloadAvailability.get(blockSlot % SLOTS_PER_HISTORICAL_ROOT);
+      return {...result, checkpointPayloadStatus: payloadAvailable ? PayloadStatus.FULL : PayloadStatus.EMPTY};
+    }
+
+    // Pre-Gloas: always FULL
+    return {...result, checkpointPayloadStatus: PayloadStatus.FULL};
+  }
+
+  /**
+   * Get checkpoint payload status for an arbitrary checkpoint epoch using state blockRoots.
+   * Used during fork choice initialization from unfinalized state.
+   * For anchor checkpoint, see computeAnchorCheckpoint() which uses a more efficient approach.
+   * For proto array-based lookup during block processing, see
+   * ForkChoice.getCheckpointPayloadStatusFromAncestor().
+   */
+  getCheckpointPayloadStatus(checkpointEpoch: Epoch): PayloadStatus {
+    const checkpointSlot = computeStartSlotAtEpoch(checkpointEpoch);
+
+    if (this.config.getForkSeq(checkpointSlot) >= ForkSeq.gloas) {
+      // Non-skipped: blockRoot at checkpoint slot differs from blockRoot at slot-1
+      if (!byteArrayEquals(this.getBlockRootAtSlot(checkpointSlot), this.getBlockRootAtSlot(checkpointSlot - 1))) {
+        // Non-skipped: payload not arrived at the time block is processed
+        return PayloadStatus.EMPTY;
+      }
+
+      // Skipped: walk back to find actual block slot, check executionPayloadAvailability there
+      let actualSlot = checkpointSlot;
+      while (
+        actualSlot > 0 &&
+        byteArrayEquals(this.getBlockRootAtSlot(actualSlot), this.getBlockRootAtSlot(actualSlot - 1))
+      ) {
+        actualSlot--;
+      }
+      const payloadAvailable = this.executionPayloadAvailability.get(actualSlot % SLOTS_PER_HISTORICAL_ROOT);
+      return payloadAvailable ? PayloadStatus.FULL : PayloadStatus.EMPTY;
+    }
+
+    // Pre-Gloas: always FULL
+    return PayloadStatus.FULL;
   }
 
   // Sync committees

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -9,6 +9,7 @@ import {
   Epoch,
   ExecutionPayloadBid,
   ExecutionPayloadHeader,
+  PayloadStatus,
   Root,
   RootHex,
   SignedBeaconBlock,
@@ -183,7 +184,12 @@ export interface IBeaconStateView {
     justifiedCheckpoint: phase0.Checkpoint;
     finalizedCheckpoint: phase0.Checkpoint;
   };
-  computeAnchorCheckpoint(): {checkpoint: phase0.Checkpoint; blockHeader: phase0.BeaconBlockHeader};
+  computeAnchorCheckpoint(): {
+    checkpoint: phase0.Checkpoint;
+    checkpointPayloadStatus: PayloadStatus;
+    blockHeader: phase0.BeaconBlockHeader;
+  };
+  getCheckpointPayloadStatus(checkpointEpoch: Epoch): PayloadStatus;
 
   // this is for backward compatible
   clonedCount: number;

--- a/packages/types/src/forkChoice.ts
+++ b/packages/types/src/forkChoice.ts
@@ -1,0 +1,9 @@
+/**
+ * Payload status for ePBS (Gloas fork)
+ * Spec: gloas/fork-choice.md#constants
+ */
+export enum PayloadStatus {
+  PENDING = 0,
+  EMPTY = 1,
+  FULL = 2,
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,6 +5,8 @@ import * as ssz from "./sszTypes.js";
 import {sszTypesFor} from "./sszTypes.js";
 export {sszTypesFor, SSZTypesFor, ssz};
 
+// Fork choice
+export * from "./forkChoice.js";
 export * from "./utils/array.js";
 // Container utils
 export * from "./utils/container.js";


### PR DESCRIPTION
**Motivation**

The previous `getCheckpointPayloadStatus` function always read `state.executionPayloadAvailability` at the checkpoint slot for Gloas, without distinguishing between skipped and non-skipped slots. For non-skipped slots, the payload hasn't arrived yet at the time the block is processed, so the status should be `EMPTY`. For skipped slots, we need to look up the actual block's slot and check its payload availability.

**Description**

- Move `PayloadStatus` enum from `@lodestar/fork-choice` to `@lodestar/types` (re-exported from fork-choice for backward compatibility)
- Add `getCheckpointPayloadStatus(epoch)` method to `IBeaconStateView` — uses blockRoots comparison to detect skipped slots, walks back to find actual block slot
- Enhance `computeAnchorCheckpoint()` to return `checkpointPayloadStatus` using efficient `state.slot === latestBlockHeader.slot` comparison
- Add `getCheckpointPayloadStatusFromAncestor()` method on `ForkChoice` — uses proto array `getAncestor()` for O(1) skipped-slot detection during block processing
- Remove standalone `getCheckpointPayloadStatus()` function; all consumers migrated to the new APIs

**AI Assistance Disclosure**

Used Claude Code for implementation assistance.