### PR TITLE
fix: add proposer index bounds check before signature verification

### DIFF
--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -197,7 +197,7 @@ export async function validateGossipBlock(
     }
   }
 
-  // [REJECT] The proposer_index is valid -- i.e. block.proposer_index < len(state.validators)
+  // [REJECT] The proposer index is a valid validator index
   if (proposerIndex >= blockState.validatorCount) {
     throw new BlockGossipError(GossipAction.REJECT, {code: BlockErrorCode.UNKNOWN_PROPOSER, proposerIndex});
   }

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -197,6 +197,11 @@ export async function validateGossipBlock(
     }
   }
 
+  // [REJECT] The proposer_index is valid -- i.e. block.proposer_index < len(state.validators)
+  if (proposerIndex >= blockState.validatorCount) {
+    throw new BlockGossipError(GossipAction.REJECT, {code: BlockErrorCode.UNKNOWN_PROPOSER, proposerIndex});
+  }
+
   // [REJECT] The proposer signature, signed_beacon_block.signature, is valid with respect to the proposer_index pubkey.
   if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockSlot, blockRoot, signedBlock.signature)) {
     const signatureSet = getBlockProposerSignatureSet(chain.config, signedBlock);


### PR DESCRIPTION
## Summary
- Add explicit `proposer_index < len(state.validators)` bounds check before signature verification in gossip block validation
- Without this, an out-of-range proposer index causes `Missing pubkey for validator index` crash in the pubkey cache instead of a clean REJECT
- Uses existing `BlockErrorCode.UNKNOWN_PROPOSER` error code

Spec reference: `[REJECT] The proposer_index is valid -- i.e. block.proposer_index < len(state.validators)`

## Test plan
- [x] `gossip_beacon_block__reject_invalid_proposer_index` now passes for both phase0 and bellatrix (was crashing before)
- [x] All 306 networking spec tests pass (minimal preset)
- [x] Build passes with no type errors

🤖 Generated with AI assistance