### PR TITLE
fix: fail fast when nativeStateView is enabled

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
@@ -3,6 +3,7 @@ import {
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
   IBeaconStateView,
+  assertNativeStateViewSupported,
   createBeaconStateViewForHistoricalRegen,
 } from "@lodestar/state-transition";
 import {byteArrayEquals} from "@lodestar/utils";
@@ -19,6 +20,7 @@ export async function getNearestState(
   db: IBeaconDb,
   nativeStateView: boolean
 ): Promise<IBeaconStateView> {
+  assertNativeStateViewSupported(nativeStateView, "historical state regeneration");
   const stateBytesArr = await db.stateArchive.binaries({limit: 1, lte: slot, reverse: true});
   if (!stateBytesArr.length) {
     throw new Error("No near state found in the database");

--- a/packages/beacon-node/test/unit/chain/archiveStore/getHistoricalState.test.ts
+++ b/packages/beacon-node/test/unit/chain/archiveStore/getHistoricalState.test.ts
@@ -1,0 +1,33 @@
+import {describe, expect, it, vi} from "vitest";
+import {createBeaconConfig} from "@lodestar/config";
+import {chainConfig} from "@lodestar/config/default";
+import {NativeStateViewError, NativeStateViewErrorCode} from "@lodestar/state-transition";
+import {getHistoricalState} from "../../../../src/chain/archiveStore/historicalState/getHistoricalState.js";
+import {type IBeaconDb} from "../../../../src/db/index.js";
+
+describe("getHistoricalState", () => {
+  it("fails before touching the database when nativeStateView is enabled", async () => {
+    const stateArchive = {
+      binaries: vi.fn(async () => []),
+    } satisfies Pick<IBeaconDb["stateArchive"], "binaries">;
+    const blockArchive = {
+      valuesStream: vi.fn(async function* () {}),
+    } satisfies Pick<IBeaconDb["blockArchive"], "valuesStream">;
+    const db = {stateArchive, blockArchive} as unknown as IBeaconDb;
+    const config = createBeaconConfig(chainConfig, new Uint8Array(32));
+
+    const error = await getHistoricalState(1, config, db, true).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(NativeStateViewError);
+    if (!(error instanceof NativeStateViewError)) {
+      return;
+    }
+
+    expect(error.type).toEqual({
+      code: NativeStateViewErrorCode.NOT_IMPLEMENTED,
+      context: "historical state regeneration",
+    });
+    expect(stateArchive.binaries).not.toHaveBeenCalled();
+    expect(blockArchive.valuesStream).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -7,7 +7,12 @@ import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {LoggerNode, getNodeLogger} from "@lodestar/logger/node";
 import {ACTIVE_PRESET, PresetName} from "@lodestar/params";
-import {createBeaconStateView, createPubkeyCache, syncPubkeys} from "@lodestar/state-transition";
+import {
+  createBeaconStateView,
+  createNativeStateViewError,
+  createPubkeyCache,
+  syncPubkeys,
+} from "@lodestar/state-transition";
 import {ErrorAborted, bytesToInt, formatBytes} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
 import {BeaconNodeOptions, getBeaconConfigFromArgs} from "../../config/index.js";
@@ -15,6 +20,7 @@ import {getNetworkBootnodes, isKnownNetworkName, readBootnodes} from "../../netw
 import {GlobalArgs, parseBeaconNodeArgs} from "../../options/index.js";
 import {LogArgs} from "../../options/logOptions.js";
 import {
+  YargsError,
   cleanOldLogFiles,
   mkdir,
   onGracefulShutdown,
@@ -80,7 +86,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
     const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
     const pubkeyCache = createPubkeyCache();
     syncPubkeys(pubkeyCache, anchorState.validators.getAllReadonlyValues());
-    const anchorStateView = args["chain.nativeStateView"]
+    const anchorStateView = options.chain.nativeStateView
       ? createBeaconStateView({useNative: true, stateBytes: anchorStateBytes})
       : createBeaconStateView({useNative: false, anchorState, config: beaconConfig, pubkeyCache});
 
@@ -177,6 +183,11 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
   const {config, network} = getBeaconConfigFromArgs(args);
 
   const beaconNodeOptions = new BeaconNodeOptions(parseBeaconNodeArgs(args));
+  const parsedOptions = beaconNodeOptions.getWithDefaults();
+  if (parsedOptions.chain.nativeStateView) {
+    const error = createNativeStateViewError("beacon startup");
+    throw new YargsError(`[${error.type.code}] ${error.message}`);
+  }
 
   const {version, commit} = getVersionData();
   const beaconPaths = getBeaconPaths(args, network);

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -284,7 +284,8 @@ Will double processing times. Use only for debugging purposes.",
 
   "chain.nativeStateView": {
     hidden: true,
-    description: "Use native (Zig) BeaconStateView instead of JS implementation",
+    description:
+      "Reserved for a future native (Zig) BeaconStateView implementation. Not implemented yet; enabling it fails fast.",
     type: "boolean",
     default: defaultOptions.chain.nativeStateView,
     group: "chain",

--- a/packages/cli/test/unit/cmds/beacon.test.ts
+++ b/packages/cli/test/unit/cmds/beacon.test.ts
@@ -7,12 +7,14 @@ import {describe, expect, it} from "vitest";
 import {ENR, SignableENR} from "@chainsafe/enr";
 import {chainConfigToJson} from "@lodestar/config";
 import {chainConfig} from "@lodestar/config/default";
+import {NativeStateViewErrorCode} from "@lodestar/state-transition";
 import {LogLevel} from "@lodestar/utils";
 import {beaconHandlerInit} from "../../../src/cmds/beacon/handler.js";
 import {initPrivateKeyAndEnr, isLocalMultiAddr} from "../../../src/cmds/beacon/initPeerIdAndEnr.js";
 import {BeaconArgs} from "../../../src/cmds/beacon/options.js";
 import {createFromJSON, exportToJSON} from "../../../src/config/peerId.js";
 import {GlobalArgs} from "../../../src/options/globalOptions.js";
+import {YargsError} from "../../../src/util/index.js";
 import {testFilesDir, testLogger} from "../../utils.js";
 
 describe("cmds / beacon / args handler", () => {
@@ -92,6 +94,18 @@ describe("cmds / beacon / args handler", () => {
 
     // Okay to hardcode, since this value will never change
     expect(network).toBe(networkName);
+  });
+
+  it("Fails fast when nativeStateView is enabled", async () => {
+    const error = await runBeaconHandlerInit({"chain.nativeStateView": true}).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(YargsError);
+    if (!(error instanceof YargsError)) {
+      return;
+    }
+
+    expect(error.message).toContain(NativeStateViewErrorCode.NOT_IMPLEMENTED);
+    expect(error.message).toContain("--chain.nativeStateView");
   });
 });
 

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -60,7 +60,14 @@ export {
   isStatePostFulu,
   isStatePostGloas,
 } from "./stateView/interface.js";
-export {createBeaconStateView, createBeaconStateViewForHistoricalRegen} from "./stateView/stateViewFactory.js";
+export {
+  NativeStateViewError,
+  NativeStateViewErrorCode,
+  assertNativeStateViewSupported,
+  createBeaconStateView,
+  createBeaconStateViewForHistoricalRegen,
+  createNativeStateViewError,
+} from "./stateView/stateViewFactory.js";
 export type {
   BeaconStateAllForks,
   BeaconStateAltair,

--- a/packages/state-transition/src/stateView/stateViewFactory.ts
+++ b/packages/state-transition/src/stateView/stateViewFactory.ts
@@ -1,10 +1,37 @@
 import {BeaconConfig} from "@lodestar/config";
+import {LodestarError} from "@lodestar/utils";
 import {PubkeyCache, createPubkeyCache} from "../cache/pubkeyCache.js";
 import {createCachedBeaconState} from "../cache/stateCache.js";
 import {BeaconStateAllForks} from "../cache/types.js";
 import {getStateTypeFromBytes} from "../util/sszBytes.js";
 import {BeaconStateView} from "./beaconStateView.js";
 import {IBeaconStateView} from "./interface.js";
+
+export enum NativeStateViewErrorCode {
+  NOT_IMPLEMENTED = "NATIVE_STATE_VIEW_NOT_IMPLEMENTED",
+}
+
+export type NativeStateViewContext = "beacon startup" | "historical state regeneration";
+
+export type NativeStateViewErrorType = {
+  code: NativeStateViewErrorCode.NOT_IMPLEMENTED;
+  context: NativeStateViewContext;
+};
+
+export class NativeStateViewError extends LodestarError<NativeStateViewErrorType> {}
+
+export function createNativeStateViewError(context: NativeStateViewContext): NativeStateViewError {
+  return new NativeStateViewError(
+    {code: NativeStateViewErrorCode.NOT_IMPLEMENTED, context},
+    `Native (Zig) BeaconStateView is not implemented for ${context}. Disable --chain.nativeStateView and retry.`
+  );
+}
+
+export function assertNativeStateViewSupported(useNative: boolean, context: NativeStateViewContext): void {
+  if (useNative) {
+    throw createNativeStateViewError(context);
+  }
+}
 
 // ---- createBeaconStateView (startup path) ----
 
@@ -30,7 +57,7 @@ type NativeOpts = {
  */
 export function createBeaconStateView(opts: NodeJSOpts | NativeOpts): IBeaconStateView {
   if (opts.useNative) {
-    throw new Error("Native (Zig) BeaconStateView not yet implemented");
+    throw createNativeStateViewError("beacon startup");
   }
   const {anchorState, config, pubkeyCache} = opts;
   const cachedState = createCachedBeaconState(anchorState, {config, pubkeyCache}, {skipSyncPubkeys: true});
@@ -68,7 +95,7 @@ type RegenNativeOpts = {
  */
 export function createBeaconStateViewForHistoricalRegen(opts: RegenNodeJSOpts | RegenNativeOpts): IBeaconStateView {
   if (opts.useNative) {
-    throw new Error("Native (Zig) BeaconStateView not yet implemented");
+    throw createNativeStateViewError("historical state regeneration");
   }
   const {config, stateBytes} = opts;
   const state = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);

--- a/packages/state-transition/test/unit/stateViewFactory.test.ts
+++ b/packages/state-transition/test/unit/stateViewFactory.test.ts
@@ -1,0 +1,38 @@
+import {describe, expect, it} from "vitest";
+import {
+  NativeStateViewError,
+  NativeStateViewErrorCode,
+  createBeaconStateView,
+  createBeaconStateViewForHistoricalRegen,
+} from "../../src/index.js";
+
+describe("stateViewFactory", () => {
+  it("throws a structured error for native state view at beacon startup", () => {
+    expectNativeStateViewError(
+      () => createBeaconStateView({useNative: true, stateBytes: new Uint8Array()}),
+      "beacon startup"
+    );
+  });
+
+  it("throws a structured error for native state view during historical regeneration", () => {
+    expectNativeStateViewError(
+      () => createBeaconStateViewForHistoricalRegen({useNative: true, stateBytes: new Uint8Array()}),
+      "historical state regeneration"
+    );
+  });
+});
+
+function expectNativeStateViewError(fn: () => void, context: "beacon startup" | "historical state regeneration"): void {
+  try {
+    fn();
+    expect.unreachable("Expected native state view guard to throw");
+  } catch (e) {
+    expect(e).toBeInstanceOf(NativeStateViewError);
+    if (!(e instanceof NativeStateViewError)) {
+      return;
+    }
+
+    expect(e.type).toEqual({code: NativeStateViewErrorCode.NOT_IMPLEMENTED, context});
+    expect(e.message).toContain("--chain.nativeStateView");
+  }
+}


### PR DESCRIPTION
**Motivation**

`nativeStateView` can be enabled today, but the process only fails later with a generic "not yet implemented" error after startup work has already begun. This follow-up to #9067 makes the unsupported path fail fast with a stable error code and clearer operator guidance.

**Description**

- add a shared `NativeStateViewError` with `NATIVE_STATE_VIEW_NOT_IMPLEMENTED`
- reject `--chain.nativeStateView` early in beacon startup
- guard historical state regeneration before any DB reads and clarify the hidden CLI flag description
- add focused tests for the factory guard, historical regen guard, and CLI fail-fast path

**AI Assistance Disclosure**

> I consulted Codex to implement and validate the change.