### PR TITLE
fix: only allow attestations for known payload statuses

### DIFF
--- a/packages/fork-choice/src/forkChoice/errors.ts
+++ b/packages/fork-choice/src/forkChoice/errors.ts
@@ -57,6 +57,10 @@ export enum InvalidAttestationCode {
    * The attestation data index is invalid for a Gloas block (must be 0 or 1).
    */
   INVALID_DATA_INDEX = "INVALID_DATA_INDEX",
+  /**
+   * The attestation votes for a full payload (index=1) but the payload state is not known.
+   */
+  UNKNOWN_PAYLOAD_STATUS = "UNKNOWN_PAYLOAD_STATUS",
 }
 
 export type InvalidAttestation =
@@ -69,7 +73,8 @@ export type InvalidAttestation =
   | {code: InvalidAttestationCode.INVALID_TARGET; attestation: RootHex; local: RootHex}
   | {code: InvalidAttestationCode.ATTESTS_TO_FUTURE_BLOCK; block: Slot; attestation: Slot}
   | {code: InvalidAttestationCode.FUTURE_SLOT; attestationSlot: Slot; latestPermissibleSlot: Slot}
-  | {code: InvalidAttestationCode.INVALID_DATA_INDEX; index: number};
+  | {code: InvalidAttestationCode.INVALID_DATA_INDEX; index: number}
+  | {code: InvalidAttestationCode.UNKNOWN_PAYLOAD_STATUS; beaconBlockRoot: RootHex};
 
 export enum ForkChoiceErrorCode {
   INVALID_ATTESTATION = "FORKCHOICE_ERROR_INVALID_ATTESTATION",

--- a/packages/fork-choice/src/forkChoice/errors.ts
+++ b/packages/fork-choice/src/forkChoice/errors.ts
@@ -58,7 +58,7 @@ export enum InvalidAttestationCode {
    */
   INVALID_DATA_INDEX = "INVALID_DATA_INDEX",
   /**
-   * The attestation votes for a full payload (index=1) but the payload state is not known.
+   * The attestation votes for a full payload (index=1) but the payload status is not known.
    */
   UNKNOWN_PAYLOAD_STATUS = "UNKNOWN_PAYLOAD_STATUS",
 }

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1696,6 +1696,20 @@ export class ForkChoice implements IForkChoice {
       });
     }
 
+    // If attesting for a full node, the payload must be known
+    if (isGloasBlock(block) && attestationData.index === 1) {
+      const fullNodeIndex = this.protoArray.getNodeIndexByRootAndStatus(beaconBlockRootHex, PayloadStatus.FULL);
+      if (fullNodeIndex === undefined) {
+        throw new ForkChoiceError({
+          code: ForkChoiceErrorCode.INVALID_ATTESTATION,
+          err: {
+            code: InvalidAttestationCode.UNKNOWN_PAYLOAD_STATUS,
+            beaconBlockRoot: beaconBlockRootHex,
+          },
+        });
+      }
+    }
+
     this.validatedAttestationDatas.add(attDataRoot);
   }
 


### PR DESCRIPTION
See https://github.com/ethereum/consensus-specs/pull/4918