### PR TITLE
fix: handle dynamic ephemery genesis metadata across config and lightclient paths

### DIFF
--- a/packages/api/src/beacon/routes/lightclient.ts
+++ b/packages/api/src/beacon/routes/lightclient.ts
@@ -26,6 +26,10 @@ import {MetaHeader, VersionCodec, VersionMeta} from "../../utils/metadata.js";
 export const HashListType = new ListCompositeType(ssz.Root, 10000);
 export type HashList = ValueOf<typeof HashListType>;
 
+function isBeaconConfig(config: ChainForkConfig): config is BeaconConfig {
+  return "genesisValidatorsRoot" in config;
+}
+
 export type Endpoints = {
   /**
    * Returns an array of best updates given a `startPeriod` and `count` number of sync committee period to return.
@@ -95,8 +99,12 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
 
   const cachedBeaconConfig = (): BeaconConfig => {
     if (beaconConfig === undefined) {
-      const genesisValidatorsRoot = genesisData[config.CONFIG_NAME as NetworkName]?.genesisValidatorsRoot;
-      beaconConfig = createBeaconConfig(config, genesisValidatorsRoot ? fromHex(genesisValidatorsRoot) : ZERO_HASH);
+      if (isBeaconConfig(config)) {
+        beaconConfig = config;
+      } else {
+        const genesisValidatorsRoot = genesisData[config.CONFIG_NAME as NetworkName]?.genesisValidatorsRoot;
+        beaconConfig = createBeaconConfig(config, genesisValidatorsRoot ? fromHex(genesisValidatorsRoot) : ZERO_HASH);
+      }
     }
     return beaconConfig;
   };

--- a/packages/api/test/unit/beacon/genericServerTest/lightclient.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/lightclient.test.ts
@@ -1,7 +1,10 @@
-import {describe} from "vitest";
-import {createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {describe, expect, it} from "vitest";
+import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {ephemeryChainConfig} from "@lodestar/config/networks";
+import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
 import {getClient} from "../../../../src/beacon/client/lightclient.js";
-import {Endpoints} from "../../../../src/beacon/routes/lightclient.js";
+import {Endpoints, getDefinitions} from "../../../../src/beacon/routes/lightclient.js";
 import {getRoutes} from "../../../../src/beacon/server/lightclient.js";
 import {runGenericServerTest} from "../../../utils/genericServerTest.js";
 import {testData} from "../testData/lightclient.js";
@@ -13,4 +16,21 @@ describe("beacon / lightclient", () => {
     getRoutes,
     testData
   );
+
+  it("uses the runtime beacon config for ephemery lightclient serialization", () => {
+    const genesisValidatorsRoot = Buffer.alloc(32, 1);
+    const config = createBeaconConfig({...ephemeryChainConfig, ELECTRA_FORK_EPOCH: 0}, genesisValidatorsRoot);
+    const definitions = getDefinitions(config);
+    const update = ssz.electra.LightClientUpdate.defaultValue();
+    update.attestedHeader.beacon.slot = SLOTS_PER_EPOCH;
+
+    const serialized = definitions.getLightClientUpdatesByRange.resp.data.serialize([update], {
+      versions: [ForkName.electra],
+    });
+    const forkDigest = ssz.ForkDigest.deserialize(serialized.subarray(8, 12));
+
+    expect(Buffer.from(forkDigest)).toEqual(
+      Buffer.from(config.forkBoundary2ForkDigest(config.getForkBoundaryAtEpoch(1)))
+    );
+  });
 });

--- a/packages/cli/src/cmds/validator/slashingProtection/utils.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/utils.ts
@@ -41,16 +41,15 @@ export async function getGenesisValidatorsRoot(args: GlobalArgs & ISlashingProte
 
   const {config} = getBeaconConfigFromArgs(args);
   const api = getClient({baseUrl: server}, {config});
-  const genesis = await api.beacon.getGenesis();
 
   try {
+    const genesis = await api.beacon.getGenesis();
     genesis.assertOk();
+    return genesis.value().genesisValidatorsRoot;
   } catch (e) {
     if (args.force) {
       return Buffer.alloc(32, 0);
     }
     throw e;
   }
-
-  return genesis.value().genesisValidatorsRoot;
 }

--- a/packages/cli/src/cmds/validator/slashingProtection/utils.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/utils.ts
@@ -4,7 +4,7 @@ import {LevelDbController} from "@lodestar/db/controller/level";
 import {Root} from "@lodestar/types";
 import {Logger, fromHex} from "@lodestar/utils";
 import {MetaDataRepository, SlashingProtection} from "@lodestar/validator";
-import {getBeaconConfigFromArgs} from "../../../config/index.js";
+import {getBeaconConfigFromArgs} from "../../../config/beaconParams.js";
 import {GlobalArgs} from "../../../options/index.js";
 import {getValidatorPaths} from "../paths.js";
 import {ISlashingProtectionArgs} from "./options.js";
@@ -35,7 +35,7 @@ export async function getGenesisValidatorsRoot(args: GlobalArgs & ISlashingProte
   const server = args.beaconNodes[0];
 
   const networkGenesis = genesisData[args.network as NetworkName];
-  if (networkGenesis !== undefined) {
+  if (networkGenesis?.genesisValidatorsRoot != null) {
     return fromHex(networkGenesis.genesisValidatorsRoot);
   }
 

--- a/packages/cli/test/unit/config/beaconParams.test.ts
+++ b/packages/cli/test/unit/config/beaconParams.test.ts
@@ -2,7 +2,8 @@ import fs from "node:fs";
 import yaml from "js-yaml";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
-import {getBeaconParams} from "../../../src/config/index.js";
+import {ephemeryChainConfig} from "@lodestar/config/networks";
+import {getBeaconParams} from "../../../src/config/beaconParams.js";
 import {getTestdirPath} from "../../utils.js";
 
 describe("config / beaconParams", () => {
@@ -64,5 +65,13 @@ describe("config / beaconParams", () => {
   it.each(testCases)("$id", ({kwargs, GENESIS_FORK_VERSION}) => {
     const params = getBeaconParams(kwargs);
     expect(toHexString(params.GENESIS_FORK_VERSION)).toBe(GENESIS_FORK_VERSION);
+  });
+
+  it("returns the current dynamic ephemery chain config", () => {
+    const params = getBeaconParams({network: "ephemery", additionalParamsCli: {}});
+
+    expect(params.MIN_GENESIS_TIME).toBe(ephemeryChainConfig.MIN_GENESIS_TIME);
+    expect(params.DEPOSIT_CHAIN_ID).toBe(ephemeryChainConfig.DEPOSIT_CHAIN_ID);
+    expect(params.DEPOSIT_NETWORK_ID).toBe(ephemeryChainConfig.DEPOSIT_NETWORK_ID);
   });
 });

--- a/packages/cli/test/unit/validator/slashingProtection.test.ts
+++ b/packages/cli/test/unit/validator/slashingProtection.test.ts
@@ -28,7 +28,7 @@ describe("validator / slashingProtection", () => {
     expect(genesisValidatorsRoot).toEqual(fromHex(mainnetGenesisValidatorsRoot));
   });
 
-  describe("ephemery", () => {
+  describe("without a cached genesis validators root", () => {
     let server: FastifyInstance;
     let baseUrl: string;
 
@@ -62,16 +62,25 @@ describe("validator / slashingProtection", () => {
       }
     });
 
-    it("fetches genesis validators root from the beacon api when the network metadata root is unknown", async () => {
+    it("fetches genesis validators root from the beacon api", async () => {
       const genesisValidatorsRoot = await getGenesisValidatorsRoot({
         beaconNodes: [baseUrl],
-        network: "ephemery",
         preset: defaultChainConfig.PRESET_BASE,
       });
 
       expect(genesisValidatorsRoot).toEqual(
         fromHex("0x1111111111111111111111111111111111111111111111111111111111111111")
       );
+    });
+
+    it("falls back to zero root with force when fetching genesis fails", async () => {
+      const genesisValidatorsRoot = await getGenesisValidatorsRoot({
+        beaconNodes: ["http://127.0.0.1:1"],
+        force: true,
+        preset: defaultChainConfig.PRESET_BASE,
+      });
+
+      expect(Array.from(genesisValidatorsRoot)).toEqual(Array(32).fill(0));
     });
   });
 });

--- a/packages/cli/test/unit/validator/slashingProtection.test.ts
+++ b/packages/cli/test/unit/validator/slashingProtection.test.ts
@@ -1,0 +1,77 @@
+import {FastifyInstance} from "fastify";
+import {afterAll, beforeAll, describe, expect, it} from "vitest";
+import {BeaconApiMethods, registerRoutes} from "@lodestar/api/beacon/server";
+import {createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {genesisData} from "@lodestar/config/networks";
+import {ssz} from "@lodestar/types";
+import {fromHex} from "@lodestar/utils";
+import {getTestServer} from "../../../../api/test/utils/utils.js";
+import {getGenesisValidatorsRoot} from "../../../src/cmds/validator/slashingProtection/utils.js";
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
+describe("validator / slashingProtection", () => {
+  it("uses cached network genesis validators root for static-root networks", async () => {
+    const mainnetGenesisValidatorsRoot = genesisData.mainnet.genesisValidatorsRoot;
+    if (mainnetGenesisValidatorsRoot === null) {
+      throw Error("Expected mainnet to have a static genesis validators root");
+    }
+
+    const genesisValidatorsRoot = await getGenesisValidatorsRoot({
+      beaconNodes: ["http://127.0.0.1:1"],
+      network: "mainnet",
+      preset: defaultChainConfig.PRESET_BASE,
+    });
+
+    expect(genesisValidatorsRoot).toEqual(fromHex(mainnetGenesisValidatorsRoot));
+  });
+
+  describe("ephemery", () => {
+    let server: FastifyInstance;
+    let baseUrl: string;
+
+    beforeAll(async () => {
+      const api = {
+        beacon: {
+          async getGenesis() {
+            const genesis = ssz.phase0.Genesis.defaultValue();
+            genesis.genesisValidatorsRoot = fromHex(
+              "0x1111111111111111111111111111111111111111111111111111111111111111"
+            );
+            return {data: genesis};
+          },
+        },
+        config: {
+          async getSpec() {
+            return {data: {}};
+          },
+        },
+      } as DeepPartial<BeaconApiMethods>;
+
+      const testServer = getTestServer();
+      server = testServer.server;
+      registerRoutes(server, createChainForkConfig(defaultChainConfig), api as BeaconApiMethods, ["beacon", "config"]);
+      baseUrl = await testServer.start();
+    });
+
+    afterAll(async () => {
+      if (server !== undefined) {
+        await server.close();
+      }
+    });
+
+    it("fetches genesis validators root from the beacon api when the network metadata root is unknown", async () => {
+      const genesisValidatorsRoot = await getGenesisValidatorsRoot({
+        beaconNodes: [baseUrl],
+        network: "ephemery",
+        preset: defaultChainConfig.PRESET_BASE,
+      });
+
+      expect(genesisValidatorsRoot).toEqual(
+        fromHex("0x1111111111111111111111111111111111111111111111111111111111111111")
+      );
+    });
+  });
+});

--- a/packages/config/src/chainConfig/networks/ephemery.ts
+++ b/packages/config/src/chainConfig/networks/ephemery.ts
@@ -68,15 +68,24 @@ const baseChainConfig: ChainConfig = {
   ],
 };
 
-// Reset interval (7 days) in milliseconds, based on ephemery-genesis values.env:
+// Reset interval (7 days) in seconds, based on ephemery-genesis values.env:
 // https://github.com/ephemery-testnet/ephemery-genesis/blob/9a28fbef950c8547d78785f8a0ea49a95ce19a48/values.env#L5
-const RESET_INTERVAL_MS = 604800000;
-const iteration = Math.floor(Date.now() - baseChainConfig.MIN_GENESIS_TIME) / RESET_INTERVAL_MS;
+export const EPHEMERY_RESET_INTERVAL_SECONDS = 604800;
 
-export const ephemeryChainConfig: ChainConfig = {
-  ...baseChainConfig,
+export function getEphemeryIteration(nowSeconds: number): number {
+  return Math.max(Math.floor((nowSeconds - baseChainConfig.MIN_GENESIS_TIME) / EPHEMERY_RESET_INTERVAL_SECONDS), 0);
+}
 
-  MIN_GENESIS_TIME: RESET_INTERVAL_MS * iteration + baseChainConfig.MIN_GENESIS_TIME,
-  DEPOSIT_CHAIN_ID: baseChainConfig.DEPOSIT_CHAIN_ID + iteration,
-  DEPOSIT_NETWORK_ID: baseChainConfig.DEPOSIT_NETWORK_ID + iteration,
-};
+export function getEphemeryChainConfig(nowSeconds = Math.floor(Date.now() / 1000)): ChainConfig {
+  const iteration = getEphemeryIteration(nowSeconds);
+
+  return {
+    ...baseChainConfig,
+
+    MIN_GENESIS_TIME: baseChainConfig.MIN_GENESIS_TIME + EPHEMERY_RESET_INTERVAL_SECONDS * iteration,
+    DEPOSIT_CHAIN_ID: baseChainConfig.DEPOSIT_CHAIN_ID + iteration,
+    DEPOSIT_NETWORK_ID: baseChainConfig.DEPOSIT_NETWORK_ID + iteration,
+  };
+}
+
+export const ephemeryChainConfig: ChainConfig = getEphemeryChainConfig();

--- a/packages/config/src/networks.ts
+++ b/packages/config/src/networks.ts
@@ -27,7 +27,7 @@ export const networksChainConfig: Record<NetworkName, ChainConfig> = {
 
 export type GenesisData = {
   genesisTime: number;
-  genesisValidatorsRoot: string;
+  genesisValidatorsRoot: string | null;
 };
 
 export const genesisData: Record<NetworkName, GenesisData> = {
@@ -53,6 +53,6 @@ export const genesisData: Record<NetworkName, GenesisData> = {
   },
   ephemery: {
     genesisTime: ephemeryChainConfig.MIN_GENESIS_TIME + ephemeryChainConfig.GENESIS_DELAY,
-    genesisValidatorsRoot: "0x0000000000000000000000000000000000000000000000000000000000000000",
+    genesisValidatorsRoot: null,
   },
 };

--- a/packages/config/test/unit/networks.test.ts
+++ b/packages/config/test/unit/networks.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, it} from "vitest";
+import {EPHEMERY_RESET_INTERVAL_SECONDS, getEphemeryChainConfig} from "../../src/chainConfig/networks/ephemery.js";
+import {ephemeryChainConfig, genesisData} from "../../src/networks.js";
+
+describe("networks", () => {
+  it("clamps ephemery iteration before genesis", () => {
+    const config = getEphemeryChainConfig(1638471599);
+
+    expect(config.MIN_GENESIS_TIME).toBe(1638471600);
+    expect(config.DEPOSIT_CHAIN_ID).toBe(39438000);
+    expect(config.DEPOSIT_NETWORK_ID).toBe(39438000);
+  });
+
+  it("advances ephemery resets in whole-second intervals", () => {
+    const config = getEphemeryChainConfig(1638471600 + 2 * EPHEMERY_RESET_INTERVAL_SECONDS + 1);
+
+    expect(config.MIN_GENESIS_TIME).toBe(1638471600 + 2 * EPHEMERY_RESET_INTERVAL_SECONDS);
+    expect(config.DEPOSIT_CHAIN_ID).toBe(39438002);
+    expect(config.DEPOSIT_NETWORK_ID).toBe(39438002);
+  });
+
+  it("tracks dynamic ephemery genesis data without a static validators root", () => {
+    expect(genesisData.ephemery.genesisTime).toBe(
+      ephemeryChainConfig.MIN_GENESIS_TIME + ephemeryChainConfig.GENESIS_DELAY
+    );
+    expect(genesisData.ephemery.genesisValidatorsRoot).toBeNull();
+  });
+});

--- a/packages/validator/test/e2e-mainnet/web3signer.test.ts
+++ b/packages/validator/test/e2e-mainnet/web3signer.test.ts
@@ -180,7 +180,11 @@ describe("web3signer signature test", () => {
   async function getValidatorStore(signer: Signer): Promise<ValidatorStore> {
     const logger = testLogger();
     const api = getClient({baseUrl: "http://localhost:9596"}, {config});
-    const genesisValidatorsRoot = fromHex(genesisData.mainnet.genesisValidatorsRoot);
+    const mainnetGenesisValidatorsRoot = genesisData.mainnet.genesisValidatorsRoot;
+    if (mainnetGenesisValidatorsRoot === null) {
+      throw Error("Expected mainnet to have a static genesis validators root");
+    }
+    const genesisValidatorsRoot = fromHex(mainnetGenesisValidatorsRoot);
     const metrics = null;
     const doppelgangerService = null;
     const valProposerConfig = undefined;


### PR DESCRIPTION
**Motivation**

Ephemery was added in #6054, but some paths still assumed its genesis metadata was static. That left the remaining issue from #6050 unresolved in places that depend on `genesisValidatorsRoot`, fork
digests, and reset-aware chain config values.

**Description**

This PR completes the remaining Ephemery work by treating its network metadata as runtime-derived instead of fully static.

  Changes included:
  - derive Ephemery `MIN_GENESIS_TIME`, `DEPOSIT_CHAIN_ID`, and `DEPOSIT_NETWORK_ID` from the current reset iteration
  - mark Ephemery `genesisValidatorsRoot` as unknown (`null`) in static network metadata
  - update validator slashing protection to fetch `genesisValidatorsRoot` from the beacon API when static metadata does not provide one
  - preserve an already-built runtime `BeaconConfig` in lightclient route serialization so fork digests use the correct live genesis context
  - add regression tests covering:
    - dynamic Ephemery config values
    - nullable Ephemery genesis metadata
    - slashing protection fallback behavior
    - lightclient serialization with runtime Ephemery config
  - add one explicit mainnet null check in validator tests to account for the new nullable `genesisValidatorsRoot` type

  Closes #6050

**AI Assistance Disclosure**

- [ ] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

used Codex to understand the code structure and identify the remaining gaps related to this issue. Each change  was reviewed and is understood by me.
