### PR TITLE
fix: use fork choice for parent payload status in block production

### DIFF
--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -150,8 +150,11 @@ export function initializeForkChoiceFromFinalizedState(
 
         ...(isStatePostBellatrix(state) && state.isExecutionStateType && state.isMergeTransitionComplete
           ? {
+              // For a PENDING gloas ProtoBlock we don't know the payload hash until the envelope is
+              // imported; use the bid's parent_block_hash as the placeholder, matching how onBlock
+              // initializes the field (see forkChoice.ts::onBlock).
               executionPayloadBlockHash: isStatePostGloas(state)
-                ? toRootHex(state.latestBlockHash)
+                ? toRootHex(state.latestExecutionPayloadBid.parentBlockHash)
                 : toRootHex(state.latestExecutionPayloadHeader.blockHash),
               // TODO GLOAS: executionPayloadNumber is not tracked in BeaconState post-gloas (EIP-7732 removed
               // latestExecutionPayloadHeader). Using 0 as unavailable fallback until a solution is found.
@@ -162,7 +165,7 @@ export function initializeForkChoiceFromFinalizedState(
 
         dataAvailabilityStatus: DataAvailabilityStatus.PreData,
         payloadStatus: isForkPostGloas ? PayloadStatus.PENDING : PayloadStatus.FULL, // TODO GLOAS: Post-gloas how do we know if the checkpoint payload is FULL or EMPTY?
-        parentBlockHash: isStatePostGloas(state) ? toRootHex(state.latestBlockHash) : null,
+        parentBlockHash: isStatePostGloas(state) ? toRootHex(state.latestExecutionPayloadBid.parentBlockHash) : null,
       },
       currentSlot
     ),
@@ -249,8 +252,10 @@ export function initializeForkChoiceFromUnfinalizedState(
     unfinalizedState.isExecutionStateType &&
     unfinalizedState.isMergeTransitionComplete
       ? {
+          // See note in initializeForkChoiceFromFinalizedState: PENDING gloas ProtoBlock uses
+          // bid.parentBlockHash as the placeholder for the unknown payload hash.
           executionPayloadBlockHash: isStatePostGloas(unfinalizedState)
-            ? toRootHex(unfinalizedState.latestBlockHash)
+            ? toRootHex(unfinalizedState.latestExecutionPayloadBid.parentBlockHash)
             : toRootHex(unfinalizedState.latestExecutionPayloadHeader.blockHash),
           // TODO GLOAS: executionPayloadNumber is not tracked in BeaconState post-gloas (EIP-7732 removed
           // latestExecutionPayloadHeader). Using 0 as unavailable fallback until a solution is found.
@@ -261,7 +266,9 @@ export function initializeForkChoiceFromUnfinalizedState(
 
     dataAvailabilityStatus: DataAvailabilityStatus.PreData,
     payloadStatus: isForkPostGloas ? PayloadStatus.PENDING : PayloadStatus.FULL, // TODO GLOAS: Post-gloas how do we know if the checkpoint payload is FULL or EMPTY?
-    parentBlockHash: isStatePostGloas(unfinalizedState) ? toRootHex(unfinalizedState.latestBlockHash) : null,
+    parentBlockHash: isStatePostGloas(unfinalizedState)
+      ? toRootHex(unfinalizedState.latestExecutionPayloadBid.parentBlockHash)
+      : null,
   };
 
   const parentSlot = blockHeader.slot - 1;

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -150,7 +150,9 @@ export function initializeForkChoiceFromFinalizedState(
 
         ...(isStatePostBellatrix(state) && state.isExecutionStateType && state.isMergeTransitionComplete
           ? {
-              executionPayloadBlockHash: toRootHex(state.latestBlockHash),
+              executionPayloadBlockHash: isStatePostGloas(state)
+                ? toRootHex(state.latestBlockHash)
+                : toRootHex(state.latestExecutionPayloadHeader.blockHash),
               // TODO GLOAS: executionPayloadNumber is not tracked in BeaconState post-gloas (EIP-7732 removed
               // latestExecutionPayloadHeader). Using 0 as unavailable fallback until a solution is found.
               executionPayloadNumber: isStatePostGloas(state) ? 0 : state.payloadBlockNumber,
@@ -247,7 +249,9 @@ export function initializeForkChoiceFromUnfinalizedState(
     unfinalizedState.isExecutionStateType &&
     unfinalizedState.isMergeTransitionComplete
       ? {
-          executionPayloadBlockHash: toRootHex(unfinalizedState.latestBlockHash),
+          executionPayloadBlockHash: isStatePostGloas(unfinalizedState)
+            ? toRootHex(unfinalizedState.latestBlockHash)
+            : toRootHex(unfinalizedState.latestExecutionPayloadHeader.blockHash),
           // TODO GLOAS: executionPayloadNumber is not tracked in BeaconState post-gloas (EIP-7732 removed
           // latestExecutionPayloadHeader). Using 0 as unavailable fallback until a solution is found.
           executionPayloadNumber: isStatePostGloas(unfinalizedState) ? 0 : unfinalizedState.payloadBlockNumber,

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -151,7 +151,7 @@ export function initializeForkChoiceFromFinalizedState(
         ...(isStatePostBellatrix(state) && state.isExecutionStateType && state.isMergeTransitionComplete
           ? {
               executionPayloadBlockHash: isStatePostGloas(state)
-                ? toRootHex(state.latestExecutionPayloadBid.parentBlockHash)
+                ? toRootHex(state.latestBlockHash)
                 : toRootHex(state.latestExecutionPayloadHeader.blockHash),
               // TODO GLOAS: executionPayloadNumber is not tracked in BeaconState post-gloas (EIP-7732 removed
               // latestExecutionPayloadHeader). Using 0 as unavailable fallback until a solution is found.
@@ -162,7 +162,7 @@ export function initializeForkChoiceFromFinalizedState(
 
         dataAvailabilityStatus: DataAvailabilityStatus.PreData,
         payloadStatus: isForkPostGloas ? PayloadStatus.PENDING : PayloadStatus.FULL, // TODO GLOAS: Post-gloas how do we know if the checkpoint payload is FULL or EMPTY?
-        parentBlockHash: isStatePostGloas(state) ? toRootHex(state.latestExecutionPayloadBid.parentBlockHash) : null,
+        parentBlockHash: isStatePostGloas(state) ? toRootHex(state.latestBlockHash) : null,
       },
       currentSlot
     ),
@@ -250,7 +250,7 @@ export function initializeForkChoiceFromUnfinalizedState(
     unfinalizedState.isMergeTransitionComplete
       ? {
           executionPayloadBlockHash: isStatePostGloas(unfinalizedState)
-            ? toRootHex(unfinalizedState.latestExecutionPayloadBid.parentBlockHash)
+            ? toRootHex(unfinalizedState.latestBlockHash)
             : toRootHex(unfinalizedState.latestExecutionPayloadHeader.blockHash),
           // TODO GLOAS: executionPayloadNumber is not tracked in BeaconState post-gloas (EIP-7732 removed
           // latestExecutionPayloadHeader). Using 0 as unavailable fallback until a solution is found.
@@ -261,9 +261,7 @@ export function initializeForkChoiceFromUnfinalizedState(
 
     dataAvailabilityStatus: DataAvailabilityStatus.PreData,
     payloadStatus: isForkPostGloas ? PayloadStatus.PENDING : PayloadStatus.FULL, // TODO GLOAS: Post-gloas how do we know if the checkpoint payload is FULL or EMPTY?
-    parentBlockHash: isStatePostGloas(unfinalizedState)
-      ? toRootHex(unfinalizedState.latestExecutionPayloadBid.parentBlockHash)
-      : null,
+    parentBlockHash: isStatePostGloas(unfinalizedState) ? toRootHex(unfinalizedState.latestBlockHash) : null,
   };
 
   const parentSlot = blockHeader.slot - 1;

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -150,9 +150,6 @@ export function initializeForkChoiceFromFinalizedState(
 
         ...(isStatePostBellatrix(state) && state.isExecutionStateType && state.isMergeTransitionComplete
           ? {
-              // For a PENDING gloas ProtoBlock we don't know the payload hash until the envelope is
-              // imported; use the bid's parent_block_hash as the placeholder, matching how onBlock
-              // initializes the field (see forkChoice.ts::onBlock).
               executionPayloadBlockHash: isStatePostGloas(state)
                 ? toRootHex(state.latestExecutionPayloadBid.parentBlockHash)
                 : toRootHex(state.latestExecutionPayloadHeader.blockHash),
@@ -252,8 +249,6 @@ export function initializeForkChoiceFromUnfinalizedState(
     unfinalizedState.isExecutionStateType &&
     unfinalizedState.isMergeTransitionComplete
       ? {
-          // See note in initializeForkChoiceFromFinalizedState: PENDING gloas ProtoBlock uses
-          // bid.parentBlockHash as the placeholder for the unknown payload hash.
           executionPayloadBlockHash: isStatePostGloas(unfinalizedState)
             ? toRootHex(unfinalizedState.latestExecutionPayloadBid.parentBlockHash)
             : toRootHex(unfinalizedState.latestExecutionPayloadHeader.blockHash),

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -8,9 +8,10 @@ import {
   computeEpochAtSlot,
   computeTimeAtSlot,
   isStatePostBellatrix,
+  isStatePostGloas,
 } from "@lodestar/state-transition";
-import {Slot} from "@lodestar/types";
-import {Logger, fromHex, isErrorAborted, sleep} from "@lodestar/utils";
+import {Bytes32, Slot} from "@lodestar/types";
+import {Logger, fromHex, isErrorAborted, sleep, toRootHex} from "@lodestar/utils";
 import {GENESIS_SLOT, ZERO_HASH_HEX} from "../constants/constants.js";
 import {BuilderStatus} from "../execution/builder/http.js";
 import {Metrics} from "../metrics/index.js";
@@ -156,25 +157,39 @@ export class PrepareNextSlotScheduler {
               this.logger.error("Builder disabled as the check status api failed", {prepareSlot}, e as Error);
             });
           }
+        }
 
+        if (!isStatePostBellatrix(updatedPrepareState)) {
+          throw new Error("Expected Bellatrix state for payload attributes");
+        }
+
+        // Compute parentHash once — used by both prepareExecutionPayload and SSE
+        const parentBlockRoot = fromHex(updatedHeadRoot);
+        let parentHash: Bytes32;
+        if (isStatePostGloas(updatedPrepareState)) {
+          const bid = updatedPrepareState.latestExecutionPayloadBid;
+          parentHash = this.chain.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
+            ? bid.blockHash
+            : bid.parentBlockHash;
+        } else {
+          parentHash = updatedPrepareState.latestBlockHash;
+        }
+
+        if (feeRecipient) {
           const preparationTime =
             computeTimeAtSlot(this.config, prepareSlot, this.chain.genesisTime) - Date.now() / 1000;
           this.metrics?.blockPayload.payloadAdvancePrepTime.observe(preparationTime);
-          if (!isStatePostBellatrix(updatedPrepareState)) {
-            throw new Error("Expected Bellatrix state for payload preparation");
-          }
 
           const safeBlockHash = getSafeExecutionBlockHash(this.chain.forkChoice);
           const finalizedBlockHash =
             this.chain.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
-          // awaiting here instead of throwing an async call because there is no other task
-          // left for scheduler and this gives nice sematics to catch and log errors in the
-          // try/catch wrapper here.
+
           await prepareExecutionPayload(
             this.chain,
             this.logger,
             fork as ForkPostBellatrix, // State is of execution type
-            fromHex(updatedHeadRoot),
+            parentBlockRoot,
+            parentHash,
             safeBlockHash,
             finalizedBlockHash,
             updatedPrepareState,
@@ -187,10 +202,6 @@ export class PrepareNextSlotScheduler {
           });
         }
 
-        if (!isStatePostBellatrix(updatedPrepareState)) {
-          throw new Error("Expected Bellatrix state for payload attributes");
-        }
-
         this.computeStateHashTreeRoot(updatedPrepareState, isEpochTransition);
 
         // If emitPayloadAttributes is true emit a SSE payloadAttributes event
@@ -201,7 +212,8 @@ export class PrepareNextSlotScheduler {
           const data = getPayloadAttributesForSSE(fork as ForkPostBellatrix, this.chain, {
             prepareState: updatedPrepareState,
             prepareSlot,
-            parentBlockRoot: fromHex(headRoot),
+            parentBlockRoot,
+            parentHash,
             // The likely consumers of this API are builders and will anyway ignore the
             // feeRecipient, so just pass zero hash for now till a real use case arises
             feeRecipient: "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -163,16 +163,14 @@ export class PrepareNextSlotScheduler {
           throw new Error("Expected Bellatrix state for payload attributes");
         }
 
-        // Compute parentHash once — used by both prepareExecutionPayload and SSE
         const parentBlockRoot = fromHex(updatedHeadRoot);
-        let parentHash: Bytes32;
+        let parentBlockHash: Bytes32;
         if (isStatePostGloas(updatedPrepareState)) {
-          const bid = updatedPrepareState.latestExecutionPayloadBid;
-          parentHash = this.chain.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
-            ? bid.blockHash
-            : bid.parentBlockHash;
+          parentBlockHash = this.chain.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
+            ? updatedPrepareState.latestExecutionPayloadBid.blockHash
+            : updatedPrepareState.latestExecutionPayloadBid.parentBlockHash;
         } else {
-          parentHash = updatedPrepareState.latestExecutionPayloadHeader.blockHash;
+          parentBlockHash = updatedPrepareState.latestExecutionPayloadHeader.blockHash;
         }
 
         if (feeRecipient) {
@@ -192,7 +190,7 @@ export class PrepareNextSlotScheduler {
             this.logger,
             fork as ForkPostBellatrix, // State is of execution type
             parentBlockRoot,
-            parentHash,
+            parentBlockHash,
             safeBlockHash,
             finalizedBlockHash,
             updatedPrepareState,
@@ -216,7 +214,7 @@ export class PrepareNextSlotScheduler {
             prepareState: updatedPrepareState,
             prepareSlot,
             parentBlockRoot,
-            parentHash,
+            parentBlockHash,
             // The likely consumers of this API are builders and will anyway ignore the
             // feeRecipient, so just pass zero hash for now till a real use case arises
             feeRecipient: "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -172,7 +172,7 @@ export class PrepareNextSlotScheduler {
             ? bid.blockHash
             : bid.parentBlockHash;
         } else {
-          parentHash = updatedPrepareState.latestBlockHash;
+          parentHash = updatedPrepareState.latestExecutionPayloadHeader.blockHash;
         }
 
         if (feeRecipient) {

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -230,7 +230,7 @@ export class PrepareNextSlotScheduler {
       //  + if next slot is a skipped slot, it'd help getting target checkpoint state faster to validate attestations
       if (isEpochTransition) {
         this.metrics?.precomputeNextEpochTransition.count.inc({result: "success"}, 1);
-        const previousHits = this.chain.regen.updatePreComputedCheckpoint(updatedHeadRoot, nextEpoch);
+        const previousHits = this.chain.regen.updatePreComputedCheckpoint(headRoot, nextEpoch);
         if (previousHits === 0) {
           this.metrics?.precomputeNextEpochTransition.waste.inc();
         }

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -164,10 +164,9 @@ export class PrepareNextSlotScheduler {
           throw new Error("Expected Bellatrix state for payload attributes");
         }
 
-        const parentBlockRoot = fromHex(updatedHeadRoot);
         let parentBlockHash: Bytes32;
         if (isStatePostGloas(updatedPrepareState)) {
-          parentBlockHash = this.chain.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
+          parentBlockHash = this.chain.forkChoice.shouldExtendPayload(updatedHeadRoot)
             ? updatedPrepareState.latestExecutionPayloadBid.blockHash
             : updatedPrepareState.latestExecutionPayloadBid.parentBlockHash;
         } else {
@@ -190,7 +189,7 @@ export class PrepareNextSlotScheduler {
             this.chain,
             this.logger,
             fork as ForkPostBellatrix, // State is of execution type
-            parentBlockRoot,
+            fromHex(updatedHeadRoot),
             parentBlockHash,
             safeBlockHash,
             finalizedBlockHash,
@@ -214,7 +213,7 @@ export class PrepareNextSlotScheduler {
           const data = getPayloadAttributesForSSE(fork as ForkPostBellatrix, this.chain, {
             prepareState: updatedPrepareState,
             prepareSlot,
-            parentBlockRoot,
+            parentBlockRoot: fromHex(updatedHeadRoot),
             parentBlockHash,
             // The likely consumers of this API are builders and will anyway ignore the
             // feeRecipient, so just pass zero hash for now till a real use case arises

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -11,7 +11,7 @@ import {
   isStatePostGloas,
 } from "@lodestar/state-transition";
 import {Bytes32, Slot} from "@lodestar/types";
-import {Logger, fromHex, isErrorAborted, sleep, toRootHex} from "@lodestar/utils";
+import {Logger, fromHex, isErrorAborted, sleep} from "@lodestar/utils";
 import {GENESIS_SLOT, ZERO_HASH_HEX} from "../constants/constants.js";
 import {BuilderStatus} from "../execution/builder/http.js";
 import {Metrics} from "../metrics/index.js";

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -82,6 +82,8 @@ export class PrepareNextSlotScheduler {
       // calling updateHead() here before we produce a block to reduce reorg possibility
       const headBlock = this.chain.recomputeForkChoiceHead(ForkchoiceCaller.prepareNextSlot);
       const {slot: headSlot, blockRoot: headRoot} = headBlock;
+      // may be updated below if we predict a proposer-boost-reorg
+      let updatedHeadRoot = headRoot;
 
       // PS: previously this was comparing slots, but that gave no leway on the skipped
       // slots on epoch bounday. Making it more fluid.
@@ -124,7 +126,6 @@ export class PrepareNextSlotScheduler {
         const proposerIndex = prepareState.getBeaconProposer(prepareSlot);
         const feeRecipient = this.chain.beaconProposerCache.get(proposerIndex);
         let updatedPrepareState = prepareState;
-        let updatedHeadRoot = headRoot;
 
         if (feeRecipient) {
           // If we are proposing next slot, we need to predict if we can proposer-boost-reorg or not
@@ -230,7 +231,7 @@ export class PrepareNextSlotScheduler {
       //  + if next slot is a skipped slot, it'd help getting target checkpoint state faster to validate attestations
       if (isEpochTransition) {
         this.metrics?.precomputeNextEpochTransition.count.inc({result: "success"}, 1);
-        const previousHits = this.chain.regen.updatePreComputedCheckpoint(headRoot, nextEpoch);
+        const previousHits = this.chain.regen.updatePreComputedCheckpoint(updatedHeadRoot, nextEpoch);
         if (previousHits === 0) {
           this.metrics?.precomputeNextEpochTransition.waste.inc();
         }

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -184,6 +184,9 @@ export class PrepareNextSlotScheduler {
           const finalizedBlockHash =
             this.chain.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
 
+          // awaiting here instead of throwing an async call because there is no other task
+          // left for scheduler and this gives nice semantics to catch and log errors in the
+          // try/catch wrapper here.
           await prepareExecutionPayload(
             this.chain,
             this.logger,

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -213,7 +213,7 @@ export class PrepareNextSlotScheduler {
           const data = getPayloadAttributesForSSE(fork as ForkPostBellatrix, this.chain, {
             prepareState: updatedPrepareState,
             prepareSlot,
-            parentBlockRoot: fromHex(updatedHeadRoot),
+            parentBlockRoot: fromHex(headRoot),
             parentBlockHash,
             // The likely consumers of this API are builders and will anyway ignore the
             // feeRecipient, so just pass zero hash for now till a real use case arises

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -620,8 +620,9 @@ export async function prepareExecutionPayload(
 ): Promise<{prepType: PayloadPreparationType; payloadId: PayloadId}> {
   let parentHash: Bytes32;
   if (isStatePostGloas(state)) {
-    const bid = state.latestExecutionPayloadBid;
-    parentHash = chain.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot)) ? bid.blockHash : bid.parentBlockHash;
+    parentHash = chain.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
+      ? state.latestExecutionPayloadBid.blockHash
+      : state.latestExecutionPayloadBid.parentBlockHash;
   } else {
     parentHash = state.latestBlockHash;
   }
@@ -761,7 +762,6 @@ function preparePayloadAttributes(
   fork: ForkPostBellatrix,
   chain: {
     config: ChainForkConfig;
-    forkChoice: IForkChoice;
   },
   {
     prepareState,

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {IForkChoice, PayloadStatus, ProtoBlock, getSafeExecutionBlockHash} from "@lodestar/fork-choice";
+import {IForkChoice, ProtoBlock, getSafeExecutionBlockHash} from "@lodestar/fork-choice";
 import {
   BUILDER_INDEX_SELF_BUILD,
   ForkName,
@@ -775,7 +775,7 @@ function preparePayloadAttributes(
 
     if (
       isStatePostGloas(prepareState) &&
-      chain.forkChoice.getBlockHex(toRootHex(parentBlockRoot), PayloadStatus.FULL) === null
+      !chain.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
     ) {
       // When the parent block is empty, state.payloadExpectedWithdrawals holds a batch
       // already deducted from CL balances but never credited on the EL (the envelope

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -219,7 +219,7 @@ export async function produceBlockBody<T extends BlockType>(
     });
 
     // Get execution payload from EL
-    const parentHash = this.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
+    const parentBlockHash = this.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
       ? currentState.latestExecutionPayloadBid.blockHash
       : currentState.latestExecutionPayloadBid.parentBlockHash;
     const prepareRes = await prepareExecutionPayload(
@@ -227,7 +227,7 @@ export async function produceBlockBody<T extends BlockType>(
       this.logger,
       fork,
       parentBlockRoot,
-      parentHash,
+      parentBlockHash,
       safeBlockHash,
       finalizedBlockHash ?? ZERO_HASH_HEX,
       currentState,
@@ -264,8 +264,8 @@ export async function produceBlockBody<T extends BlockType>(
 
     // Create self-build execution payload bid
     const bid: gloas.ExecutionPayloadBid = {
-      parentBlockHash: parentHash,
-      parentBlockRoot: parentBlockRoot,
+      parentBlockHash,
+      parentBlockRoot,
       blockHash: executionPayload.blockHash,
       prevRandao: currentState.getRandaoMix(currentState.epoch),
       feeRecipient: executionPayload.feeRecipient,
@@ -614,12 +614,11 @@ export async function prepareExecutionPayload(
   chain: {
     executionEngine: IExecutionEngine;
     config: ChainForkConfig;
-    forkChoice: IForkChoice;
   },
   logger: Logger,
   fork: ForkPostBellatrix,
   parentBlockRoot: Root,
-  parentHash: Bytes32,
+  parentBlockHash: Bytes32,
   safeBlockHash: RootHex,
   finalizedBlockHash: RootHex,
   state: IBeaconStateViewBellatrix,
@@ -629,7 +628,7 @@ export async function prepareExecutionPayload(
   const prevRandao = state.getRandaoMix(state.epoch);
 
   const payloadIdCached = chain.executionEngine.payloadIdCache.get({
-    headBlockHash: toRootHex(parentHash),
+    headBlockHash: toRootHex(parentBlockHash),
     finalizedBlockHash,
     timestamp: numToQuantity(timestamp),
     prevRandao: toHex(prevRandao),
@@ -658,13 +657,13 @@ export async function prepareExecutionPayload(
       prepareState: state,
       prepareSlot: state.slot,
       parentBlockRoot,
-      parentHash,
+      parentBlockHash,
       feeRecipient: suggestedFeeRecipient,
     });
 
     payloadId = await chain.executionEngine.notifyForkchoiceUpdate(
       fork,
-      toRootHex(parentHash),
+      toRootHex(parentBlockHash),
       safeBlockHash,
       finalizedBlockHash,
       attributes
@@ -716,27 +715,30 @@ export function getPayloadAttributesForSSE(
     prepareState,
     prepareSlot,
     parentBlockRoot,
+    parentBlockHash,
     feeRecipient,
-    parentHash,
   }: {
     prepareState: IBeaconStateViewBellatrix;
     prepareSlot: Slot;
     parentBlockRoot: Root;
+    parentBlockHash: Bytes32;
     feeRecipient: string;
-    parentHash: Bytes32;
   }
 ): SSEPayloadAttributes {
   const payloadAttributes = preparePayloadAttributes(fork, chain, {
     prepareState,
     prepareSlot,
     parentBlockRoot,
-    parentHash,
+    parentBlockHash,
     feeRecipient,
   });
 
   let parentBlockNumber: number;
   if (isForkPostGloas(fork)) {
-    const parentBlock = chain.forkChoice.getBlockHexAndBlockHash(toRootHex(parentBlockRoot), toRootHex(parentHash));
+    const parentBlock = chain.forkChoice.getBlockHexAndBlockHash(
+      toRootHex(parentBlockRoot),
+      toRootHex(parentBlockHash)
+    );
     if (parentBlock?.executionPayloadBlockHash == null) {
       throw Error(`Parent block not found in fork choice root=${toRootHex(parentBlockRoot)}`);
     }
@@ -750,7 +752,7 @@ export function getPayloadAttributesForSSE(
     proposalSlot: prepareSlot,
     parentBlockNumber,
     parentBlockRoot,
-    parentBlockHash: parentHash,
+    parentBlockHash,
     payloadAttributes,
   };
   return ssePayloadAttributes;
@@ -765,13 +767,13 @@ function preparePayloadAttributes(
     prepareState,
     prepareSlot,
     parentBlockRoot,
-    parentHash,
+    parentBlockHash,
     feeRecipient,
   }: {
     prepareState: IBeaconStateViewBellatrix;
     prepareSlot: Slot;
     parentBlockRoot: Root;
-    parentHash: Bytes32;
+    parentBlockHash: Bytes32;
     feeRecipient: string;
   }
 ): SSEPayloadAttributes["payloadAttributes"] {
@@ -789,7 +791,7 @@ function preparePayloadAttributes(
     }
 
     if (isStatePostGloas(prepareState)) {
-      const isExtendingPayload = byteArrayEquals(parentHash, prepareState.latestExecutionPayloadBid.blockHash);
+      const isExtendingPayload = byteArrayEquals(parentBlockHash, prepareState.latestExecutionPayloadBid.blockHash);
       // When the parent block is empty, state.payloadExpectedWithdrawals holds a batch
       // already deducted from CL balances but never credited on the EL (the envelope
       // was not delivered). The next payload must carry those same withdrawals to

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -47,7 +47,7 @@ import {
   fulu,
   gloas,
 } from "@lodestar/types";
-import {Logger, fromHex, sleep, toHex, toPubkeyHex, toRootHex} from "@lodestar/utils";
+import {Logger, byteArrayEquals, fromHex, sleep, toHex, toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {ZERO_HASH_HEX} from "../../constants/index.js";
 import {numToQuantity} from "../../execution/engine/utils.js";
 import {
@@ -618,7 +618,13 @@ export async function prepareExecutionPayload(
   state: IBeaconStateViewBellatrix,
   suggestedFeeRecipient: string
 ): Promise<{prepType: PayloadPreparationType; payloadId: PayloadId}> {
-  const parentHash = state.latestBlockHash;
+  let parentHash: Bytes32;
+  if (isStatePostGloas(state)) {
+    const bid = state.latestExecutionPayloadBid;
+    parentHash = chain.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot)) ? bid.blockHash : bid.parentBlockHash;
+  } else {
+    parentHash = state.latestBlockHash;
+  }
   const timestamp = computeTimeAtSlot(chain.config, state.slot, state.genesisTime);
   const prevRandao = state.getRandaoMix(state.epoch);
 
@@ -652,6 +658,7 @@ export async function prepareExecutionPayload(
       prepareState: state,
       prepareSlot: state.slot,
       parentBlockRoot,
+      parentHash,
       feeRecipient: suggestedFeeRecipient,
     });
 
@@ -712,11 +719,19 @@ export function getPayloadAttributesForSSE(
     feeRecipient,
   }: {prepareState: IBeaconStateViewBellatrix; prepareSlot: Slot; parentBlockRoot: Root; feeRecipient: string}
 ): SSEPayloadAttributes {
-  const parentHash = prepareState.latestBlockHash;
+  let parentHash: Bytes32;
+  if (isStatePostGloas(prepareState)) {
+    parentHash = chain.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
+      ? prepareState.latestExecutionPayloadBid.blockHash
+      : prepareState.latestExecutionPayloadBid.parentBlockHash;
+  } else {
+    parentHash = prepareState.latestBlockHash;
+  }
   const payloadAttributes = preparePayloadAttributes(fork, chain, {
     prepareState,
     prepareSlot,
     parentBlockRoot,
+    parentHash,
     feeRecipient,
   });
 
@@ -752,11 +767,13 @@ function preparePayloadAttributes(
     prepareState,
     prepareSlot,
     parentBlockRoot,
+    parentHash,
     feeRecipient,
   }: {
     prepareState: IBeaconStateViewBellatrix;
     prepareSlot: Slot;
     parentBlockRoot: Root;
+    parentHash: Bytes32;
     feeRecipient: string;
   }
 ): SSEPayloadAttributes["payloadAttributes"] {
@@ -773,16 +790,15 @@ function preparePayloadAttributes(
       throw new Error("Expected Capella state for withdrawals");
     }
 
-    if (
-      isStatePostGloas(prepareState) &&
-      !chain.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
-    ) {
+    if (isStatePostGloas(prepareState)) {
+      const isExtendingPayload = byteArrayEquals(parentHash, prepareState.latestExecutionPayloadBid.blockHash);
       // When the parent block is empty, state.payloadExpectedWithdrawals holds a batch
       // already deducted from CL balances but never credited on the EL (the envelope
       // was not delivered). The next payload must carry those same withdrawals to
       // restore CL/EL consistency, otherwise validators permanently lose that balance.
-      (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
-        prepareState.payloadExpectedWithdrawals;
+      (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals = isExtendingPayload
+        ? prepareState.getExpectedWithdrawals().expectedWithdrawals
+        : prepareState.payloadExpectedWithdrawals;
     } else {
       // withdrawals logic is now fork aware as it changes on electra fork post capella
       (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -773,9 +773,10 @@ function preparePayloadAttributes(
       throw new Error("Expected Capella state for withdrawals");
     }
 
-    const isParentBlockFull = chain.forkChoice.getBlockHex(toRootHex(parentBlockRoot), PayloadStatus.FULL) !== null;
-
-    if (isStatePostGloas(prepareState) && !isParentBlockFull) {
+    if (
+      isStatePostGloas(prepareState) &&
+      chain.forkChoice.getBlockHex(toRootHex(parentBlockRoot), PayloadStatus.FULL) === null
+    ) {
       // When the parent block is empty, state.payloadExpectedWithdrawals holds a batch
       // already deducted from CL balances but never credited on the EL (the envelope
       // was not delivered). The next payload must carry those same withdrawals to

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {IForkChoice, ProtoBlock, getSafeExecutionBlockHash} from "@lodestar/fork-choice";
+import {IForkChoice, PayloadStatus, ProtoBlock, getSafeExecutionBlockHash} from "@lodestar/fork-choice";
 import {
   BUILDER_INDEX_SELF_BUILD,
   ForkName,
@@ -19,7 +19,6 @@ import {
   IBeaconStateView,
   type IBeaconStateViewBellatrix,
   computeTimeAtSlot,
-  isParentBlockFull,
   isStatePostBellatrix,
   isStatePostCapella,
   isStatePostGloas,
@@ -609,6 +608,7 @@ export async function prepareExecutionPayload(
   chain: {
     executionEngine: IExecutionEngine;
     config: ChainForkConfig;
+    forkChoice: IForkChoice;
   },
   logger: Logger,
   fork: ForkPostBellatrix,
@@ -746,6 +746,7 @@ function preparePayloadAttributes(
   fork: ForkPostBellatrix,
   chain: {
     config: ChainForkConfig;
+    forkChoice: IForkChoice;
   },
   {
     prepareState,
@@ -772,7 +773,9 @@ function preparePayloadAttributes(
       throw new Error("Expected Capella state for withdrawals");
     }
 
-    if (isStatePostGloas(prepareState) && !isParentBlockFull(prepareState)) {
+    const isParentBlockFull = chain.forkChoice.getBlockHex(toRootHex(parentBlockRoot), PayloadStatus.FULL) !== null;
+
+    if (isStatePostGloas(prepareState) && !isParentBlockFull) {
       // When the parent block is empty, state.payloadExpectedWithdrawals holds a batch
       // already deducted from CL balances but never credited on the EL (the envelope
       // was not delivered). The next payload must carry those same withdrawals to

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -219,11 +219,16 @@ export async function produceBlockBody<T extends BlockType>(
     });
 
     // Get execution payload from EL
+    const parentBid = currentState.latestExecutionPayloadBid;
+    const parentHash = this.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
+      ? parentBid.blockHash
+      : parentBid.parentBlockHash;
     const prepareRes = await prepareExecutionPayload(
       this,
       this.logger,
       fork,
       parentBlockRoot,
+      parentHash,
       safeBlockHash,
       finalizedBlockHash ?? ZERO_HASH_HEX,
       currentState,
@@ -260,7 +265,7 @@ export async function produceBlockBody<T extends BlockType>(
 
     // Create self-build execution payload bid
     const bid: gloas.ExecutionPayloadBid = {
-      parentBlockHash: currentState.latestBlockHash,
+      parentBlockHash: parentHash,
       parentBlockRoot: parentBlockRoot,
       blockHash: executionPayload.blockHash,
       prevRandao: currentState.getRandaoMix(currentState.epoch),
@@ -339,6 +344,7 @@ export async function produceBlockBody<T extends BlockType>(
             this.logger,
             fork,
             parentBlockRoot,
+            currentState.latestBlockHash,
             safeBlockHash,
             finalizedBlockHash ?? ZERO_HASH_HEX,
             currentState,
@@ -447,6 +453,7 @@ export async function produceBlockBody<T extends BlockType>(
           this.logger,
           fork,
           parentBlockRoot,
+          currentState.latestBlockHash,
           safeBlockHash,
           finalizedBlockHash ?? ZERO_HASH_HEX,
           currentState,
@@ -613,19 +620,12 @@ export async function prepareExecutionPayload(
   logger: Logger,
   fork: ForkPostBellatrix,
   parentBlockRoot: Root,
+  parentHash: Bytes32,
   safeBlockHash: RootHex,
   finalizedBlockHash: RootHex,
   state: IBeaconStateViewBellatrix,
   suggestedFeeRecipient: string
 ): Promise<{prepType: PayloadPreparationType; payloadId: PayloadId}> {
-  let parentHash: Bytes32;
-  if (isStatePostGloas(state)) {
-    parentHash = chain.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
-      ? state.latestExecutionPayloadBid.blockHash
-      : state.latestExecutionPayloadBid.parentBlockHash;
-  } else {
-    parentHash = state.latestBlockHash;
-  }
   const timestamp = computeTimeAtSlot(chain.config, state.slot, state.genesisTime);
   const prevRandao = state.getRandaoMix(state.epoch);
 
@@ -718,16 +718,15 @@ export function getPayloadAttributesForSSE(
     prepareSlot,
     parentBlockRoot,
     feeRecipient,
-  }: {prepareState: IBeaconStateViewBellatrix; prepareSlot: Slot; parentBlockRoot: Root; feeRecipient: string}
-): SSEPayloadAttributes {
-  let parentHash: Bytes32;
-  if (isStatePostGloas(prepareState)) {
-    parentHash = chain.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
-      ? prepareState.latestExecutionPayloadBid.blockHash
-      : prepareState.latestExecutionPayloadBid.parentBlockHash;
-  } else {
-    parentHash = prepareState.latestBlockHash;
+    parentHash,
+  }: {
+    prepareState: IBeaconStateViewBellatrix;
+    prepareSlot: Slot;
+    parentBlockRoot: Root;
+    feeRecipient: string;
+    parentHash: Bytes32;
   }
+): SSEPayloadAttributes {
   const payloadAttributes = preparePayloadAttributes(fork, chain, {
     prepareState,
     prepareSlot,

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -219,10 +219,9 @@ export async function produceBlockBody<T extends BlockType>(
     });
 
     // Get execution payload from EL
-    const parentBid = currentState.latestExecutionPayloadBid;
     const parentHash = this.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot))
-      ? parentBid.blockHash
-      : parentBid.parentBlockHash;
+      ? currentState.latestExecutionPayloadBid.blockHash
+      : currentState.latestExecutionPayloadBid.parentBlockHash;
     const prepareRes = await prepareExecutionPayload(
       this,
       this.logger,
@@ -344,7 +343,7 @@ export async function produceBlockBody<T extends BlockType>(
             this.logger,
             fork,
             parentBlockRoot,
-            currentState.latestBlockHash,
+            currentState.latestExecutionPayloadHeader.blockHash,
             safeBlockHash,
             finalizedBlockHash ?? ZERO_HASH_HEX,
             currentState,
@@ -453,7 +452,7 @@ export async function produceBlockBody<T extends BlockType>(
           this.logger,
           fork,
           parentBlockRoot,
-          currentState.latestBlockHash,
+          currentState.latestExecutionPayloadHeader.blockHash,
           safeBlockHash,
           finalizedBlockHash ?? ZERO_HASH_HEX,
           currentState,

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -6,7 +6,7 @@ import {BeaconApiMethods} from "@lodestar/api/beacon/server";
 import {BeaconConfig} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
 import {ZERO_HASH_HEX} from "@lodestar/params";
-import {IBeaconStateView, PubkeyCache, isStatePostBellatrix} from "@lodestar/state-transition";
+import {IBeaconStateView, PubkeyCache, isStatePostBellatrix, isStatePostGloas} from "@lodestar/state-transition";
 import {phase0} from "@lodestar/types";
 import {sleep, toRootHex} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
@@ -223,7 +223,9 @@ export class BeaconNode {
     if (opts.executionEngine.mode === "mock") {
       const eth1BlockHash =
         isStatePostBellatrix(anchorState) && anchorState.isExecutionStateType
-          ? toRootHex(anchorState.latestBlockHash)
+          ? isStatePostGloas(anchorState)
+            ? toRootHex(anchorState.latestBlockHash)
+            : toRootHex(anchorState.latestExecutionPayloadHeader.blockHash)
           : undefined;
       executionEngineOpts = {
         ...opts.executionEngine,

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -224,7 +224,7 @@ export class BeaconNode {
       const eth1BlockHash =
         isStatePostBellatrix(anchorState) && anchorState.isExecutionStateType
           ? isStatePostGloas(anchorState)
-            ? toRootHex(anchorState.latestExecutionPayloadBid.parentBlockHash)
+            ? toRootHex(anchorState.latestBlockHash)
             : toRootHex(anchorState.latestExecutionPayloadHeader.blockHash)
           : undefined;
       executionEngineOpts = {

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -224,7 +224,7 @@ export class BeaconNode {
       const eth1BlockHash =
         isStatePostBellatrix(anchorState) && anchorState.isExecutionStateType
           ? isStatePostGloas(anchorState)
-            ? toRootHex(anchorState.latestBlockHash)
+            ? toRootHex(anchorState.latestExecutionPayloadBid.parentBlockHash)
             : toRootHex(anchorState.latestExecutionPayloadHeader.blockHash)
           : undefined;
       executionEngineOpts = {

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -312,6 +312,14 @@ export class ForkChoice implements IForkChoice {
   }
 
   /**
+   * Decides whether to extend an available payload from the previous slot,
+   * corresponding to the beacon block `blockRoot`.
+   */
+  shouldExtendPayload(blockRoot: RootHex): boolean {
+    return this.protoArray.shouldExtendPayload(blockRoot, this.proposerBoostRoot);
+  }
+
+  /**
    * To predict the proposer head of the next slot. That is, to predict if proposer-boost-reorg could happen.
    * Reason why we can't be certain is because information of the head block is not fully available yet
    * since the current slot hasn't ended especially the attesters' votes.

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -241,6 +241,7 @@ export interface IForkChoice {
   getBlockDefaultStatus(blockRoot: Root): ProtoBlock | null;
   getBlockHexDefaultStatus(blockRoot: RootHex): ProtoBlock | null;
   getBlockHexAndBlockHash(blockRoot: RootHex, blockHash: RootHex): ProtoBlock | null;
+  shouldExtendPayload(blockRoot: RootHex): boolean;
   getFinalizedBlock(): ProtoBlock;
   getJustifiedBlock(): ProtoBlock;
   getFinalizedCheckpointSlot(): Slot;

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -708,7 +708,7 @@ export class ProtoArray {
    * Spec: gloas/fork-choice.md#new-should_extend_payload
    *
    * Returns true if payload is verified (FULL variant exists) AND:
-   * 1. Payload is timely and data available, OR
+   * 1. Payload is timely, OR
    * 2. No proposer boost root (empty/zero hash), OR
    * 3. Proposer boost root's parent is not this block, OR
    * 4. Proposer boost root extends FULL parent

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -684,8 +684,8 @@ export class ProtoArray {
    * Determine if we should extend the payload (prefer FULL over EMPTY)
    * Spec: gloas/fork-choice.md#new-should_extend_payload
    *
-   * Returns true if:
-   * 1. Payload is timely, OR
+   * Returns true if payload is verified (FULL variant exists) AND:
+   * 1. Payload is timely and data available, OR
    * 2. No proposer boost root (empty/zero hash), OR
    * 3. Proposer boost root's parent is not this block, OR
    * 4. Proposer boost root extends FULL parent
@@ -694,6 +694,10 @@ export class ProtoArray {
    * @param proposerBoostRoot - Current proposer boost root (from ForkChoice)
    */
   shouldExtendPayload(blockRoot: RootHex, proposerBoostRoot: RootHex | null): boolean {
+    if (!this.hasPayload(blockRoot)) {
+      return false;
+    }
+
     // Condition 1: Payload is timely
     if (this.isPayloadTimely(blockRoot)) {
       return true;

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -216,8 +216,12 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
   // bellatrix
 
   get latestExecutionPayloadHeader(): ExecutionPayloadHeader {
-    if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.bellatrix) {
+    const forkSeq = this.config.getForkSeq(this.cachedState.slot);
+    if (forkSeq < ForkSeq.bellatrix) {
       throw new Error("latestExecutionPayloadHeader is not available before Bellatrix");
+    }
+    if (forkSeq >= ForkSeq.gloas) {
+      throw new Error("latestExecutionPayloadHeader is not available after Gloas");
     }
 
     if (this._latestExecutionPayloadHeader === null) {
@@ -338,13 +342,6 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
   }
 
   // gloas
-
-  get latestBlockHash(): Bytes32 {
-    if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
-      throw new Error("latestBlockHash is only available from Gloas onwards");
-    }
-    return (this.cachedState as CachedBeaconStateGloas).latestBlockHash;
-  }
 
   get executionPayloadAvailability(): BitArray {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -84,8 +84,6 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
   private _currentEpochParticipation: Uint8Array | null = null;
   // bellatrix
   private _latestExecutionPayloadHeader: ExecutionPayloadHeader | null = null;
-  // Caches the cross-fork latestBlockHash value
-  private _latestBlockHash: Bytes32 | null = null;
   // capella
   private _historicalSummaries: capella.HistoricalSummaries | null = null;
   // electra
@@ -232,30 +230,6 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
   }
 
   /**
-   * Cross-fork accessor for the execution block hash of the most recently included payload.
-   * Pre-gloas: reads from latestExecutionPayloadHeader.blockHash.
-   * Gloas+: reads the dedicated latestBlockHash field (EIP-7732).
-   */
-  get latestBlockHash(): Bytes32 {
-    const forkSeq = this.config.getForkSeq(this.cachedState.slot);
-    if (forkSeq < ForkSeq.bellatrix) {
-      throw new Error("latestBlockHash is not available before Bellatrix");
-    }
-
-    if (this._latestBlockHash === null) {
-      if (forkSeq >= ForkSeq.gloas) {
-        this._latestBlockHash = (this.cachedState as CachedBeaconStateGloas).latestBlockHash;
-      } else {
-        this._latestBlockHash = (
-          this.cachedState as CachedBeaconStateExecutions
-        ).latestExecutionPayloadHeader.blockHash;
-      }
-    }
-
-    return this._latestBlockHash;
-  }
-
-  /**
    * The execution block number of the most recently included payload.
    * Named payloadBlockNumber (not latestBlockNumber) to mirror ExecutionPayloadHeader.blockNumber pre-gloas.
    * Only available from bellatrix through fulu — not tracked on BeaconState in gloas+ (EIP-7732).
@@ -364,6 +338,13 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
   }
 
   // gloas
+
+  get latestBlockHash(): Bytes32 {
+    if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
+      throw new Error("latestBlockHash is only available from Gloas onwards");
+    }
+    return (this.cachedState as CachedBeaconStateGloas).latestBlockHash;
+  }
 
   get executionPayloadAvailability(): BitArray {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -343,6 +343,13 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
 
   // gloas
 
+  get latestBlockHash(): Bytes32 {
+    if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
+      throw new Error("latestBlockHash is not available before Gloas");
+    }
+    return (this.cachedState as CachedBeaconStateGloas).latestBlockHash;
+  }
+
   get executionPayloadAvailability(): BitArray {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
       throw new Error("executionPayloadAvailability is not available before Gloas");

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -237,8 +237,10 @@ export interface IBeaconStateViewFulu extends IBeaconStateViewElectra {
 /** Gloas+ state fields — use isStatePostGloas() guard */
 export interface IBeaconStateViewGloas extends IBeaconStateViewFulu {
   forkName: ForkPostGloas;
-  /** The execution block hash on the BeaconState (EIP-7732 dedicated field, replaces header-based access). */
-  latestBlockHash: Bytes32;
+  /** Removed from BeaconState in gloas (EIP-7732). Use latestExecutionPayloadBid.blockHash instead. */
+  latestExecutionPayloadHeader: never;
+  /** Removed from BeaconState in gloas (EIP-7732). */
+  payloadBlockNumber: never;
   executionPayloadAvailability: BitArray;
   latestExecutionPayloadBid: ExecutionPayloadBid;
   payloadExpectedWithdrawals: capella.Withdrawal[];
@@ -257,7 +259,14 @@ export interface IBeaconStateViewGloas extends IBeaconStateViewFulu {
  * forkName as ForkName since the class wraps any fork's state.
  * Sub-interfaces retain their narrowed forkName discriminants for caller-side type guards.
  */
-export type IBeaconStateViewLatestFork = Omit<IBeaconStateViewGloas, "forkName"> & {forkName: ForkName};
+export type IBeaconStateViewLatestFork = Omit<
+  IBeaconStateViewGloas,
+  "forkName" | "latestExecutionPayloadHeader" | "payloadBlockNumber"
+> & {
+  forkName: ForkName;
+  latestExecutionPayloadHeader: ExecutionPayloadHeader;
+  payloadBlockNumber: number;
+};
 export function isStatePostAltair(state: IBeaconStateView): state is IBeaconStateViewAltair {
   return isForkPostAltair(state.forkName);
 }

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -237,11 +237,10 @@ export interface IBeaconStateViewFulu extends IBeaconStateViewElectra {
 /** Gloas+ state fields — use isStatePostGloas() guard */
 export interface IBeaconStateViewGloas extends IBeaconStateViewFulu {
   forkName: ForkPostGloas;
-  /** Removed from BeaconState in gloas (EIP-7732); use latestBlockHash instead. */
+  /** Removed from BeaconState in gloas. Use `latestBlockHash` instead. */
   latestExecutionPayloadHeader: never;
-  /** Removed from BeaconState in gloas (EIP-7732). */
+  /** Removed from BeaconState in gloas. */
   payloadBlockNumber: never;
-  /** The execution block hash on the BeaconState (EIP-7732 dedicated field, replaces header-based access). */
   latestBlockHash: Bytes32;
   executionPayloadAvailability: BitArray;
   latestExecutionPayloadBid: ExecutionPayloadBid;

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -237,10 +237,12 @@ export interface IBeaconStateViewFulu extends IBeaconStateViewElectra {
 /** Gloas+ state fields — use isStatePostGloas() guard */
 export interface IBeaconStateViewGloas extends IBeaconStateViewFulu {
   forkName: ForkPostGloas;
-  /** Removed from BeaconState in gloas (EIP-7732). Use latestExecutionPayloadBid.blockHash instead. */
+  /** Removed from BeaconState in gloas (EIP-7732); use latestBlockHash instead. */
   latestExecutionPayloadHeader: never;
   /** Removed from BeaconState in gloas (EIP-7732). */
   payloadBlockNumber: never;
+  /** The execution block hash on the BeaconState (EIP-7732 dedicated field, replaces header-based access). */
+  latestBlockHash: Bytes32;
   executionPayloadAvailability: BitArray;
   latestExecutionPayloadBid: ExecutionPayloadBid;
   payloadExpectedWithdrawals: capella.Withdrawal[];

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -188,13 +188,6 @@ export interface IBeaconStateViewBellatrix extends IBeaconStateViewAltair {
   forkName: ForkPostBellatrix;
   latestExecutionPayloadHeader: ExecutionPayloadHeader;
   /**
-   * Cross-fork accessor for the execution block hash of the most recently included payload.
-   * Pre-gloas: returns latestExecutionPayloadHeader.blockHash (bellatrix–fulu).
-   * Gloas+: returns the dedicated latestBlockHash state field (EIP-7732).
-   * Throws before bellatrix.
-   */
-  latestBlockHash: Bytes32;
-  /**
    * The execution block number of the most recently included payload.
    * Named payloadBlockNumber (not latestBlockNumber) to mirror ExecutionPayloadHeader.blockNumber pre-gloas.
    * Only available from bellatrix through fulu — not tracked on BeaconState in gloas+ (EIP-7732).
@@ -244,6 +237,8 @@ export interface IBeaconStateViewFulu extends IBeaconStateViewElectra {
 /** Gloas+ state fields — use isStatePostGloas() guard */
 export interface IBeaconStateViewGloas extends IBeaconStateViewFulu {
   forkName: ForkPostGloas;
+  /** The execution block hash on the BeaconState (EIP-7732 dedicated field, replaces header-based access). */
+  latestBlockHash: Bytes32;
   executionPayloadAvailability: BitArray;
   latestExecutionPayloadBid: ExecutionPayloadBid;
   payloadExpectedWithdrawals: capella.Withdrawal[];

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -11,7 +11,6 @@ import {
 import {BuilderIndex, Epoch, ValidatorIndex, gloas} from "@lodestar/types";
 import {AttestationData} from "@lodestar/types/phase0";
 import {byteArrayEquals} from "@lodestar/utils";
-import {IBeaconStateViewGloas} from "../stateView/interface.js";
 import {CachedBeaconStateGloas} from "../types.js";
 import {getBlockRootAtSlot} from "./blockRoot.js";
 import {computeEpochAtSlot} from "./epoch.js";
@@ -168,6 +167,6 @@ export function isAttestationSameSlotRootCache(rootCache: RootCache, data: Attes
   return isMatchingBlockRoot && isCurrentBlockRoot;
 }
 
-export function isParentBlockFull(state: CachedBeaconStateGloas | IBeaconStateViewGloas): boolean {
+export function isParentBlockFull(state: CachedBeaconStateGloas): boolean {
   return byteArrayEquals(state.latestExecutionPayloadBid.blockHash, state.latestBlockHash);
 }


### PR DESCRIPTION
related to changes in https://github.com/ethereum/consensus-specs/pull/5094, we wanna avoid using `is_parent_block_full`