### PR TITLE
refactor: revert dual-state cache architecture from ePBS

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -48,7 +48,7 @@ import type {BeaconChain} from "../chain.js";
 import {ChainEvent, ReorgEventData} from "../emitter.js";
 import {ForkchoiceCaller} from "../forkChoice/index.js";
 import {REPROCESS_MIN_TIME_TO_NEXT_SLOT_SEC} from "../reprocess.js";
-import {toCheckpointHexPayload} from "../stateCache/persistentCheckpointsCache.js";
+import {toCheckpointHex} from "../stateCache/persistentCheckpointsCache.js";
 import {isBlockInputBlobs, isBlockInputColumns} from "./blockInput/blockInput.js";
 import {AttestationImportOpt, FullyVerifiedBlock, ImportBlockOpts} from "./types.js";
 import {getCheckpointFromState} from "./utils/checkpoint.js";
@@ -519,7 +519,7 @@ export async function importBlock(
     this.emitter.emit(ChainEvent.checkpoint, cp, checkpointState);
 
     // Note: in-lined code from previos handler of ChainEvent.checkpoint
-    this.logger.verbose("Checkpoint processed", toCheckpointHexPayload(cp, payloadPresent));
+    this.logger.verbose("Checkpoint processed", toCheckpointHex(cp));
 
     const activeValidatorsCount = checkpointState.activeValidatorCount;
     this.metrics?.currentActiveValidators.set(activeValidatorsCount);
@@ -537,7 +537,7 @@ export async function importBlock(
       const justifiedEpoch = justifiedCheckpoint.epoch;
       const preJustifiedEpoch = parentBlockSummary.justifiedEpoch;
       if (justifiedEpoch > preJustifiedEpoch) {
-        this.logger.verbose("Checkpoint justified", toCheckpointHexPayload(justifiedCheckpoint, payloadPresent));
+        this.logger.verbose("Checkpoint justified", toCheckpointHex(justifiedCheckpoint));
         this.metrics?.previousJustifiedEpoch.set(checkpointState.previousJustifiedCheckpoint.epoch);
         this.metrics?.currentJustifiedEpoch.set(justifiedCheckpoint.epoch);
       }
@@ -551,7 +551,7 @@ export async function importBlock(
           state: toRootHex(checkpointState.hashTreeRoot()),
           executionOptimistic: false,
         });
-        this.logger.verbose("Checkpoint finalized", toCheckpointHexPayload(finalizedCheckpoint, payloadPresent));
+        this.logger.verbose("Checkpoint finalized", toCheckpointHex(finalizedCheckpoint));
         this.metrics?.finalizedEpoch.set(finalizedCheckpoint.epoch);
       }
     }

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -2,14 +2,7 @@ import path from "node:path";
 import {PrivateKey} from "@libp2p/interface";
 import {Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {
-  CheckpointWithPayloadStatus,
-  IForkChoice,
-  PayloadStatus,
-  ProtoBlock,
-  UpdateHeadOpt,
-  getCheckpointPayloadStatus,
-} from "@lodestar/fork-choice";
+import {CheckpointWithPayloadStatus, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
 import {LoggerNode} from "@lodestar/logger/node";
 import {
   BUILDER_INDEX_SELF_BUILD,
@@ -390,8 +383,7 @@ export class BeaconChain implements IBeaconChain {
     const {checkpoint} = anchorState.computeAnchorCheckpoint();
     blockStateCache.add(anchorState);
     blockStateCache.setHeadState(anchorState);
-    const payloadPresent = getCheckpointPayloadStatus(config, anchorState, checkpoint.epoch) === PayloadStatus.FULL;
-    checkpointStateCache.add(checkpoint, anchorState, payloadPresent);
+    checkpointStateCache.add(checkpoint, anchorState);
 
     const forkChoice = initializeForkChoice(
       config,
@@ -685,7 +677,7 @@ export class BeaconChain implements IBeaconChain {
 
     // TODO GLOAS: Need to revisit the design of this api. Currently we just retrieve FULL state of the checkpoint for backwards compatibility.
     // because pre-gloas we always store FULL checkpoint state.
-    const persistedKey = checkpointToDatastoreKey(checkpoint, true);
+    const persistedKey = checkpointToDatastoreKey(checkpoint);
     return this.cpStateDatastore.read(persistedKey);
   }
 
@@ -1470,10 +1462,6 @@ export class BeaconChain implements IBeaconChain {
 
   private onClockEpoch(epoch: Epoch): void {
     this.metrics?.clockEpoch.set(epoch);
-
-    if (epoch === this.config.GLOAS_FORK_EPOCH) {
-      this.regen.upgradeForGloas(epoch);
-    }
 
     this.seenAttesters.prune(epoch);
     this.seenAggregators.prune(epoch);

--- a/packages/beacon-node/src/chain/regen/interface.ts
+++ b/packages/beacon-node/src/chain/regen/interface.ts
@@ -54,7 +54,6 @@ export interface IStateRegenerator extends IStateRegeneratorInternal {
   addCheckpointState(cp: phase0.Checkpoint, item: IBeaconStateView, payloadPresent: boolean): void;
   updateHeadState(newHead: ProtoBlock, maybeHeadState: IBeaconStateView): void;
   updatePreComputedCheckpoint(rootHex: RootHex, epoch: Epoch, payloadPresent: boolean): number | null;
-  upgradeForGloas(epoch: Epoch): void;
 }
 
 /**

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -1,8 +1,8 @@
 import {routes} from "@lodestar/api";
-import {IForkChoice, PayloadStatus, ProtoBlock} from "@lodestar/fork-choice";
+import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {IBeaconStateView, computeEpochAtSlot} from "@lodestar/state-transition";
 import {BeaconBlock, Epoch, RootHex, Slot, isGloasBeaconBlock, phase0} from "@lodestar/types";
-import {Logger, fromHex, toRootHex} from "@lodestar/utils";
+import {Logger, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
 import {JobItemQueue} from "../../util/queue/index.js";
 import {BlockStateCache, CheckpointHexPayload, CheckpointStateCache} from "../stateCache/types.js";
@@ -104,19 +104,9 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     const parentEpoch = computeEpochAtSlot(parentBlock.slot);
     const blockEpoch = computeEpochAtSlot(block.slot);
 
-    // Convert PayloadStatus to payloadPresent boolean
-    if (parentBlock.payloadStatus === PayloadStatus.PENDING) {
-      throw new RegenError({
-        code: RegenErrorCode.UNEXPECTED_PAYLOAD_STATUS,
-        blockRoot: block.parentRoot,
-        payloadStatus: parentBlock.payloadStatus,
-      });
-    }
-    const payloadPresent = parentBlock.payloadStatus === PayloadStatus.FULL;
-
     // Check the checkpoint cache (if the pre-state is a checkpoint state)
     if (parentEpoch < blockEpoch) {
-      const checkpointState = this.checkpointStateCache.getLatest(parentRoot, blockEpoch, payloadPresent);
+      const checkpointState = this.checkpointStateCache.getLatest(parentRoot, blockEpoch);
       if (checkpointState && computeEpochAtSlot(checkpointState.slot) === blockEpoch) {
         return checkpointState;
       }
@@ -150,19 +140,7 @@ export class QueuedStateRegenerator implements IStateRegenerator {
    * Get state closest to head
    */
   getClosestHeadState(head: ProtoBlock): IBeaconStateView | null {
-    // Convert PayloadStatus to payloadPresent boolean
-    if (head.payloadStatus === PayloadStatus.PENDING) {
-      throw new RegenError({
-        code: RegenErrorCode.UNEXPECTED_PAYLOAD_STATUS,
-        blockRoot: fromHex(head.blockRoot),
-        payloadStatus: head.payloadStatus,
-      });
-    }
-    const payloadPresent = head.payloadStatus === PayloadStatus.FULL;
-    return (
-      this.checkpointStateCache.getLatest(head.blockRoot, Infinity, payloadPresent) ||
-      this.blockStateCache.get(head.stateRoot)
-    );
+    return this.checkpointStateCache.getLatest(head.blockRoot, Infinity) || this.blockStateCache.get(head.stateRoot);
   }
 
   pruneOnCheckpoint(finalizedEpoch: Epoch, justifiedEpoch: Epoch, headStateRoot: RootHex): void {
@@ -190,9 +168,8 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     this.blockStateCache.add(payloadState);
   }
 
-  // TODO GLOAS: This should also be called when importing execution payload after we implement it
-  addCheckpointState(cp: phase0.Checkpoint, item: IBeaconStateView, payloadPresent: boolean): void {
-    this.checkpointStateCache.add(cp, item, payloadPresent);
+  addCheckpointState(cp: phase0.Checkpoint, item: IBeaconStateView, _payloadPresent: boolean): void {
+    this.checkpointStateCache.add(cp, item);
   }
 
   updateHeadState(newHead: ProtoBlock, maybeHeadState: IBeaconStateView): void {
@@ -228,13 +205,8 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     }
   }
 
-  updatePreComputedCheckpoint(rootHex: RootHex, epoch: Epoch, payloadPresent: boolean): number | null {
-    return this.checkpointStateCache.updatePreComputedCheckpoint(rootHex, epoch, payloadPresent);
-  }
-
-  upgradeForGloas(epoch: Epoch): void {
-    this.logger.verbose("Upgrading block state cache for Gloas fork", {epoch});
-    this.blockStateCache.upgradeToGloas();
+  updatePreComputedCheckpoint(rootHex: RootHex, epoch: Epoch, _payloadPresent: boolean): number | null {
+    return this.checkpointStateCache.updatePreComputedCheckpoint(rootHex, epoch);
   }
 
   /**

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -1,6 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {IForkChoice, PayloadStatus, ProtoBlock} from "@lodestar/fork-choice";
-import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
@@ -110,19 +110,9 @@ export class StateRegenerator implements IStateRegeneratorInternal {
     const {checkpointStateCache} = this.modules;
     const epoch = computeEpochAtSlot(slot);
 
-    // Convert PayloadStatus to payloadPresent boolean
-    if (block.payloadStatus === PayloadStatus.PENDING) {
-      throw new RegenError({
-        code: RegenErrorCode.UNEXPECTED_PAYLOAD_STATUS,
-        blockRoot: fromHex(blockRoot),
-        payloadStatus: block.payloadStatus,
-      });
-    }
-    const payloadPresent = block.payloadStatus === PayloadStatus.FULL;
-
     const latestCheckpointStateCtx = allowDiskReload
-      ? await checkpointStateCache.getOrReloadLatest(blockRoot, epoch, payloadPresent)
-      : checkpointStateCache.getLatest(blockRoot, epoch, payloadPresent);
+      ? await checkpointStateCache.getOrReloadLatest(blockRoot, epoch)
+      : checkpointStateCache.getLatest(blockRoot, epoch);
 
     // If a checkpoint state exists with the given checkpoint root, it either is in requested epoch
     // or needs to have empty slots processed until the requested epoch
@@ -176,18 +166,9 @@ export class StateRegenerator implements IStateRegeneratorInternal {
       if (!lastBlockToReplay) continue;
       const epoch = computeEpochAtSlot(lastBlockToReplay.slot - 1);
 
-      // Convert PayloadStatus to payloadPresent boolean
-      if (b.payloadStatus === PayloadStatus.PENDING) {
-        throw new RegenError({
-          code: RegenErrorCode.INTERNAL_ERROR,
-          message: `Unexpected PENDING payloadStatus for ancestor block ${b.blockRoot} at slot ${b.slot}`,
-        });
-      }
-      const payloadPresent = b.payloadStatus === PayloadStatus.FULL;
-
       state = allowDiskReload
-        ? await checkpointStateCache.getOrReloadLatest(b.blockRoot, epoch, payloadPresent)
-        : checkpointStateCache.getLatest(b.blockRoot, epoch, payloadPresent);
+        ? await checkpointStateCache.getOrReloadLatest(b.blockRoot, epoch)
+        : checkpointStateCache.getLatest(b.blockRoot, epoch);
       if (state) {
         break;
       }
@@ -375,7 +356,7 @@ export async function processSlotsToNearestCheckpoint(
   const postSlot = slot;
   const preEpoch = computeEpochAtSlot(preSlot);
   let postState = preState;
-  const {config, checkpointStateCache, emitter, metrics, logger} = modules;
+  const {checkpointStateCache, emitter, metrics, logger} = modules;
   let count = 0;
 
   for (
@@ -402,8 +383,7 @@ export async function processSlotsToNearestCheckpoint(
     // processSlots() only does epoch transitions, never processes payloads
     // Pre-Gloas: payloadPresent is always true (execution payload embedded in block)
     // Post-Gloas: result is a block state (payloadPresent=false)
-    const isPayloadPresent = config.getForkSeq(checkpointState.slot) < ForkSeq.gloas;
-    checkpointStateCache.add(cp, checkpointState, isPayloadPresent);
+    checkpointStateCache.add(cp, checkpointState);
     // consumers should not mutate state ever
     emitter?.emit(ChainEvent.checkpoint, cp, checkpointState);
 

--- a/packages/beacon-node/src/chain/stateCache/datastore/db.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/db.ts
@@ -1,6 +1,6 @@
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Epoch, phase0, ssz} from "@lodestar/types";
-import {MapDef, byteArrayEquals} from "@lodestar/utils";
+import {MapDef} from "@lodestar/utils";
 import {IBeaconDb} from "../../../db/interface.js";
 import {
   getLastProcessedSlotFromBeaconStateSerialized,
@@ -14,8 +14,8 @@ import {CPStateDatastore, DatastoreKey} from "./types.js";
 export class DbCPStateDatastore implements CPStateDatastore {
   constructor(private readonly db: IBeaconDb) {}
 
-  async write(cpKey: phase0.Checkpoint, stateBytes: Uint8Array, payloadPresent: boolean): Promise<DatastoreKey> {
-    const serializedCheckpoint = checkpointToDatastoreKey(cpKey, payloadPresent);
+  async write(cpKey: phase0.Checkpoint, stateBytes: Uint8Array): Promise<DatastoreKey> {
+    const serializedCheckpoint = checkpointToDatastoreKey(cpKey);
     await this.db.checkpointState.putBinary(serializedCheckpoint, stateBytes);
     return serializedCheckpoint;
   }
@@ -40,30 +40,18 @@ export class DbCPStateDatastore implements CPStateDatastore {
   }
 }
 
-function extractCheckpointBytes(key: DatastoreKey): Uint8Array {
-  const fixedSize = ssz.phase0.Checkpoint.minSize;
-  return key.subarray(0, fixedSize);
-}
-
 export function datastoreKeyToCheckpoint(key: DatastoreKey): phase0.Checkpoint {
-  return ssz.phase0.Checkpoint.deserialize(extractCheckpointBytes(key));
+  return ssz.phase0.Checkpoint.deserialize(key);
 }
 
-export function checkpointToDatastoreKey(cp: phase0.Checkpoint, payloadPresent: boolean): DatastoreKey {
-  const cpBytes = ssz.phase0.Checkpoint.serialize(cp);
-  const key = new Uint8Array(cpBytes.length + 1);
-  key.set(cpBytes);
-  key[cpBytes.length] = payloadPresent ? 1 : 0;
-  return key;
-}
-
-function isPayloadCheckpointState(key: DatastoreKey): boolean {
-  return key.at(-1) === 1;
+export function checkpointToDatastoreKey(cp: phase0.Checkpoint): DatastoreKey {
+  return ssz.phase0.Checkpoint.serialize(cp);
 }
 
 /**
- * Get the latest "safe" checkpoint state the node can use to boot from
- *   - its last processed block slot should be at epoch boundary (CRCS) or last slot of previous epoch (PRCS)
+ * Get the latest safe checkpoint state the node can use to boot from
+ *   - it should be the checkpoint state that's unique in its epoch
+ *   - its last processed block slot should be at epoch boundary or last slot of previous epoch
  *   - state slot should be at epoch boundary
  *   - state slot should be equal to epoch * SLOTS_PER_EPOCH
  *
@@ -82,20 +70,9 @@ export async function getLatestSafeDatastoreKey(
 
   const dataStoreKeyByEpoch: Map<Epoch, DatastoreKey> = new Map();
   for (const [epoch, keys] of checkpointsByEpoch.entries()) {
+    // only consider epochs with a single checkpoint to avoid ambiguity from forks
     if (keys.length === 1) {
-      // PRCS (skipped slot) or CRCS and no payloadPresent
-      // Pre-gloas always fall into this case
       dataStoreKeyByEpoch.set(epoch, keys[0]);
-    } else if (keys.length === 2) {
-      // CRCS without payload and CRCS with payload
-      // ie Two keys for the same checkpoint with different payloadPresent suffix (FULL/EMPTY)
-      // TODO GLOAS: Here we pick FULL key, there is a chance that payload is orphaned hence we not be able to sync
-      const cp0 = extractCheckpointBytes(keys[0]);
-      const cp1 = extractCheckpointBytes(keys[1]);
-      if (byteArrayEquals(cp0, cp1)) {
-        const fullKey = isPayloadCheckpointState(keys[0]) ? keys[0] : keys[1];
-        dataStoreKeyByEpoch.set(epoch, fullKey);
-      }
     }
   }
 

--- a/packages/beacon-node/src/chain/stateCache/datastore/file.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/file.ts
@@ -1,13 +1,12 @@
 import path from "node:path";
-import {phase0} from "@lodestar/types";
+import {phase0, ssz} from "@lodestar/types";
 import {fromHex, toHex} from "@lodestar/utils";
 import {ensureDir, readFile, readFileNames, removeFile, writeIfNotExist} from "../../../util/file.js";
-import {checkpointToDatastoreKey, getLatestSafeDatastoreKey} from "./db.js";
+import {getLatestSafeDatastoreKey} from "./db.js";
 import {CPStateDatastore, DatastoreKey} from "./types.js";
 
 const CHECKPOINT_STATES_FOLDER = "checkpoint_states";
-/** 41 bytes (40 checkpoint + 1 payloadPresent) = 82 hex chars + "0x" prefix = 84 */
-const CHECKPOINT_FILE_NAME_LENGTH = 84;
+const CHECKPOINT_FILE_NAME_LENGTH = 82;
 
 /**
  * Implementation of CPStateDatastore using file system, this is beneficial for debugging.
@@ -29,8 +28,8 @@ export class FileCPStateDatastore implements CPStateDatastore {
     }
   }
 
-  async write(cpKey: phase0.Checkpoint, stateBytes: Uint8Array, payloadPresent: boolean): Promise<DatastoreKey> {
-    const serializedCheckpoint = checkpointToDatastoreKey(cpKey, payloadPresent);
+  async write(cpKey: phase0.Checkpoint, stateBytes: Uint8Array): Promise<DatastoreKey> {
+    const serializedCheckpoint = ssz.phase0.Checkpoint.serialize(cpKey);
     const filePath = path.join(this.folderPath, toHex(serializedCheckpoint));
     await writeIfNotExist(filePath, stateBytes);
     return serializedCheckpoint;

--- a/packages/beacon-node/src/chain/stateCache/datastore/types.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/types.ts
@@ -1,12 +1,11 @@
 import {phase0} from "@lodestar/types";
 
-// With db implementation, persistedKey is serialized data of a checkpoint + 1
-// ie a fixed size of `ssz.phase0.Checkpoint.minSize + 1`
+// With db implementation, persistedKey is serialized data of a checkpoint
 export type DatastoreKey = Uint8Array;
 
 // Make this generic to support testing
 export interface CPStateDatastore {
-  write: (cpKey: phase0.Checkpoint, stateBytes: Uint8Array, payloadPresent: boolean) => Promise<DatastoreKey>;
+  write: (cpKey: phase0.Checkpoint, stateBytes: Uint8Array) => Promise<DatastoreKey>;
   remove: (key: DatastoreKey) => Promise<void>;
   read: (key: DatastoreKey) => Promise<Uint8Array | null>;
   readLatestSafe: () => Promise<Uint8Array | null>;

--- a/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
@@ -20,11 +20,6 @@ export type FIFOBlockStateCacheOpts = {
  *                                                                                             clock slot
  */
 export const DEFAULT_MAX_BLOCK_STATES = 64;
-/**
- * For Gloas (ePBS), each block can have two states: block state and payload state.
- * Double the cache size to maintain the same effective block depth.
- */
-export const DEFAULT_MAX_BLOCK_STATES_GLOAS = 128;
 
 /**
  * New implementation of BlockStateCache that keeps the most recent n states consistently
@@ -46,7 +41,7 @@ export const DEFAULT_MAX_BLOCK_STATES_GLOAS = 128;
  * The maintained key order would be: 11 -> 13 -> 12 -> 10, and state 10 will be pruned first.
  */
 export class FIFOBlockStateCache implements BlockStateCache {
-  private maxStates: number;
+  readonly maxStates: number;
 
   private readonly cache: MapTracker<string, IBeaconStateView>;
   /**
@@ -170,10 +165,6 @@ export class FIFOBlockStateCache implements BlockStateCache {
       this.keyOrder.pop();
       this.cache.delete(key);
     }
-  }
-
-  upgradeToGloas(): void {
-    this.maxStates = DEFAULT_MAX_BLOCK_STATES_GLOAS;
   }
 
   /**

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -744,7 +744,13 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
           } else {
             // delete the state from memory
             this.cache.delete(cpKey);
-            this.epochIndex.get(epoch)?.delete(rootHex);
+            const rootSet = this.epochIndex.get(epoch);
+            if (rootSet) {
+              rootSet.delete(rootHex);
+              if (rootSet.size === 0) {
+                this.epochIndex.delete(epoch);
+              }
+            }
           }
           this.metrics?.cpStateCache.statePruneFromMemoryCount.inc();
           this.logger.verbose("Pruned checkpoint state from memory", logMeta);

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -1,6 +1,5 @@
 import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
-import {CheckpointWithPayloadStatus} from "@lodestar/fork-choice";
 import {IBeaconStateView, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, RootHex, phase0} from "@lodestar/types";
 import {Logger, MapDef, fromHex, sleep, toHex, toRootHex} from "@lodestar/utils";
@@ -10,7 +9,7 @@ import {IClock} from "../../util/clock.js";
 import {serializeState} from "../serializeState.js";
 import {CPStateDatastore, DatastoreKey} from "./datastore/index.js";
 import {MapTracker} from "./mapMetrics.js";
-import {BlockStateCache, CacheItemType, CheckpointHexPayload, CheckpointStateCache} from "./types.js";
+import {BlockStateCache, CacheItemType, CheckpointHex, CheckpointHexPayload, CheckpointStateCache} from "./types.js";
 
 export type PersistentCheckpointStateCacheOpts = {
   /** Keep max n state epochs in memory, persist the rest to disk */
@@ -49,22 +48,6 @@ type PersistedCacheItem = {
 type CacheItem = InMemoryCacheItem | PersistedCacheItem;
 
 type LoadedStateBytesData = {persistedKey: DatastoreKey; stateBytes: Uint8Array};
-
-/** Bitmask for tracking which payload variants exist per root in the epochIndex */
-enum PayloadAvailability {
-  NOT_PRESENT = 1,
-  PRESENT = 2,
-}
-
-const PAYLOAD_AVAILABILITY_ALL = [PayloadAvailability.NOT_PRESENT, PayloadAvailability.PRESENT] as const;
-
-function toPayloadAvailability(payloadPresent: boolean): PayloadAvailability {
-  return payloadPresent ? PayloadAvailability.PRESENT : PayloadAvailability.NOT_PRESENT;
-}
-
-function fromPayloadAvailability(flag: PayloadAvailability): boolean {
-  return flag === PayloadAvailability.PRESENT;
-}
 
 /**
  * Before n-historical states, lodestar keeps all checkpoint states since finalized
@@ -118,8 +101,8 @@ const PROCESS_CHECKPOINT_STATES_BPS = 6667;
  */
 export class PersistentCheckpointStateCache implements CheckpointStateCache {
   private readonly cache: MapTracker<CacheKey, CacheItem>;
-  /** Epoch -> Map<blockRoot, PayloadAvailability bitmask> */
-  private readonly epochIndex = new MapDef<Epoch, Map<RootHex, number>>(() => new Map());
+  /** Epoch -> Set<blockRoot> */
+  private readonly epochIndex = new MapDef<Epoch, Set<RootHex>>(() => new Set<string>());
   private readonly config: BeaconConfig;
   private readonly metrics: Metrics | null | undefined;
   private readonly logger: Logger;
@@ -215,18 +198,13 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    * - Get block for processing
    * - Regen head state
    */
-  async getOrReload(cp: CheckpointHexPayload): Promise<IBeaconStateView | null> {
+  async getOrReload(cp: CheckpointHex): Promise<IBeaconStateView | null> {
     const stateOrStateBytesData = await this.getStateOrLoadDb(cp);
     if (stateOrStateBytesData === null || isBeaconStateView(stateOrStateBytesData)) {
       return stateOrStateBytesData ?? null;
     }
     const {persistedKey, stateBytes} = stateOrStateBytesData;
-    const logMeta = {
-      epoch: cp.epoch,
-      rootHex: cp.rootHex,
-      payloadPresent: cp.payloadPresent,
-      persistedKey: toHex(persistedKey),
-    };
+    const logMeta = {persistedKey: toHex(persistedKey)};
     this.logger.debug("Reload: read state successful", logMeta);
     this.metrics?.cpStateCache.stateReloadSecFromSlot.observe(
       this.clock?.secFromSlot(this.clock?.currentSlot ?? 0) ?? 0
@@ -264,7 +242,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       // only remove persisted state once we reload successfully
       const cpKey = toCacheKey(cp);
       this.cache.set(cpKey, {type: CacheItemType.inMemory, state: newCachedState, persistedKey});
-      this.addToEpochIndex(cp.epoch, cp.rootHex, cp.payloadPresent);
+      this.epochIndex.getOrDefault(cp.epoch).add(cp.rootHex);
       // don't prune from memory here, call it at the last 1/3 of slot 0 of an epoch
       return newCachedState;
     } catch (e) {
@@ -276,7 +254,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   /**
    * Return either state or state bytes loaded from db.
    */
-  async getStateOrBytes(cp: CheckpointHexPayload): Promise<IBeaconStateView | Uint8Array | null> {
+  async getStateOrBytes(cp: CheckpointHex): Promise<IBeaconStateView | Uint8Array | null> {
     const stateOrLoadedState = await this.getStateOrLoadDb(cp);
     if (stateOrLoadedState === null || isBeaconStateView(stateOrLoadedState)) {
       return stateOrLoadedState;
@@ -287,7 +265,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   /**
    * Return either state or state bytes with persisted key loaded from db.
    */
-  async getStateOrLoadDb(cp: CheckpointHexPayload): Promise<IBeaconStateView | LoadedStateBytesData | null> {
+  async getStateOrLoadDb(cp: CheckpointHex): Promise<IBeaconStateView | LoadedStateBytesData | null> {
     const cpKey = toCacheKey(cp);
     const inMemoryState = this.get(cpKey);
     if (inMemoryState) {
@@ -318,7 +296,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   /**
    * Similar to get() api without reloading from disk
    */
-  get(cpOrKey: CheckpointHexPayload | CacheKey): IBeaconStateView | null {
+  get(cpOrKey: CheckpointHex | CacheKey): IBeaconStateView | null {
     this.metrics?.cpStateCache.lookups.inc();
     const cpKey = typeof cpOrKey === "string" ? cpOrKey : toCacheKey(cpOrKey);
     const cacheItem = this.cache.get(cpKey);
@@ -344,11 +322,9 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
 
   /**
    * Add a state of a checkpoint to this cache, prune from memory if necessary.
-   * @param payloadPresent - For Gloas: true if this is payload state, false if block state.
-   *                         Always true for pre-Gloas.
    */
-  add(cp: phase0.Checkpoint, state: IBeaconStateView, payloadPresent: boolean): void {
-    const cpHex = toCheckpointHexPayload(cp, payloadPresent);
+  add(cp: phase0.Checkpoint, state: IBeaconStateView): void {
+    const cpHex = toCheckpointHex(cp);
     const key = toCacheKey(cpHex);
     const cacheItem = this.cache.get(key);
     this.metrics?.cpStateCache.adds.inc();
@@ -359,32 +335,27 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       this.logger.verbose("Added checkpoint state to memory but a persisted key existed", {
         epoch: cp.epoch,
         rootHex: cpHex.rootHex,
-        payloadPresent,
         persistedKey: toHex(persistedKey),
       });
     } else {
       this.cache.set(key, {type: CacheItemType.inMemory, state});
-      this.logger.verbose("Added checkpoint state to memory", {
-        epoch: cp.epoch,
-        rootHex: cpHex.rootHex,
-        payloadPresent,
-      });
+      this.logger.verbose("Added checkpoint state to memory", {epoch: cp.epoch, rootHex: cpHex.rootHex});
     }
-    this.addToEpochIndex(cp.epoch, cpHex.rootHex, cpHex.payloadPresent);
+    this.epochIndex.getOrDefault(cp.epoch).add(cpHex.rootHex);
     this.prunePersistedStates();
   }
 
   /**
    * Searches in-memory state for the latest cached state with a `root` without reload, starting with `epoch` and descending
    */
-  getLatest(rootHex: RootHex, maxEpoch: Epoch, payloadPresent: boolean): IBeaconStateView | null {
+  getLatest(rootHex: RootHex, maxEpoch: Epoch): IBeaconStateView | null {
     // sort epochs in descending order, only consider epochs lte `epoch`
     const epochs = Array.from(this.epochIndex.keys())
       .sort((a, b) => b - a)
       .filter((e) => e <= maxEpoch);
     for (const epoch of epochs) {
-      if (this.hasPayloadVariant(epoch, rootHex, payloadPresent)) {
-        const inMemoryClonedState = this.get({rootHex, epoch, payloadPresent});
+      if (this.epochIndex.get(epoch)?.has(rootHex)) {
+        const inMemoryClonedState = this.get({rootHex, epoch});
         if (inMemoryClonedState) {
           return inMemoryClonedState;
         }
@@ -400,24 +371,20 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    * - Get block for processing
    * - Regen head state
    */
-  async getOrReloadLatest(
-    rootHex: RootHex,
-    maxEpoch: Epoch,
-    payloadPresent: boolean
-  ): Promise<IBeaconStateView | null> {
+  async getOrReloadLatest(rootHex: RootHex, maxEpoch: Epoch): Promise<IBeaconStateView | null> {
     // sort epochs in descending order, only consider epochs lte `epoch`
     const epochs = Array.from(this.epochIndex.keys())
       .sort((a, b) => b - a)
       .filter((e) => e <= maxEpoch);
     for (const epoch of epochs) {
-      if (this.hasPayloadVariant(epoch, rootHex, payloadPresent)) {
+      if (this.epochIndex.get(epoch)?.has(rootHex)) {
         try {
-          const state = await this.getOrReload({rootHex, epoch, payloadPresent});
+          const state = await this.getOrReload({rootHex, epoch});
           if (state) {
             return state;
           }
         } catch (e) {
-          this.logger.debug("Error get or reload state", {epoch, rootHex, payloadPresent}, e as Error);
+          this.logger.debug("Error get or reload state", {epoch, rootHex}, e as Error);
         }
       }
     }
@@ -427,12 +394,10 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   /**
    * Update the precomputed checkpoint and return the number of hits for the
    * previous one (if any).
-   * @param payloadPresent - For Gloas: true if head block has FULL payload, false if EMPTY.
-   *                         Always true for pre-Gloas.
    */
-  updatePreComputedCheckpoint(rootHex: RootHex, epoch: Epoch, payloadPresent: boolean): number | null {
+  updatePreComputedCheckpoint(rootHex: RootHex, epoch: Epoch): number | null {
     const previousHits = this.preComputedCheckpointHits;
-    this.preComputedCheckpoint = toCacheKey({rootHex, epoch, payloadPresent});
+    this.preComputedCheckpoint = toCacheKey({rootHex, epoch});
     this.preComputedCheckpointHits = 0;
     return previousHits;
   }
@@ -506,9 +471,6 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    * - 2 then we'll persist {root: b2, epoch n-2} checkpoint state to disk, there are also 2 checkpoint states in memory at epoch n, same to the above (maxEpochsInMemory=1)
    *
    * As of Mar 2024, it takes <=350ms to persist a holesky state on fast server
-   *
-   * For Gloas: Processes both block state and payload state variants together. The decision of which roots to persist/prune
-   * is based on root canonicality (from state's view), not payload presence. Both variants are managed as a unit.
    */
   async processState(blockRootHex: RootHex, state: IBeaconStateView): Promise<number> {
     let persistCount = 0;
@@ -579,7 +541,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    *
    * Use seed state from the block cache if cannot find any seed states within this cache.
    */
-  findSeedStateToReload(reloadedCp: CheckpointHexPayload): IBeaconStateView {
+  findSeedStateToReload(reloadedCp: CheckpointHex): IBeaconStateView {
     const maxEpoch = Math.max(...Array.from(this.epochIndex.keys()));
     const reloadedCpSlot = computeStartSlotAtEpoch(reloadedCp.epoch);
     let firstState: IBeaconStateView | null = null;
@@ -592,35 +554,31 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
         return firstState;
       }
 
-      for (const [rootHex, bitmask] of this.epochIndex.get(epoch) || []) {
-        for (const flag of PAYLOAD_AVAILABILITY_ALL) {
-          if (!(bitmask & flag)) continue;
-          const payloadPresent = fromPayloadAvailability(flag);
-          const cpKey = toCacheKey({rootHex, epoch, payloadPresent});
-          const cacheItem = this.cache.get(cpKey);
-          if (cacheItem === undefined) {
-            continue;
+      for (const rootHex of this.epochIndex.get(epoch) || []) {
+        const cpKey = toCacheKey({rootHex, epoch});
+        const cacheItem = this.cache.get(cpKey);
+        if (cacheItem === undefined) {
+          continue;
+        }
+        if (isInMemoryCacheItem(cacheItem)) {
+          const {state} = cacheItem;
+          if (firstState === null) {
+            firstState = state;
           }
-          if (isInMemoryCacheItem(cacheItem)) {
-            const {state} = cacheItem;
-            if (firstState === null) {
-              firstState = state;
-            }
-            const cpLog = {cpEpoch: epoch, cpRoot: rootHex, payloadPresent};
+          const cpLog = {cpEpoch: epoch, cpRoot: rootHex};
 
-            try {
-              // amongst states of the same epoch, choose the one with the same view of reloadedCp
-              if (
-                reloadedCpSlot < state.slot &&
-                toRootHex(state.getBlockRootAtSlot(reloadedCpSlot)) === reloadedCp.rootHex
-              ) {
-                this.logger.verbose("Reload: use checkpoint state as seed state", {...cpLog, ...logCtx});
-                return state;
-              }
-            } catch (e) {
-              // getBlockRootAtSlot may throw error
-              this.logger.debug("Error finding checkpoint state to reload", {...cpLog, ...logCtx}, e as Error);
+          try {
+            // amongst states of the same epoch, choose the one with the same view of reloadedCp
+            if (
+              reloadedCpSlot < state.slot &&
+              toRootHex(state.getBlockRootAtSlot(reloadedCpSlot)) === reloadedCp.rootHex
+            ) {
+              this.logger.verbose("Reload: use checkpoint state as seed state", {...cpLog, ...logCtx});
+              return state;
             }
+          } catch (e) {
+            // getBlockRootAtSlot may throw error
+            this.logger.debug("Error finding checkpoint state to reload", {...cpLog, ...logCtx}, e as Error);
           }
         }
       }
@@ -635,31 +593,6 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   clear(): void {
     this.cache.clear();
     this.epochIndex.clear();
-  }
-
-  private addToEpochIndex(epoch: Epoch, rootHex: RootHex, payloadPresent: boolean): void {
-    const rootMap = this.epochIndex.getOrDefault(epoch);
-    rootMap.set(rootHex, (rootMap.get(rootHex) ?? 0) | toPayloadAvailability(payloadPresent));
-  }
-
-  private removeFromEpochIndex(epoch: Epoch, rootHex: RootHex, payloadPresent: boolean): void {
-    const rootMap = this.epochIndex.get(epoch);
-    if (rootMap === undefined) return;
-    const existing = rootMap.get(rootHex);
-    if (existing === undefined) return;
-    const updated = existing & ~toPayloadAvailability(payloadPresent);
-    if (updated === 0) {
-      rootMap.delete(rootHex);
-      if (rootMap.size === 0) {
-        this.epochIndex.delete(epoch);
-      }
-    } else {
-      rootMap.set(rootHex, updated);
-    }
-  }
-
-  private hasPayloadVariant(epoch: Epoch, rootHex: RootHex, payloadPresent: boolean): boolean {
-    return Boolean((this.epochIndex.get(epoch)?.get(rootHex) ?? 0) & toPayloadAvailability(payloadPresent));
   }
 
   /** ONLY FOR DEBUGGING PURPOSES. For lodestar debug API */
@@ -736,7 +669,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     const prevEpochRoot = toRootHex(state.getBlockRootAtSlot(epochBoundarySlot - 1));
 
     // for each epoch, usually there are 2 rootHexes respective to the 2 checkpoint states: Previous Root Checkpoint State and Current Root Checkpoint State
-    const cpRootHexMap = this.epochIndex.get(epoch) ?? new Map<RootHex, number>();
+    const cpRootHexes = this.epochIndex.get(epoch) ?? [];
     const persistedRootHexes = new Set<RootHex>();
 
     // 1) if there is no CRCS, persist PRCS (block 0 of epoch is skipped). In this case prevEpochRoot === epochBoundaryHex
@@ -745,81 +678,76 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     persistedRootHexes.add(epochBoundaryHex);
 
     // 3) persist any states with unknown roots to this state
-    for (const rootHex of cpRootHexMap.keys()) {
+    for (const rootHex of cpRootHexes) {
       if (rootHex !== epochBoundaryHex && rootHex !== prevEpochRoot) {
         persistedRootHexes.add(rootHex);
       }
     }
 
-    for (const [rootHex, bitmask] of cpRootHexMap) {
-      for (const flag of PAYLOAD_AVAILABILITY_ALL) {
-        if (!(bitmask & flag)) continue;
-        const payloadPresent = fromPayloadAvailability(flag);
-        const cpKey = toCacheKey({epoch: epoch, rootHex, payloadPresent});
-        const cacheItem = this.cache.get(cpKey);
+    for (const rootHex of cpRootHexes) {
+      const cpKey = toCacheKey({epoch: epoch, rootHex});
+      const cacheItem = this.cache.get(cpKey);
 
-        if (cacheItem !== undefined && isInMemoryCacheItem(cacheItem)) {
-          let {persistedKey} = cacheItem;
-          const {state} = cacheItem;
-          const logMeta = {
-            stateSlot: state.slot,
-            rootHex,
-            payloadPresent,
-            epochBoundaryHex,
-            persistedKey: persistedKey ? toHex(persistedKey) : "",
-          };
+      if (cacheItem !== undefined && isInMemoryCacheItem(cacheItem)) {
+        let {persistedKey} = cacheItem;
+        const {state} = cacheItem;
+        const logMeta = {
+          stateSlot: state.slot,
+          rootHex,
+          epochBoundaryHex,
+          persistedKey: persistedKey ? toHex(persistedKey) : "",
+        };
 
-          if (persistedRootHexes.has(rootHex)) {
-            if (persistedKey) {
-              // we don't care if the checkpoint state is already persisted
-              this.logger.verbose("Pruned checkpoint state from memory but no need to persist", logMeta);
-            } else {
-              // persist and do not update epochIndex
-              this.metrics?.cpStateCache.statePersistSecFromSlot.observe(
-                this.clock?.secFromSlot(this.clock?.currentSlot ?? 0) ?? 0
-              );
-              const cpPersist = {epoch: epoch, root: fromHex(rootHex)};
-              // It's not sustainable to allocate ~240MB for each state every epoch, so we use buffer pool to reuse the memory.
-              // As monitored on holesky as of Jan 2024:
-              //   - This does not increase heap allocation while gc time is the same
-              //   - It helps stabilize persist time and save ~300ms in average (1.5s vs 1.2s)
-              //   - It also helps the state reload to save ~500ms in average (4.3s vs 3.8s)
-              //   - Also `serializeState.test.ts` perf test shows a lot of differences allocating ~240MB once vs per state serialization
-              const timer = this.metrics?.stateSerializeDuration.startTimer({
-                source: AllocSource.PERSISTENT_CHECKPOINTS_CACHE_STATE,
-              });
-              persistedKey = await serializeState(
-                state,
-                AllocSource.PERSISTENT_CHECKPOINTS_CACHE_STATE,
-                (stateBytes) => {
-                  timer?.();
-                  return this.datastore.write(cpPersist, stateBytes, payloadPresent);
-                },
-                this.bufferPool
-              );
-
-              persistCount++;
-              this.logger.verbose("Pruned checkpoint state from memory and persisted to disk", {
-                ...logMeta,
-                persistedKey: toHex(persistedKey),
-              });
-            }
-            // overwrite cpKey, this means the state is deleted from memory
-            this.cache.set(cpKey, {type: CacheItemType.persisted, value: persistedKey});
+        if (persistedRootHexes.has(rootHex)) {
+          if (persistedKey) {
+            // we don't care if the checkpoint state is already persisted
+            this.logger.verbose("Pruned checkpoint state from memory but no need to persist", logMeta);
           } else {
-            if (persistedKey) {
-              // persisted file will be eventually deleted by the archive task
-              // this also means the state is deleted from memory
-              this.cache.set(cpKey, {type: CacheItemType.persisted, value: persistedKey});
-              // do not update epochIndex
-            } else {
-              // delete the state from memory
-              this.cache.delete(cpKey);
-              this.removeFromEpochIndex(epoch, rootHex, payloadPresent);
-            }
-            this.metrics?.cpStateCache.statePruneFromMemoryCount.inc();
-            this.logger.verbose("Pruned checkpoint state from memory", logMeta);
+            // persist and do not update epochIndex
+            this.metrics?.cpStateCache.statePersistSecFromSlot.observe(
+              this.clock?.secFromSlot(this.clock?.currentSlot ?? 0) ?? 0
+            );
+            const cpPersist = {epoch: epoch, root: fromHex(rootHex)};
+            // It's not sustainable to allocate ~240MB for each state every epoch, so we use buffer pool to reuse the memory.
+            // As monitored on holesky as of Jan 2024:
+            //   - This does not increase heap allocation while gc time is the same
+            //   - It helps stabilize persist time and save ~300ms in average (1.5s vs 1.2s)
+            //   - It also helps the state reload to save ~500ms in average (4.3s vs 3.8s)
+            //   - Also `serializeState.test.ts` perf test shows a lot of differences allocating ~240MB once vs per state serialization
+            const timer = this.metrics?.stateSerializeDuration.startTimer({
+              source: AllocSource.PERSISTENT_CHECKPOINTS_CACHE_STATE,
+            });
+            persistedKey = await serializeState(
+              state,
+              AllocSource.PERSISTENT_CHECKPOINTS_CACHE_STATE,
+              (stateBytes) => {
+                timer?.();
+                return this.datastore.write(cpPersist, stateBytes);
+              },
+              this.bufferPool
+            );
+
+            persistCount++;
+            this.logger.verbose("Pruned checkpoint state from memory and persisted to disk", {
+              ...logMeta,
+              persistedKey: toHex(persistedKey),
+            });
           }
+          // overwrite cpKey, this means the state is deleted from memory
+          this.cache.set(cpKey, {type: CacheItemType.persisted, value: persistedKey});
+        } else {
+          if (persistedKey) {
+            // persisted file will be eventually deleted by the archive task
+            // this also means the state is deleted from memory
+            this.cache.set(cpKey, {type: CacheItemType.persisted, value: persistedKey});
+            // do not update epochIndex
+          } else {
+            // delete the state from memory
+            this.cache.delete(cpKey);
+            this.epochIndex.get(epoch)?.delete(rootHex);
+          }
+          this.metrics?.cpStateCache.statePruneFromMemoryCount.inc();
+          this.logger.verbose("Pruned checkpoint state from memory", logMeta);
         }
       }
     }
@@ -832,40 +760,26 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    */
   private async deleteAllEpochItems(epoch: Epoch): Promise<void> {
     let persistCount = 0;
-    const rootHexMap = this.epochIndex.get(epoch) || new Map<RootHex, number>();
-    for (const [rootHex, bitmask] of rootHexMap) {
-      for (const flag of PAYLOAD_AVAILABILITY_ALL) {
-        if (!(bitmask & flag)) continue;
-        const payloadPresent = fromPayloadAvailability(flag);
-        const key = toCacheKey({rootHex, epoch, payloadPresent});
-        const cacheItem = this.cache.get(key);
+    const rootHexes = this.epochIndex.get(epoch) || [];
+    for (const rootHex of rootHexes) {
+      const key = toCacheKey({rootHex, epoch});
+      const cacheItem = this.cache.get(key);
 
-        if (cacheItem) {
-          const persistedKey = isPersistedCacheItem(cacheItem) ? cacheItem.value : cacheItem.persistedKey;
-          if (persistedKey) {
-            await this.datastore.remove(persistedKey);
-            persistCount++;
-            this.metrics?.cpStateCache.persistedStateRemoveCount.inc();
-          }
+      if (cacheItem) {
+        const persistedKey = isPersistedCacheItem(cacheItem) ? cacheItem.value : cacheItem.persistedKey;
+        if (persistedKey) {
+          await this.datastore.remove(persistedKey);
+          persistCount++;
+          this.metrics?.cpStateCache.persistedStateRemoveCount.inc();
         }
-        this.cache.delete(key);
-        this.logger.verbose("Pruned checkpoint state", {
-          epoch,
-          rootHex,
-          payloadPresent,
-          type: cacheItem ? (isPersistedCacheItem(cacheItem) ? "persisted" : "in-memory") : "missing",
-        });
       }
+      this.cache.delete(key);
     }
     this.epochIndex.delete(epoch);
-    this.logger.verbose("Pruned all checkpoint states for epoch", {
+    this.logger.verbose("Pruned checkpoint states for epoch", {
       epoch,
       persistCount,
-      items: Array.from(rootHexMap.entries())
-        .flatMap(([rootHex, bitmask]) =>
-          PAYLOAD_AVAILABILITY_ALL.filter((f) => bitmask & f).map((f) => `${rootHex}:${fromPayloadAvailability(f)}`)
-        )
-        .join(","),
+      rootHexes: Array.from(rootHexes).join(","),
     });
   }
 
@@ -916,57 +830,39 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   }
 }
 
-export function toCheckpointHexPayload(checkpoint: phase0.Checkpoint, payloadPresent: boolean): CheckpointHexPayload {
+export function toCheckpointHex(checkpoint: phase0.Checkpoint): CheckpointHex {
   return {
     epoch: checkpoint.epoch,
     rootHex: toRootHex(checkpoint.root),
-    payloadPresent,
   };
 }
 
-/**
- * Convert fork-choice CheckpointWithPayloadStatus to beacon-node CheckpointHexPayload.
- * Maps PayloadStatus enum to boolean payloadPresent.
- * @throws Error if checkpoint has PENDING payload status (ambiguous which variant to use)
- */
-export function fcCheckpointToHexPayload(checkpoint: CheckpointWithPayloadStatus): CheckpointHexPayload {
-  const PayloadStatus = {PENDING: 0, EMPTY: 1, FULL: 2} as const;
-
-  if (checkpoint.payloadStatus === PayloadStatus.PENDING) {
-    throw Error(
-      `Cannot convert checkpoint with PENDING payload status at epoch ${checkpoint.epoch} root ${checkpoint.rootHex}`
-    );
-  }
-
+/** TODO GLOAS: remove after rolling back regen dual-state changes */
+export function fcCheckpointToHexPayload(checkpoint: {
+  epoch: Epoch;
+  rootHex: RootHex;
+  payloadStatus?: number;
+}): CheckpointHexPayload {
   return {
     epoch: checkpoint.epoch,
     rootHex: checkpoint.rootHex,
-    payloadPresent: checkpoint.payloadStatus === PayloadStatus.FULL,
+    payloadPresent: true,
   };
 }
 
-export function toCheckpointKey(cp: CheckpointHexPayload): string {
-  return `${cp.rootHex}:${cp.epoch}:${cp.payloadPresent}`;
+export function toCheckpointKey(cp: CheckpointHex): string {
+  return `${cp.rootHex}:${cp.epoch}`;
 }
 
-/**
- * Convert checkpoint to cache key string.
- * Format: `{rootHex}_{epoch}_{payloadPresent}`
- */
-function toCacheKey(cp: CheckpointHexPayload): CacheKey {
-  return `${cp.rootHex}_${cp.epoch}_${cp.payloadPresent}`;
+function toCacheKey(cp: CheckpointHex): CacheKey {
+  return `${cp.rootHex}_${cp.epoch}`;
 }
 
-function fromCacheKey(key: CacheKey): CheckpointHexPayload {
-  const parts = key.split("_");
-  const rootHex = parts[0];
-  const epoch = Number(parts[1]);
-  // For backward compatibility with old format (rootHex_epoch), default to true
-  const payloadPresent = parts.length > 2 ? parts[2] === "true" : true;
+function fromCacheKey(key: CacheKey): CheckpointHex {
+  const [rootHex, epoch] = key.split("_");
   return {
     rootHex,
-    epoch,
-    payloadPresent,
+    epoch: Number(epoch),
   };
 }
 

--- a/packages/beacon-node/src/chain/stateCache/types.ts
+++ b/packages/beacon-node/src/chain/stateCache/types.ts
@@ -2,10 +2,9 @@ import {routes} from "@lodestar/api";
 import {IBeaconStateView} from "@lodestar/state-transition";
 import {Epoch, RootHex, phase0} from "@lodestar/types";
 
-/**
- * Checkpoint hex representation for state cache keys.
- * Extends CheckpointWithHex (from fork-choice) with payloadPresent.
- */
+export type CheckpointHex = {epoch: Epoch; rootHex: RootHex};
+
+/** TODO GLOAS: payloadPresent is ignored — remove after rolling back regen dual-state changes */
 export type CheckpointHexPayload = {epoch: Epoch; rootHex: RootHex; payloadPresent: boolean};
 
 /**
@@ -35,8 +34,6 @@ export interface BlockStateCache {
   size: number;
   prune(headStateRootHex: RootHex): void;
   deleteAllBeforeEpoch(finalizedEpoch: Epoch): void;
-  /** Upgrade cache capacity for Gloas fork (2x states for block + payload states) */
-  upgradeToGloas(): void;
   dumpSummary(): routes.lodestar.StateCacheItem[];
   /** Expose beacon states stored in cache. Use with caution */
   getStates(): IterableIterator<IBeaconStateView>;
@@ -65,13 +62,13 @@ export interface BlockStateCache {
  */
 export interface CheckpointStateCache {
   init?: () => Promise<void>;
-  getOrReload(cp: CheckpointHexPayload): Promise<IBeaconStateView | null>;
-  getStateOrBytes(cp: CheckpointHexPayload): Promise<IBeaconStateView | Uint8Array | null>;
-  get(cpOrKey: CheckpointHexPayload | string): IBeaconStateView | null;
-  add(cp: phase0.Checkpoint, state: IBeaconStateView, payloadPresent: boolean): void;
-  getLatest(rootHex: RootHex, maxEpoch: Epoch, payloadPresent: boolean): IBeaconStateView | null;
-  getOrReloadLatest(rootHex: RootHex, maxEpoch: Epoch, payloadPresent: boolean): Promise<IBeaconStateView | null>;
-  updatePreComputedCheckpoint(rootHex: RootHex, epoch: Epoch, payloadPresent: boolean): number | null;
+  getOrReload(cp: CheckpointHex): Promise<IBeaconStateView | null>;
+  getStateOrBytes(cp: CheckpointHex): Promise<IBeaconStateView | Uint8Array | null>;
+  get(cpOrKey: CheckpointHex | string): IBeaconStateView | null;
+  add(cp: phase0.Checkpoint, state: IBeaconStateView): void;
+  getLatest(rootHex: RootHex, maxEpoch: Epoch): IBeaconStateView | null;
+  getOrReloadLatest(rootHex: RootHex, maxEpoch: Epoch): Promise<IBeaconStateView | null>;
+  updatePreComputedCheckpoint(rootHex: RootHex, epoch: Epoch): number | null;
   prune(finalizedEpoch: Epoch, justifiedEpoch: Epoch): void;
   pruneFinalized(finalizedEpoch: Epoch): void;
   processState(blockRootHex: RootHex, state: IBeaconStateView): Promise<number>;

--- a/packages/beacon-node/test/unit-minimal/chain/stateCache/persistentCheckpointsCache.test.ts
+++ b/packages/beacon-node/test/unit-minimal/chain/stateCache/persistentCheckpointsCache.test.ts
@@ -15,9 +15,9 @@ import {FIFOBlockStateCache} from "../../../../src/chain/index.js";
 import {checkpointToDatastoreKey} from "../../../../src/chain/stateCache/datastore/index.js";
 import {
   PersistentCheckpointStateCache,
-  toCheckpointHexPayload,
+  toCheckpointHex,
 } from "../../../../src/chain/stateCache/persistentCheckpointsCache.js";
-import {CheckpointHexPayload} from "../../../../src/chain/stateCache/types.js";
+import {CheckpointHex} from "../../../../src/chain/stateCache/types.js";
 import {getTestDatastore} from "../../../utils/chain/stateCache/datastore.js";
 import {generateCachedState} from "../../../utils/state.js";
 
@@ -28,10 +28,7 @@ describe("PersistentCheckpointStateCache", () => {
 
   let root0a: Buffer, root0b: Buffer, root1: Buffer, root2: Buffer;
   let cp0a: phase0.Checkpoint, cp0b: phase0.Checkpoint, cp1: phase0.Checkpoint, cp2: phase0.Checkpoint;
-  let cp0aHex: CheckpointHexPayload,
-    cp0bHex: CheckpointHexPayload,
-    cp1Hex: CheckpointHexPayload,
-    cp2Hex: CheckpointHexPayload;
+  let cp0aHex: CheckpointHex, cp0bHex: CheckpointHex, cp1Hex: CheckpointHex, cp2Hex: CheckpointHex;
   let persistent0bKey: RootHex;
   const startSlotEpoch20 = computeStartSlotAtEpoch(20);
   const startSlotEpoch21 = computeStartSlotAtEpoch(21);
@@ -61,8 +58,8 @@ describe("PersistentCheckpointStateCache", () => {
     cp0b = {epoch: 20, root: root0b};
     cp1 = {epoch: 21, root: root1};
     cp2 = {epoch: 22, root: root2};
-    [cp0aHex, cp0bHex, cp1Hex, cp2Hex] = [cp0a, cp0b, cp1, cp2].map((cp) => toCheckpointHexPayload(cp, true));
-    persistent0bKey = toHexString(checkpointToDatastoreKey(cp0b, true));
+    [cp0aHex, cp0bHex, cp1Hex, cp2Hex] = [cp0a, cp0b, cp1, cp2].map((cp) => toCheckpointHex(cp));
+    persistent0bKey = toHexString(checkpointToDatastoreKey(cp0b));
     const allStates = [cp0a, cp0b, cp1, cp2]
       .map((cp) => generateCachedState({slot: cp.epoch * SLOTS_PER_EPOCH}))
       .map((state, i) => {
@@ -112,30 +109,28 @@ describe("PersistentCheckpointStateCache", () => {
       },
       {maxCPStateEpochsInMemory: 2}
     );
-    cache.add(cp0a, states["cp0a"], true);
-    cache.add(cp0b, states["cp0b"], true);
-    cache.add(cp1, states["cp1"], true);
+    cache.add(cp0a, states["cp0a"]);
+    cache.add(cp0b, states["cp0b"]);
+    cache.add(cp1, states["cp1"]);
   });
 
   it("getLatest", () => {
     // cp0
-    expect(cache.getLatest(cp0aHex.rootHex, cp0a.epoch, true)?.hashTreeRoot()).toEqual(states["cp0a"].hashTreeRoot());
-    expect(cache.getLatest(cp0aHex.rootHex, cp0a.epoch + 1, true)?.hashTreeRoot()).toEqual(
-      states["cp0a"].hashTreeRoot()
-    );
-    expect(cache.getLatest(cp0aHex.rootHex, cp0a.epoch - 1, true)?.hashTreeRoot()).toBeUndefined();
+    expect(cache.getLatest(cp0aHex.rootHex, cp0a.epoch)?.hashTreeRoot()).toEqual(states["cp0a"].hashTreeRoot());
+    expect(cache.getLatest(cp0aHex.rootHex, cp0a.epoch + 1)?.hashTreeRoot()).toEqual(states["cp0a"].hashTreeRoot());
+    expect(cache.getLatest(cp0aHex.rootHex, cp0a.epoch - 1)?.hashTreeRoot()).toBeUndefined();
 
     // cp1
-    expect(cache.getLatest(cp1Hex.rootHex, cp1.epoch, true)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
-    expect(cache.getLatest(cp1Hex.rootHex, cp1.epoch + 1, true)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
-    expect(cache.getLatest(cp1Hex.rootHex, cp1.epoch - 1, true)?.hashTreeRoot()).toBeUndefined();
+    expect(cache.getLatest(cp1Hex.rootHex, cp1.epoch)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
+    expect(cache.getLatest(cp1Hex.rootHex, cp1.epoch + 1)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
+    expect(cache.getLatest(cp1Hex.rootHex, cp1.epoch - 1)?.hashTreeRoot()).toBeUndefined();
 
     // cp2
-    expect(cache.getLatest(cp2Hex.rootHex, cp2.epoch, true)?.hashTreeRoot()).toBeUndefined();
+    expect(cache.getLatest(cp2Hex.rootHex, cp2.epoch)?.hashTreeRoot()).toBeUndefined();
   });
 
   it("getOrReloadLatest", async () => {
-    cache.add(cp2, states["cp2"], true);
+    cache.add(cp2, states["cp2"]);
     expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
 
     // cp0b is persisted
@@ -143,21 +138,19 @@ describe("PersistentCheckpointStateCache", () => {
     expect(Array.from(fileApisBuffer.keys())).toEqual([persistent0bKey]);
 
     // getLatest() does not reload from disk
-    expect(cache.getLatest(cp0aHex.rootHex, cp0a.epoch, true)).toBeNull();
-    expect(cache.getLatest(cp0bHex.rootHex, cp0b.epoch, true)).toBeNull();
+    expect(cache.getLatest(cp0aHex.rootHex, cp0a.epoch)).toBeNull();
+    expect(cache.getLatest(cp0bHex.rootHex, cp0b.epoch)).toBeNull();
 
     // cp0a has the root from previous epoch so we only prune it from db
-    expect(await cache.getOrReloadLatest(cp0aHex.rootHex, cp0a.epoch, true)).toBeNull();
+    expect(await cache.getOrReloadLatest(cp0aHex.rootHex, cp0a.epoch)).toBeNull();
     // but getOrReloadLatest() does for cp0b
-    expect((await cache.getOrReloadLatest(cp0bHex.rootHex, cp0b.epoch, true))?.serialize()).toEqual(stateBytes["cp0b"]);
-    expect((await cache.getOrReloadLatest(cp0bHex.rootHex, cp0b.epoch + 1, true))?.serialize()).toEqual(
-      stateBytes["cp0b"]
-    );
-    expect((await cache.getOrReloadLatest(cp0bHex.rootHex, cp0b.epoch - 1, true))?.serialize()).toBeUndefined();
+    expect((await cache.getOrReloadLatest(cp0bHex.rootHex, cp0b.epoch))?.serialize()).toEqual(stateBytes["cp0b"]);
+    expect((await cache.getOrReloadLatest(cp0bHex.rootHex, cp0b.epoch + 1))?.serialize()).toEqual(stateBytes["cp0b"]);
+    expect((await cache.getOrReloadLatest(cp0bHex.rootHex, cp0b.epoch - 1))?.serialize()).toBeUndefined();
   });
 
   it("pruneFinalized and getStateOrBytes", async () => {
-    cache.add(cp2, states["cp2"], true);
+    cache.add(cp2, states["cp2"]);
     expect(((await cache.getStateOrBytes(cp0bHex)) as IBeaconStateView).hashTreeRoot()).toEqual(
       states["cp0b"].hashTreeRoot()
     );
@@ -191,9 +184,9 @@ describe("PersistentCheckpointStateCache", () => {
         },
         {maxCPStateEpochsInMemory: 2}
       );
-      cache.add(cp0a, states["cp0a"], true);
-      cache.add(cp0b, states["cp0b"], true);
-      cache.add(cp1, states["cp1"], true);
+      cache.add(cp0a, states["cp0a"]);
+      cache.add(cp0b, states["cp0b"]);
+      cache.add(cp1, states["cp1"]);
     });
 
     //     epoch: 19         20           21         22          23
@@ -204,7 +197,7 @@ describe("PersistentCheckpointStateCache", () => {
     //                       |
     //                       0a
     it("single state at lowest memory epoch", async () => {
-      cache.add(cp2, states["cp2"], true);
+      cache.add(cp2, states["cp2"]);
       expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
       expect(cache.findSeedStateToReload(cp0aHex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(cache.findSeedStateToReload(cp0bHex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
@@ -220,7 +213,7 @@ describe("PersistentCheckpointStateCache", () => {
     //                                    ^           ^
     //                           cp1a={0a, 21}       {0a, 22}=cp2a
     it("multiple states at lowest memory epoch", async () => {
-      cache.add(cp2, states["cp2"], true);
+      cache.add(cp2, states["cp2"]);
       expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
 
       const cp1a = {epoch: 21, root: root0a};
@@ -228,14 +221,14 @@ describe("PersistentCheckpointStateCache", () => {
       cp1aState.slot = 21 * SLOTS_PER_EPOCH;
       cp1aState.blockRoots.set(startSlotEpoch21 % SLOTS_PER_HISTORICAL_ROOT, root0a);
       cp1aState.commit();
-      cache.add(cp1a, new BeaconStateView(cp1aState), true);
+      cache.add(cp1a, new BeaconStateView(cp1aState));
 
       const cp2a = {epoch: 22, root: root0a};
       const cp2aState = cp1aState.clone();
       cp2aState.slot = 22 * SLOTS_PER_EPOCH;
       cp2aState.blockRoots.set(startSlotEpoch22 % SLOTS_PER_HISTORICAL_ROOT, root0a);
       cp2aState.commit();
-      cache.add(cp2a, new BeaconStateView(cp2aState), true);
+      cache.add(cp2a, new BeaconStateView(cp2aState));
 
       const root3 = Buffer.alloc(32, 100);
       const state3 = cp2aState.clone();
@@ -249,9 +242,9 @@ describe("PersistentCheckpointStateCache", () => {
       expect(cache.findSeedStateToReload(cp0bHex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       const randomRoot = Buffer.alloc(32, 101);
       // for other random root it'll pick the first state of epoch 21 which is states["cp1"]
-      expect(
-        cache.findSeedStateToReload({epoch: 20, rootHex: toHexString(randomRoot), payloadPresent: true})?.hashTreeRoot()
-      ).toEqual(states["cp1"].hashTreeRoot());
+      expect(cache.findSeedStateToReload({epoch: 20, rootHex: toHexString(randomRoot)})?.hashTreeRoot()).toEqual(
+        states["cp1"].hashTreeRoot()
+      );
     });
   });
 
@@ -268,9 +261,9 @@ describe("PersistentCheckpointStateCache", () => {
         },
         {maxCPStateEpochsInMemory: 2}
       );
-      cache.add(cp0a, states["cp0a"], true);
-      cache.add(cp0b, states["cp0b"], true);
-      cache.add(cp1, states["cp1"], true);
+      cache.add(cp0a, states["cp0a"]);
+      cache.add(cp0b, states["cp0b"]);
+      cache.add(cp1, states["cp1"]);
     });
 
     //     epoch: 19         20           21         22          23
@@ -282,7 +275,7 @@ describe("PersistentCheckpointStateCache", () => {
     //                       0a
     it("no reorg", async () => {
       expect(fileApisBuffer.size).toEqual(0);
-      cache.add(cp2, states["cp2"], true);
+      cache.add(cp2, states["cp2"]);
       expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
       expect(cache.get(cp2Hex)?.hashTreeRoot()).toEqual(states["cp2"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
@@ -317,7 +310,7 @@ describe("PersistentCheckpointStateCache", () => {
     it("reorg in same epoch", async () => {
       // mostly the same to the above test
       expect(fileApisBuffer.size).toEqual(0);
-      cache.add(cp2, states["cp2"], true);
+      cache.add(cp2, states["cp2"]);
       expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
       expect(cache.get(cp2Hex)?.hashTreeRoot()).toEqual(states["cp2"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
@@ -361,7 +354,7 @@ describe("PersistentCheckpointStateCache", () => {
     //                                               {1a, 22}=cp2a
     it("reorg 1 epoch", async () => {
       // process root2 state
-      cache.add(cp2, states["cp2"], true);
+      cache.add(cp2, states["cp2"]);
       expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
@@ -373,7 +366,7 @@ describe("PersistentCheckpointStateCache", () => {
       // assuming reorg block is at slot 5 of epoch 21
       cp2aState.blockRoots.set((startSlotEpoch21 + 5) % SLOTS_PER_HISTORICAL_ROOT, root1a);
       cp2aState.blockRoots.set(startSlotEpoch22 % SLOTS_PER_HISTORICAL_ROOT, root1a);
-      cache.add(cp2a, new BeaconStateView(cp2aState), true);
+      cache.add(cp2a, new BeaconStateView(cp2aState));
 
       // block state of root3 in epoch 22 is built on cp2a
       const blockStateRoot3 = cp2aState.clone();
@@ -385,7 +378,7 @@ describe("PersistentCheckpointStateCache", () => {
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // epoch 22 has 2 checkpoint states
       expect(cache.get(cp2Hex)).not.toBeNull();
-      expect(cache.get(toCheckpointHexPayload(cp2a, true))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp2a))).not.toBeNull();
       // epoch 21 has 1 checkpoint state
       expect(cache.get(cp1Hex)).not.toBeNull();
       // epoch 20 has 0 checkpoint state
@@ -405,14 +398,12 @@ describe("PersistentCheckpointStateCache", () => {
     //                            cp1a={0a, 21}     {0a, 22}=cp2a
     it("reorg 2 epochs", async () => {
       // process root2 state
-      cache.add(cp2, states["cp2"], true);
+      cache.add(cp2, states["cp2"]);
       expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       // reload cp0b from disk
-      expect((await cache.getOrReload(toCheckpointHexPayload(cp0b, true)))?.serialize()).toStrictEqual(
-        stateBytes["cp0b"]
-      );
+      expect((await cache.getOrReload(toCheckpointHex(cp0b)))?.serialize()).toStrictEqual(stateBytes["cp0b"]);
 
       // regen generates cp1a
       const root0a = Buffer.alloc(32, 100);
@@ -421,14 +412,14 @@ describe("PersistentCheckpointStateCache", () => {
       cp1aState.slot = 21 * SLOTS_PER_EPOCH;
       // assuming reorg block is at slot 5 of epoch 20
       cp1aState.blockRoots.set((startSlotEpoch20 + 5) % SLOTS_PER_HISTORICAL_ROOT, root0a);
-      cache.add(cp1a, new BeaconStateView(cp1aState), true);
+      cache.add(cp1a, new BeaconStateView(cp1aState));
 
       // regen generates cp2a
       const cp2a = {epoch: 22, root: root0a};
       const cp2aState = cp1aState.clone();
       cp2aState.slot = 22 * SLOTS_PER_EPOCH;
       cp2aState.blockRoots.set(startSlotEpoch22 % SLOTS_PER_HISTORICAL_ROOT, root0a);
-      cache.add(cp2a, new BeaconStateView(cp2aState), true);
+      cache.add(cp2a, new BeaconStateView(cp2aState));
 
       // block state of root3 in epoch 22 is built on cp2a
       const blockStateRoot3 = cp2aState.clone();
@@ -440,9 +431,9 @@ describe("PersistentCheckpointStateCache", () => {
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // epoch 21 and 22 have 2 checkpoint states
       expect(cache.get(cp1Hex)).not.toBeNull();
-      expect(cache.get(toCheckpointHexPayload(cp1a, true))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp1a))).not.toBeNull();
       expect(cache.get(cp2Hex)).not.toBeNull();
-      expect(cache.get(toCheckpointHexPayload(cp2a, true))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp2a))).not.toBeNull();
       // epoch 20 has 0 checkpoint state
       expect(cache.get(cp0aHex)).toBeNull();
       expect(cache.get(cp0bHex)).toBeNull();
@@ -460,28 +451,28 @@ describe("PersistentCheckpointStateCache", () => {
     //                            cp1a={0a, 21}     {0a, 22}=cp2a
     it("reorg 3 epochs, persist cp 0a", async () => {
       // process root2 state
-      cache.add(cp2, states["cp2"], true);
+      cache.add(cp2, states["cp2"]);
       expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // cp0a was pruned from memory and not in disc
       expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
 
       // regen needs to regen cp0a
-      cache.add(cp0a, states["cp0a"], true);
+      cache.add(cp0a, states["cp0a"]);
 
       // regen generates cp1a
       const cp1a = {epoch: 21, root: root0a};
       const cp1aState = generateCachedState({slot: 21 * SLOTS_PER_EPOCH});
       cp1aState.blockRoots.set((startSlotEpoch20 - 1) % SLOTS_PER_HISTORICAL_ROOT, root0a);
       cp1aState.blockRoots.set(startSlotEpoch20 % SLOTS_PER_HISTORICAL_ROOT, root0a);
-      cache.add(cp1a, new BeaconStateView(cp1aState), true);
+      cache.add(cp1a, new BeaconStateView(cp1aState));
 
       // regen generates cp2a
       const cp2a = {epoch: 22, root: root0a};
       const cp2aState = cp1aState.clone();
       cp2aState.slot = 22 * SLOTS_PER_EPOCH;
       cp2aState.blockRoots.set(startSlotEpoch21 % SLOTS_PER_HISTORICAL_ROOT, root0a);
-      cache.add(cp2a, new BeaconStateView(cp2aState), true);
+      cache.add(cp2a, new BeaconStateView(cp2aState));
 
       // block state of root3 in epoch 22 is built on cp2a
       const blockStateRoot3 = cp2aState.clone();
@@ -496,9 +487,9 @@ describe("PersistentCheckpointStateCache", () => {
       await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
       // epoch 21 and 22 have 2 checkpoint states
       expect(cache.get(cp1Hex)).not.toBeNull();
-      expect(cache.get(toCheckpointHexPayload(cp1a, true))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp1a))).not.toBeNull();
       expect(cache.get(cp2Hex)).not.toBeNull();
-      expect(cache.get(toCheckpointHexPayload(cp2a, true))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp2a))).not.toBeNull();
       // epoch 20 has 0 checkpoint state
       expect(cache.get(cp0aHex)).toBeNull();
       expect(cache.get(cp0bHex)).toBeNull();
@@ -516,14 +507,14 @@ describe("PersistentCheckpointStateCache", () => {
     //                            cp1b={0b, 21}     {0b, 22}=cp2b
     it("reorg 3 epochs, prune but no persist", async () => {
       // process root2 state
-      cache.add(cp2, states["cp2"], true);
+      cache.add(cp2, states["cp2"]);
       expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // cp0a was pruned from memory and not in disc
       expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
 
       // regen needs to reload cp0b
-      cache.add(cp0b, states["cp0b"], true);
+      cache.add(cp0b, states["cp0b"]);
       expect(((await cache.getStateOrBytes(cp0bHex)) as IBeaconStateView).hashTreeRoot()).toEqual(
         states["cp0b"].hashTreeRoot()
       );
@@ -533,14 +524,14 @@ describe("PersistentCheckpointStateCache", () => {
       const cp1bState = states["cp0b"].cachedState.clone();
       cp1bState.slot = 21 * SLOTS_PER_EPOCH;
       cp1bState.blockRoots.set(startSlotEpoch21 % SLOTS_PER_HISTORICAL_ROOT, root0b);
-      cache.add(cp1b, new BeaconStateView(cp1bState), true);
+      cache.add(cp1b, new BeaconStateView(cp1bState));
 
       // regen generates cp2b
       const cp2b = {epoch: 22, root: root0b};
       const cp2bState = cp1bState.clone();
       cp2bState.slot = 22 * SLOTS_PER_EPOCH;
       cp2bState.blockRoots.set(startSlotEpoch22 % SLOTS_PER_HISTORICAL_ROOT, root0b);
-      cache.add(cp2b, new BeaconStateView(cp2bState), true);
+      cache.add(cp2b, new BeaconStateView(cp2bState));
 
       // block state of root3 in epoch 22 is built on cp2a
       const blockStateRoot3 = cp2bState.clone();
@@ -554,9 +545,9 @@ describe("PersistentCheckpointStateCache", () => {
 
       // epoch 21 and 22 have 2 checkpoint states
       expect(cache.get(cp1Hex)).not.toBeNull();
-      expect(cache.get(toCheckpointHexPayload(cp1b, true))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp1b))).not.toBeNull();
       expect(cache.get(cp2Hex)).not.toBeNull();
-      expect(cache.get(toCheckpointHexPayload(cp2b, true))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp2b))).not.toBeNull();
       // epoch 20 has 0 checkpoint state
       expect(cache.get(cp0aHex)).toBeNull();
       expect(cache.get(cp0bHex)).toBeNull();
@@ -576,8 +567,8 @@ describe("PersistentCheckpointStateCache", () => {
         },
         {maxCPStateEpochsInMemory: 1}
       );
-      cache.add(cp0a, states["cp0a"], true);
-      cache.add(cp0b, states["cp0b"], true);
+      cache.add(cp0a, states["cp0a"]);
+      cache.add(cp0b, states["cp0b"]);
     });
 
     //     epoch: 19         20           21         22          23
@@ -589,7 +580,7 @@ describe("PersistentCheckpointStateCache", () => {
     //                       0a
     it("no reorg", async () => {
       expect(fileApisBuffer.size).toEqual(0);
-      cache.add(cp1, states["cp1"], true);
+      cache.add(cp1, states["cp1"]);
       expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
@@ -624,7 +615,7 @@ describe("PersistentCheckpointStateCache", () => {
     it("reorg in same epoch", async () => {
       // almost the same to "no reorg" test
       expect(fileApisBuffer.size).toEqual(0);
-      cache.add(cp1, states["cp1"], true);
+      cache.add(cp1, states["cp1"]);
       expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
@@ -674,7 +665,7 @@ describe("PersistentCheckpointStateCache", () => {
       await assertPersistedCheckpointState([], []);
 
       // cp1
-      cache.add(cp1, states["cp1"], true);
+      cache.add(cp1, states["cp1"]);
       expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
@@ -685,7 +676,7 @@ describe("PersistentCheckpointStateCache", () => {
       const cp1aState = state1a.clone();
       cp1aState.slot = 21 * SLOTS_PER_EPOCH;
       const cp1a = {epoch: 21, root: root1a};
-      cache.add(cp1a, new BeaconStateView(cp1aState), true);
+      cache.add(cp1a, new BeaconStateView(cp1aState));
       const blockStateRoot2 = cp1aState.clone();
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
@@ -694,8 +685,8 @@ describe("PersistentCheckpointStateCache", () => {
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       // keep these 2 cp states at epoch 21
-      expect(cache.get(toCheckpointHexPayload(cp1a, true))).not.toBeNull();
-      expect(cache.get(toCheckpointHexPayload(cp1, true))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp1a))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp1))).not.toBeNull();
     });
 
     //     epoch: 19         20           21         22          23
@@ -708,7 +699,7 @@ describe("PersistentCheckpointStateCache", () => {
     it("reorg 1 epoch, no persist 0b", async () => {
       expect(fileApisBuffer.size).toEqual(0);
       // cp1
-      cache.add(cp1, states["cp1"], true);
+      cache.add(cp1, states["cp1"]);
       expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
@@ -716,7 +707,7 @@ describe("PersistentCheckpointStateCache", () => {
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
 
       // simulate regen
-      cache.add(cp0b, states["cp0b"], true);
+      cache.add(cp0b, states["cp0b"]);
       expect(((await cache.getStateOrBytes(cp0bHex)) as IBeaconStateView).hashTreeRoot()).toEqual(
         states["cp0b"].hashTreeRoot()
       );
@@ -724,7 +715,7 @@ describe("PersistentCheckpointStateCache", () => {
       const cp1bState = states["cp0b"].cachedState.clone();
       cp1bState.slot = 21 * SLOTS_PER_EPOCH;
       const cp1b = {epoch: 21, root: root0b};
-      cache.add(cp1b, new BeaconStateView(cp1bState), true);
+      cache.add(cp1b, new BeaconStateView(cp1bState));
       const blockStateRoot2 = cp1bState.clone();
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
@@ -734,8 +725,8 @@ describe("PersistentCheckpointStateCache", () => {
       // but cp0b in-memory state is pruned
       expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
       // keep these 2 cp states at epoch 21
-      expect(cache.get(toCheckpointHexPayload(cp1b, true))).not.toBeNull();
-      expect(cache.get(toCheckpointHexPayload(cp1, true))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp1b))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp1))).not.toBeNull();
     });
 
     //     epoch: 19         20           21         22          23
@@ -762,7 +753,7 @@ describe("PersistentCheckpointStateCache", () => {
       await assertPersistedCheckpointState([], []);
 
       // cp1
-      cache.add(cp1, states["cp1"], true);
+      cache.add(cp1, states["cp1"]);
       expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
@@ -776,11 +767,11 @@ describe("PersistentCheckpointStateCache", () => {
       expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
 
       // root2, regen cp0a
-      cache.add(cp0a, states["cp0a"], true);
+      cache.add(cp0a, states["cp0a"]);
       const cp1aState = state1a.clone();
       cp1aState.slot = 21 * SLOTS_PER_EPOCH;
       const cp1a = {epoch: 21, root: root1a};
-      cache.add(cp1a, new BeaconStateView(cp1aState), true);
+      cache.add(cp1a, new BeaconStateView(cp1aState));
       const blockStateRoot2 = cp1aState.clone();
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
@@ -789,8 +780,8 @@ describe("PersistentCheckpointStateCache", () => {
       await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       // keep these 2 cp states at epoch 21
-      expect(cache.get(toCheckpointHexPayload(cp1a, true))).not.toBeNull();
-      expect(cache.get(toCheckpointHexPayload(cp1, true))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp1a))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp1))).not.toBeNull();
     });
 
     //     epoch: 19         20           21         22          23
@@ -804,7 +795,7 @@ describe("PersistentCheckpointStateCache", () => {
     //                               cp1a={0a, 21}
     it("reorg 2 epochs", async () => {
       // cp1
-      cache.add(cp1, states["cp1"], true);
+      cache.add(cp1, states["cp1"]);
       expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
@@ -818,11 +809,11 @@ describe("PersistentCheckpointStateCache", () => {
       expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
 
       // root2, regen cp0a
-      cache.add(cp0a, states["cp0a"], true);
+      cache.add(cp0a, states["cp0a"]);
       const cp1aState = states["cp0a"].cachedState.clone();
       cp1aState.slot = 21 * SLOTS_PER_EPOCH;
       const cp1a = {epoch: 21, root: root0a};
-      cache.add(cp1a, new BeaconStateView(cp1aState), true);
+      cache.add(cp1a, new BeaconStateView(cp1aState));
       const blockStateRoot2 = cp1aState.clone();
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
@@ -831,8 +822,8 @@ describe("PersistentCheckpointStateCache", () => {
       await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       // keep these 2 cp states at epoch 21
-      expect(cache.get(toCheckpointHexPayload(cp1a, true))).not.toBeNull();
-      expect(cache.get(toCheckpointHexPayload(cp1, true))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp1a))).not.toBeNull();
+      expect(cache.get(toCheckpointHex(cp1))).not.toBeNull();
     });
 
     describe("processState, maxEpochsInMemory = 0", () => {
@@ -848,8 +839,8 @@ describe("PersistentCheckpointStateCache", () => {
           },
           {maxCPStateEpochsInMemory: 0}
         );
-        cache.add(cp0a, states["cp0a"], true);
-        cache.add(cp0b, states["cp0b"], true);
+        cache.add(cp0a, states["cp0a"]);
+        cache.add(cp0b, states["cp0b"]);
       });
 
       //     epoch: 19         20           21         22          23
@@ -900,7 +891,7 @@ describe("PersistentCheckpointStateCache", () => {
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
 
         // simulate reload cp1b
-        cache.add(cp0b, states["cp0b"], true);
+        cache.add(cp0b, states["cp0b"]);
         expect(((await cache.getStateOrBytes(cp0bHex)) as IBeaconStateView).hashTreeRoot()).toEqual(
           states["cp0b"].hashTreeRoot()
         );
@@ -945,7 +936,7 @@ describe("PersistentCheckpointStateCache", () => {
         state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH + 3;
         state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
         // state transition add to cache
-        cache.add(cp0b, states["cp0b"], true);
+        cache.add(cp0b, states["cp0b"]);
         // do not processState root1a because it's late
 
         // no need to reload cp0b because it's available in block state
@@ -954,7 +945,7 @@ describe("PersistentCheckpointStateCache", () => {
         state1b.slot = state1a.slot + 1;
         state1b.blockRoots.set(state1b.slot % SLOTS_PER_HISTORICAL_ROOT, root1b);
         // state transition add to cache
-        cache.add(cp0a, states["cp0a"], true);
+        cache.add(cp0a, states["cp0a"]);
 
         // need to persist 2 checkpoint states
         expect(await cache.processState(toHexString(root1b), new BeaconStateView(state1b))).toEqual(2);
@@ -992,7 +983,7 @@ describe("PersistentCheckpointStateCache", () => {
         state1b.slot = state1a.slot + 1;
         state1b.blockRoots.set(state1b.slot % SLOTS_PER_HISTORICAL_ROOT, root1b);
         // regen should reload cp0a from disk
-        cache.add(cp0a, states["cp0a"], true);
+        cache.add(cp0a, states["cp0a"]);
         expect(await cache.processState(toHexString(root1b), new BeaconStateView(state1b))).toEqual(1);
         await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
 
@@ -1016,18 +1007,18 @@ describe("PersistentCheckpointStateCache", () => {
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
 
-        cache.add(cp1, states["cp1"], true);
+        cache.add(cp1, states["cp1"]);
         expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
         await assertPersistedCheckpointState([cp0b, cp1], [stateBytes["cp0b"], stateBytes["cp1"]]);
 
         // regen should populate cp0a and cp1a checkpoint states
-        cache.add(cp0a, states["cp0a"], true);
+        cache.add(cp0a, states["cp0a"]);
         const cp1a = {epoch: 21, root: root0a};
         const cp1aState = states["cp0a"].cachedState.clone();
         cp1aState.blockRoots.set((20 * SLOTS_PER_EPOCH) % SLOTS_PER_HISTORICAL_ROOT, root0a);
         cp1aState.blockRoots.set((21 * SLOTS_PER_EPOCH) % SLOTS_PER_HISTORICAL_ROOT, root0a);
         cp1aState.slot = 21 * SLOTS_PER_EPOCH;
-        cache.add(cp1a, new BeaconStateView(cp1aState), true);
+        cache.add(cp1a, new BeaconStateView(cp1aState));
 
         const root2 = Buffer.alloc(32, 100);
         const state2 = cp1aState.clone();
@@ -1044,13 +1035,13 @@ describe("PersistentCheckpointStateCache", () => {
   });
 
   async function assertPersistedCheckpointState(cps: phase0.Checkpoint[], stateBytesArr: Uint8Array[]): Promise<void> {
-    const persistedKeys = cps.map((cp) => toHexString(checkpointToDatastoreKey(cp, true)));
+    const persistedKeys = cps.map((cp) => toHexString(checkpointToDatastoreKey(cp)));
     expect(Array.from(fileApisBuffer.keys())).toStrictEqual(persistedKeys);
     for (const [i, persistedKey] of persistedKeys.entries()) {
       expect(fileApisBuffer.get(persistedKey)).toStrictEqual(stateBytesArr[i]);
     }
     for (const [i, cp] of cps.entries()) {
-      const cpHex = toCheckpointHexPayload(cp, true);
+      const cpHex = toCheckpointHex(cp);
       expect(await cache.getStateOrBytes(cpHex)).toStrictEqual(stateBytesArr[i]);
       // simple get() does not reload from disk
       expect(cache.get(cpHex)).toBeNull();

--- a/packages/beacon-node/test/unit/chain/regen/regen.test.ts
+++ b/packages/beacon-node/test/unit/chain/regen/regen.test.ts
@@ -85,9 +85,9 @@ describe("regen", () => {
         {maxCPStateEpochsInMemory: 2}
       );
 
-      cache.add(cp0a, states["cp0a"], true);
-      cache.add(cp0b, states["cp0b"], true);
-      cache.add(cp1, states["cp1"], true);
+      cache.add(cp0a, states["cp0a"]);
+      cache.add(cp0b, states["cp0b"]);
+      cache.add(cp1, states["cp1"]);
     });
 
     /**

--- a/packages/beacon-node/test/utils/chain/stateCache/datastore.ts
+++ b/packages/beacon-node/test/utils/chain/stateCache/datastore.ts
@@ -3,8 +3,8 @@ import {CPStateDatastore, checkpointToDatastoreKey} from "../../../../src/chain/
 
 export function getTestDatastore(fileApisBuffer: Map<string, Uint8Array>): CPStateDatastore {
   const datastore: CPStateDatastore = {
-    write: (cp, stateBytes, payloadPresent) => {
-      const persistentKey = checkpointToDatastoreKey(cp, payloadPresent);
+    write: (cp, stateBytes) => {
+      const persistentKey = checkpointToDatastoreKey(cp);
       const stringKey = toHexString(persistentKey);
       if (!fileApisBuffer.has(stringKey)) {
         fileApisBuffer.set(stringKey, stateBytes);


### PR DESCRIPTION
To prepare state cache for ethereum/consensus-specs#5094.

Original epbs state cache PR: #8868 


## Summary
- Removes `payloadPresent` tracking from `CheckpointStateCache`, its datastore layer, and `FIFOBlockStateCache`
- Reverts `epochIndex` from bitmask-based `Map<RootHex, number>` back to `Set<RootHex>`
- Simplifies cache key format from `{rootHex}_{epoch}_{payloadPresent}` to `{rootHex}_{epoch}`
- Removes `upgradeToGloas()` / `upgradeForGloas()` block state cache upgrade path
- Removes `PayloadAvailability` enum and dual-variant iteration in persist/prune/reload paths
- Drops `payloadPresent` suffix from datastore checkpoint keys

This reverts the dual-state architecture introduced in #8868, where each Gloas block produced both a block state and a payload state. The consensus specs have since moved to a single-state model (consensus-specs PR #5094), making this complexity unnecessary.

The regen interface still carries `payloadPresent` parameters as a pass-through — these are ignored by the cache and will be cleaned up in a follow-up PR.

> This PR was written with AI assistance (Claude Code) for code generation and codebase understanding.

## Test plan
- [ ] `pnpm check-types` passes
- [ ] `pnpm lint` passes
- [ ] `persistentCheckpointsCache.test.ts` unit tests pass
- [ ] `regen.test.ts` unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)