### PR TITLE
docs: add spec comment for envelope signature validation

### DIFF
--- a/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
@@ -121,6 +121,8 @@ async function validateExecutionPayloadEnvelope(
     throw new Error(`Expected gloas+ state for execution payload envelope validation, got fork=${blockState.forkName}`);
   }
 
+  // [REJECT] `signed_execution_payload_envelope.signature` is valid as verified
+  // by `verify_execution_payload_envelope_signature`.
   const signatureSet = getExecutionPayloadEnvelopeSignatureSet(
     chain.config,
     chain.pubkeyCache,


### PR DESCRIPTION
Add missing `[REJECT]` spec comment for `signed_execution_payload_envelope` signature verification, aligned with https://github.com/ethereum/consensus-specs/pull/5002 wording.