### PR TITLE
refactor: align bid filtering with consensus spec

### DIFF
--- a/packages/beacon-node/src/chain/opPools/executionPayloadBidPool.ts
+++ b/packages/beacon-node/src/chain/opPools/executionPayloadBidPool.ts
@@ -59,13 +59,13 @@ export class ExecutionPayloadBidPool {
   }
 
   /**
-   * Return the highest-value bid matching slot, parent block root, and parent block hash.
+   * Return the highest-value bid matching slot, parent block hash, and parent block root.
    * Used for gossip validation and block production.
    */
   getBestBid(
-    parentBlockRoot: BlockRootHex,
+    slot: Slot,
     parentBlockHash: BlockHashHex,
-    slot: Slot
+    parentBlockRoot: BlockRootHex
   ): gloas.ExecutionPayloadBid | null {
     const bidByParentHash = this.bidByParentHashByParentRootBySlot.get(slot)?.get(parentBlockRoot);
     return bidByParentHash?.get(parentBlockHash) ?? null;

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -89,7 +89,7 @@ async function validateExecutionPayloadBid(
 
   // [IGNORE] this bid is the highest value bid seen for the tuple
   // `(bid.slot, bid.parent_block_hash, bid.parent_block_root)`.
-  const bestBid = chain.executionPayloadBidPool.getBestBid(parentBlockRootHex, parentBlockHashHex, bid.slot);
+  const bestBid = chain.executionPayloadBidPool.getBestBid(bid.slot, parentBlockHashHex, parentBlockRootHex);
   if (bestBid !== null && bestBid.value >= bid.value) {
     throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
       code: ExecutionPayloadBidErrorCode.BID_TOO_LOW,

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -87,8 +87,8 @@ async function validateExecutionPayloadBid(
     });
   }
 
-  // [IGNORE] this bid is the highest value bid seen for the corresponding slot
-  // and the given parent block hash.
+  // [IGNORE] this bid is the highest value bid seen for the tuple
+  // (bid.slot, bid.parent_block_hash, bid.parent_block_root).
   const bestBid = chain.executionPayloadBidPool.getBestBid(parentBlockRootHex, parentBlockHashHex, bid.slot);
   if (bestBid !== null && bestBid.value >= bid.value) {
     throw new ExecutionPayloadBidError(GossipAction.IGNORE, {

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -88,7 +88,7 @@ async function validateExecutionPayloadBid(
   }
 
   // [IGNORE] this bid is the highest value bid seen for the tuple
-  // (bid.slot, bid.parent_block_hash, bid.parent_block_root).
+  // `(bid.slot, bid.parent_block_hash, bid.parent_block_root)`.
   const bestBid = chain.executionPayloadBidPool.getBestBid(parentBlockRootHex, parentBlockHashHex, bid.slot);
   if (bestBid !== null && bestBid.value >= bid.value) {
     throw new ExecutionPayloadBidError(GossipAction.IGNORE, {


### PR DESCRIPTION
Update to match https://github.com/ethereum/consensus-specs/pull/5001 wording. The underlying implementation already keys bids by the (slot, parent_block_root, parent_block_hash) tuple.