### PR TITLE
refactor: use consistent names for state after payload is applied

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1642,7 +1642,7 @@ export function getValidatorApi(
         throw Error("Cached block production result is not full block");
       }
 
-      const {executionPayload, executionRequests, envelopeStateRoot} = produceResult as ProduceFullGloas;
+      const {executionPayload, executionRequests, payloadStateRoot} = produceResult as ProduceFullGloas;
 
       const envelope: gloas.ExecutionPayloadEnvelope = {
         payload: executionPayload,
@@ -1650,7 +1650,7 @@ export function getValidatorApi(
         builderIndex: BUILDER_INDEX_SELF_BUILD,
         beaconBlockRoot,
         slot,
-        stateRoot: envelopeStateRoot,
+        stateRoot: payloadStateRoot,
       };
 
       logger.info("Produced execution payload envelope", {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1642,7 +1642,7 @@ export function getValidatorApi(
         throw Error("Cached block production result is not full block");
       }
 
-      const {executionPayload, executionRequests, payloadStateRoot} = produceResult as ProduceFullGloas;
+      const {executionPayload, executionRequests, payloadEnvelopeStateRoot} = produceResult as ProduceFullGloas;
 
       const envelope: gloas.ExecutionPayloadEnvelope = {
         payload: executionPayload,
@@ -1650,7 +1650,7 @@ export function getValidatorApi(
         builderIndex: BUILDER_INDEX_SELF_BUILD,
         beaconBlockRoot,
         slot,
-        stateRoot: payloadStateRoot,
+        stateRoot: payloadEnvelopeStateRoot,
       };
 
       logger.info("Produced execution payload envelope", {

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -89,7 +89,7 @@ export async function processBlocks(
       (block, i): FullyVerifiedBlock => ({
         blockInput: block,
         postBlockState: postStates[i],
-        postEnvelopeState: null,
+        postPayloadState: null,
         parentBlockSlot: parentSlots[i],
         executionStatus: executionStatuses[i],
         // start supporting optimistic syncing/processing

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -103,7 +103,7 @@ type FullyVerifiedBlockBase = {
 /**
  * A wrapper around a `SignedBeaconBlock` that indicates that this block is fully verified and ready to import.
  *
- * Discriminated union on `postEnvelopeState`:
+ * Discriminated union on `postPayloadState`:
  * - `null`  → block has no pre-verified envelope; `executionStatus` is any `BlockExecutionStatus`
  * - non-null → envelope was pre-verified during state transition; `executionStatus` is narrowed to
  *              `Valid | Syncing` (matching what `forkChoice.onExecutionPayload` expects)
@@ -111,12 +111,12 @@ type FullyVerifiedBlockBase = {
 export type FullyVerifiedBlock = FullyVerifiedBlockBase &
   (
     | {
-        postEnvelopeState: null;
+        postPayloadState: null;
         /** If the execution payload couldn't be verified because of EL syncing status, used in optimistic sync or for merge block */
         executionStatus: BlockExecutionStatus;
       }
     | {
-        postEnvelopeState: IBeaconStateView;
+        postPayloadState: IBeaconStateView;
         executionStatus: PayloadExecutionStatus;
       }
   );

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -100,7 +100,7 @@ import {
 } from "./opPools/index.js";
 import {IChainOptions} from "./options.js";
 import {PrepareNextSlotScheduler} from "./prepareNextSlot.js";
-import {computeEnvelopeStateRoot, computeNewStateRoot} from "./produceBlock/computeNewStateRoot.js";
+import {computePayloadEnvelopeStateRoot, computeNewStateRoot} from "./produceBlock/computeNewStateRoot.js";
 import {AssembledBlockType, BlockType, ProduceFullGloas, ProduceResult} from "./produceBlock/index.js";
 import {BlockAttributes, produceBlockBody, produceCommonBlockBody} from "./produceBlock/produceBlockBody.js";
 import {QueuedStateRegenerator, RegenCaller} from "./regen/index.js";
@@ -1081,8 +1081,8 @@ export class BeaconChain implements IBeaconChain {
       if (!isStatePostGloas(postState)) {
         throw Error(`Expected gloas+ post-state for execution payload envelope, got fork=${postState.forkName}`);
       }
-      const envelopeStateRoot = computeEnvelopeStateRoot(this.metrics, postState, envelope);
-      gloasResult.envelopeStateRoot = envelopeStateRoot;
+      const payloadStateRoot = computePayloadEnvelopeStateRoot(this.metrics, postState, envelope);
+      gloasResult.payloadStateRoot = payloadStateRoot;
     }
 
     // Track the produced block for consensus broadcast validations, later validation, etc.

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -100,7 +100,7 @@ import {
 } from "./opPools/index.js";
 import {IChainOptions} from "./options.js";
 import {PrepareNextSlotScheduler} from "./prepareNextSlot.js";
-import {computePayloadEnvelopeStateRoot, computeNewStateRoot} from "./produceBlock/computeNewStateRoot.js";
+import {computeNewStateRoot, computePayloadEnvelopeStateRoot} from "./produceBlock/computeNewStateRoot.js";
 import {AssembledBlockType, BlockType, ProduceFullGloas, ProduceResult} from "./produceBlock/index.js";
 import {BlockAttributes, produceBlockBody, produceCommonBlockBody} from "./produceBlock/produceBlockBody.js";
 import {QueuedStateRegenerator, RegenCaller} from "./regen/index.js";
@@ -1054,7 +1054,7 @@ export class BeaconChain implements IBeaconChain {
       body,
     } as AssembledBlockType<T>;
 
-    const {newStateRoot, proposerReward, postState} = computeNewStateRoot(this.metrics, state, block);
+    const {newStateRoot, proposerReward, postBlockState} = computeNewStateRoot(this.metrics, state, block);
     block.stateRoot = newStateRoot;
     const blockRoot =
       produceResult.type === BlockType.Full
@@ -1078,11 +1078,11 @@ export class BeaconChain implements IBeaconChain {
         slot,
         stateRoot: ZERO_HASH,
       };
-      if (!isStatePostGloas(postState)) {
-        throw Error(`Expected gloas+ post-state for execution payload envelope, got fork=${postState.forkName}`);
+      if (!isStatePostGloas(postBlockState)) {
+        throw Error(`Expected gloas+ post-state for execution payload envelope, got fork=${postBlockState.forkName}`);
       }
-      const payloadStateRoot = computePayloadEnvelopeStateRoot(this.metrics, postState, envelope);
-      gloasResult.payloadStateRoot = payloadStateRoot;
+      const payloadEnvelopeStateRoot = computePayloadEnvelopeStateRoot(this.metrics, postBlockState, envelope);
+      gloasResult.payloadEnvelopeStateRoot = payloadEnvelopeStateRoot;
     }
 
     // Track the produced block for consensus broadcast validations, later validation, etc.

--- a/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
+++ b/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
@@ -19,11 +19,11 @@ export function computeNewStateRoot(
   metrics: Metrics | null,
   state: IBeaconStateView,
   block: BeaconBlock | BlindedBeaconBlock
-): {newStateRoot: Root; proposerReward: Gwei; postState: IBeaconStateView} {
+): {newStateRoot: Root; proposerReward: Gwei; postBlockState: IBeaconStateView} {
   // Set signature to zero to re-use stateTransition() function which requires the SignedBeaconBlock type
   const blockEmptySig = {message: block, signature: ZERO_HASH};
 
-  const postState = state.stateTransition(
+  const postBlockState = state.stateTransition(
     blockEmptySig,
     {
       // ExecutionPayloadStatus.valid: Assume payload valid, it has been produced by a trusted EL
@@ -42,16 +42,16 @@ export function computeNewStateRoot(
     {metrics}
   );
 
-  const {attestations, syncAggregate, slashing} = postState.proposerRewards;
+  const {attestations, syncAggregate, slashing} = postBlockState.proposerRewards;
   const proposerReward = BigInt(attestations + syncAggregate + slashing);
 
   const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
     source: StateHashTreeRootSource.computeNewStateRoot,
   });
-  const newStateRoot = postState.hashTreeRoot();
+  const newStateRoot = postBlockState.hashTreeRoot();
   hashTreeRootTimer?.();
 
-  return {newStateRoot, proposerReward, postState};
+  return {newStateRoot, proposerReward, postBlockState};
 }
 
 /**

--- a/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
+++ b/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
@@ -59,7 +59,7 @@ export function computeNewStateRoot(
  * Similar to `computeNewStateRoot` but for payload envelope processing.
  *
  */
-export function computeEnvelopeStateRoot(
+export function computePayloadEnvelopeStateRoot(
   metrics: Metrics | null,
   postBlockState: IBeaconStateViewGloas,
   envelope: gloas.ExecutionPayloadEnvelope
@@ -70,7 +70,7 @@ export function computeEnvelopeStateRoot(
   };
 
   const processEnvelopeTimer = metrics?.blockPayload.executionPayloadEnvelopeProcessingTime.startTimer();
-  const postEnvelopeState = postBlockState.processExecutionPayloadEnvelope(signedEnvelope, {
+  const postPayloadState = postBlockState.processExecutionPayloadEnvelope(signedEnvelope, {
     // Signature is zero-ed (G2_POINT_AT_INFINITY), skip verification
     verifySignature: false,
     // State root is being computed here, the envelope doesn't have it yet
@@ -81,9 +81,9 @@ export function computeEnvelopeStateRoot(
   processEnvelopeTimer?.();
 
   const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
-    source: StateHashTreeRootSource.computeEnvelopeStateRoot,
+    source: StateHashTreeRootSource.computePayloadEnvelopeStateRoot,
   });
-  const stateRoot = postEnvelopeState.hashTreeRoot();
+  const stateRoot = postPayloadState.hashTreeRoot();
   hashTreeRootTimer?.();
 
   return stateRoot;

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -111,11 +111,11 @@ export type ProduceFullGloas = {
   blobsBundle: BlobsBundle<ForkPostGloas>;
   cells: fulu.Cell[][];
   /**
-   * Cached payload state root computed during block production.
+   * Cached payload envelope state root computed during block production.
    * This is the state root after running `processExecutionPayloadEnvelope` on the
    * post-block state, and later used to construct the `ExecutionPayloadEnvelope`.
    */
-  payloadStateRoot: Root;
+  payloadEnvelopeStateRoot: Root;
 };
 export type ProduceFullFulu = {
   type: BlockType.Full;

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -111,11 +111,11 @@ export type ProduceFullGloas = {
   blobsBundle: BlobsBundle<ForkPostGloas>;
   cells: fulu.Cell[][];
   /**
-   * Cached envelope state root computed during block production.
+   * Cached payload state root computed during block production.
    * This is the state root after running `processExecutionPayloadEnvelope` on the
    * post-block state, and later used to construct the `ExecutionPayloadEnvelope`.
    */
-  envelopeStateRoot: Root;
+  payloadStateRoot: Root;
 };
 export type ProduceFullFulu = {
   type: BlockType.Full;

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -76,7 +76,7 @@ export enum StateHashTreeRootSource {
   prepareNextEpoch = "prepare_next_epoch",
   regenState = "regen_state",
   computeNewStateRoot = "compute_new_state_root",
-  computeEnvelopeStateRoot = "compute_envelope_state_root",
+  computePayloadEnvelopeStateRoot = "compute_payload_envelope_state_root",
 }
 
 /**


### PR DESCRIPTION
Rename `postEnvelopeState` to `postPayloadState` for consistency with the naming used in `importExecutionPayload` and regen caching methods.

Closes #9126