### PR TITLE
refactor: rename executionPayloadStateRoot to payloadStateRoot

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -983,7 +983,7 @@ export class ForkChoice implements IForkChoice {
     blockRoot: RootHex,
     executionPayloadBlockHash: RootHex,
     executionPayloadNumber: number,
-    executionPayloadStateRoot: RootHex,
+    payloadStateRoot: RootHex,
     executionStatus: PayloadExecutionStatus
   ): void {
     this.protoArray.onExecutionPayload(
@@ -991,7 +991,7 @@ export class ForkChoice implements IForkChoice {
       this.fcStore.currentSlot,
       executionPayloadBlockHash,
       executionPayloadNumber,
-      executionPayloadStateRoot,
+      payloadStateRoot,
       this.proposerBoostRoot,
       executionStatus
     );

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -198,13 +198,13 @@ export interface IForkChoice {
    * @param blockRoot - The beacon block root for which the payload arrived
    * @param executionPayloadBlockHash - The block hash of the execution payload
    * @param executionPayloadNumber - The block number of the execution payload
-   * @param executionPayloadStateRoot - The execution payload state root ie. the root of post-state after processExecutionPayloadEnvelope()
+   * @param payloadStateRoot - The payload state root ie. the root of post-state after processExecutionPayloadEnvelope()
    */
   onExecutionPayload(
     blockRoot: RootHex,
     executionPayloadBlockHash: RootHex,
     executionPayloadNumber: number,
-    executionPayloadStateRoot: RootHex,
+    payloadStateRoot: RootHex,
     executionStatus: PayloadExecutionStatus
   ): void;
   /**

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -541,7 +541,7 @@ export class ProtoArray {
     currentSlot: Slot,
     executionPayloadBlockHash: RootHex,
     executionPayloadNumber: number,
-    executionPayloadStateRoot: RootHex,
+    payloadStateRoot: RootHex,
     proposerBoostRoot: RootHex | null,
     executionStatus: PayloadExecutionStatus
   ): void {
@@ -597,7 +597,7 @@ export class ProtoArray {
       executionStatus,
       executionPayloadBlockHash,
       executionPayloadNumber,
-      stateRoot: executionPayloadStateRoot,
+      stateRoot: payloadStateRoot,
     };
 
     const fullIndex = this.nodes.length;


### PR DESCRIPTION
## Summary

Align naming with ethereum/consensus-specs#4930 which renamed `execution_payload_states` to `payload_states`.

- Rename `executionPayloadStateRoot` → `payloadStateRoot` in fork-choice package

## Test plan

- Pure rename, no logic changes
- [ ] `pnpm build` compiles cleanly
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)