### PR TITLE
fix: use expected withdrawals from state when parent is empty

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -19,6 +19,7 @@ import {
   IBeaconStateView,
   type IBeaconStateViewBellatrix,
   computeTimeAtSlot,
+  isParentBlockFull,
   isStatePostBellatrix,
   isStatePostCapella,
   isStatePostGloas,
@@ -771,9 +772,18 @@ function preparePayloadAttributes(
       throw new Error("Expected Capella state for withdrawals");
     }
 
-    // withdrawals logic is now fork aware as it changes on electra fork post capella
-    (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
-      prepareState.getExpectedWithdrawals().expectedWithdrawals;
+    if (isStatePostGloas(prepareState) && !isParentBlockFull(prepareState)) {
+      // When the parent block is empty, state.payloadExpectedWithdrawals holds a batch
+      // already deducted from CL balances but never credited on the EL (the envelope
+      // was not delivered). The next payload must carry those same withdrawals to
+      // restore CL/EL consistency, otherwise validators permanently lose that balance.
+      (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
+        prepareState.payloadExpectedWithdrawals;
+    } else {
+      // withdrawals logic is now fork aware as it changes on electra fork post capella
+      (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
+        prepareState.getExpectedWithdrawals().expectedWithdrawals;
+    }
   }
 
   if (ForkSeq[fork] >= ForkSeq.deneb) {

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -92,6 +92,7 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
   // gloas
   private _executionPayloadAvailability: BitArray | null = null;
   private _latestExecutionPayloadBid: ExecutionPayloadBid | null = null;
+  private _payloadExpectedWithdrawals: capella.Withdrawal[] | null = null;
 
   constructor(readonly cachedState: CachedBeaconStateAllForks) {
     this.config = cachedState.config;
@@ -361,7 +362,7 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
 
   get executionPayloadAvailability(): BitArray {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
-      throw new Error("executionPayloadAvailability is not available before GLOAS");
+      throw new Error("executionPayloadAvailability is not available before Gloas");
     }
 
     if (this._executionPayloadAvailability === null) {
@@ -375,7 +376,7 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
 
   get latestExecutionPayloadBid(): ExecutionPayloadBid {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
-      throw new Error("latestExecutionPayloadBid is not available before GLOAS");
+      throw new Error("latestExecutionPayloadBid is not available before Gloas");
     }
 
     if (this._latestExecutionPayloadBid === null) {
@@ -386,9 +387,22 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
     return this._latestExecutionPayloadBid;
   }
 
+  get payloadExpectedWithdrawals(): capella.Withdrawal[] {
+    if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
+      throw new Error("payloadExpectedWithdrawals is not available before Gloas");
+    }
+
+    if (this._payloadExpectedWithdrawals === null) {
+      this._payloadExpectedWithdrawals = (
+        this.cachedState as CachedBeaconStateGloas
+      ).payloadExpectedWithdrawals.toValue();
+    }
+    return this._payloadExpectedWithdrawals;
+  }
+
   getBuilder(index: BuilderIndex): gloas.Builder {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
-      throw new Error("Builders are not supported before GLOAS");
+      throw new Error("Builders are not supported before Gloas");
     }
 
     return (this.cachedState as CachedBeaconStateGloas).builders.getReadonly(index);
@@ -396,7 +410,7 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
 
   canBuilderCoverBid(builderIndex: BuilderIndex, bidAmount: number): boolean {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
-      throw new Error("Builders are not supported before GLOAS");
+      throw new Error("Builders are not supported before Gloas");
     }
 
     return canBuilderCoverBid(this.cachedState as CachedBeaconStateGloas, builderIndex, bidAmount);
@@ -408,7 +422,7 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
    */
   getIndexInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
-      throw new Error("PTC committees are not supported before GLOAS");
+      throw new Error("PTC committees are not supported before Gloas");
     }
 
     const ptcCommittee = (this.cachedState as CachedBeaconStateGloas).epochCtx.getPayloadTimelinessCommittee(slot);

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -246,6 +246,7 @@ export interface IBeaconStateViewGloas extends IBeaconStateViewFulu {
   forkName: ForkPostGloas;
   executionPayloadAvailability: BitArray;
   latestExecutionPayloadBid: ExecutionPayloadBid;
+  payloadExpectedWithdrawals: capella.Withdrawal[];
   getBuilder(index: BuilderIndex): gloas.Builder;
   canBuilderCoverBid(builderIndex: BuilderIndex, bidAmount: number): boolean;
   getIndexInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number;

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -11,6 +11,7 @@ import {
 import {BuilderIndex, Epoch, ValidatorIndex, gloas} from "@lodestar/types";
 import {AttestationData} from "@lodestar/types/phase0";
 import {byteArrayEquals} from "@lodestar/utils";
+import {IBeaconStateViewGloas} from "../stateView/interface.js";
 import {CachedBeaconStateGloas} from "../types.js";
 import {getBlockRootAtSlot} from "./blockRoot.js";
 import {computeEpochAtSlot} from "./epoch.js";
@@ -167,6 +168,6 @@ export function isAttestationSameSlotRootCache(rootCache: RootCache, data: Attes
   return isMatchingBlockRoot && isCurrentBlockRoot;
 }
 
-export function isParentBlockFull(state: CachedBeaconStateGloas): boolean {
+export function isParentBlockFull(state: CachedBeaconStateGloas | IBeaconStateViewGloas): boolean {
   return byteArrayEquals(state.latestExecutionPayloadBid.blockHash, state.latestBlockHash);
 }


### PR DESCRIPTION
See https://github.com/ethereum/consensus-specs/pull/5069, we already handle this correctly on `epbs-devnet-0` branch but we haven't brought this change to `unstable` branch yet.

Closes https://github.com/ChainSafe/lodestar/issues/8953