### PR TITLE
fix: validate MIN_EPOCHS for blob/data column by range/root requests

### DIFF
--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -96,11 +96,12 @@ export function validateBeaconBlocksByRangeRequest(
   if (count < 1) {
     throw new ResponseError(RespStatus.INVALID_REQUEST, "count < 1");
   }
-  // TODO: validate against MIN_EPOCHS_FOR_BLOCK_REQUESTS
   if (startSlot < GENESIS_SLOT) {
     throw new ResponseError(RespStatus.INVALID_REQUEST, "startSlot < genesis");
   }
 
+  // The phase0 req/resp spec defines the recent range peers MUST support serving.
+  // Archival peers may still serve older retained blocks.
   // step > 1 is deprecated, see https://github.com/ethereum/consensus-specs/pull/2856
 
   const maxRequestBlocks = isForkPostDeneb(config.getForkName(startSlot))

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -101,7 +101,8 @@ export function validateBeaconBlocksByRangeRequest(
   }
 
   // The phase0 req/resp spec defines the recent range peers MUST support serving.
-  // Archival peers may still serve older retained blocks.
+  // Archival nodes may still serve older retained blocks to allow genesis sync.
+
   // step > 1 is deprecated, see https://github.com/ethereum/consensus-specs/pull/2856
 
   const maxRequestBlocks = isForkPostDeneb(config.getForkName(startSlot))

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -100,7 +100,7 @@ export function validateBeaconBlocksByRangeRequest(
     throw new ResponseError(RespStatus.INVALID_REQUEST, "startSlot < genesis");
   }
 
-  // The phase0 req/resp spec defines the recent range peers MUST support serving.
+  // The phase0 req/resp spec uses MIN_EPOCHS_FOR_BLOCK_REQUESTS to define the minimum range peers MUST serve.
   // Archival nodes may still serve older retained blocks to allow genesis sync.
 
   // step > 1 is deprecated, see https://github.com/ethereum/consensus-specs/pull/2856

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRoot.ts
@@ -10,6 +10,7 @@ export async function* onBeaconBlocksByRoot(
 ): AsyncIterable<ResponseOutgoing> {
   // The phase0 req/resp spec uses MIN_EPOCHS_FOR_BLOCK_REQUESTS to define the minimum range peers MUST serve.
   // Archival nodes may still serve older retained blocks to allow genesis sync.
+
   for (const blockRoot of requestBody) {
     const root = blockRoot;
     const block = await chain.getSerializedBlockByRoot(toRootHex(root));

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRoot.ts
@@ -8,6 +8,8 @@ export async function* onBeaconBlocksByRoot(
   requestBody: BeaconBlocksByRootRequest,
   chain: IBeaconChain
 ): AsyncIterable<ResponseOutgoing> {
+  // The phase0 req/resp spec uses MIN_EPOCHS_FOR_BLOCK_REQUESTS to define the minimum range peers MUST serve.
+  // Archival nodes may still serve older retained blocks to allow genesis sync.
   for (const blockRoot of requestBody) {
     const root = blockRoot;
     const block = await chain.getSerializedBlockByRoot(toRootHex(root));

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
@@ -2,7 +2,7 @@ import {ChainConfig} from "@lodestar/config";
 import {BLOB_SIDECAR_FIXED_SIZE, GENESIS_SLOT} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
-import {Slot, deneb} from "@lodestar/types";
+import {Epoch, Slot, deneb} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
 import {IBeaconDb} from "../../../db/index.js";
@@ -14,7 +14,7 @@ export async function* onBlobSidecarsByRange(
   db: IBeaconDb
 ): AsyncIterable<ResponseOutgoing> {
   // Non-finalized range of blobs
-  const {startSlot, count} = validateBlobSidecarsByRangeRequest(chain.config, request);
+  const {startSlot, count} = validateBlobSidecarsByRangeRequest(chain.config, chain.clock.currentEpoch, request);
   const endSlot = startSlot + count;
 
   const finalized = db.blobSidecarsArchive;
@@ -94,6 +94,7 @@ export function* iterateBlobBytesFromWrapper(
 
 export function validateBlobSidecarsByRangeRequest(
   config: ChainConfig,
+  currentEpoch: Epoch,
   request: deneb.BlobSidecarsByRangeRequest
 ): deneb.BlobSidecarsByRangeRequest {
   const {startSlot} = request;
@@ -102,9 +103,20 @@ export function validateBlobSidecarsByRangeRequest(
   if (count < 1) {
     throw new ResponseError(RespStatus.INVALID_REQUEST, "count < 1");
   }
-  // TODO: validate against MIN_EPOCHS_FOR_BLOCK_REQUESTS
   if (startSlot < GENESIS_SLOT) {
     throw new ResponseError(RespStatus.INVALID_REQUEST, "startSlot < genesis");
+  }
+
+  // Spec: [max(current_epoch - MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS, DENEB_FORK_EPOCH), current_epoch]
+  const minimumRequestEpoch = Math.max(
+    currentEpoch - config.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS,
+    config.DENEB_FORK_EPOCH
+  );
+  if (computeEpochAtSlot(startSlot) < minimumRequestEpoch) {
+    throw new ResponseError(
+      RespStatus.RESOURCE_UNAVAILABLE,
+      "startSlot is before MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS"
+    );
   }
 
   if (count > config.MAX_REQUEST_BLOCKS_DENEB) {

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRoot.ts
@@ -12,6 +12,13 @@ export async function* onBlobSidecarsByRoot(
 ): AsyncIterable<ResponseOutgoing> {
   const finalizedSlot = chain.forkChoice.getFinalizedBlock().slot;
 
+  // Spec: [max(current_epoch - MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS, DENEB_FORK_EPOCH), current_epoch]
+  const currentEpoch = chain.clock.currentEpoch;
+  const minimumRequestEpoch = Math.max(
+    currentEpoch - chain.config.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS,
+    chain.config.DENEB_FORK_EPOCH
+  );
+
   // In sidecars by root request, it can be expected that sidecar requests will be come
   // clustured by blockroots, and this helps us save db lookups once we load sidecars
   // for a root
@@ -26,6 +33,10 @@ export async function* onBlobSidecarsByRoot(
     // SPEC: Clients MUST support requesting blocks and sidecars since the latest finalized epoch.
     // https://github.com/ethereum/consensus-specs/blob/11a037fd9227e29ee809c9397b09f8cc3383a8c0/specs/eip4844/p2p-interface.md#beaconblockandblobssidecarbyroot-v1
     if (!block || block.slot <= finalizedSlot) {
+      continue;
+    }
+
+    if (computeEpochAtSlot(block.slot) < minimumRequestEpoch) {
       continue;
     }
 

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
@@ -3,7 +3,7 @@ import {ChainConfig} from "@lodestar/config";
 import {GENESIS_SLOT} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
-import {ColumnIndex, fulu} from "@lodestar/types";
+import {ColumnIndex, Epoch, fulu} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
 import {IBeaconDb} from "../../../db/index.js";
@@ -21,7 +21,11 @@ export async function* onDataColumnSidecarsByRange(
   peerClient: string
 ): AsyncIterable<ResponseOutgoing> {
   // Non-finalized range of columns
-  const {startSlot, count, columns: requestedColumns} = validateDataColumnSidecarsByRangeRequest(chain.config, request);
+  const {
+    startSlot,
+    count,
+    columns: requestedColumns,
+  } = validateDataColumnSidecarsByRangeRequest(chain.config, chain.clock.currentEpoch, request);
   const availableColumns = validateRequestedDataColumns(chain, requestedColumns);
   const endSlot = startSlot + count;
 
@@ -139,6 +143,7 @@ export async function* onDataColumnSidecarsByRange(
 
 export function validateDataColumnSidecarsByRangeRequest(
   config: ChainConfig,
+  currentEpoch: Epoch,
   request: fulu.DataColumnSidecarsByRangeRequest
 ): fulu.DataColumnSidecarsByRangeRequest {
   const {startSlot, columns} = request;
@@ -147,9 +152,20 @@ export function validateDataColumnSidecarsByRangeRequest(
   if (count < 1) {
     throw new ResponseError(RespStatus.INVALID_REQUEST, "count < 1");
   }
-  // TODO: validate against MIN_EPOCHS_FOR_BLOCK_REQUESTS
   if (startSlot < GENESIS_SLOT) {
     throw new ResponseError(RespStatus.INVALID_REQUEST, "startSlot < genesis");
+  }
+
+  // Spec: [max(current_epoch - MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS, FULU_FORK_EPOCH), current_epoch]
+  const minimumRequestEpoch = Math.max(
+    currentEpoch - config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS,
+    config.FULU_FORK_EPOCH
+  );
+  if (computeEpochAtSlot(startSlot) < minimumRequestEpoch) {
+    throw new ResponseError(
+      RespStatus.RESOURCE_UNAVAILABLE,
+      "startSlot is before MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS"
+    );
   }
 
   if (count > config.MAX_REQUEST_BLOCKS_DENEB) {

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
@@ -85,8 +85,9 @@ export function validateExecutionPayloadEnvelopesByRangeRequest(
     throw new ResponseError(RespStatus.INVALID_REQUEST, "startSlot < genesis");
   }
 
-  // Retained historical envelopes remain serveable. Actual availability is determined
-  // by earliestAvailableSlot / archive retention, not by a current-epoch floor here.
+  // The gloas req/resp spec defines the recent range peers MUST support serving.
+  // Archival nodes may still serve older retained payloads to allow genesis sync.
+
   if (count > config.MAX_REQUEST_BLOCKS_DENEB) {
     count = config.MAX_REQUEST_BLOCKS_DENEB;
   }

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
@@ -81,11 +81,12 @@ export function validateExecutionPayloadEnvelopesByRangeRequest(
   if (count < 1) {
     throw new ResponseError(RespStatus.INVALID_REQUEST, "count < 1");
   }
-  // TODO: validate against MIN_EPOCHS_FOR_BLOCK_REQUESTS
   if (startSlot < GENESIS_SLOT) {
     throw new ResponseError(RespStatus.INVALID_REQUEST, "startSlot < genesis");
   }
 
+  // Retained historical envelopes remain serveable. Actual availability is determined
+  // by earliestAvailableSlot / archive retention, not by a current-epoch floor here.
   if (count > config.MAX_REQUEST_BLOCKS_DENEB) {
     count = config.MAX_REQUEST_BLOCKS_DENEB;
   }

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
@@ -85,7 +85,7 @@ export function validateExecutionPayloadEnvelopesByRangeRequest(
     throw new ResponseError(RespStatus.INVALID_REQUEST, "startSlot < genesis");
   }
 
-  // The gloas req/resp spec defines the recent range peers MUST support serving.
+  // The gloas req/resp spec uses MIN_EPOCHS_FOR_BLOCK_REQUESTS to define the minimum range peers MUST serve.
   // Archival nodes may still serve older retained payloads to allow genesis sync.
 
   if (count > config.MAX_REQUEST_BLOCKS_DENEB) {

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
@@ -10,6 +10,8 @@ export async function* onExecutionPayloadEnvelopesByRoot(
   chain: IBeaconChain,
   db: IBeaconDb
 ): AsyncIterable<ResponseOutgoing> {
+  // The gloas req/resp spec uses MIN_EPOCHS_FOR_BLOCK_REQUESTS to define the minimum range peers MUST serve.
+  // Archival nodes may still serve older retained payloads to allow genesis sync.
   for (const root of requestBody) {
     const rootHex = toRootHex(root);
     const block = chain.forkChoice.getBlockHexDefaultStatus(rootHex);

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
@@ -12,6 +12,7 @@ export async function* onExecutionPayloadEnvelopesByRoot(
 ): AsyncIterable<ResponseOutgoing> {
   // The gloas req/resp spec uses MIN_EPOCHS_FOR_BLOCK_REQUESTS to define the minimum range peers MUST serve.
   // Archival nodes may still serve older retained payloads to allow genesis sync.
+
   for (const root of requestBody) {
     const rootHex = toRootHex(root);
     const block = chain.forkChoice.getBlockHexDefaultStatus(rootHex);

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
@@ -10,13 +10,6 @@ export async function* onExecutionPayloadEnvelopesByRoot(
   chain: IBeaconChain,
   db: IBeaconDb
 ): AsyncIterable<ResponseOutgoing> {
-  // Spec: [max(GLOAS_FORK_EPOCH, current_epoch - MIN_EPOCHS_FOR_BLOCK_REQUESTS), current_epoch]
-  const currentEpoch = chain.clock.currentEpoch;
-  const minimumRequestEpoch = Math.max(
-    currentEpoch - chain.config.MIN_EPOCHS_FOR_BLOCK_REQUESTS,
-    chain.config.GLOAS_FORK_EPOCH
-  );
-
   for (const root of requestBody) {
     const rootHex = toRootHex(root);
     const block = chain.forkChoice.getBlockHexDefaultStatus(rootHex);
@@ -27,16 +20,11 @@ export async function* onExecutionPayloadEnvelopesByRoot(
       continue;
     }
 
-    const requestedEpoch = computeEpochAtSlot(slot);
-    if (requestedEpoch < minimumRequestEpoch) {
-      continue;
-    }
-
     const envelopeBytes = await chain.getSerializedExecutionPayloadEnvelope(slot, rootHex);
     if (envelopeBytes) {
       yield {
         data: envelopeBytes,
-        boundary: chain.config.getForkBoundaryAtEpoch(requestedEpoch),
+        boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(slot)),
       };
     }
   }


### PR DESCRIPTION
Add `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS` validation to `blobSidecarsByRange` and `blobSidecarsByRoot` and `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` validation to `dataColumnSidecarsByRange`. Respond with `RESOURCE_UNAVAILABLE` for requests before the minimum epoch per spec.

For blocks and execution payload envelopes, retain historical serving to support genesis sync and archival peers. Remove the pre-existing epoch floor from `executionPayloadEnvelopesByRoot` to align with this approach.

Closes #9107