### PR TITLE
fix: skip light client processing for gloas blocks

### DIFF
--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -272,6 +272,14 @@ export class LightClientServer {
       return;
     }
 
+    // TODO GLOAS: Light client updates for gloas are not yet updated in the spec.
+    // The block body no longer contains execution payload, so `blockToLightClientHeader`
+    // cannot construct a header from a gloas block. Skip all light client processing
+    // for post-gloas blocks, revisit once there is a spec for it.
+    if (this.config.getForkSeq(block.slot) >= ForkSeq.gloas) {
+      return;
+    }
+
     // What is the syncAggregate signing?
     // From the state-transition
     // ```


### PR DESCRIPTION
In gloas, the `executionPayload` is no longer part of `BeaconBlockBody`, so `blockToLightClientHeader`  throws for gloas blocks. There is also no light client spec update for gloas yet, but likely we will call the light client server handler in `importExecutionPayload` instead.