### PR TITLE
feat: add endpoint to craft attester slashings from blocks

### DIFF
--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -409,12 +409,10 @@ export type Endpoints = {
 
 export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoints> {
   function assertBlocksMatchFork(signedBlocks: SignedBeaconBlock[], expectedFork: ForkName): void {
-    for(const block of signedBlocks) {
+    for (const block of signedBlocks) {
       const blockFork = config.getForkName(block.message.slot);
       if (blockFork !== expectedFork) {
-        throw new Error(
-          `Block at slot ${block.message.slot} is from fork ${blockFork}, expected ${expectedFork}`
-        );
+        throw new Error(`Block at slot ${block.message.slot} is from fork ${blockFork}, expected ${expectedFork}`);
       }
     }
   }

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -1,6 +1,16 @@
 import {ContainerType, Type, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {ArrayOf, BeaconState, Epoch, RootHex, Slot, ValidatorIndex, ssz} from "@lodestar/types";
+import {
+  ArrayOf,
+  AttesterSlashing,
+  BeaconState,
+  Epoch,
+  RootHex,
+  SignedBeaconBlock,
+  Slot,
+  ValidatorIndex,
+  ssz,
+} from "@lodestar/types";
 import {
   EmptyArgs,
   EmptyMeta,
@@ -11,10 +21,13 @@ import {
   JsonOnlyResponseCodec,
   WithVersion,
 } from "../../utils/codecs.js";
+import {toForkName} from "../../utils/fork.js";
+import {fromHeaders} from "../../utils/headers.js";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {
   ExecutionOptimisticFinalizedAndVersionCodec,
   ExecutionOptimisticFinalizedAndVersionMeta,
+  MetaHeader,
   VersionCodec,
   VersionMeta,
 } from "../../utils/metadata.js";
@@ -382,6 +395,15 @@ export type Endpoints = {
     CustodyInfo,
     EmptyMeta
   >;
+
+  /** Craft attester slashings from the attestations in the provided blocks */
+  getAttesterSlashingsFromBlocks: Endpoint<
+    "POST",
+    {signedBlocks: SignedBeaconBlock[]},
+    {body: unknown; headers: {[MetaHeader.Version]: string}},
+    AttesterSlashing[],
+    VersionMeta
+  >;
 };
 
 export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpoints> {
@@ -601,6 +623,46 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       method: "GET",
       req: EmptyRequestCodec,
       resp: JsonOnlyResponseCodec,
+    },
+    getAttesterSlashingsFromBlocks: {
+      url: "/eth/v1/lodestar/blocks/attester_slashings",
+      method: "POST",
+      req: {
+        writeReqJson: ({signedBlocks}) => {
+          const fork = _config.getForkName(signedBlocks[0]?.message.slot ?? 0);
+          return {
+            body: ArrayOf(ssz[fork].SignedBeaconBlock).toJson(signedBlocks as SignedBeaconBlock<typeof fork>[]),
+            headers: {[MetaHeader.Version]: fork},
+          };
+        },
+        parseReqJson: ({body, headers}) => {
+          const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
+          return {
+            signedBlocks: ArrayOf(ssz[fork].SignedBeaconBlock).fromJson(body) as SignedBeaconBlock[],
+          };
+        },
+        writeReqSsz: ({signedBlocks}) => {
+          const fork = _config.getForkName(signedBlocks[0]?.message.slot ?? 0);
+          return {
+            body: ArrayOf(ssz[fork].SignedBeaconBlock).serialize(signedBlocks as SignedBeaconBlock<typeof fork>[]),
+            headers: {[MetaHeader.Version]: fork},
+          };
+        },
+        parseReqSsz: ({body, headers}) => {
+          const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
+          return {
+            signedBlocks: ArrayOf(ssz[fork].SignedBeaconBlock).deserialize(body) as SignedBeaconBlock[],
+          };
+        },
+        schema: {
+          body: Schema.ObjectArray,
+          headers: {[MetaHeader.Version]: Schema.String},
+        },
+      },
+      resp: {
+        data: WithVersion((fork) => ArrayOf(ssz[fork].AttesterSlashing)),
+        meta: VersionCodec,
+      },
     },
   };
 }

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -1,5 +1,6 @@
 import {ContainerType, Type, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
+import {ForkName} from "@lodestar/params";
 import {
   ArrayOf,
   AttesterSlashing,
@@ -406,7 +407,18 @@ export type Endpoints = {
   >;
 };
 
-export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpoints> {
+export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoints> {
+  function assertBlocksMatchFork(signedBlocks: SignedBeaconBlock[], expectedFork: ForkName): void {
+    for(const block of signedBlocks) {
+      const blockFork = config.getForkName(block.message.slot);
+      if (blockFork !== expectedFork) {
+        throw new Error(
+          `Block at slot ${block.message.slot} is from fork ${blockFork}, expected ${expectedFork}`
+        );
+      }
+    }
+  }
+
   return {
     writeHeapdump: {
       url: "/eth/v1/lodestar/write_heapdump",
@@ -629,7 +641,8 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       method: "POST",
       req: {
         writeReqJson: ({signedBlocks}) => {
-          const fork = _config.getForkName(signedBlocks[0]?.message.slot ?? 0);
+          if (signedBlocks.length === 0) throw new Error("No blocks provided.");
+          const fork = config.getForkName(signedBlocks[0].message.slot);
           return {
             body: ArrayOf(ssz[fork].SignedBeaconBlock).toJson(signedBlocks as SignedBeaconBlock<typeof fork>[]),
             headers: {[MetaHeader.Version]: fork},
@@ -637,12 +650,13 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         },
         parseReqJson: ({body, headers}) => {
           const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
-          return {
-            signedBlocks: ArrayOf(ssz[fork].SignedBeaconBlock).fromJson(body) as SignedBeaconBlock[],
-          };
+          const signedBlocks = ArrayOf(ssz[fork].SignedBeaconBlock).fromJson(body) as SignedBeaconBlock[];
+          assertBlocksMatchFork(signedBlocks, fork);
+          return {signedBlocks};
         },
         writeReqSsz: ({signedBlocks}) => {
-          const fork = _config.getForkName(signedBlocks[0]?.message.slot ?? 0);
+          if (signedBlocks.length === 0) throw new Error("No blocks provided.");
+          const fork = config.getForkName(signedBlocks[0].message.slot);
           return {
             body: ArrayOf(ssz[fork].SignedBeaconBlock).serialize(signedBlocks as SignedBeaconBlock<typeof fork>[]),
             headers: {[MetaHeader.Version]: fork},
@@ -650,9 +664,9 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         },
         parseReqSsz: ({body, headers}) => {
           const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
-          return {
-            signedBlocks: ArrayOf(ssz[fork].SignedBeaconBlock).deserialize(body) as SignedBeaconBlock[],
-          };
+          const signedBlocks = ArrayOf(ssz[fork].SignedBeaconBlock).deserialize(body) as SignedBeaconBlock[];
+          assertBlocksMatchFork(signedBlocks, fork);
+          return {signedBlocks};
         },
         schema: {
           body: Schema.ObjectArray,

--- a/packages/beacon-node/src/api/impl/lodestar/attesterSlashing.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/attesterSlashing.ts
@@ -1,6 +1,6 @@
 import {ForkSeq} from "@lodestar/params";
-import {isSlashableAttestationData} from "@lodestar/state-transition";
-import {AttesterSlashing, IndexedAttestation, IndexedAttestationBigint, ssz} from "@lodestar/types";
+import {isSlashableAttestationData, toIndexedAttestationBigint} from "@lodestar/state-transition";
+import {AttesterSlashing, IndexedAttestation} from "@lodestar/types";
 
 /**
  * Find all slashable pairs within a list of IndexedAttestations and
@@ -55,15 +55,4 @@ function hasIntersection(indices1: number[], indices2: number[]): boolean {
   }
 
   return false;
-}
-
-/**
- * Convert IndexedAttestation to IndexedAttestationBigint via SSZ roundtrip.
- * Both types share the same binary layout — only the JS numeric representation differs.
- */
-function toIndexedAttestationBigint(att: IndexedAttestation, fork: ForkSeq): IndexedAttestationBigint {
-  const sszType = fork >= ForkSeq.electra ? ssz.electra.IndexedAttestation : ssz.phase0.IndexedAttestation;
-  const sszTypeBigint =
-    fork >= ForkSeq.electra ? ssz.electra.IndexedAttestationBigint : ssz.phase0.IndexedAttestationBigint;
-  return sszTypeBigint.deserialize(sszType.serialize(att));
 }

--- a/packages/beacon-node/src/api/impl/lodestar/attesterSlashing.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/attesterSlashing.ts
@@ -1,23 +1,6 @@
 import {ForkSeq} from "@lodestar/params";
-import {AttesterSlashing, IndexedAttestation, IndexedAttestationBigint, phase0, ssz} from "@lodestar/types";
-
-/**
- * Check if two attestation data are slashable according to Casper FFG rules.
- *
- * Similar to isSlashableAttestationData in state-transition/util/attestation.ts
- * but operates on non-bigint types and checks surround votes in both directions,
- * since we're detecting slashable pairs rather than validating an already-ordered slashing.
- */
-export function isSlashableAttestationPair(data1: phase0.AttestationData, data2: phase0.AttestationData): boolean {
-  // Double vote
-  if (!ssz.phase0.AttestationData.equals(data1, data2) && data1.target.epoch === data2.target.epoch) return true;
-
-  // Surround vote, bidirectional
-  if (data1.source.epoch < data2.source.epoch && data2.target.epoch < data1.target.epoch) return true;
-  if (data2.source.epoch < data1.source.epoch && data1.target.epoch < data2.target.epoch) return true;
-
-  return false;
-}
+import {isSlashableAttestationData} from "@lodestar/state-transition";
+import {AttesterSlashing, IndexedAttestation, IndexedAttestationBigint, ssz} from "@lodestar/types";
 
 /**
  * Find all slashable pairs within a list of IndexedAttestations and
@@ -30,17 +13,22 @@ export function getAttesterSlashingsFromIndexedAttestations(
   const slashings: AttesterSlashing[] = [];
 
   for (let i = 0; i < indexedAttestations.length; i++) {
-    const att1 = indexedAttestations[i];
-
     for (let j = i + 1; j < indexedAttestations.length; j++) {
-      const att2 = indexedAttestations[j];
+      const [first, second] =
+        indexedAttestations[j].data.source.epoch < indexedAttestations[i].data.source.epoch
+          ? [indexedAttestations[j], indexedAttestations[i]]
+          : [indexedAttestations[i], indexedAttestations[j]];
 
-      if (!isSlashableAttestationPair(att1.data, att2.data)) continue;
-      if (!hasIntersection(att1.attestingIndices, att2.attestingIndices)) continue;
+      if (!hasIntersection(first.attestingIndices, second.attestingIndices)) continue;
+
+      const firstBigint = toIndexedAttestationBigint(first, fork);
+      const secondBigint = toIndexedAttestationBigint(second, fork);
+
+      if (!isSlashableAttestationData(firstBigint.data, secondBigint.data)) continue;
 
       slashings.push({
-        attestation1: toIndexedAttestationBigint(att1, fork),
-        attestation2: toIndexedAttestationBigint(att2, fork),
+        attestation1: firstBigint,
+        attestation2: secondBigint,
       });
     }
   }

--- a/packages/beacon-node/src/api/impl/lodestar/attesterSlashing.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/attesterSlashing.ts
@@ -14,6 +14,8 @@ export function getAttesterSlashingsFromIndexedAttestations(
 
   for (let i = 0; i < indexedAttestations.length; i++) {
     for (let j = i + 1; j < indexedAttestations.length; j++) {
+      // Order by source epoch so the surrounding attestation is always first,
+      // matching what isSlashableAttestationData expects (one-directional check).
       const [first, second] =
         indexedAttestations[j].data.source.epoch < indexedAttestations[i].data.source.epoch
           ? [indexedAttestations[j], indexedAttestations[i]]

--- a/packages/beacon-node/src/api/impl/lodestar/attesterSlashing.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/attesterSlashing.ts
@@ -1,0 +1,79 @@
+import {ForkSeq} from "@lodestar/params";
+import {AttesterSlashing, IndexedAttestation, IndexedAttestationBigint, phase0, ssz} from "@lodestar/types";
+
+/**
+ * Check if two attestation data are slashable according to Casper FFG rules.
+ *
+ * Similar to isSlashableAttestationData in state-transition/util/attestation.ts
+ * but operates on non-bigint types and checks surround votes in both directions,
+ * since we're detecting slashable pairs rather than validating an already-ordered slashing.
+ */
+export function isSlashableAttestationPair(data1: phase0.AttestationData, data2: phase0.AttestationData): boolean {
+  // Double vote
+  if (!ssz.phase0.AttestationData.equals(data1, data2) && data1.target.epoch === data2.target.epoch) return true;
+
+  // Surround vote, bidirectional
+  if (data1.source.epoch < data2.source.epoch && data2.target.epoch < data1.target.epoch) return true;
+  if (data2.source.epoch < data1.source.epoch && data1.target.epoch < data2.target.epoch) return true;
+
+  return false;
+}
+
+/**
+ * Find all slashable pairs within a list of IndexedAttestations and
+ * construct AttesterSlashing objects for each.
+ */
+export function getAttesterSlashingsFromIndexedAttestations(
+  fork: ForkSeq,
+  indexedAttestations: IndexedAttestation[]
+): AttesterSlashing[] {
+  const slashings: AttesterSlashing[] = [];
+
+  for (let i = 0; i < indexedAttestations.length; i++) {
+    const att1 = indexedAttestations[i];
+
+    for (let j = i + 1; j < indexedAttestations.length; j++) {
+      const att2 = indexedAttestations[j];
+
+      if (!isSlashableAttestationPair(att1.data, att2.data)) continue;
+      if (!hasIntersection(att1.attestingIndices, att2.attestingIndices)) continue;
+
+      slashings.push({
+        attestation1: toIndexedAttestationBigint(att1, fork),
+        attestation2: toIndexedAttestationBigint(att2, fork),
+      });
+    }
+  }
+
+  return slashings;
+}
+
+/**
+ * Check if two sorted arrays share at least one common element.
+ * attestingIndices are sorted per spec.
+ */
+function hasIntersection(indices1: number[], indices2: number[]): boolean {
+  let i = 0;
+  let j = 0;
+
+  while (i < indices1.length && j < indices2.length) {
+    if (indices1[i] === indices2[j]) {
+      return true;
+    }
+    if (indices1[i] < indices2[j]) i++;
+    else j++;
+  }
+
+  return false;
+}
+
+/**
+ * Convert IndexedAttestation to IndexedAttestationBigint via SSZ roundtrip.
+ * Both types share the same binary layout — only the JS numeric representation differs.
+ */
+function toIndexedAttestationBigint(att: IndexedAttestation, fork: ForkSeq): IndexedAttestationBigint {
+  const sszType = fork >= ForkSeq.electra ? ssz.electra.IndexedAttestation : ssz.phase0.IndexedAttestation;
+  const sszTypeBigint =
+    fork >= ForkSeq.electra ? ssz.electra.IndexedAttestationBigint : ssz.phase0.IndexedAttestationBigint;
+  return sszTypeBigint.deserialize(sszType.serialize(att));
+}

--- a/packages/beacon-node/src/api/impl/lodestar/attesterSlashing.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/attesterSlashing.ts
@@ -1,5 +1,9 @@
 import {ForkSeq} from "@lodestar/params";
-import {isSlashableAttestationData, toIndexedAttestationBigint} from "@lodestar/state-transition";
+import {
+  getIntersectingIndices,
+  isSlashableAttestationData,
+  toIndexedAttestationBigint,
+} from "@lodestar/state-transition";
 import {AttesterSlashing, IndexedAttestation} from "@lodestar/types";
 
 /**
@@ -21,7 +25,7 @@ export function getAttesterSlashingsFromIndexedAttestations(
           ? [indexedAttestations[j], indexedAttestations[i]]
           : [indexedAttestations[i], indexedAttestations[j]];
 
-      if (!hasIntersection(first.attestingIndices, second.attestingIndices)) continue;
+      if (getIntersectingIndices(first.attestingIndices, second.attestingIndices).length === 0) continue;
 
       const firstBigint = toIndexedAttestationBigint(first, fork);
       const secondBigint = toIndexedAttestationBigint(second, fork);
@@ -36,23 +40,4 @@ export function getAttesterSlashingsFromIndexedAttestations(
   }
 
   return slashings;
-}
-
-/**
- * Check if two sorted arrays share at least one common element.
- * attestingIndices are sorted per spec.
- */
-function hasIntersection(indices1: number[], indices2: number[]): boolean {
-  let i = 0;
-  let j = 0;
-
-  while (i < indices1.length && j < indices2.length) {
-    if (indices1[i] === indices2[j]) {
-      return true;
-    }
-    if (indices1[i] < indices2[j]) i++;
-    else j++;
-  }
-
-  return false;
 }

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -3,8 +3,8 @@ import {ApplicationMethods} from "@lodestar/api/server";
 import {ChainForkConfig} from "@lodestar/config";
 import {Repository} from "@lodestar/db";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {isStatePostCapella} from "@lodestar/state-transition";
-import {ssz} from "@lodestar/types";
+import {computeStartSlotAtEpoch, getIndexedAttestation, isStatePostCapella} from "@lodestar/state-transition";
+import {Attestation, Epoch, IndexedAttestation, ssz} from "@lodestar/types";
 import {Checkpoint} from "@lodestar/types/phase0";
 import {fromHex, toHex, toRootHex} from "@lodestar/utils";
 import {BeaconChain} from "../../../chain/index.js";
@@ -16,6 +16,7 @@ import {ProfileThread, profileThread, writeHeapSnapshot} from "../../../util/pro
 import {getStateResponseWithRegen} from "../beacon/state/utils.js";
 import {ApiError} from "../errors.js";
 import {ApiModules} from "../types.js";
+import {getAttesterSlashingsFromIndexedAttestations} from "./attesterSlashing.js";
 
 export function getLodestarApi({
   chain,
@@ -270,6 +271,50 @@ export function getLodestarApi({
           earliestCustodiedSlot: chain.earliestAvailableSlot,
           custodyGroupCount: targetCustodyGroupCount,
           custodyColumns,
+        },
+      };
+    },
+
+    async getAttesterSlashingsFromBlocks({signedBlocks}) {
+      if (signedBlocks.length === 0) {
+        throw new ApiError(400, "No blocks provided");
+      }
+
+      const attestations = new Map<Epoch, Attestation[]>();
+
+      for (const block of signedBlocks) {
+        const attestationsOfABlock = block.message.body.attestations;
+        for (const attestation of attestationsOfABlock) {
+          const epoch = attestation.data.target.epoch;
+          let attestationsPerEpoch = attestations.get(epoch);
+          if (!attestationsPerEpoch) {
+            attestationsPerEpoch = [];
+            attestations.set(epoch, attestationsPerEpoch);
+          }
+          attestationsPerEpoch.push(attestation);
+        }
+      }
+
+      const indexedAttestations: IndexedAttestation[] = [];
+      // Assume all blocks are from the same fork
+      const forkSeq = config.getForkSeq(signedBlocks[0].message.slot);
+
+      for (const [epoch, attestationsPerEpoch] of attestations) {
+        const slot = computeStartSlotAtEpoch(epoch);
+        const {state} = await getStateResponseWithRegen(chain, slot);
+        const stateView = state instanceof Uint8Array ? chain.getHeadState().loadOtherState(state) : state;
+        const shuffling = stateView.getShufflingAtEpoch(epoch);
+        for (const attestation of attestationsPerEpoch) {
+          indexedAttestations.push(getIndexedAttestation(shuffling, forkSeq, attestation));
+        }
+      }
+
+      const result = getAttesterSlashingsFromIndexedAttestations(forkSeq, indexedAttestations);
+
+      return {
+        data: result,
+        meta: {
+          version: config.getForkName(signedBlocks[0].message.slot),
         },
       };
     },

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -3,7 +3,12 @@ import {ApplicationMethods} from "@lodestar/api/server";
 import {ChainForkConfig} from "@lodestar/config";
 import {Repository} from "@lodestar/db";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {computeStartSlotAtEpoch, getIndexedAttestation, isStatePostCapella} from "@lodestar/state-transition";
+import {
+  computeEpochAtSlot,
+  computeStartSlotAtEpoch,
+  getIndexedAttestation,
+  isStatePostCapella,
+} from "@lodestar/state-transition";
 import {Attestation, Epoch, IndexedAttestation, ssz} from "@lodestar/types";
 import {Checkpoint} from "@lodestar/types/phase0";
 import {fromHex, toHex, toRootHex} from "@lodestar/utils";
@@ -285,7 +290,7 @@ export function getLodestarApi({
       for (const block of signedBlocks) {
         const attestationsOfABlock = block.message.body.attestations;
         for (const attestation of attestationsOfABlock) {
-          const epoch = attestation.data.target.epoch;
+          const epoch = computeEpochAtSlot(attestation.data.slot);
           let attestationsPerEpoch = attestations.get(epoch);
           if (!attestationsPerEpoch) {
             attestationsPerEpoch = [];

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -281,10 +281,6 @@ export function getLodestarApi({
     },
 
     async getAttesterSlashingsFromBlocks({signedBlocks}) {
-      if (signedBlocks.length === 0) {
-        throw new ApiError(400, "No blocks provided");
-      }
-
       const attestations = new Map<Epoch, Attestation[]>();
 
       for (const block of signedBlocks) {

--- a/packages/beacon-node/test/unit/api/impl/lodestar/AttesterSlashing.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/lodestar/AttesterSlashing.test.ts
@@ -19,8 +19,8 @@ describe("api - lodestar - attesterSlashing", () => {
 
       const result = getAttesterSlashingsFromIndexedAttestations(ForkSeq.phase0, [attestation1, attestation2]);
       expect(result).toHaveLength(1);
-      expect(result[0].attestation1.data.beaconBlockRoot).toEqual(attestation2.data.beaconBlockRoot);
-      expect(result[0].attestation2.data.beaconBlockRoot).toEqual(attestation1.data.beaconBlockRoot);
+      expect(result[0].attestation1.data.beaconBlockRoot).toEqual(attestation1.data.beaconBlockRoot);
+      expect(result[0].attestation2.data.beaconBlockRoot).toEqual(attestation2.data.beaconBlockRoot);
     });
     it("surrounding vote - first direction - slashing", () => {
       const attestation1 = ssz.phase0.IndexedAttestation.defaultValue();

--- a/packages/beacon-node/test/unit/api/impl/lodestar/AttesterSlashing.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/lodestar/AttesterSlashing.test.ts
@@ -1,0 +1,100 @@
+import {describe, expect, it} from "vitest";
+import {ForkSeq} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
+import {
+  getAttesterSlashingsFromIndexedAttestations,
+  isSlashableAttestationPair,
+} from "../../../../../src/api/impl/lodestar/attesterSlashing.js";
+
+describe("api - lodestar - attesterSlashing", () => {
+  describe("isSlashableAttestationPair", () => {
+    it("non-slashable attestation pair", () => {
+      const data1 = ssz.phase0.AttestationData.defaultValue();
+      const data2 = ssz.phase0.AttestationData.defaultValue();
+
+      data2.target.epoch = 1;
+
+      expect(isSlashableAttestationPair(data1, data2)).toBe(false);
+    });
+    it("non-slashable attestation pair - identical data", () => {
+      const data1 = ssz.phase0.AttestationData.defaultValue();
+      const data2 = ssz.phase0.AttestationData.defaultValue();
+
+      expect(isSlashableAttestationPair(data1, data2)).toBe(false);
+    });
+    it("slashable attestation pair - double vote", () => {
+      const data1 = ssz.phase0.AttestationData.defaultValue();
+      const data2 = ssz.phase0.AttestationData.defaultValue();
+
+      data2.beaconBlockRoot = new Uint8Array(32).fill(1);
+
+      expect(isSlashableAttestationPair(data1, data2)).toBe(true);
+    });
+    it("slashable attestation pair - surround vote - first direction", () => {
+      const data1 = ssz.phase0.AttestationData.defaultValue();
+      const data2 = ssz.phase0.AttestationData.defaultValue();
+
+      data1.source.epoch = 1;
+      data1.target.epoch = 4;
+      data2.source.epoch = 2;
+      data2.target.epoch = 3;
+
+      expect(isSlashableAttestationPair(data1, data2)).toBe(true);
+    });
+    it("slashable attestation pair - surround vote - second direction", () => {
+      const data1 = ssz.phase0.AttestationData.defaultValue();
+      const data2 = ssz.phase0.AttestationData.defaultValue();
+
+      data1.source.epoch = 2;
+      data1.target.epoch = 3;
+      data2.source.epoch = 1;
+      data2.target.epoch = 4;
+
+      expect(isSlashableAttestationPair(data1, data2)).toBe(true);
+    });
+  });
+
+  describe("getAttesterSlashingsFromIndexedAttestations", () => {
+    it("empty input - empty output", () => {
+      expect(getAttesterSlashingsFromIndexedAttestations(ForkSeq.phase0, [])).toStrictEqual([]);
+    });
+    it("vote contradiction - same validator - slashing", () => {
+      const attestation1 = ssz.phase0.IndexedAttestation.defaultValue();
+      const attestation2 = ssz.phase0.IndexedAttestation.defaultValue();
+
+      attestation2.data.beaconBlockRoot = new Uint8Array(32).fill(1);
+
+      attestation1.attestingIndices.push(1);
+      attestation2.attestingIndices.push(1);
+
+      const result = getAttesterSlashingsFromIndexedAttestations(ForkSeq.phase0, [attestation1, attestation2]);
+      expect(result).toHaveLength(1);
+      expect(result[0].attestation1.data.beaconBlockRoot).toEqual(attestation1.data.beaconBlockRoot);
+      expect(result[0].attestation2.data.beaconBlockRoot).toEqual(attestation2.data.beaconBlockRoot);
+    });
+    it("vote contradiction - different validators - no slashing", () => {
+      const attestation1 = ssz.phase0.IndexedAttestation.defaultValue();
+      const attestation2 = ssz.phase0.IndexedAttestation.defaultValue();
+
+      attestation2.data.beaconBlockRoot = new Uint8Array(32).fill(1);
+
+      attestation1.attestingIndices.push(1);
+      attestation2.attestingIndices.push(2);
+
+      expect(getAttesterSlashingsFromIndexedAttestations(ForkSeq.phase0, [attestation1, attestation2])).toStrictEqual(
+        []
+      );
+    });
+    it("agreeing votes - different validators - no slashing", () => {
+      const attestation1 = ssz.phase0.IndexedAttestation.defaultValue();
+      const attestation2 = ssz.phase0.IndexedAttestation.defaultValue();
+
+      attestation1.attestingIndices.push(1);
+      attestation2.attestingIndices.push(2);
+
+      expect(getAttesterSlashingsFromIndexedAttestations(ForkSeq.phase0, [attestation1, attestation2])).toStrictEqual(
+        []
+      );
+    });
+  });
+});

--- a/packages/beacon-node/test/unit/api/impl/lodestar/AttesterSlashing.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/lodestar/AttesterSlashing.test.ts
@@ -1,64 +1,14 @@
 import {describe, expect, it} from "vitest";
 import {ForkSeq} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
-import {
-  getAttesterSlashingsFromIndexedAttestations,
-  isSlashableAttestationPair,
-} from "../../../../../src/api/impl/lodestar/attesterSlashing.js";
+import {getAttesterSlashingsFromIndexedAttestations} from "../../../../../src/api/impl/lodestar/attesterSlashing.js";
 
 describe("api - lodestar - attesterSlashing", () => {
-  describe("isSlashableAttestationPair", () => {
-    it("non-slashable attestation pair", () => {
-      const data1 = ssz.phase0.AttestationData.defaultValue();
-      const data2 = ssz.phase0.AttestationData.defaultValue();
-
-      data2.target.epoch = 1;
-
-      expect(isSlashableAttestationPair(data1, data2)).toBe(false);
-    });
-    it("non-slashable attestation pair - identical data", () => {
-      const data1 = ssz.phase0.AttestationData.defaultValue();
-      const data2 = ssz.phase0.AttestationData.defaultValue();
-
-      expect(isSlashableAttestationPair(data1, data2)).toBe(false);
-    });
-    it("slashable attestation pair - double vote", () => {
-      const data1 = ssz.phase0.AttestationData.defaultValue();
-      const data2 = ssz.phase0.AttestationData.defaultValue();
-
-      data2.beaconBlockRoot = new Uint8Array(32).fill(1);
-
-      expect(isSlashableAttestationPair(data1, data2)).toBe(true);
-    });
-    it("slashable attestation pair - surround vote - first direction", () => {
-      const data1 = ssz.phase0.AttestationData.defaultValue();
-      const data2 = ssz.phase0.AttestationData.defaultValue();
-
-      data1.source.epoch = 1;
-      data1.target.epoch = 4;
-      data2.source.epoch = 2;
-      data2.target.epoch = 3;
-
-      expect(isSlashableAttestationPair(data1, data2)).toBe(true);
-    });
-    it("slashable attestation pair - surround vote - second direction", () => {
-      const data1 = ssz.phase0.AttestationData.defaultValue();
-      const data2 = ssz.phase0.AttestationData.defaultValue();
-
-      data1.source.epoch = 2;
-      data1.target.epoch = 3;
-      data2.source.epoch = 1;
-      data2.target.epoch = 4;
-
-      expect(isSlashableAttestationPair(data1, data2)).toBe(true);
-    });
-  });
-
   describe("getAttesterSlashingsFromIndexedAttestations", () => {
     it("empty input - empty output", () => {
       expect(getAttesterSlashingsFromIndexedAttestations(ForkSeq.phase0, [])).toStrictEqual([]);
     });
-    it("vote contradiction - same validator - slashing", () => {
+    it("double vote - slashing", () => {
       const attestation1 = ssz.phase0.IndexedAttestation.defaultValue();
       const attestation2 = ssz.phase0.IndexedAttestation.defaultValue();
 
@@ -69,8 +19,42 @@ describe("api - lodestar - attesterSlashing", () => {
 
       const result = getAttesterSlashingsFromIndexedAttestations(ForkSeq.phase0, [attestation1, attestation2]);
       expect(result).toHaveLength(1);
+      expect(result[0].attestation1.data.beaconBlockRoot).toEqual(attestation2.data.beaconBlockRoot);
+      expect(result[0].attestation2.data.beaconBlockRoot).toEqual(attestation1.data.beaconBlockRoot);
+    });
+    it("surrounding vote - first direction - slashing", () => {
+      const attestation1 = ssz.phase0.IndexedAttestation.defaultValue();
+      const attestation2 = ssz.phase0.IndexedAttestation.defaultValue();
+
+      attestation1.attestingIndices.push(1);
+      attestation2.attestingIndices.push(1);
+
+      attestation1.data.source.epoch = 1;
+      attestation1.data.target.epoch = 4;
+      attestation2.data.source.epoch = 2;
+      attestation2.data.target.epoch = 3;
+
+      const result = getAttesterSlashingsFromIndexedAttestations(ForkSeq.phase0, [attestation1, attestation2]);
+      expect(result).toHaveLength(1);
       expect(result[0].attestation1.data.beaconBlockRoot).toEqual(attestation1.data.beaconBlockRoot);
       expect(result[0].attestation2.data.beaconBlockRoot).toEqual(attestation2.data.beaconBlockRoot);
+    });
+    it("surrounding vote - second direction - slashing", () => {
+      const attestation1 = ssz.phase0.IndexedAttestation.defaultValue();
+      const attestation2 = ssz.phase0.IndexedAttestation.defaultValue();
+
+      attestation1.attestingIndices.push(1);
+      attestation2.attestingIndices.push(1);
+
+      attestation1.data.source.epoch = 2;
+      attestation1.data.target.epoch = 3;
+      attestation2.data.source.epoch = 1;
+      attestation2.data.target.epoch = 4;
+
+      const result = getAttesterSlashingsFromIndexedAttestations(ForkSeq.phase0, [attestation1, attestation2]);
+      expect(result).toHaveLength(1);
+      expect(result[0].attestation1.data.beaconBlockRoot).toEqual(attestation2.data.beaconBlockRoot);
+      expect(result[0].attestation2.data.beaconBlockRoot).toEqual(attestation1.data.beaconBlockRoot);
     });
     it("vote contradiction - different validators - no slashing", () => {
       const attestation1 = ssz.phase0.IndexedAttestation.defaultValue();

--- a/packages/state-transition/src/util/attestation.ts
+++ b/packages/state-transition/src/util/attestation.ts
@@ -1,5 +1,6 @@
 import {MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {AttesterSlashing, Slot, ValidatorIndex, phase0, ssz} from "@lodestar/types";
+import {ForkSeq} from "@lodestar/params";
+import {AttesterSlashing, Slot, ValidatorIndex, phase0, IndexedAttestation, IndexedAttestationBigint, ssz} from "@lodestar/types";
 
 /**
  * Check if [[data1]] and [[data2]] are slashable according to Casper FFG rules.
@@ -33,4 +34,15 @@ export function getAttesterSlashableIndices(attesterSlashing: AttesterSlashing):
     }
   }
   return indices;
+}
+
+/**
+ * Convert IndexedAttestation to IndexedAttestationBigint via SSZ roundtrip.
+ * Both types share the same binary layout — only the JS numeric representation differs.
+ */
+export function toIndexedAttestationBigint(att: IndexedAttestation, fork: ForkSeq): IndexedAttestationBigint {
+  const sszType = fork >= ForkSeq.electra ? ssz.electra.IndexedAttestation : ssz.phase0.IndexedAttestation;
+  const sszTypeBigint =
+    fork >= ForkSeq.electra ? ssz.electra.IndexedAttestationBigint : ssz.phase0.IndexedAttestationBigint;
+  return sszTypeBigint.deserialize(sszType.serialize(att));
 }

--- a/packages/state-transition/src/util/attestation.ts
+++ b/packages/state-transition/src/util/attestation.ts
@@ -1,6 +1,13 @@
-import {MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {ForkSeq} from "@lodestar/params";
-import {AttesterSlashing, Slot, ValidatorIndex, phase0, IndexedAttestation, IndexedAttestationBigint, ssz} from "@lodestar/types";
+import {ForkSeq, MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {
+  AttesterSlashing,
+  IndexedAttestation,
+  IndexedAttestationBigint,
+  Slot,
+  ValidatorIndex,
+  phase0,
+  ssz,
+} from "@lodestar/types";
 
 /**
  * Check if [[data1]] and [[data2]] are slashable according to Casper FFG rules.
@@ -23,17 +30,27 @@ export function isValidAttestationSlot(attestationSlot: Slot, currentSlot: Slot)
   );
 }
 
-export function getAttesterSlashableIndices(attesterSlashing: AttesterSlashing): ValidatorIndex[] {
+/**
+ * Compute the intersection of two sorted validator index lists.
+ * Both inputs must be sorted in ascending order (per spec).
+ */
+export function getIntersectingIndices(indices1: ValidatorIndex[], indices2: ValidatorIndex[]): ValidatorIndex[] {
   const indices: ValidatorIndex[] = [];
-  const attSet1 = new Set(attesterSlashing.attestation1.attestingIndices);
-  const attArr2 = attesterSlashing.attestation2.attestingIndices;
-  for (let i = 0, len = attArr2.length; i < len; i++) {
-    const index = attArr2[i];
-    if (attSet1.has(index)) {
+  const alreadyPresent = new Set(indices1);
+  for (let i = 0, len = indices2.length; i < len; i++) {
+    const index = indices2[i];
+    if (alreadyPresent.has(index)) {
       indices.push(index);
     }
   }
   return indices;
+}
+
+export function getAttesterSlashableIndices(attesterSlashing: AttesterSlashing): ValidatorIndex[] {
+  return getIntersectingIndices(
+    attesterSlashing.attestation1.attestingIndices,
+    attesterSlashing.attestation2.attestingIndices
+  );
 }
 
 /**


### PR DESCRIPTION
**Motivation**

Introduce an attester slashings endpoint

**Description**

Upon reviewing the full discussion on PR #8054 I made changes that should fit the final decisions, such as having a stateful handler. Also for this primary version it is considered that all blocks are from the same fork (in a single request).

Manual testing on local `lodestar dev` node confirms routing, serialization, regen, and handler work end-to-end (returns empty slashings as expected for honest blocks).

Opened as a draft to validate the direction while tests are still in the making.

What is missing:
- Unit and e2e tests (edit: tests are added)
- Edge case covering (potential)

Closes #7962

**AI Assistance Disclosure**
Written with assistance from Claude. Used for navigating the codebase, understanding existing patterns, and reviewing the approach. Every line was reviewed and understood before committing.
