### PR TITLE
feat: add cached PTC window to the state

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@chainsafe/persistent-merkle-tree": "^1.2.1",
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@lodestar/config": "workspace:^",
     "@lodestar/params": "workspace:^",
     "@lodestar/types": "workspace:^",

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -780,7 +780,8 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
                     (data as BlockContents).block as BeaconBlock<ForkPreDeneb> // <- tranformation
                   );
           },
-          deserialize(data, {executionPayloadBlinded, version}) {
+          deserialize(data, meta) {
+            const {executionPayloadBlinded, version} = meta as ProduceBlockV3Meta;
             return executionPayloadBlinded
               ? getPostBellatrixForkTypes(version).BlindedBeaconBlock.deserialize(data)
               : isForkPostDeneb(version)

--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -118,7 +118,10 @@ export type ResponseDataCodec<T, M> = {
   toJson: (data: T, meta: M) => unknown; // server
   fromJson: (data: unknown, meta: M) => T; // client
   serialize: (data: T, meta: M) => Uint8Array; // server
-  deserialize: (data: Uint8Array, meta: M) => T; // client
+  // `meta` is typed as `any` so SSZ `Type<T>.deserialize(data, opts?)` satisfies the shape.
+  // Route-specific deserializers (e.g. `WithVersion`) cast to their expected meta internally.
+  // biome-ignore lint/suspicious/noExplicitAny: contravariant workaround for ssz Type.deserialize(opts?)
+  deserialize: (data: Uint8Array, meta: any) => T; // client
 };
 
 export type ResponseMetadataCodec<T> = {

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -118,7 +118,7 @@
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/pubkey-index-map": "^3.0.0",
     "@chainsafe/snappy-wasm": "^0.5.0",
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@chainsafe/threads": "^1.11.3",
     "@crate-crypto/node-eth-kzg": "0.9.1",
     "@fastify/bearer-auth": "^10.0.1",

--- a/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
+++ b/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
@@ -18,7 +18,8 @@ export async function validateApiPayloadAttestationMessage(
   chain: IBeaconChain,
   payloadAttestationMessage: gloas.PayloadAttestationMessage
 ): Promise<PayloadAttestationValidationResult> {
-  return validatePayloadAttestationMessage(chain, payloadAttestationMessage);
+  const prioritizeBls = true;
+  return validatePayloadAttestationMessage(chain, payloadAttestationMessage, prioritizeBls);
 }
 
 export async function validateGossipPayloadAttestationMessage(
@@ -30,7 +31,8 @@ export async function validateGossipPayloadAttestationMessage(
 
 async function validatePayloadAttestationMessage(
   chain: IBeaconChain,
-  payloadAttestationMessage: gloas.PayloadAttestationMessage
+  payloadAttestationMessage: gloas.PayloadAttestationMessage,
+  prioritizeBls = false
 ): Promise<PayloadAttestationValidationResult> {
   const {data, validatorIndex} = payloadAttestationMessage;
   const epoch = computeEpochAtSlot(data.slot);
@@ -102,7 +104,7 @@ async function validatePayloadAttestationMessage(
     payloadAttestationMessage.signature
   );
 
-  if (!(await chain.bls.verifySignatureSets([signatureSet]))) {
+  if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true, priority: prioritizeBls}))) {
     throw new PayloadAttestationError(GossipAction.REJECT, {
       code: PayloadAttestationErrorCode.INVALID_SIGNATURE,
     });

--- a/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
+++ b/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
@@ -7,6 +7,7 @@ import {
   CachedBeaconStateAllForks,
   CachedBeaconStateAltair,
   CachedBeaconStateFulu,
+  CachedBeaconStateGloas,
   EpochTransitionCache,
   beforeProcessEpoch,
 } from "@lodestar/state-transition";
@@ -50,6 +51,9 @@ const epochTransitionFns: Record<string, EpochTransitionFn> = {
   proposer_lookahead: (state, epochTransitionCache) => {
     const fork = state.config.getForkSeq(state.slot);
     epochFns.processProposerLookahead(fork, state as CachedBeaconStateFulu, epochTransitionCache);
+  },
+  ptc_window: (state, epochTransitionCache) => {
+    epochFns.processPtcWindow(state as CachedBeaconStateGloas, epochTransitionCache);
   },
   builder_pending_payments: epochFns.processBuilderPendingPayments as EpochTransitionFn,
 };

--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -588,11 +588,11 @@ const forkChoiceTest =
           name.includes("voting_source_beyond_two_epoch") ||
           name.includes("justified_update_always_if_better") ||
           name.includes("justified_update_not_realized_finality") ||
-          // TODO GLOAS: Requires should_apply_proposer_boost (gloas/fork-choice.md#new-should_apply_proposer_boost)
-          // which conditionally suppresses proposer boost when the parent is weak and from the previous slot.
-          // Pre-Gloas forks always apply boost; Gloas adds is_head_weak + equivocation checks.
+          // TODO GLOAS: These tests will be unskipped by https://github.com/ChainSafe/lodestar/pull/9233
           (name.includes("gloas") &&
-            name.includes("include_votes_another_empty_chain_with_enough_ffg_votes_previous_epoch")) ||
+            (name.includes("simple_attempted_reorg_without_enough_ffg_votes") ||
+              name.includes("include_votes_another_empty_chain_with_enough_ffg_votes_current_epoch") ||
+              name.includes("include_votes_another_empty_chain_without_enough_ffg_votes_current_epoch"))) ||
           // TODO GLOAS: These two tests are affected by the wrong proposer boost cutoff time from the
           // consensus-specs and thus have wrong expectation of proposer boost. Our implementation
           // should pass these two tests after https://github.com/ethereum/consensus-specs/pull/5095

--- a/packages/beacon-node/test/spec/presets/sanity.test.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.test.ts
@@ -46,7 +46,7 @@ const sanitySlots: TestRunnerFn<SanitySlotsTestCase, BeaconStateAllForks> = (for
         post: ssz[fork].BeaconState,
       },
       shouldError: (testCase) => !testCase.post,
-      timeout: 30000,
+      timeout: 60000,
       getExpected: (testCase) => testCase.post,
       expectFunc: (_testCase, expected, actual) => {
         expectEqualBeaconState(fork, expected, actual);

--- a/packages/beacon-node/test/spec/presets/sanity.test.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.test.ts
@@ -46,7 +46,7 @@ const sanitySlots: TestRunnerFn<SanitySlotsTestCase, BeaconStateAllForks> = (for
         post: ssz[fork].BeaconState,
       },
       shouldError: (testCase) => !testCase.post,
-      timeout: 60000,
+      timeout: 30000,
       getExpected: (testCase) => testCase.post,
       expectFunc: (_testCase, expected, actual) => {
         expectEqualBeaconState(fork, expected, actual);

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -73,7 +73,7 @@ export const defaultSkipOpts: SkipOpts = {
     /^fulu\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^.+\/light_client\/data_collection\/.*/,
     /^gloas\/ssz_static\/ForkChoiceNode.*$/,
-    // Ignore the partial data column container additions for now. Unskip them when 
+    // Ignore the partial data column container additions for now. Unskip them when
     // cell level DAS is ready
     /^fulu\/ssz_static\/PartialDataColumn(Header|PartsMetadata|Sidecar)\/.*$/,
     /^gloas\/ssz_static\/PartialDataColumn(Header|PartsMetadata|Sidecar)\/.*$/,

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -73,7 +73,8 @@ export const defaultSkipOpts: SkipOpts = {
     /^fulu\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^.+\/light_client\/data_collection\/.*/,
     /^gloas\/ssz_static\/ForkChoiceNode.*$/,
-    // Ignore the partial data column container additions for now; they are outside the alpha.4/#4979 runtime scope.
+    // Ignore the partial data column container additions for now. Unskip them when 
+    // cell level DAS is ready
     /^fulu\/ssz_static\/PartialDataColumn(Header|PartsMetadata|Sidecar)\/.*$/,
     /^gloas\/ssz_static\/PartialDataColumn(Header|PartsMetadata|Sidecar)\/.*$/,
   ],

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -74,12 +74,11 @@ export const defaultSkipOpts: SkipOpts = {
     /^.+\/light_client\/data_collection\/.*/,
     /^gloas\/fork_choice\/.*$/,
     /^gloas\/ssz_static\/ForkChoiceNode.*$/,
+    // Ignore the partial data column container additions for now; they are outside the alpha.4/#4979 runtime scope.
+    /^fulu\/ssz_static\/PartialDataColumn(Header|PartsMetadata|Sidecar)\/.*$/,
+    /^gloas\/ssz_static\/PartialDataColumn(Header|PartsMetadata|Sidecar)\/.*$/,
   ],
-  skippedTests: [
-    // TODO GLOAS: broken in v1.7.0-alpha.3 due to missing voluntary_exit.ssz_snappy input file
-    // Fixed by https://github.com/ethereum/consensus-specs/pull/5005 in v1.7.0-alpha.4
-    /^gloas\/operations\/voluntary_exit\/pyspec_tests\/builder_voluntary_exit__success$/,
-  ],
+  skippedTests: [],
   skippedRunners: [],
 };
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
     "@chainsafe/enr": "^6.0.1",
     "@chainsafe/persistent-merkle-tree": "^1.2.1",
     "@chainsafe/pubkey-index-map": "^3.0.0",
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@chainsafe/threads": "^1.11.3",
     "@libp2p/crypto": "^5.1.13",
     "@libp2p/interface": "^3.1.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -66,7 +66,7 @@
   ],
   "dependencies": {
     "@chainsafe/as-sha256": "^1.2.0",
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@lodestar/params": "workspace:^",
     "@lodestar/spec-test-util": "workspace:^",
     "@lodestar/types": "workspace:^",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -43,7 +43,7 @@
     "check-readme": "pnpm exec ts-node ../../scripts/check_readme.ts"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@lodestar/config": "workspace:^",
     "@lodestar/utils": "workspace:^",
     "classic-level": "^1.4.1"

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -39,7 +39,7 @@
     "check-readme": "pnpm exec ts-node ../../scripts/check_readme.ts"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@lodestar/config": "workspace:^",
     "@lodestar/params": "workspace:^",
     "@lodestar/state-transition": "workspace:^",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -66,7 +66,7 @@
     "@chainsafe/bls": "8.2.0",
     "@chainsafe/blst": "^2.2.0",
     "@chainsafe/persistent-merkle-tree": "^1.2.1",
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@lodestar/api": "workspace:^",
     "@lodestar/config": "workspace:^",
     "@lodestar/params": "workspace:^",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -74,7 +74,7 @@
     "winston-transport": "^4.5.0"
   },
   "devDependencies": {
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@chainsafe/threads": "^1.11.3",
     "@lodestar/test-utils": "workspace:^",
     "@types/triple-beam": "^1.3.2"

--- a/packages/reqresp/package.json
+++ b/packages/reqresp/package.json
@@ -56,7 +56,7 @@
     "uint8arraylist": "^2.4.7"
   },
   "devDependencies": {
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@libp2p/crypto": "^5.1.13",
     "@libp2p/logger": "^6.2.2",
     "@libp2p/peer-id": "^6.0.4",

--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -60,7 +60,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@lodestar/types": "workspace:^",
     "vitest": "catalog:"
   }

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -65,7 +65,7 @@
     "@chainsafe/persistent-merkle-tree": "^1.2.1",
     "@chainsafe/persistent-ts": "^1.0.0",
     "@chainsafe/pubkey-index-map": "^3.0.0",
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@chainsafe/swap-or-not-shuffle": "^1.2.1",
     "@lodestar/config": "workspace:^",
     "@lodestar/params": "workspace:^",

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -1032,15 +1032,15 @@ export class EpochCache {
       throw new Error("Payload Timeliness Committee is not available before gloas fork");
     }
 
+    if (epoch === this.epoch - 1) {
+      return this.previousPayloadTimelinessCommittees[slot % SLOTS_PER_EPOCH];
+    }
+
     if (epoch === this.epoch) {
       return this.payloadTimelinessCommittees[slot % SLOTS_PER_EPOCH];
     }
 
-    if (epoch === this.epoch - 1 && this.previousPayloadTimelinessCommittees.length > 0) {
-      return this.previousPayloadTimelinessCommittees[slot % SLOTS_PER_EPOCH];
-    }
-
-    if (epoch === this.epoch + 1 && this.nextPayloadTimelinessCommittees.length > 0) {
+    if (epoch === this.epoch + 1) {
       return this.nextPayloadTimelinessCommittees[slot % SLOTS_PER_EPOCH];
     }
 

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -32,10 +32,10 @@ import {
   calculateShufflingDecisionRoot,
   computeEpochShuffling,
 } from "../util/epochShuffling.js";
+import {getPtcWindowEpochCacheData} from "../util/gloas.js";
 import {
   computeActivationExitEpoch,
   computeEpochAtSlot,
-  computePayloadTimelinessCommitteesForEpoch,
   computeProposers,
   computeSyncPeriodAtEpoch,
   getActivationChurnLimit,
@@ -56,7 +56,7 @@ import {sumTargetUnslashedBalanceIncrements} from "../util/targetUnslashedBalanc
 import {EffectiveBalanceIncrements, getEffectiveBalanceIncrementsWithLen} from "./effectiveBalanceIncrements.js";
 import {EpochTransitionCache} from "./epochTransitionCache.js";
 import {PubkeyCache, createPubkeyCache, syncPubkeys} from "./pubkeyCache.js";
-import {CachedBeaconStateAllForks, CachedBeaconStateFulu} from "./stateCache.js";
+import {CachedBeaconStateAllForks, CachedBeaconStateFulu, CachedBeaconStateGloas} from "./stateCache.js";
 import {
   SyncCommitteeCache,
   SyncCommitteeCacheEmpty,
@@ -226,11 +226,12 @@ export class EpochCache {
   /** TODO: Indexed SyncCommitteeCache */
   nextSyncCommitteeIndexed: SyncCommitteeCache;
 
-  // TODO GLOAS: See if we need to cache PTC for next epoch
   // PTC for previous epoch, required for slot N block validating slot N-1 attestations
   previousPayloadTimelinessCommittees: Uint32Array[];
   // PTC for current epoch, computed eagerly at epoch transition
   payloadTimelinessCommittees: Uint32Array[];
+  // PTC for next epoch, precomputed from the ptc window for future duty serving
+  nextPayloadTimelinessCommittees: Uint32Array[];
 
   // TODO: Helper stats
   syncPeriod: SyncPeriod;
@@ -270,6 +271,7 @@ export class EpochCache {
     nextSyncCommitteeIndexed: SyncCommitteeCache;
     previousPayloadTimelinessCommittees: Uint32Array[];
     payloadTimelinessCommittees: Uint32Array[];
+    nextPayloadTimelinessCommittees: Uint32Array[];
     epoch: Epoch;
     syncPeriod: SyncPeriod;
   }) {
@@ -301,6 +303,7 @@ export class EpochCache {
     this.nextSyncCommitteeIndexed = data.nextSyncCommitteeIndexed;
     this.previousPayloadTimelinessCommittees = data.previousPayloadTimelinessCommittees;
     this.payloadTimelinessCommittees = data.payloadTimelinessCommittees;
+    this.nextPayloadTimelinessCommittees = data.nextPayloadTimelinessCommittees;
     this.epoch = data.epoch;
     this.syncPeriod = data.syncPeriod;
   }
@@ -451,25 +454,13 @@ export class EpochCache {
       nextSyncCommitteeIndexed = new SyncCommitteeCacheEmpty();
     }
 
-    // Compute PTC for all slots in the prev/current epoch
+    // Copy previous/current epoch PTC slices from state.ptcWindow once, then serve hot-path lookups from epochCtx.
     let previousPayloadTimelinessCommittees: Uint32Array[] = [];
     let payloadTimelinessCommittees: Uint32Array[] = [];
+    let nextPayloadTimelinessCommittees: Uint32Array[] = [];
     if (currentEpoch >= config.GLOAS_FORK_EPOCH) {
-      payloadTimelinessCommittees = computePayloadTimelinessCommitteesForEpoch(
-        state,
-        currentEpoch,
-        currentShuffling.committees,
-        effectiveBalanceIncrements
-      );
-
-      if (!isGenesis && previousEpoch >= config.GLOAS_FORK_EPOCH) {
-        previousPayloadTimelinessCommittees = computePayloadTimelinessCommitteesForEpoch(
-          state,
-          previousEpoch,
-          previousShuffling.committees,
-          effectiveBalanceIncrements
-        );
-      }
+      ({previousPayloadTimelinessCommittees, payloadTimelinessCommittees, nextPayloadTimelinessCommittees} =
+        getPtcWindowEpochCacheData(state as CachedBeaconStateGloas));
     }
 
     // Precompute churnLimit for efficient initiateValidatorExit() during block proposing MUST be recompute everytime the
@@ -546,6 +537,7 @@ export class EpochCache {
       nextSyncCommitteeIndexed,
       previousPayloadTimelinessCommittees,
       payloadTimelinessCommittees,
+      nextPayloadTimelinessCommittees,
       epoch: currentEpoch,
       syncPeriod: computeSyncPeriodAtEpoch(currentEpoch),
     });
@@ -592,6 +584,7 @@ export class EpochCache {
       nextSyncCommitteeIndexed: this.nextSyncCommitteeIndexed,
       previousPayloadTimelinessCommittees: this.previousPayloadTimelinessCommittees,
       payloadTimelinessCommittees: this.payloadTimelinessCommittees,
+      nextPayloadTimelinessCommittees: this.nextPayloadTimelinessCommittees,
       epoch: this.epoch,
       syncPeriod: this.syncPeriod,
     });
@@ -702,14 +695,13 @@ export class EpochCache {
 
     this.proposersPrevEpoch = this.proposers;
     if (upcomingEpoch >= this.config.GLOAS_FORK_EPOCH) {
-      // Shift and compute current epoch PTC eagerly for all slots
-      this.previousPayloadTimelinessCommittees = this.payloadTimelinessCommittees;
-      this.payloadTimelinessCommittees = computePayloadTimelinessCommitteesForEpoch(
-        state,
-        upcomingEpoch,
-        this.currentShuffling.committees,
-        this.effectiveBalanceIncrements
-      );
+      // processPtcWindow() already rotated the canonical state field earlier in process_epoch.
+      // Copy the previous/current epoch slices into epochCtx so validation stays on cached arrays.
+      ({
+        previousPayloadTimelinessCommittees: this.previousPayloadTimelinessCommittees,
+        payloadTimelinessCommittees: this.payloadTimelinessCommittees,
+        nextPayloadTimelinessCommittees: this.nextPayloadTimelinessCommittees,
+      } = getPtcWindowEpochCacheData(state as CachedBeaconStateGloas));
     }
     if (upcomingEpoch >= this.config.FULU_FORK_EPOCH) {
       // Populate proposer cache with lookahead from state
@@ -1040,6 +1032,10 @@ export class EpochCache {
 
     if (epoch === this.epoch - 1 && this.previousPayloadTimelinessCommittees.length > 0) {
       return this.previousPayloadTimelinessCommittees[slot % SLOTS_PER_EPOCH];
+    }
+
+    if (epoch === this.epoch + 1 && this.nextPayloadTimelinessCommittees.length > 0) {
+      return this.nextPayloadTimelinessCommittees[slot % SLOTS_PER_EPOCH];
     }
 
     throw new Error(`Payload Timeliness Committee is not available for slot=${slot}`);

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -688,20 +688,26 @@ export class EpochCache {
   /**
    * At fork boundary, this runs post-fork logic and it happens after `upgradeState*` is called.
    */
-  finalProcessEpoch(state: CachedBeaconStateAllForks): void {
+  finalProcessEpoch(state: CachedBeaconStateAllForks, epochTransitionCache: EpochTransitionCache): void {
     // this.epoch was updated at the end of afterProcessEpoch()
     const upcomingEpoch = this.epoch;
     const epochAfterUpcoming = upcomingEpoch + 1;
 
     this.proposersPrevEpoch = this.proposers;
     if (upcomingEpoch >= this.config.GLOAS_FORK_EPOCH) {
-      // processPtcWindow() already rotated the canonical state field earlier in process_epoch.
-      // Copy the previous/current epoch slices into epochCtx so validation stays on cached arrays.
-      ({
-        previousPayloadTimelinessCommittees: this.previousPayloadTimelinessCommittees,
-        payloadTimelinessCommittees: this.payloadTimelinessCommittees,
-        nextPayloadTimelinessCommittees: this.nextPayloadTimelinessCommittees,
-      } = getPtcWindowEpochCacheData(state as CachedBeaconStateGloas));
+      if (epochTransitionCache.nextEpochPayloadTimelinessCommittees) {
+        // shift arrays from transition cache
+        this.previousPayloadTimelinessCommittees = this.payloadTimelinessCommittees;
+        this.payloadTimelinessCommittees = this.nextPayloadTimelinessCommittees;
+        this.nextPayloadTimelinessCommittees = epochTransitionCache.nextEpochPayloadTimelinessCommittees;
+      } else {
+        // Fork boundary: processPtcWindow didn't run, read from freshly initialized state.ptcWindow
+        ({
+          previousPayloadTimelinessCommittees: this.previousPayloadTimelinessCommittees,
+          payloadTimelinessCommittees: this.payloadTimelinessCommittees,
+          nextPayloadTimelinessCommittees: this.nextPayloadTimelinessCommittees,
+        } = getPtcWindowEpochCacheData(state as CachedBeaconStateGloas));
+      }
     }
     if (upcomingEpoch >= this.config.FULU_FORK_EPOCH) {
       // Populate proposer cache with lookahead from state

--- a/packages/state-transition/src/cache/epochTransitionCache.ts
+++ b/packages/state-transition/src/cache/epochTransitionCache.ts
@@ -159,6 +159,12 @@ export interface EpochTransitionCache {
   nextShuffling: EpochShuffling | null;
 
   /**
+   * Pre-computed PTC for epoch N + MIN_SEED_LOOKAHEAD + 1, populated by processPtcWindow (Gloas+).
+   * Used by finalProcessEpoch to shift PTC arrays in epoch cache without reading from state.
+   */
+  nextEpochPayloadTimelinessCommittees: Uint32Array[] | null;
+
+  /**
    * Altair specific, this is total active balances for the next epoch.
    * This is only used in `afterProcessEpoch` to compute base reward and sync participant reward.
    * It's not efficient to calculate it at that time since it requires looping through all active validators,
@@ -502,6 +508,7 @@ export function beforeProcessEpoch(
     indicesToEject,
     nextShufflingActiveIndices,
     nextShuffling: null,
+    nextEpochPayloadTimelinessCommittees: null,
     // to be updated in processEffectiveBalanceUpdates
     nextEpochTotalActiveBalanceByIncrement: 0,
     isActivePrevEpoch,

--- a/packages/state-transition/src/epoch/index.ts
+++ b/packages/state-transition/src/epoch/index.ts
@@ -16,7 +16,6 @@ import {
   CachedBeaconStatePhase0,
   EpochTransitionCache,
 } from "../types.js";
-import {processPtcWindow} from "../util/gloas.js";
 import {processBuilderPendingPayments} from "./processBuilderPendingPayments.js";
 import {processEffectiveBalanceUpdates} from "./processEffectiveBalanceUpdates.js";
 import {processEth1DataReset} from "./processEth1DataReset.js";
@@ -29,6 +28,7 @@ import {processParticipationRecordUpdates} from "./processParticipationRecordUpd
 import {processPendingConsolidations} from "./processPendingConsolidations.js";
 import {processPendingDeposits} from "./processPendingDeposits.js";
 import {processProposerLookahead} from "./processProposerLookahead.js";
+import {processPtcWindow} from "./processPtcWindow.js";
 import {processRandaoMixesReset} from "./processRandaoMixesReset.js";
 import {processRegistryUpdates} from "./processRegistryUpdates.js";
 import {processRewardsAndPenalties} from "./processRewardsAndPenalties.js";

--- a/packages/state-transition/src/epoch/index.ts
+++ b/packages/state-transition/src/epoch/index.ts
@@ -16,6 +16,7 @@ import {
   CachedBeaconStatePhase0,
   EpochTransitionCache,
 } from "../types.js";
+import {processPtcWindow} from "../util/gloas.js";
 import {processBuilderPendingPayments} from "./processBuilderPendingPayments.js";
 import {processEffectiveBalanceUpdates} from "./processEffectiveBalanceUpdates.js";
 import {processEth1DataReset} from "./processEth1DataReset.js";
@@ -55,6 +56,7 @@ export {
   processPendingDeposits,
   processPendingConsolidations,
   processProposerLookahead,
+  processPtcWindow,
   processBuilderPendingPayments,
 };
 
@@ -81,6 +83,7 @@ export enum EpochTransitionStep {
   processPendingDeposits = "processPendingDeposits",
   processPendingConsolidations = "processPendingConsolidations",
   processProposerLookahead = "processProposerLookahead",
+  processPtcWindow = "processPtcWindow",
   processBuilderPendingPayments = "processBuilderPendingPayments",
 }
 
@@ -209,6 +212,12 @@ export function processEpoch(
       step: EpochTransitionStep.processProposerLookahead,
     });
     processProposerLookahead(fork, state as CachedBeaconStateFulu, cache);
+    timer?.();
+  }
+
+  if (fork >= ForkSeq.gloas) {
+    const timer = metrics?.epochTransitionStepTime.startTimer({step: EpochTransitionStep.processPtcWindow});
+    processPtcWindow(state as CachedBeaconStateGloas, cache);
     timer?.();
   }
 }

--- a/packages/state-transition/src/epoch/processPtcWindow.ts
+++ b/packages/state-transition/src/epoch/processPtcWindow.ts
@@ -13,25 +13,26 @@ import {computePayloadTimelinessCommitteesForEpoch} from "../util/seed.js";
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/gloas/beacon-chain.md#new-process_ptc_window
  */
 export function processPtcWindow(state: CachedBeaconStateGloas, cache: EpochTransitionCache): void {
-  const epoch = state.epochCtx.epoch + MIN_SEED_LOOKAHEAD + 1;
-  const nextShuffling = cache.nextShuffling ?? computeEpochShuffling(state, cache.nextShufflingActiveIndices, epoch);
-  cache.nextShuffling = nextShuffling;
+  const nextEpoch = state.epochCtx.epoch + MIN_SEED_LOOKAHEAD + 1;
+  const nextEpochShuffling =
+    cache.nextShuffling ?? computeEpochShuffling(state, cache.nextShufflingActiveIndices, nextEpoch);
+  cache.nextShuffling = nextEpochShuffling;
 
-  const lastEpochPayloadTimelinessCommittees = computePayloadTimelinessCommitteesForEpoch(
+  const newNextPayloadTimelinessCommittees = computePayloadTimelinessCommitteesForEpoch(
     state,
-    epoch,
-    nextShuffling.committees,
+    nextEpoch,
+    nextEpochShuffling.committees,
     state.epochCtx.effectiveBalanceIncrements
   );
 
   // Stash for finalProcessEpoch to shift into epoch cache
-  cache.nextEpochPayloadTimelinessCommittees = lastEpochPayloadTimelinessCommittees;
+  cache.nextEpochPayloadTimelinessCommittees = newNextPayloadTimelinessCommittees;
 
   // Write shifted window to state: current(N) + next(N+1) + newlyComputed(N+2)
   // From the perspective of upcoming epoch N+1, this is previous + current + next
   state.ptcWindow = ssz.gloas.PtcWindow.toViewDU([
     ...state.epochCtx.payloadTimelinessCommittees,
     ...state.epochCtx.nextPayloadTimelinessCommittees,
-    ...lastEpochPayloadTimelinessCommittees,
+    ...newNextPayloadTimelinessCommittees,
   ]);
 }

--- a/packages/state-transition/src/epoch/processPtcWindow.ts
+++ b/packages/state-transition/src/epoch/processPtcWindow.ts
@@ -30,6 +30,7 @@ export function processPtcWindow(state: CachedBeaconStateGloas, cache: EpochTran
 
   // Write shifted window to state: current(N) + next(N+1) + newlyComputed(N+2)
   // From the perspective of upcoming epoch N+1, this is previous + current + next
+  // TODO: Remove Array.from() once @chainsafe/ssz is upgraded to v1.3.1+ (accepts Uint32Array directly)
   state.ptcWindow = ssz.gloas.PtcWindow.toViewDU([
     ...state.epochCtx.payloadTimelinessCommittees.map((c) => Array.from(c)),
     ...state.epochCtx.nextPayloadTimelinessCommittees.map((c) => Array.from(c)),

--- a/packages/state-transition/src/epoch/processPtcWindow.ts
+++ b/packages/state-transition/src/epoch/processPtcWindow.ts
@@ -1,0 +1,38 @@
+import {MIN_SEED_LOOKAHEAD} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
+import {CachedBeaconStateGloas, EpochTransitionCache} from "../types.js";
+import {computeEpochShuffling} from "../util/epochShuffling.js";
+import {computePayloadTimelinessCommitteesForEpoch} from "../util/seed.js";
+
+/**
+ * Update the `ptc_window` field in the beacon state by shifting out the oldest epoch's
+ * PTC entries and appending newly computed entries for the next lookahead epoch.
+ * Stashes the computed PTCs in the transition cache for finalProcessEpoch to shift
+ * into the epoch cache without reading from state.
+ *
+ * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/gloas/beacon-chain.md#process_ptc_window
+ */
+export function processPtcWindow(state: CachedBeaconStateGloas, cache: EpochTransitionCache): void {
+  const nextEpoch = state.epochCtx.epoch + MIN_SEED_LOOKAHEAD + 1;
+  const nextShuffling =
+    cache.nextShuffling ?? computeEpochShuffling(state, cache.nextShufflingActiveIndices, nextEpoch);
+  cache.nextShuffling = nextShuffling;
+
+  const nextEpochPtcs = computePayloadTimelinessCommitteesForEpoch(
+    state,
+    nextEpoch,
+    nextShuffling.committees,
+    state.epochCtx.effectiveBalanceIncrements
+  );
+
+  // Stash for finalProcessEpoch to shift into epoch cache
+  cache.nextEpochPayloadTimelinessCommittees = nextEpochPtcs;
+
+  // Write shifted window to state: current(N) + next(N+1) + newlyComputed(N+2)
+  // From the perspective of upcoming epoch N+1, this is previous + current + next
+  state.ptcWindow = ssz.gloas.PtcWindow.toViewDU([
+    ...state.epochCtx.payloadTimelinessCommittees.map((c) => Array.from(c)),
+    ...state.epochCtx.nextPayloadTimelinessCommittees.map((c) => Array.from(c)),
+    ...nextEpochPtcs.map((c) => Array.from(c)),
+  ]);
+}

--- a/packages/state-transition/src/epoch/processPtcWindow.ts
+++ b/packages/state-transition/src/epoch/processPtcWindow.ts
@@ -10,30 +10,28 @@ import {computePayloadTimelinessCommitteesForEpoch} from "../util/seed.js";
  * Stashes the computed PTCs in the transition cache for finalProcessEpoch to shift
  * into the epoch cache without reading from state.
  *
- * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/gloas/beacon-chain.md#process_ptc_window
+ * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/gloas/beacon-chain.md#new-process_ptc_window
  */
 export function processPtcWindow(state: CachedBeaconStateGloas, cache: EpochTransitionCache): void {
-  const nextEpoch = state.epochCtx.epoch + MIN_SEED_LOOKAHEAD + 1;
-  const nextShuffling =
-    cache.nextShuffling ?? computeEpochShuffling(state, cache.nextShufflingActiveIndices, nextEpoch);
+  const epoch = state.epochCtx.epoch + MIN_SEED_LOOKAHEAD + 1;
+  const nextShuffling = cache.nextShuffling ?? computeEpochShuffling(state, cache.nextShufflingActiveIndices, epoch);
   cache.nextShuffling = nextShuffling;
 
-  const nextEpochPtcs = computePayloadTimelinessCommitteesForEpoch(
+  const lastEpochPayloadTimelinessCommittees = computePayloadTimelinessCommitteesForEpoch(
     state,
-    nextEpoch,
+    epoch,
     nextShuffling.committees,
     state.epochCtx.effectiveBalanceIncrements
   );
 
   // Stash for finalProcessEpoch to shift into epoch cache
-  cache.nextEpochPayloadTimelinessCommittees = nextEpochPtcs;
+  cache.nextEpochPayloadTimelinessCommittees = lastEpochPayloadTimelinessCommittees;
 
   // Write shifted window to state: current(N) + next(N+1) + newlyComputed(N+2)
   // From the perspective of upcoming epoch N+1, this is previous + current + next
-  // TODO: Remove Array.from() once @chainsafe/ssz is upgraded to v1.3.1+ (accepts Uint32Array directly)
   state.ptcWindow = ssz.gloas.PtcWindow.toViewDU([
-    ...state.epochCtx.payloadTimelinessCommittees.map((c) => Array.from(c)),
-    ...state.epochCtx.nextPayloadTimelinessCommittees.map((c) => Array.from(c)),
-    ...nextEpochPtcs.map((c) => Array.from(c)),
+    ...state.epochCtx.payloadTimelinessCommittees,
+    ...state.epochCtx.nextPayloadTimelinessCommittees,
+    ...lastEpochPayloadTimelinessCommittees,
   ]);
 }

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -5,7 +5,7 @@ import {isValidDepositSignature} from "../block/processDeposit.js";
 import {applyDepositForBuilder} from "../block/processDepositRequest.js";
 import {getCachedBeaconState} from "../cache/stateCache.js";
 import {CachedBeaconStateFulu, CachedBeaconStateGloas} from "../types.js";
-import {isBuilderWithdrawalCredential} from "../util/gloas.js";
+import {initializePtcWindow, isBuilderWithdrawalCredential} from "../util/gloas.js";
 import {isValidatorKnown} from "../util/index.js";
 
 /**
@@ -61,6 +61,7 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
   stateGloasView.pendingPartialWithdrawals = stateGloasCloned.pendingPartialWithdrawals;
   stateGloasView.pendingConsolidations = stateGloasCloned.pendingConsolidations;
   stateGloasView.proposerLookahead = stateGloasCloned.proposerLookahead;
+  stateGloasView.ptcWindow = ssz.gloas.PtcWindow.toViewDU(initializePtcWindow(stateFulu));
 
   for (let i = 0; i < SLOTS_PER_HISTORICAL_ROOT; i++) {
     stateGloasView.executionPayloadAvailability.set(i, true);

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -283,7 +283,7 @@ function processSlotsWithTransientCache(
       {
         const timer = metrics?.epochTransitionStepTime.startTimer({step: EpochTransitionStep.finalProcessEpoch});
         // last step to prepare epoch data that depends on the upgraded state, for example proposerLookahead of BeaconStateFulu
-        postState.epochCtx.finalProcessEpoch(postState);
+        postState.epochCtx.finalProcessEpoch(postState, epochTransitionCache);
         timer?.();
       }
 

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -15,10 +15,17 @@ import {processDeposit} from "../block/processDeposit.js";
 import {EpochCacheImmutableData} from "../cache/epochCache.js";
 import {createCachedBeaconState} from "../cache/stateCache.js";
 import {increaseBalance} from "../index.js";
-import {BeaconStateAllForks, CachedBeaconStateAllForks, CachedBeaconStateElectra} from "../types.js";
+import {
+  BeaconStateAllForks,
+  CachedBeaconStateAllForks,
+  CachedBeaconStateElectra,
+  CachedBeaconStateFulu,
+} from "../types.js";
 import {newFilledArray} from "./array.js";
 import {getTemporaryBlockHeader} from "./blockRoot.js";
 import {computeEpochAtSlot} from "./epoch.js";
+import {initializeProposerLookahead} from "./fulu.js";
+import {initializePtcWindow} from "./gloas.js";
 import {getNextSyncCommittee} from "./syncCommittee.js";
 import {getActiveValidatorIndices, getMaxEffectiveBalance} from "./validator.js";
 
@@ -326,15 +333,23 @@ export function initializeBeaconStateFromEth1(
     stateFulu.latestExecutionPayloadHeader =
       (executionPayloadHeader as CompositeViewDU<typeof ssz.fulu.ExecutionPayloadHeader>) ??
       ssz.fulu.ExecutionPayloadHeader.defaultViewDU();
+    stateFulu.proposerLookahead = ssz.fulu.ProposerLookahead.toViewDU(
+      initializeProposerLookahead(state as CachedBeaconStateElectra)
+    );
   }
 
   if (fork >= ForkSeq.gloas) {
     const stateGloas = state as CompositeViewDU<typeof ssz.gloas.BeaconState>;
     stateGloas.fork.previousVersion = config.GLOAS_FORK_VERSION;
     stateGloas.fork.currentVersion = config.GLOAS_FORK_VERSION;
+    stateGloas.ptcWindow = ssz.gloas.PtcWindow.toViewDU(initializePtcWindow(state as CachedBeaconStateFulu));
   }
 
   state.commit();
+
+  if (fork >= ForkSeq.fulu) {
+    return createCachedBeaconState(state as BeaconStateAllForks, immutableData, {skipSyncCommitteeCache: true});
+  }
 
   return state;
 }

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -15,17 +15,10 @@ import {processDeposit} from "../block/processDeposit.js";
 import {EpochCacheImmutableData} from "../cache/epochCache.js";
 import {createCachedBeaconState} from "../cache/stateCache.js";
 import {increaseBalance} from "../index.js";
-import {
-  BeaconStateAllForks,
-  CachedBeaconStateAllForks,
-  CachedBeaconStateElectra,
-  CachedBeaconStateFulu,
-} from "../types.js";
+import {BeaconStateAllForks, CachedBeaconStateAllForks, CachedBeaconStateElectra} from "../types.js";
 import {newFilledArray} from "./array.js";
 import {getTemporaryBlockHeader} from "./blockRoot.js";
 import {computeEpochAtSlot} from "./epoch.js";
-import {initializeProposerLookahead} from "./fulu.js";
-import {initializePtcWindow} from "./gloas.js";
 import {getNextSyncCommittee} from "./syncCommittee.js";
 import {getActiveValidatorIndices, getMaxEffectiveBalance} from "./validator.js";
 
@@ -333,23 +326,15 @@ export function initializeBeaconStateFromEth1(
     stateFulu.latestExecutionPayloadHeader =
       (executionPayloadHeader as CompositeViewDU<typeof ssz.fulu.ExecutionPayloadHeader>) ??
       ssz.fulu.ExecutionPayloadHeader.defaultViewDU();
-    stateFulu.proposerLookahead = ssz.fulu.ProposerLookahead.toViewDU(
-      initializeProposerLookahead(state as CachedBeaconStateElectra)
-    );
   }
 
   if (fork >= ForkSeq.gloas) {
     const stateGloas = state as CompositeViewDU<typeof ssz.gloas.BeaconState>;
     stateGloas.fork.previousVersion = config.GLOAS_FORK_VERSION;
     stateGloas.fork.currentVersion = config.GLOAS_FORK_VERSION;
-    stateGloas.ptcWindow = ssz.gloas.PtcWindow.toViewDU(initializePtcWindow(state as CachedBeaconStateFulu));
   }
 
   state.commit();
-
-  if (fork >= ForkSeq.fulu) {
-    return createCachedBeaconState(state as BeaconStateAllForks, immutableData, {skipSyncCommitteeCache: true});
-  }
 
   return state;
 }

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -10,10 +10,9 @@ import {
   PTC_SIZE,
   SLOTS_PER_EPOCH,
 } from "@lodestar/params";
-import {BuilderIndex, Epoch, ValidatorIndex, gloas, ssz} from "@lodestar/types";
+import {BuilderIndex, Epoch, ValidatorIndex, gloas} from "@lodestar/types";
 import {AttestationData} from "@lodestar/types/phase0";
 import {byteArrayEquals} from "@lodestar/utils";
-import type {EpochTransitionCache} from "../cache/epochTransitionCache.js";
 import type {CachedBeaconStateFulu, CachedBeaconStateGloas} from "../cache/stateCache.js";
 import type {IBeaconStateViewGloas} from "../stateView/interface.js";
 import {getBlockRootAtSlot} from "./blockRoot.js";
@@ -201,42 +200,21 @@ export function initializePtcWindow(state: CachedBeaconStateFulu): number[][] {
   return ptcWindow;
 }
 
-export function processPtcWindow(state: CachedBeaconStateGloas, cache: EpochTransitionCache): void {
-  const nextEpoch = state.epochCtx.epoch + MIN_SEED_LOOKAHEAD + 1;
-  const nextShuffling =
-    cache.nextShuffling ?? computeEpochShuffling(state, cache.nextShufflingActiveIndices, nextEpoch);
-  cache.nextShuffling = nextShuffling;
-
-  const remainingPtcWindow = state.ptcWindow.toValue().slice(SLOTS_PER_EPOCH);
-  const nextEpochPtcs = computePayloadTimelinessCommitteesForEpoch(
-    state,
-    nextEpoch,
-    nextShuffling.committees,
-    state.epochCtx.effectiveBalanceIncrements
-  );
-
-  state.ptcWindow = ssz.gloas.PtcWindow.toViewDU([
-    ...remainingPtcWindow,
-    ...nextEpochPtcs.map((committee) => Array.from(committee)),
-  ]);
-}
-
 export function getPtcWindowEpochCacheData(state: CachedBeaconStateGloas): {
   previousPayloadTimelinessCommittees: Uint32Array[];
   payloadTimelinessCommittees: Uint32Array[];
   nextPayloadTimelinessCommittees: Uint32Array[];
 } {
-  const ptcWindow = state.ptcWindow.toValue();
+  const toUint32Arrays = (views: ReturnType<typeof state.ptcWindow.getReadonlyByRange>) =>
+    views.map((v) => Uint32Array.from(v.getAll()));
+
+  const previousPtcWindow = state.ptcWindow.getReadonlyByRange(0, SLOTS_PER_EPOCH);
+  const currentPtcWindow = state.ptcWindow.getReadonlyByRange(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH);
+  const nextPtcWindow = state.ptcWindow.getReadonlyByRange(2 * SLOTS_PER_EPOCH, SLOTS_PER_EPOCH);
 
   return {
-    previousPayloadTimelinessCommittees: ptcWindow
-      .slice(0, SLOTS_PER_EPOCH)
-      .map((committee: ValidatorIndex[]) => Uint32Array.from(committee)),
-    payloadTimelinessCommittees: ptcWindow
-      .slice(SLOTS_PER_EPOCH, 2 * SLOTS_PER_EPOCH)
-      .map((committee: ValidatorIndex[]) => Uint32Array.from(committee)),
-    nextPayloadTimelinessCommittees: ptcWindow
-      .slice(2 * SLOTS_PER_EPOCH, 3 * SLOTS_PER_EPOCH)
-      .map((committee: ValidatorIndex[]) => Uint32Array.from(committee)),
+    previousPayloadTimelinessCommittees: toUint32Arrays(previousPtcWindow),
+    payloadTimelinessCommittees: toUint32Arrays(currentPtcWindow),
+    nextPayloadTimelinessCommittees: toUint32Arrays(nextPtcWindow),
   };
 }

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -193,6 +193,7 @@ export function initializePtcWindow(state: CachedBeaconStateFulu): number[][] {
         epoch,
         shuffling.committees,
         state.epochCtx.effectiveBalanceIncrements
+      // TODO: Remove Array.from() once @chainsafe/ssz is upgraded to v1.3.1+ (accepts Uint32Array directly)
       ).map((committee) => Array.from(committee))
     );
   }

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -6,16 +6,22 @@ import {
   EFFECTIVE_BALANCE_INCREMENT,
   FAR_FUTURE_EPOCH,
   MIN_DEPOSIT_AMOUNT,
+  MIN_SEED_LOOKAHEAD,
+  PTC_SIZE,
   SLOTS_PER_EPOCH,
 } from "@lodestar/params";
-import {BuilderIndex, Epoch, ValidatorIndex, gloas} from "@lodestar/types";
+import {BuilderIndex, Epoch, ValidatorIndex, gloas, ssz} from "@lodestar/types";
 import {AttestationData} from "@lodestar/types/phase0";
 import {byteArrayEquals} from "@lodestar/utils";
-import {IBeaconStateViewGloas} from "../stateView/interface.js";
-import {CachedBeaconStateGloas} from "../types.js";
+import type {EpochTransitionCache} from "../cache/epochTransitionCache.js";
+import type {CachedBeaconStateFulu, CachedBeaconStateGloas} from "../cache/stateCache.js";
+import type {IBeaconStateViewGloas} from "../stateView/interface.js";
 import {getBlockRootAtSlot} from "./blockRoot.js";
 import {computeEpochAtSlot} from "./epoch.js";
+import {computeEpochShuffling} from "./epochShuffling.js";
 import {RootCache} from "./rootCache.js";
+import {computePayloadTimelinessCommitteesForEpoch} from "./seed.js";
+import {getActiveValidatorIndices} from "./validator.js";
 
 export function isBuilderWithdrawalCredential(withdrawalCredentials: Uint8Array): boolean {
   return withdrawalCredentials[0] === BUILDER_WITHDRAWAL_PREFIX;
@@ -170,4 +176,67 @@ export function isAttestationSameSlotRootCache(rootCache: RootCache, data: Attes
 
 export function isParentBlockFull(state: CachedBeaconStateGloas | IBeaconStateViewGloas): boolean {
   return byteArrayEquals(state.latestExecutionPayloadBid.blockHash, state.latestBlockHash);
+}
+
+export function initializePtcWindow(state: CachedBeaconStateFulu): number[][] {
+  const ptcWindow = Array.from({length: SLOTS_PER_EPOCH}, () => Array.from(new Uint32Array(PTC_SIZE)));
+  const currentEpoch = state.epochCtx.epoch;
+
+  for (let epochOffset = 0; epochOffset <= MIN_SEED_LOOKAHEAD; epochOffset++) {
+    const epoch = currentEpoch + epochOffset;
+    const shuffling =
+      state.epochCtx.getShufflingAtEpochOrNull(epoch) ??
+      computeEpochShuffling(state, getActiveValidatorIndices(state, epoch), epoch);
+
+    ptcWindow.push(
+      ...computePayloadTimelinessCommitteesForEpoch(
+        state,
+        epoch,
+        shuffling.committees,
+        state.epochCtx.effectiveBalanceIncrements
+      ).map((committee) => Array.from(committee))
+    );
+  }
+
+  return ptcWindow;
+}
+
+export function processPtcWindow(state: CachedBeaconStateGloas, cache: EpochTransitionCache): void {
+  const nextEpoch = state.epochCtx.epoch + MIN_SEED_LOOKAHEAD + 1;
+  const nextShuffling =
+    cache.nextShuffling ?? computeEpochShuffling(state, cache.nextShufflingActiveIndices, nextEpoch);
+  cache.nextShuffling = nextShuffling;
+
+  const remainingPtcWindow = state.ptcWindow.toValue().slice(SLOTS_PER_EPOCH);
+  const nextEpochPtcs = computePayloadTimelinessCommitteesForEpoch(
+    state,
+    nextEpoch,
+    nextShuffling.committees,
+    state.epochCtx.effectiveBalanceIncrements
+  );
+
+  state.ptcWindow = ssz.gloas.PtcWindow.toViewDU([
+    ...remainingPtcWindow,
+    ...nextEpochPtcs.map((committee) => Array.from(committee)),
+  ]);
+}
+
+export function getPtcWindowEpochCacheData(state: CachedBeaconStateGloas): {
+  previousPayloadTimelinessCommittees: Uint32Array[];
+  payloadTimelinessCommittees: Uint32Array[];
+  nextPayloadTimelinessCommittees: Uint32Array[];
+} {
+  const ptcWindow = state.ptcWindow.toValue();
+
+  return {
+    previousPayloadTimelinessCommittees: ptcWindow
+      .slice(0, SLOTS_PER_EPOCH)
+      .map((committee: ValidatorIndex[]) => Uint32Array.from(committee)),
+    payloadTimelinessCommittees: ptcWindow
+      .slice(SLOTS_PER_EPOCH, 2 * SLOTS_PER_EPOCH)
+      .map((committee: ValidatorIndex[]) => Uint32Array.from(committee)),
+    nextPayloadTimelinessCommittees: ptcWindow
+      .slice(2 * SLOTS_PER_EPOCH, 3 * SLOTS_PER_EPOCH)
+      .map((committee: ValidatorIndex[]) => Uint32Array.from(committee)),
+  };
 }

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -177,8 +177,8 @@ export function isParentBlockFull(state: CachedBeaconStateGloas | IBeaconStateVi
   return byteArrayEquals(state.latestExecutionPayloadBid.blockHash, state.latestBlockHash);
 }
 
-export function initializePtcWindow(state: CachedBeaconStateFulu): number[][] {
-  const ptcWindow = Array.from({length: SLOTS_PER_EPOCH}, () => Array.from(new Uint32Array(PTC_SIZE)));
+export function initializePtcWindow(state: CachedBeaconStateFulu): Uint32Array[] {
+  const ptcWindow: Uint32Array[] = Array.from({length: SLOTS_PER_EPOCH}, () => new Uint32Array(PTC_SIZE));
   const currentEpoch = state.epochCtx.epoch;
 
   for (let epochOffset = 0; epochOffset <= MIN_SEED_LOOKAHEAD; epochOffset++) {
@@ -193,8 +193,7 @@ export function initializePtcWindow(state: CachedBeaconStateFulu): number[][] {
         epoch,
         shuffling.committees,
         state.epochCtx.effectiveBalanceIncrements
-        // TODO: Remove Array.from() once @chainsafe/ssz is upgraded to v1.3.1+ (accepts Uint32Array directly)
-      ).map((committee) => Array.from(committee))
+      )
     );
   }
 

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -193,7 +193,7 @@ export function initializePtcWindow(state: CachedBeaconStateFulu): number[][] {
         epoch,
         shuffling.committees,
         state.epochCtx.effectiveBalanceIncrements
-      // TODO: Remove Array.from() once @chainsafe/ssz is upgraded to v1.3.1+ (accepts Uint32Array directly)
+        // TODO: Remove Array.from() once @chainsafe/ssz is upgraded to v1.3.1+ (accepts Uint32Array directly)
       ).map((committee) => Array.from(committee))
     );
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -81,7 +81,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@lodestar/params": "workspace:^",
     "ethereum-cryptography": "^2.0.0"
   },

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -1,9 +1,17 @@
-import {BitVectorType, ContainerType, ListBasicType, ListCompositeType, VectorCompositeType} from "@chainsafe/ssz";
+import {
+  BitVectorType,
+  ContainerType,
+  ListBasicType,
+  ListCompositeType,
+  VectorBasicType,
+  VectorCompositeType,
+} from "@chainsafe/ssz";
 import {
   BUILDER_PENDING_WITHDRAWALS_LIMIT,
   BUILDER_REGISTRY_LIMIT,
   HISTORICAL_ROOTS_LIMIT,
   MAX_PAYLOAD_ATTESTATIONS,
+  MIN_SEED_LOOKAHEAD,
   NUMBER_OF_COLUMNS,
   PTC_SIZE,
   SLOTS_PER_EPOCH,
@@ -64,6 +72,12 @@ export const BuilderPendingPayment = new ContainerType(
     withdrawal: BuilderPendingWithdrawal,
   },
   {typeName: "BuilderPendingPayment", jsonCase: "eth2"}
+);
+
+export const PayloadTimelinessCommittee = new VectorBasicType(ValidatorIndex, PTC_SIZE);
+export const PtcWindow = new VectorCompositeType(
+  PayloadTimelinessCommittee,
+  (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH
 );
 
 export const PayloadAttestationData = new ContainerType(
@@ -263,6 +277,7 @@ export const BeaconState = new ContainerType(
     builderPendingWithdrawals: new ListCompositeType(BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT), // New in GLOAS:EIP7732
     latestBlockHash: Bytes32, // New in GLOAS:EIP7732
     payloadExpectedWithdrawals: capellaSsz.Withdrawals, // New in GLOAS:EIP7732
+    ptcWindow: PtcWindow, // New in GLOAS:EIP7732
   },
   {typeName: "BeaconState", jsonCase: "eth2"}
 );

--- a/packages/types/src/gloas/types.ts
+++ b/packages/types/src/gloas/types.ts
@@ -4,6 +4,8 @@ import * as ssz from "./sszTypes.js";
 export type Builder = ValueOf<typeof ssz.Builder>;
 export type BuilderPendingWithdrawal = ValueOf<typeof ssz.BuilderPendingWithdrawal>;
 export type BuilderPendingPayment = ValueOf<typeof ssz.BuilderPendingPayment>;
+export type PayloadTimelinessCommittee = ValueOf<typeof ssz.PayloadTimelinessCommittee>;
+export type PtcWindow = ValueOf<typeof ssz.PtcWindow>;
 export type PayloadAttestationData = ValueOf<typeof ssz.PayloadAttestationData>;
 export type PayloadAttestation = ValueOf<typeof ssz.PayloadAttestation>;
 export type PayloadAttestationMessage = ValueOf<typeof ssz.PayloadAttestationMessage>;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -53,7 +53,7 @@
     "js-yaml": "^4.1.0"
   },
   "devDependencies": {
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@types/js-yaml": "^4.0.5",
     "@types/yargs": "^17.0.24",
     "prom-client": "^15.1.0"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@chainsafe/blst": "^2.2.0",
-    "@chainsafe/ssz": "^1.2.2",
+    "@chainsafe/ssz": "^1.4.0",
     "@lodestar/api": "workspace:^",
     "@lodestar/config": "workspace:^",
     "@lodestar/db": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@lodestar/config':
         specifier: workspace:^
         version: link:../config
@@ -247,8 +247,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@chainsafe/threads':
         specifier: ^1.11.3
         version: 1.11.3
@@ -449,8 +449,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@chainsafe/threads':
         specifier: ^1.11.3
         version: 1.11.3
@@ -582,8 +582,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@lodestar/params':
         specifier: workspace:^
         version: link:../params
@@ -600,8 +600,8 @@ importers:
   packages/db:
     dependencies:
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@lodestar/config':
         specifier: workspace:^
         version: link:../config
@@ -680,8 +680,8 @@ importers:
   packages/fork-choice:
     dependencies:
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@lodestar/config':
         specifier: workspace:^
         version: link:../config
@@ -710,8 +710,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@lodestar/api':
         specifier: workspace:^
         version: link:../api
@@ -772,8 +772,8 @@ importers:
         version: 4.6.0
     devDependencies:
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@chainsafe/threads':
         specifier: ^1.11.3
         version: 1.11.3
@@ -924,8 +924,8 @@ importers:
         version: 2.4.8
     devDependencies:
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@libp2p/crypto':
         specifier: ^5.1.13
         version: 5.1.13
@@ -948,8 +948,8 @@ importers:
   packages/spec-test-util:
     dependencies:
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@lodestar/types':
         specifier: workspace:^
         version: link:../types
@@ -984,8 +984,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@chainsafe/swap-or-not-shuffle':
         specifier: ^1.2.1
         version: 1.2.1
@@ -1043,8 +1043,8 @@ importers:
   packages/types:
     dependencies:
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@lodestar/params':
         specifier: workspace:^
         version: link:../params
@@ -1071,8 +1071,8 @@ importers:
         version: 4.1.1
     devDependencies:
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@types/js-yaml':
         specifier: ^4.0.5
         version: 4.0.5
@@ -1089,8 +1089,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@chainsafe/ssz':
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.4.0
+        version: 1.4.0
       '@lodestar/api':
         specifier: workspace:^
         version: link:../api
@@ -1505,6 +1505,9 @@ packages:
   '@chainsafe/persistent-merkle-tree@1.2.1':
     resolution: {integrity: sha512-AOSEVLfaqwb9eTCKuY1ri0DrRxVQ3Rh+we1VBj1GahUGfEdE8OC3Vkbca7Up6RoI9Ip9FLnI31Y7AjKH9ZqAGA==}
 
+  '@chainsafe/persistent-merkle-tree@1.2.5':
+    resolution: {integrity: sha512-uyv3/nHkD8vNXjdez6q89rhXwGDUp3YX2mBbOwB7/xelgZ9E7hc3HQgOuq1EdfM9Vyh09jiwimXF/hskmymOfQ==}
+
   '@chainsafe/persistent-ts@1.0.0':
     resolution: {integrity: sha512-Xwu59vDQwJWcF4QbIdi9gvRVnkLBOc7Y5JUpINS4TVRtp4omhjEsqO4rFSCUhC8opyg1HcNSQEjL4IgYLGouuw==}
 
@@ -1576,8 +1579,8 @@ packages:
   '@chainsafe/ssz@0.11.1':
     resolution: {integrity: sha512-cB8dBkgGN6ZoeOKuk+rIRHKN0L5i9JLGeC0Lui71QX0TuLcQKwgbfkUexpyJxnGFatWf8yeJxlOjozMn/OTP0g==}
 
-  '@chainsafe/ssz@1.2.2':
-    resolution: {integrity: sha512-kIA3fJO6h2RsQndsNBlCSQYB4xfdZGMQvNPKPgbiB0mysV6okuxeJU3Nyl16xDCKv3tqej76eGYHcyjMVt7V1w==}
+  '@chainsafe/ssz@1.4.0':
+    resolution: {integrity: sha512-DRje073CIU0lvIdNKmW89jAo4UAidoKpgYco5wvQve8WK1DUk/YS/54c5FX/e/iiKiJ1mo44CNCg4xiKWY3/yQ==}
 
   '@chainsafe/swap-or-not-shuffle-darwin-arm64@1.2.1':
     resolution: {integrity: sha512-kTewLZe1KqMAJ1gHfagOxo0BI4kTcMOAkGJ7pRLFM5ZkL2P7sh3/4ixnjdbtMkO207vMZEZL3fxJSSs14kg9Kg==}
@@ -7941,6 +7944,12 @@ snapshots:
       '@chainsafe/hashtree': 1.0.2
       '@noble/hashes': 1.8.0
 
+  '@chainsafe/persistent-merkle-tree@1.2.5':
+    dependencies:
+      '@chainsafe/as-sha256': 1.2.0
+      '@chainsafe/hashtree': 1.0.2
+      '@noble/hashes': 1.8.0
+
   '@chainsafe/persistent-ts@1.0.0': {}
 
   '@chainsafe/prometheus-gc-stats@1.0.2(prom-client@15.1.3)':
@@ -7989,10 +7998,10 @@ snapshots:
       '@chainsafe/as-sha256': 0.4.1
       '@chainsafe/persistent-merkle-tree': 0.6.1
 
-  '@chainsafe/ssz@1.2.2':
+  '@chainsafe/ssz@1.4.0':
     dependencies:
       '@chainsafe/as-sha256': 1.2.0
-      '@chainsafe/persistent-merkle-tree': 1.2.1
+      '@chainsafe/persistent-merkle-tree': 1.2.5
 
   '@chainsafe/swap-or-not-shuffle-darwin-arm64@1.2.1':
     optional: true

--- a/spec-tests-version.json
+++ b/spec-tests-version.json
@@ -1,6 +1,6 @@
 {
   "ethereumConsensusSpecsTests": {
-    "specVersion": "v1.7.0-alpha.3",
+    "specVersion": "v1.7.0-alpha.4",
     "specTestsRepoUrl": "https://github.com/ethereum/consensus-specs",
     "outputDirBase": "spec-tests",
     "testsToDownload": [

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.7.0-alpha.3
+version: v1.7.0-alpha.4
 style: full
 
 specrefs:
@@ -54,6 +54,12 @@ exceptions:
   containers:
     # gloas
     - ForkChoiceNode#gloas
+    - PartialDataColumnHeader#gloas
+
+    # fulu (not implemented yet)
+    - PartialDataColumnHeader#fulu
+    - PartialDataColumnPartsMetadata#fulu
+    - PartialDataColumnSidecar#fulu
 
     # heze (not implemented)
     - BeaconState#heze
@@ -65,6 +71,7 @@ exceptions:
   dataclasses:
     # phase0
     - LatestMessage#phase0
+    - Seen#phase0
 
     # bellatrix
     - OptimisticStore#bellatrix
@@ -93,6 +100,15 @@ exceptions:
   functions:
     # phase0
     - bytes_to_uint64#phase0
+    - compute_time_at_slot_ms#phase0
+    - is_not_from_future_slot#phase0
+    - is_within_slot_range#phase0
+    - validate_attester_slashing_gossip#phase0
+    - validate_beacon_aggregate_and_proof_gossip#phase0
+    - validate_beacon_attestation_gossip#phase0
+    - validate_beacon_block_gossip#phase0
+    - validate_proposer_slashing_gossip#phase0
+    - validate_voluntary_exit_gossip#phase0
     - compute_fork_version#phase0
     - compute_proposer_score#phase0
     - get_aggregate_signature#phase0
@@ -259,6 +275,8 @@ exceptions:
     - vanishing_polynomialcoeff#fulu
     - verify_cell_kzg_proof_batch#fulu
     - verify_cell_kzg_proof_batch_impl#fulu
+    - verify_partial_data_column_header_inclusion_proof#fulu
+    - verify_partial_data_column_sidecar_kzg_proofs#fulu
 
     # gloas
     - add_builder_to_registry#gloas

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -572,7 +572,7 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const BeaconState =
   spec: |
-    <spec container="BeaconState" fork="gloas" hash="c33b0db2">
+    <spec container="BeaconState" fork="gloas" hash="cb308f9f">
     class BeaconState(Container):
         genesis_time: uint64
         genesis_validators_root: Root
@@ -629,12 +629,14 @@
         latest_block_hash: Hash32
         # [New in Gloas:EIP7732]
         payload_expected_withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+        # [New in Gloas:EIP7732]
+        ptc_window: Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]
     </spec>
 
 - name: BeaconState#heze
   sources: []
   spec: |
-    <spec container="BeaconState" fork="heze" hash="11cb9d81">
+    <spec container="BeaconState" fork="heze" hash="f73e357a">
     class BeaconState(Container):
         genesis_time: uint64
         genesis_validators_root: Root
@@ -682,6 +684,7 @@
         builder_pending_withdrawals: List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]
         latest_block_hash: Hash32
         payload_expected_withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+        ptc_window: Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]
     </spec>
 
 - name: BlobIdentifier#deneb

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -4679,18 +4679,23 @@
 - name: get_upcoming_proposal_slots#gloas
   sources: []
   spec: |
-    <spec fn="get_upcoming_proposal_slots" fork="gloas" hash="802ba480">
+    <spec fn="get_upcoming_proposal_slots" fork="gloas" hash="87d7a07d">
     def get_upcoming_proposal_slots(
         state: BeaconState, validator_index: ValidatorIndex
     ) -> Sequence[Slot]:
         """
-        Get the slots in the next epoch for which ``validator_index`` is proposing.
+        Get the future slots in the current epoch and the slots in the next
+        epoch for which ``validator_index`` is proposing.
         """
-        return [
-            Slot(compute_start_slot_at_epoch(get_current_epoch(state) + Epoch(1)) + offset)
-            for offset, proposer_index in enumerate(state.proposer_lookahead[SLOTS_PER_EPOCH:])
-            if validator_index == proposer_index
-        ]
+        current_epoch_start_slot = compute_start_slot_at_epoch(get_current_epoch(state))
+        upcoming_proposal_slots = []
+        for offset, proposer_index in enumerate(state.proposer_lookahead):
+            slot = Slot(current_epoch_start_slot + offset)
+            if slot <= state.slot:
+                continue
+            if validator_index == proposer_index:
+                upcoming_proposal_slots.append(slot)
+        return upcoming_proposal_slots
     </spec>
 
 - name: get_validator_activation_churn_limit#deneb

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1100,6 +1100,29 @@
         return (committee_weight * PROPOSER_SCORE_BOOST) // 100
     </spec>
 
+- name: compute_ptc#gloas
+  sources:
+    - file: packages/state-transition/src/util/seed.ts
+      search: export function computePayloadTimelinessCommitteeForSlot(
+  spec: |
+    <spec fn="compute_ptc" fork="gloas" hash="0f323552">
+    def compute_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
+        """
+        Get the payload timeliness committee for the given ``slot``.
+        """
+        epoch = compute_epoch_at_slot(slot)
+        seed = hash(get_seed(state, epoch, DOMAIN_PTC_ATTESTER) + uint_to_bytes(slot))
+        indices: List[ValidatorIndex] = []
+        # Concatenate all committees for this slot in order
+        committees_per_slot = get_committee_count_per_slot(state, epoch)
+        for i in range(committees_per_slot):
+            committee = get_beacon_committee(state, slot, CommitteeIndex(i))
+            indices.extend(committee)
+        return compute_balance_weighted_selection(
+            state, indices, seed, size=PTC_SIZE, shuffle_indices=False
+        )
+    </spec>
+
 - name: compute_pulled_up_tip#phase0
   sources:
     - file: packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -4330,28 +4353,25 @@
       search: '^\s+getPayloadTimelinessCommittee\('
       regex: true
   spec: |
-    <spec fn="get_ptc" fork="gloas" hash="ae15f761">
+    <spec fn="get_ptc" fork="gloas" hash="b55ba184">
     def get_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
         """
         Get the payload timeliness committee for the given ``slot``.
         """
         epoch = compute_epoch_at_slot(slot)
-        seed = hash(get_seed(state, epoch, DOMAIN_PTC_ATTESTER) + uint_to_bytes(slot))
-        indices: List[ValidatorIndex] = []
-        # Concatenate all committees for this slot in order
-        committees_per_slot = get_committee_count_per_slot(state, epoch)
-        for i in range(committees_per_slot):
-            committee = get_beacon_committee(state, slot, CommitteeIndex(i))
-            indices.extend(committee)
-        return compute_balance_weighted_selection(
-            state, indices, seed, size=PTC_SIZE, shuffle_indices=False
-        )
+        state_epoch = get_current_epoch(state)
+        if epoch < state_epoch:
+            assert epoch + 1 == state_epoch
+            return state.ptc_window[slot % SLOTS_PER_EPOCH]
+        assert epoch <= state_epoch + MIN_SEED_LOOKAHEAD
+        offset = (epoch - state_epoch + 1) * SLOTS_PER_EPOCH
+        return state.ptc_window[offset + slot % SLOTS_PER_EPOCH]
     </spec>
 
 - name: get_ptc_assignment#gloas
   sources: []
   spec: |
-    <spec fn="get_ptc_assignment" fork="gloas" hash="7fd50097">
+    <spec fn="get_ptc_assignment" fork="gloas" hash="ba09915b">
     def get_ptc_assignment(
         state: BeaconState, epoch: Epoch, validator_index: ValidatorIndex
     ) -> Optional[Slot]:
@@ -4360,8 +4380,8 @@
         index ``validator_index`` is a member of the PTC. Returns None if no
         assignment is found.
         """
-        next_epoch = Epoch(get_current_epoch(state) + 1)
-        assert epoch <= next_epoch
+        max_epoch = Epoch(get_current_epoch(state) + MIN_SEED_LOOKAHEAD)
+        assert epoch <= max_epoch
 
         start_slot = compute_start_slot_at_epoch(epoch)
         for slot in range(start_slot, start_slot + SLOTS_PER_EPOCH):
@@ -5136,6 +5156,34 @@
         for i in range(MIN_SEED_LOOKAHEAD + 1):
             lookahead.extend(get_beacon_proposer_indices(state, Epoch(current_epoch + i)))
         return lookahead
+    </spec>
+
+- name: initialize_ptc_window#gloas
+  sources:
+    - file: packages/state-transition/src/util/gloas.ts
+      search: export function initializePtcWindow(
+  spec: |
+    <spec fn="initialize_ptc_window" fork="gloas" hash="3764b7f5">
+    def initialize_ptc_window(
+        state: BeaconState,
+    ) -> Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]:
+        """
+        Return the cached PTC window starting from the current epoch.
+        Used to initialize the ``ptc_window`` field in the beacon state at genesis and after forks.
+        """
+        empty_previous_epoch = [
+            Vector[ValidatorIndex, PTC_SIZE]([ValidatorIndex(0) for _ in range(PTC_SIZE)])
+            for _ in range(SLOTS_PER_EPOCH)
+        ]
+
+        ptcs = []
+        current_epoch = get_current_epoch(state)
+        for e in range(1 + MIN_SEED_LOOKAHEAD):
+            epoch = Epoch(current_epoch + e)
+            start_slot = compute_start_slot_at_epoch(epoch)
+            ptcs += [compute_ptc(state, Slot(start_slot + i)) for i in range(SLOTS_PER_EPOCH)]
+
+        return empty_previous_epoch + ptcs
     </spec>
 
 - name: initiate_builder_exit#gloas
@@ -6275,12 +6323,21 @@
 - name: is_valid_proposal_slot#gloas
   sources: []
   spec: |
-    <spec fn="is_valid_proposal_slot" fork="gloas" hash="55b8762f">
+    <spec fn="is_valid_proposal_slot" fork="gloas" hash="33b8f094">
     def is_valid_proposal_slot(state: BeaconState, preferences: ProposerPreferences) -> bool:
         """
-        Check if the validator is the proposer for the given slot in the next epoch.
+        Check if the validator is the proposer for the given slot in the current or
+        next epoch.
         """
-        index = SLOTS_PER_EPOCH + preferences.proposal_slot % SLOTS_PER_EPOCH
+        current_epoch = get_current_epoch(state)
+        proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)
+        if proposal_epoch < current_epoch:
+            return False
+        if proposal_epoch > current_epoch + Epoch(1):
+            return False
+
+        index = (proposal_epoch - current_epoch) * SLOTS_PER_EPOCH
+        index += preferences.proposal_slot % SLOTS_PER_EPOCH
         return state.proposer_lookahead[index] == preferences.validator_index
     </spec>
 
@@ -6931,7 +6988,7 @@
 - name: on_payload_attestation_message#gloas
   sources: []
   spec: |
-    <spec fn="on_payload_attestation_message" fork="gloas" hash="b5602237">
+    <spec fn="on_payload_attestation_message" fork="gloas" hash="fd6b84cb">
     def on_payload_attestation_message(
         store: Store, ptc_message: PayloadAttestationMessage, is_from_block: bool = False
     ) -> None:
@@ -6942,6 +6999,7 @@
         # The beacon block root must be known
         data = ptc_message.data
         # PTC attestation must be for a known block. If block is unknown, delay consideration until the block is found
+        assert data.beacon_block_root in store.block_states
         state = store.block_states[data.beacon_block_root]
         ptc = get_ptc(state, data.slot)
         # PTC votes can only change the vote for their assigned beacon block, return early otherwise
@@ -8139,7 +8197,7 @@
 - name: process_epoch#gloas
   sources: []
   spec: |
-    <spec fn="process_epoch" fork="gloas" hash="393b69ef">
+    <spec fn="process_epoch" fork="gloas" hash="bf3575a9">
     def process_epoch(state: BeaconState) -> None:
         process_justification_and_finalization(state)
         process_inactivity_updates(state)
@@ -8158,6 +8216,8 @@
         process_participation_flag_updates(state)
         process_sync_committee_updates(state)
         process_proposer_lookahead(state)
+        # [New in Gloas:EIP7732]
+        process_ptc_window(state)
     </spec>
 
 - name: process_eth1_data#phase0
@@ -9208,6 +9268,26 @@
             state.builder_pending_payments[payment_index] = BuilderPendingPayment()
 
         slash_validator(state, header_1.proposer_index)
+    </spec>
+
+- name: process_ptc_window#gloas
+  sources:
+    - file: packages/state-transition/src/util/gloas.ts
+      search: export function processPtcWindow(
+  spec: |
+    <spec fn="process_ptc_window" fork="gloas" hash="7be3d509">
+    def process_ptc_window(state: BeaconState) -> None:
+        """
+        Update the cached PTC window.
+        """
+        # Shift all epochs forward by one
+        state.ptc_window[: len(state.ptc_window) - SLOTS_PER_EPOCH] = state.ptc_window[SLOTS_PER_EPOCH:]
+        # Fill in the last epoch
+        next_epoch = Epoch(get_current_epoch(state) + MIN_SEED_LOOKAHEAD + 1)
+        start_slot = compute_start_slot_at_epoch(next_epoch)
+        state.ptc_window[len(state.ptc_window) - SLOTS_PER_EPOCH :] = [
+            compute_ptc(state, Slot(slot)) for slot in range(start_slot, start_slot + SLOTS_PER_EPOCH)
+        ]
     </spec>
 
 - name: process_randao#phase0
@@ -11377,7 +11457,7 @@
     - file: packages/state-transition/src/slot/upgradeStateToGloas.ts
       search: export function upgradeStateToGloas(
   spec: |
-    <spec fn="upgrade_to_gloas" fork="gloas" hash="6e66df25">
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="8f67112c">
     def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         epoch = fulu.get_current_epoch(pre)
 
@@ -11444,6 +11524,8 @@
             latest_block_hash=pre.latest_execution_payload_header.block_hash,
             # [New in Gloas:EIP7732]
             payload_expected_withdrawals=[],
+            # [New in Gloas:EIP7732]
+            ptc_window=initialize_ptc_window(pre),
         )
 
         # [New in Gloas:EIP7732]
@@ -11455,7 +11537,7 @@
 - name: upgrade_to_heze#heze
   sources: []
   spec: |
-    <spec fn="upgrade_to_heze" fork="heze" hash="0ace9d48">
+    <spec fn="upgrade_to_heze" fork="heze" hash="57cf94bf">
     def upgrade_to_heze(pre: gloas.BeaconState) -> BeaconState:
         epoch = gloas.get_current_epoch(pre)
         latest_execution_payload_bid = ExecutionPayloadBid(
@@ -11526,6 +11608,7 @@
             builder_pending_withdrawals=pre.builder_pending_withdrawals,
             latest_block_hash=pre.latest_block_hash,
             payload_expected_withdrawals=pre.payload_expected_withdrawals,
+            ptc_window=pre.ptc_window,
         )
 
         return post

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -9277,7 +9277,7 @@
 
 - name: process_ptc_window#gloas
   sources:
-    - file: packages/state-transition/epoch/processPtcWindow.ts
+    - file: packages/state-transition/src/epoch/processPtcWindow.ts
       search: export function processPtcWindow(
   spec: |
     <spec fn="process_ptc_window" fork="gloas" hash="7be3d509">

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -9277,7 +9277,7 @@
 
 - name: process_ptc_window#gloas
   sources:
-    - file: packages/state-transition/src/util/gloas.ts
+    - file: packages/state-transition/epoch/processPtcWindow.ts
       search: export function processPtcWindow(
   spec: |
     <spec fn="process_ptc_window" fork="gloas" hash="7be3d509">


### PR DESCRIPTION
This implements minimal changes to pass `alpha.4` spec tests
- adds `ptc_window` to state based on [#4979](https://github.com/ethereum/consensus-specs/pull/4979)
- bump spec to `v1.7.0-alpha.4`
- update ethspecify
- misc changes to pass spec tests

**NOTE:** this does not implement any other changes from alpha.4 besides https://github.com/ethereum/consensus-specs/pull/4979