### PR TITLE
feat: ignore index-1 attestation when payload is missing

### DIFF
--- a/packages/beacon-node/src/chain/errors/attestationError.ts
+++ b/packages/beacon-node/src/chain/errors/attestationError.ts
@@ -190,7 +190,7 @@ export type AttestationErrorType =
   | {code: AttestationErrorCode.ATTESTER_NOT_IN_COMMITTEE}
   | {code: AttestationErrorCode.INVALID_PAYLOAD_STATUS_VALUE; attDataIndex: number}
   | {code: AttestationErrorCode.PREMATURELY_INDICATED_PAYLOAD_PRESENT}
-  | {code: AttestationErrorCode.EXECUTION_PAYLOAD_NOT_SEEN};
+  | {code: AttestationErrorCode.EXECUTION_PAYLOAD_NOT_SEEN; beaconBlockRoot: RootHex};
 
 export class AttestationError extends GossipActionError<AttestationErrorType> {
   getMetadata(): Record<string, string | number | null> {

--- a/packages/beacon-node/src/chain/errors/attestationError.ts
+++ b/packages/beacon-node/src/chain/errors/attestationError.ts
@@ -147,6 +147,10 @@ export enum AttestationErrorCode {
    * Gloas: Current slot attestation is marking payload as present
    */
   PREMATURELY_INDICATED_PAYLOAD_PRESENT = "ATTESTATION_ERROR_PREMATURELY_INDICATED_PAYLOAD_PRESENT",
+  /**
+   * Gloas: index-1 attestation but the execution payload has not been seen yet
+   */
+  EXECUTION_PAYLOAD_NOT_SEEN = "ATTESTATION_ERROR_EXECUTION_PAYLOAD_NOT_SEEN",
 }
 
 export type AttestationErrorType =
@@ -185,7 +189,8 @@ export type AttestationErrorType =
   | {code: AttestationErrorCode.NON_ZERO_ATTESTATION_DATA_INDEX}
   | {code: AttestationErrorCode.ATTESTER_NOT_IN_COMMITTEE}
   | {code: AttestationErrorCode.INVALID_PAYLOAD_STATUS_VALUE; attDataIndex: number}
-  | {code: AttestationErrorCode.PREMATURELY_INDICATED_PAYLOAD_PRESENT};
+  | {code: AttestationErrorCode.PREMATURELY_INDICATED_PAYLOAD_PRESENT}
+  | {code: AttestationErrorCode.EXECUTION_PAYLOAD_NOT_SEEN};
 
 export class AttestationError extends GossipActionError<AttestationErrorType> {
   getMetadata(): Record<string, string | number | null> {

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -90,11 +90,12 @@ async function validateAggregateAndProof(
       });
     }
 
+    // [REJECT] If `aggregate.data.index == 1` (payload present for a past
+    //   block), the execution payload for `block` passes validation.
     // [IGNORE] When `aggregate.data.index == 1` (payload present for a past block),
     // the corresponding execution payload for `block` has been seen (a client MAY queue
     // attestations for processing once the payload is retrieved and SHOULD request the
     // payload envelope via `ExecutionPayloadEnvelopesByRoot`).
-    // Only check when block is known; unknown blocks are handled by `verifyHeadBlockAndTargetRoot`
     if (block !== null && attData.index === 1 && !chain.seenPayloadEnvelope(toRootHex(attData.beaconBlockRoot))) {
       throw new AttestationError(GossipAction.IGNORE, {
         code: AttestationErrorCode.EXECUTION_PAYLOAD_NOT_SEEN,

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -99,6 +99,7 @@ async function validateAggregateAndProof(
     if (block !== null && attData.index === 1 && !chain.seenPayloadEnvelope(toRootHex(attData.beaconBlockRoot))) {
       throw new AttestationError(GossipAction.IGNORE, {
         code: AttestationErrorCode.EXECUTION_PAYLOAD_NOT_SEEN,
+        beaconBlockRoot: toRootHex(attData.beaconBlockRoot),
       });
     }
 

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -90,6 +90,16 @@ async function validateAggregateAndProof(
       });
     }
 
+    // [IGNORE] When `aggregate.data.index == 1` (payload present for a past block),
+    // the corresponding execution payload for `block` has been seen (a client MAY queue
+    // attestations for processing once the payload is retrieved and SHOULD request the
+    // payload envelope via `ExecutionPayloadEnvelopesByRoot`).
+    if (attData.index === 1 && !chain.forkChoice.hasPayloadUnsafe(attData.beaconBlockRoot)) {
+      throw new AttestationError(GossipAction.IGNORE, {
+        code: AttestationErrorCode.EXECUTION_PAYLOAD_NOT_SEEN,
+      });
+    }
+
     // [REJECT] len(committee_indices) == 1, where committee_indices = get_committee_indices(aggregate)
     committeeIndex = (aggregate as electra.Attestation).committeeBits.getSingleTrueBit();
     if (committeeIndex === null) {

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -94,7 +94,8 @@ async function validateAggregateAndProof(
     // the corresponding execution payload for `block` has been seen (a client MAY queue
     // attestations for processing once the payload is retrieved and SHOULD request the
     // payload envelope via `ExecutionPayloadEnvelopesByRoot`).
-    if (attData.index === 1 && !chain.forkChoice.hasPayloadUnsafe(attData.beaconBlockRoot)) {
+    // Only check when block is known; unknown blocks are handled by `verifyHeadBlockAndTargetRoot`
+    if (block !== null && attData.index === 1 && !chain.seenPayloadEnvelope(toRootHex(attData.beaconBlockRoot))) {
       throw new AttestationError(GossipAction.IGNORE, {
         code: AttestationErrorCode.EXECUTION_PAYLOAD_NOT_SEEN,
       });

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -325,6 +325,7 @@ async function validateAttestationNoSignatureCheck(
         if (block !== null && attData.index === 1 && !chain.seenPayloadEnvelope(toRootHex(attData.beaconBlockRoot))) {
           throw new AttestationError(GossipAction.IGNORE, {
             code: AttestationErrorCode.EXECUTION_PAYLOAD_NOT_SEEN,
+            beaconBlockRoot: toRootHex(attData.beaconBlockRoot),
           });
         }
       } else {

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -320,7 +320,8 @@ async function validateAttestationNoSignatureCheck(
         // the corresponding execution payload for `block` has been seen (a client MAY queue
         // attestations for processing once the payload is retrieved and SHOULD request the
         // payload envelope via `ExecutionPayloadEnvelopesByRoot`).
-        if (attData.index === 1 && !chain.forkChoice.hasPayloadUnsafe(attData.beaconBlockRoot)) {
+        // Only check when block is known; unknown blocks are handled by `verifyHeadBlockAndTargetRoot`
+        if (block !== null && attData.index === 1 && !chain.seenPayloadEnvelope(toRootHex(attData.beaconBlockRoot))) {
           throw new AttestationError(GossipAction.IGNORE, {
             code: AttestationErrorCode.EXECUTION_PAYLOAD_NOT_SEEN,
           });

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -316,6 +316,8 @@ async function validateAttestationNoSignatureCheck(
           });
         }
 
+        // [REJECT] If `attestation.data.index == 1` (payload present for a past
+        //   block), the execution payload for `block` passes validation.
         // [IGNORE] When `attestation.data.index == 1` (payload present for a past block),
         // the corresponding execution payload for `block` has been seen (a client MAY queue
         // attestations for processing once the payload is retrieved and SHOULD request the

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -322,7 +322,6 @@ async function validateAttestationNoSignatureCheck(
         // the corresponding execution payload for `block` has been seen (a client MAY queue
         // attestations for processing once the payload is retrieved and SHOULD request the
         // payload envelope via `ExecutionPayloadEnvelopesByRoot`).
-        // Only check when block is known; unknown blocks are handled by `verifyHeadBlockAndTargetRoot`
         if (block !== null && attData.index === 1 && !chain.seenPayloadEnvelope(toRootHex(attData.beaconBlockRoot))) {
           throw new AttestationError(GossipAction.IGNORE, {
             code: AttestationErrorCode.EXECUTION_PAYLOAD_NOT_SEEN,

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -315,6 +315,16 @@ async function validateAttestationNoSignatureCheck(
             code: AttestationErrorCode.PREMATURELY_INDICATED_PAYLOAD_PRESENT,
           });
         }
+
+        // [IGNORE] When `attestation.data.index == 1` (payload present for a past block),
+        // the corresponding execution payload for `block` has been seen (a client MAY queue
+        // attestations for processing once the payload is retrieved and SHOULD request the
+        // payload envelope via `ExecutionPayloadEnvelopesByRoot`).
+        if (attData.index === 1 && !chain.forkChoice.hasPayloadUnsafe(attData.beaconBlockRoot)) {
+          throw new AttestationError(GossipAction.IGNORE, {
+            code: AttestationErrorCode.EXECUTION_PAYLOAD_NOT_SEEN,
+          });
+        }
       } else {
         // [REJECT] attestation.data.index == 0
         if (attData.index !== 0) {

--- a/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
@@ -32,7 +32,7 @@ async function validateExecutionPayloadEnvelope(
   const {payload} = envelope;
   const blockRootHex = toRootHex(envelope.beaconBlockRoot);
 
-  // [IGNORE] The envelope's block root `envelope.block_root` has been seen (via
+  // [IGNORE] The envelope's block root `envelope.beacon_block_root` has been seen (via
   // gossip or non-gossip sources) (a client MAY queue payload for processing once
   // the block is retrieved).
   // TODO GLOAS: Need to review this, we should queue the envelope for later


### PR DESCRIPTION
- **ethereum/consensus-specs#4939**: Add IGNORE check for index-1 attestations (`beacon_attestation` and `beacon_aggregate_and_proof`) when the execution payload has not been seen. The REJECT check (payload passes validation) is inherently satisfied since FULL variants in fork choice can only have Valid or Syncing execution status. The network-layer plumbing (requesting missing envelopes via `ExecutionPayloadEnvelopesByRoot`, queuing messages) was already in place.

