### PR TITLE
fix: initialize anchor block PTC votes to all-true

### DIFF
--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -111,12 +111,9 @@ export class ProtoArray {
 
     // Anchor block PTC votes must be all-true per spec get_forkchoice_store:
     // payload_timeliness_vote={anchor_root: Vector[boolean, PTC_SIZE](True for _ in range(PTC_SIZE))}
-    // Spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/fork-choice.md#modified-get_forkchoice_store
-    const anchorVotes = protoArray.ptcVotes.get(block.blockRoot);
-    if (anchorVotes) {
-      for (let i = 0; i < PTC_SIZE; i++) {
-        anchorVotes.set(i, true);
-      }
+    // Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/gloas/fork-choice.md#modified-get_forkchoice_store
+    if (protoArray.ptcVotes.has(block.blockRoot)) {
+      protoArray.ptcVotes.set(block.blockRoot, BitArray.fromBoolArray(Array.from({length: PTC_SIZE}, () => true)));
     }
 
     return protoArray;

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -108,6 +108,19 @@ export class ProtoArray {
       currentSlot,
       null
     );
+
+    // Anchor block PTC votes must be all-true per spec get_forkchoice_store:
+    // payload_timeliness_vote={anchor_root: Vector[boolean, PTC_SIZE](True for _ in range(PTC_SIZE))}
+    // Spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/fork-choice.md#modified-get_forkchoice_store
+    if (protoArray.ptcVotes.has(block.blockRoot)) {
+      const allTrue = BitArray.fromBitLen(PTC_SIZE);
+      const bytes = allTrue.uint8Array;
+      for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = 0xff;
+      }
+      protoArray.ptcVotes.set(block.blockRoot, allTrue);
+    }
+
     return protoArray;
   }
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -112,13 +112,11 @@ export class ProtoArray {
     // Anchor block PTC votes must be all-true per spec get_forkchoice_store:
     // payload_timeliness_vote={anchor_root: Vector[boolean, PTC_SIZE](True for _ in range(PTC_SIZE))}
     // Spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/fork-choice.md#modified-get_forkchoice_store
-    if (protoArray.ptcVotes.has(block.blockRoot)) {
-      const allTrue = BitArray.fromBitLen(PTC_SIZE);
-      const bytes = allTrue.uint8Array;
-      for (let i = 0; i < bytes.length; i++) {
-        bytes[i] = 0xff;
+    const anchorVotes = protoArray.ptcVotes.get(block.blockRoot);
+    if (anchorVotes) {
+      for (let i = 0; i < PTC_SIZE; i++) {
+        anchorVotes.set(i, true);
       }
-      protoArray.ptcVotes.set(block.blockRoot, allTrue);
     }
 
     return protoArray;


### PR DESCRIPTION
## Summary

The anchor block's `payload_timeliness_vote` was initialized to all-false via `onBlock()`, but the spec's `get_forkchoice_store` requires all-true:

```python
payload_timeliness_vote={
    anchor_root: Vector[boolean, PTC_SIZE](True for _ in range(PTC_SIZE))
},
```

**Spec ref:** [`specs/gloas/fork-choice.md#modified-get_forkchoice_store`](https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/fork-choice.md#modified-get_forkchoice_store)

This ensures `is_payload_timely(anchor_root)` returns true for the anchor block, matching the assumption that the finalized anchor payload is both timely and available.

## Test plan

- [ ] Existing fork-choice tests pass
- [ ] Verify anchor block PTC votes are all-true after `ProtoArray.initialize()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)