### PR TITLE
feat: add endpoint to retrieve signed execution payload envelope

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -229,7 +229,6 @@ export type Endpoints = {
   /**
    * Get signed execution payload envelope.
    * Retrieves signed execution payload envelope for a given block id.
-   * Depending on `Accept` header it can be returned either as json or as bytes serialized by SSZ.
    */
   getSignedExecutionPayloadEnvelope: Endpoint<
     "GET",
@@ -652,7 +651,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       method: "GET",
       req: blockIdOnlyReq,
       resp: {
-        data: ssz.gloas.SignedExecutionPayloadEnvelope,
+        data: WithVersion((fork) => getPostGloasForkTypes(fork).SignedExecutionPayloadEnvelope),
         meta: ExecutionOptimisticFinalizedAndVersionCodec,
       },
     },

--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -227,6 +227,19 @@ export type Endpoints = {
   >;
 
   /**
+   * Get signed execution payload envelope.
+   * Retrieves signed execution payload envelope for a given block id.
+   * Depending on `Accept` header it can be returned either as json or as bytes serialized by SSZ.
+   */
+  getSignedExecutionPayloadEnvelope: Endpoint<
+    "GET",
+    BlockArgs,
+    {params: {block_id: string}},
+    gloas.SignedExecutionPayloadEnvelope,
+    ExecutionOptimisticFinalizedAndVersionMeta
+  >;
+
+  /**
    * Get block BlobSidecar
    * Retrieves BlobSidecar included in requested block.
    */
@@ -632,6 +645,15 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       resp: EmptyResponseCodec,
       init: {
         requestWireFormat: WireFormat.ssz,
+      },
+    },
+    getSignedExecutionPayloadEnvelope: {
+      url: "/eth/v1/beacon/execution_payload_envelope/{block_id}",
+      method: "GET",
+      req: blockIdOnlyReq,
+      resp: {
+        data: ssz.gloas.SignedExecutionPayloadEnvelope,
+        meta: ExecutionOptimisticFinalizedAndVersionCodec,
       },
     },
     getBlobSidecars: {

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -20,7 +20,7 @@ import {testData as validatorTestData} from "./testData/validator.js";
 // Solutions: https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const version = "v5.0.0-alpha.0";
+const version = "v5.0.0-alpha.1";
 const openApiFile: OpenApiFile = {
   url: `https://github.com/ethereum/beacon-APIs/releases/download/${version}/beacon-node-oapi.json`,
   filepath: path.join(__dirname, "../../../oapi-schemas/beacon-node-oapi.json"),
@@ -55,9 +55,8 @@ const ignoredOperations = [
   /* missing route */
   "getDepositSnapshot", // Won't fix for now, see https://github.com/ChainSafe/lodestar/issues/5697
   "getNextWithdrawals", // https://github.com/ChainSafe/lodestar/issues/5696
-  // TODO GLOAS: required by v5.0.0-alpha.0
+  // TODO GLOAS: required by v5.0.0-alpha.1
   "publishExecutionPayloadBid",
-  "getSignedExecutionPayloadEnvelope",
   "getPoolPayloadAttestations",
   "submitPayloadAttestationMessages",
   "getPtcDuties",
@@ -77,12 +76,9 @@ const openApiJson = await fetchOpenApiSpec(openApiFile);
 runTestCheckAgainstSpec(openApiJson, definitions, testDatas, ignoredOperations, ignoredProperties);
 
 const ignoredTopics: string[] = [
-  // TODO GLOAS: required by v5.0.0-alpha.0
+  // TODO GLOAS: required by v5.0.0-alpha.1
   "execution_payload_bid",
   "payload_attestation_message",
-  // TODO GLOAS: beacon-APIs v5.0.0-alpha.0 still documents the Fulu-shaped
-  // data_column_sidecar event example. Remove once v5.0.0-alpha.1 is released.
-  "data_column_sidecar",
 ];
 
 // eventstream types are defined as comments in the description of "examples".

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -95,6 +95,13 @@ export const testData: GenericServerTestCases<Endpoints> = {
     args: {signedExecutionPayloadEnvelope: ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue()},
     res: undefined,
   },
+  getSignedExecutionPayloadEnvelope: {
+    args: {blockId: "head"},
+    res: {
+      data: ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue(),
+      meta: {executionOptimistic: true, finalized: false, version: ForkName.gloas},
+    },
+  },
   getBlobSidecars: {
     args: {blockId: "head", indices: [0]},
     res: {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -812,6 +812,32 @@ export function getBeaconBlockApi({
       });
     },
 
+    async getSignedExecutionPayloadEnvelope({blockId}) {
+      const {block, executionOptimistic, finalized} = await getBlockResponse(chain, blockId);
+      const slot = block.message.slot;
+      const fork = config.getForkName(slot);
+
+      const blockRoot = sszTypesFor(fork).BeaconBlock.hashTreeRoot(block.message);
+      const blockRootHex = toRootHex(blockRoot);
+      if (!isForkPostGloas(fork)) {
+        throw new ApiError(
+          400,
+          `Execution payload envelopes are not available before Gloas fork, block slot=${slot} fork=${fork}`
+        );
+      }
+
+      const data = await chain.getSerializedExecutionPayloadEnvelope(slot, blockRootHex);
+
+      if (!data) {
+        throw new ApiError(404, `Execution payload envelope not found for slot=${slot} root=${blockRootHex}`);
+      }
+
+      return {
+        data,
+        meta: {executionOptimistic, finalized, version: fork},
+      };
+    },
+
     async getBlobSidecars({blockId, indices}) {
       assertUniqueItems(indices, "Duplicate indices provided");
 

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -812,7 +812,7 @@ export function getBeaconBlockApi({
       });
     },
 
-    async getSignedExecutionPayloadEnvelope({blockId}) {
+    async getSignedExecutionPayloadEnvelope({blockId}, context) {
       const {block, executionOptimistic, finalized} = await getBlockResponse(chain, blockId);
       const slot = block.message.slot;
       const fork = config.getForkName(slot);
@@ -827,7 +827,9 @@ export function getBeaconBlockApi({
       const blockRoot = config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block.message);
       const blockRootHex = toRootHex(blockRoot);
 
-      const data = await chain.getSerializedExecutionPayloadEnvelope(slot, blockRootHex);
+      const data = context?.returnBytes
+        ? await chain.getSerializedExecutionPayloadEnvelope(slot, blockRootHex)
+        : await chain.getExecutionPayloadEnvelope(slot, blockRootHex);
 
       if (!data) {
         throw new ApiError(404, `Execution payload envelope not found for slot=${slot}, blockRoot=${blockRootHex}`);

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -817,19 +817,20 @@ export function getBeaconBlockApi({
       const slot = block.message.slot;
       const fork = config.getForkName(slot);
 
-      const blockRoot = sszTypesFor(fork).BeaconBlock.hashTreeRoot(block.message);
-      const blockRootHex = toRootHex(blockRoot);
       if (!isForkPostGloas(fork)) {
         throw new ApiError(
           400,
-          `Execution payload envelopes are not available before Gloas fork, block slot=${slot} fork=${fork}`
+          `Execution payload envelopes are not available for pre-gloas fork=${fork}, slot=${slot}`
         );
       }
+
+      const blockRoot = config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block.message);
+      const blockRootHex = toRootHex(blockRoot);
 
       const data = await chain.getSerializedExecutionPayloadEnvelope(slot, blockRootHex);
 
       if (!data) {
-        throw new ApiError(404, `Execution payload envelope not found for slot=${slot} root=${blockRootHex}`);
+        throw new ApiError(404, `Execution payload envelope not found for slot=${slot}, blockRoot=${blockRootHex}`);
       }
 
       return {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -880,6 +880,22 @@ export class BeaconChain implements IBeaconChain {
     );
   }
 
+  async getExecutionPayloadEnvelope(
+    blockSlot: Slot,
+    blockRootHex: string
+  ): Promise<gloas.SignedExecutionPayloadEnvelope | null> {
+    const payloadInput = this.seenPayloadEnvelopeInputCache.get(blockRootHex);
+    if (payloadInput?.hasPayloadEnvelope()) {
+      return payloadInput.getPayloadEnvelope();
+    }
+
+    return (
+      (await this.db.executionPayloadEnvelope.get(fromHex(blockRootHex))) ??
+      (await this.db.executionPayloadEnvelopeArchive.get(blockSlot)) ??
+      null
+    );
+  }
+
   async getDataColumnSidecars(blockSlot: Slot, blockRootHex: string): Promise<DataColumnSidecar[]> {
     const fork = this.config.getForkName(blockSlot);
 

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -18,6 +18,7 @@ import {
   altair,
   capella,
   deneb,
+  gloas,
   phase0,
   rewards,
 } from "@lodestar/types";
@@ -226,6 +227,10 @@ export interface IBeaconChain {
     indices: number[]
   ): Promise<(Uint8Array | undefined)[]>;
   getSerializedExecutionPayloadEnvelope(blockSlot: Slot, blockRootHex: string): Promise<Uint8Array | null>;
+  getExecutionPayloadEnvelope(
+    blockSlot: Slot,
+    blockRootHex: string
+  ): Promise<gloas.SignedExecutionPayloadEnvelope | null>;
 
   produceCommonBlockBody(blockAttributes: BlockAttributes): Promise<CommonBlockBody>;
   produceBlock(blockAttributes: BlockAttributes & {commonBlockBodyPromise: Promise<CommonBlockBody>}): Promise<{


### PR DESCRIPTION
Add `GET /eth/v1/beacon/execution_payload_envelope/{block_id}` to retrieve signed execution payload envelope.