### PR TITLE
fix: resume spec test downloads and show progress

### DIFF
--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -10,6 +10,7 @@ const ARTIFACT_FILENAMES = new Set([
   "._.DS_Store",
   ".DS_Store",
   // File included by spec tests downloader
+  ".download-state",
   "version.txt",
 ]);
 

--- a/packages/spec-test-util/src/downloadProgress.ts
+++ b/packages/spec-test-util/src/downloadProgress.ts
@@ -189,7 +189,7 @@ function formatProgressLine(label: string, progress: ProgressEntry | undefined):
   const totalBytes = progress.totalBytes;
   const transferred = formatBytes(progress.transferredBytes);
 
-  if (totalBytes === null || totalBytes <= 0) {
+  if (totalBytes === null || !Number.isFinite(totalBytes) || totalBytes <= 0) {
     return `${label} ${transferred}`;
   }
 

--- a/packages/spec-test-util/src/downloadProgress.ts
+++ b/packages/spec-test-util/src/downloadProgress.ts
@@ -1,0 +1,218 @@
+import readline from "node:readline";
+
+const TTY_RENDER_INTERVAL_MS = 100;
+const NON_TTY_PROGRESS_MILESTONES = [10, 25, 50, 75, 100];
+
+type ProgressEntry = {
+  transferredBytes: number;
+  totalBytes: number | null;
+};
+
+export type DownloadProgressReporterOptions = {
+  log: (msg: string) => void;
+  enabled: boolean;
+};
+
+type DownloadProgressReporter = {
+  start(label: string, totalBytes: number | null): void;
+  update(label: string, transferredBytes: number): void;
+  retry(label: string, attempt: number, message: string): void;
+  downloaded(label: string, transferredBytes: number): void;
+  extracted(label: string, outputDir: string): void;
+  close(): void;
+};
+
+export function createDownloadProgressReporter({
+  log,
+  enabled,
+}: DownloadProgressReporterOptions): DownloadProgressReporter {
+  if (enabled && process.stdout.isTTY) {
+    return new TtyDownloadProgressReporter(log);
+  }
+
+  return new LogDownloadProgressReporter(log);
+}
+
+class TtyDownloadProgressReporter implements DownloadProgressReporter {
+  private readonly progressByLabel = new Map<string, ProgressEntry>();
+  private readonly orderedLabels: string[] = [];
+  private renderTimer: NodeJS.Timeout | null = null;
+  private renderedLines = 0;
+
+  constructor(private readonly log: (msg: string) => void) {}
+
+  start(label: string, totalBytes: number | null): void {
+    if (!this.progressByLabel.has(label)) {
+      this.orderedLabels.push(label);
+    }
+
+    this.progressByLabel.set(label, {transferredBytes: 0, totalBytes});
+    this.scheduleRender();
+  }
+
+  update(label: string, transferredBytes: number): void {
+    const progress = this.progressByLabel.get(label);
+    if (!progress) {
+      return;
+    }
+
+    progress.transferredBytes = transferredBytes;
+    this.scheduleRender();
+  }
+
+  retry(label: string, attempt: number, message: string): void {
+    this.logMessage(`Download attempt ${attempt} for ${label} failed: ${message}`);
+  }
+
+  downloaded(label: string, transferredBytes: number): void {
+    this.progressByLabel.delete(label);
+    this.removeLabel(label);
+    this.logMessage(`Downloaded ${label} - ${transferredBytes} bytes`);
+  }
+
+  extracted(label: string, outputDir: string): void {
+    this.logMessage(`Extracted ${label} to ${outputDir}`);
+  }
+
+  close(): void {
+    if (this.renderTimer !== null) {
+      clearTimeout(this.renderTimer);
+      this.renderTimer = null;
+    }
+
+    this.clearRenderedBlock();
+  }
+
+  private scheduleRender(): void {
+    if (this.renderTimer !== null) {
+      return;
+    }
+
+    this.renderTimer = setTimeout(() => {
+      this.renderTimer = null;
+      this.render();
+    }, TTY_RENDER_INTERVAL_MS);
+  }
+
+  private render(): void {
+    this.clearRenderedBlock();
+
+    if (this.orderedLabels.length === 0) {
+      return;
+    }
+
+    const lines = this.orderedLabels.map((label) => formatProgressLine(label, this.progressByLabel.get(label)));
+    process.stdout.write(`${lines.join("\n")}\n`);
+    this.renderedLines = lines.length;
+  }
+
+  private clearRenderedBlock(): void {
+    if (this.renderedLines === 0) {
+      return;
+    }
+
+    readline.moveCursor(process.stdout, 0, -this.renderedLines);
+    readline.cursorTo(process.stdout, 0);
+    readline.clearScreenDown(process.stdout);
+    this.renderedLines = 0;
+  }
+
+  private logMessage(message: string): void {
+    this.clearRenderedBlock();
+    this.log(message);
+    this.render();
+  }
+
+  private removeLabel(label: string): void {
+    const index = this.orderedLabels.indexOf(label);
+    if (index >= 0) {
+      this.orderedLabels.splice(index, 1);
+    }
+  }
+}
+
+class LogDownloadProgressReporter implements DownloadProgressReporter {
+  private readonly progressByLabel = new Map<string, ProgressEntry>();
+  private readonly loggedMilestonesByLabel = new Map<string, Set<number>>();
+
+  constructor(private readonly log: (msg: string) => void) {}
+
+  start(label: string, totalBytes: number | null): void {
+    this.progressByLabel.set(label, {transferredBytes: 0, totalBytes});
+    this.loggedMilestonesByLabel.set(label, new Set());
+    this.log(`Downloading ${label} - ${totalBytes ?? "unknown"} bytes`);
+  }
+
+  update(label: string, transferredBytes: number): void {
+    const progress = this.progressByLabel.get(label);
+    if (!progress || progress.totalBytes === null) {
+      return;
+    }
+
+    progress.transferredBytes = transferredBytes;
+    const percentage = Math.floor((progress.transferredBytes / progress.totalBytes) * 100);
+    const loggedMilestones = this.loggedMilestonesByLabel.get(label);
+    if (!loggedMilestones) {
+      return;
+    }
+
+    for (const milestone of NON_TTY_PROGRESS_MILESTONES) {
+      if (percentage >= milestone && !loggedMilestones.has(milestone)) {
+        loggedMilestones.add(milestone);
+        this.log(`${label} ${milestone}% (${progress.transferredBytes}/${progress.totalBytes} bytes)`);
+      }
+    }
+  }
+
+  retry(label: string, attempt: number, message: string): void {
+    this.log(`Download attempt ${attempt} for ${label} failed: ${message}`);
+  }
+
+  downloaded(label: string, transferredBytes: number): void {
+    this.progressByLabel.delete(label);
+    this.loggedMilestonesByLabel.delete(label);
+    this.log(`Downloaded ${label} - ${transferredBytes} bytes`);
+  }
+
+  extracted(label: string, outputDir: string): void {
+    this.log(`Extracted ${label} to ${outputDir}`);
+  }
+
+  close(): void {}
+}
+
+function formatProgressLine(label: string, progress: ProgressEntry | undefined): string {
+  if (!progress) {
+    return label;
+  }
+
+  const totalBytes = progress.totalBytes;
+  const transferred = formatBytes(progress.transferredBytes);
+
+  if (totalBytes === null || totalBytes <= 0) {
+    return `${label} ${transferred}`;
+  }
+
+  const percentage = Math.floor((progress.transferredBytes / totalBytes) * 100);
+  const progressBarWidth = 24;
+  const completedWidth = Math.round((Math.min(percentage, 100) / 100) * progressBarWidth);
+  const progressBar = `${"#".repeat(completedWidth)}${"-".repeat(progressBarWidth - completedWidth)}`;
+
+  return `${label} [${progressBar}] ${percentage.toString().padStart(3)}% ${transferred}/${formatBytes(totalBytes)}`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  const units = ["KiB", "MiB", "GiB", "TiB"];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+
+  return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unitIndex]}`;
+}

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -1,15 +1,18 @@
 import {execFile} from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import {Readable, Transform} from "node:stream";
 import {pipeline} from "node:stream/promises";
 import {ReadableStream as NodeReadableStream} from "node:stream/web";
 import {promisify} from "node:util";
 import {rimraf} from "rimraf";
 import {fetch, retry} from "@lodestar/utils";
+import {createDownloadProgressReporter} from "./downloadProgress.js";
 
 export const defaultSpecTestsRepoUrl = "https://github.com/ethereum/consensus-specs";
 
 const logEmpty = (): void => {};
+const DOWNLOAD_STATE_DIRNAME = ".download-state";
 
 export type DownloadTestsOptions = {
   specVersion: string;
@@ -44,65 +47,172 @@ export async function downloadGenericSpecTests<TestNames extends string>(
 ): Promise<void> {
   log(`outputDir = ${outputDir}`);
 
-  // Use version.txt as a flag to prevent re-downloading the tests
-  const versionFile = path.join(outputDir, "version.txt");
-  const existingVersion = fs.existsSync(versionFile) && fs.readFileSync(versionFile, "utf8").trim();
-
-  if (existingVersion === specVersion) {
-    return log(`version ${specVersion} already downloaded`);
-  }
-  log(`Downloading new version ${specVersion}`);
-
-  if (fs.existsSync(outputDir)) {
-    log(`Cleaning existing version ${existingVersion} at ${outputDir}`);
-    rimraf.sync(outputDir);
+  const {versionFile, stateDir, missingTests, isFullyDownloaded} = prepareOutputDir(
+    outputDir,
+    specVersion,
+    testsToDownload,
+    log
+  );
+  if (isFullyDownloaded) {
+    return;
   }
 
-  fs.mkdirSync(outputDir, {recursive: true});
+  const progressReporter = createDownloadProgressReporter({
+    log,
+    enabled: log !== logEmpty,
+  });
 
-  await Promise.all(
-    testsToDownload.map(async (test) => {
+  const results = await Promise.allSettled(
+    missingTests.map(async (test) => {
       const url = `${specTestsRepoUrl ?? defaultSpecTestsRepoUrl}/releases/download/${specVersion}/${test}.tar.gz`;
-      const tarball = path.join(outputDir, `${test}.tar.gz`);
-
-      await retry(
-        async () => {
-          const res = await fetch(url, {signal: AbortSignal.timeout(30 * 60 * 1000)});
-
-          if (!res.ok) {
-            throw new Error(`Failed to download file from ${url}: ${res.status} ${res.statusText}`);
-          }
-
-          if (!res.body) {
-            throw new Error("Response body is null");
-          }
-
-          const totalSize = res.headers.get("content-length");
-          log(`Downloading ${url} - ${totalSize} bytes`);
-
-          // stream download to local .tar.gz file
-          await pipeline(res.body as unknown as NodeReadableStream, fs.createWriteStream(tarball));
-          log(`Downloaded ${url} - ${fs.statSync(tarball).size} bytes`);
-
-          // extract tar into output directory
-          await promisify(execFile)("tar", ["-xzf", tarball, "-C", outputDir, "--exclude=._*", "--exclude=*/._*"], {
-            maxBuffer: 1000 * 1024 * 1024, // 1 GB
-          });
-          log(`Extracted ${tarball} to ${outputDir}`);
-
-          fs.unlinkSync(tarball);
-        },
-        {
-          retries: 3,
-          onRetry: (e, attempt) => {
-            log(`Download attempt ${attempt} for ${url} failed: ${e.message}`);
-          },
-        }
-      );
-
-      // download tar
+      await downloadAndExtractArchive({outputDir, stateDir, test, url, progressReporter});
     })
   );
 
+  progressReporter.close();
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      throw result.reason;
+    }
+  }
+
   fs.writeFileSync(versionFile, specVersion);
+}
+
+type PreparedOutputDir = {
+  versionFile: string;
+  stateDir: string;
+  missingTests: string[];
+  isFullyDownloaded: boolean;
+};
+
+type DownloadAndExtractArchiveOpts = {
+  outputDir: string;
+  stateDir: string;
+  test: string;
+  url: string;
+  progressReporter: ReturnType<typeof createDownloadProgressReporter>;
+};
+
+function prepareOutputDir<TestNames extends string>(
+  outputDir: string,
+  specVersion: string,
+  testsToDownload: TestNames[],
+  log: (msg: string) => void
+): PreparedOutputDir {
+  const versionFile = path.join(outputDir, "version.txt");
+  const stateDir = path.join(outputDir, DOWNLOAD_STATE_DIRNAME);
+  const outputDirExists = fs.existsSync(outputDir);
+  const existingVersion = readExistingVersion(versionFile);
+  const stateDirExists = fs.existsSync(stateDir);
+
+  if (existingVersion === specVersion) {
+    fs.mkdirSync(stateDir, {recursive: true});
+
+    if (!stateDirExists) {
+      for (const test of testsToDownload) {
+        fs.closeSync(fs.openSync(getDoneMarkerPath(stateDir, test), "w"));
+      }
+    }
+
+    const missingTests = testsToDownload.filter((test) => !fs.existsSync(getDoneMarkerPath(stateDir, test)));
+    if (missingTests.length === 0) {
+      log(`version ${specVersion} already downloaded`);
+      return {versionFile, stateDir, missingTests, isFullyDownloaded: true};
+    }
+
+    log(`Resuming version ${specVersion}`);
+    return {versionFile, stateDir, missingTests, isFullyDownloaded: false};
+  }
+
+  log(`Downloading new version ${specVersion}`);
+  if (outputDirExists) {
+    log(`Cleaning existing version ${existingVersion ?? "unknown"} at ${outputDir}`);
+    rimraf.sync(outputDir);
+  }
+
+  fs.mkdirSync(stateDir, {recursive: true});
+  fs.writeFileSync(versionFile, specVersion);
+
+  return {
+    versionFile,
+    stateDir,
+    missingTests: [...testsToDownload],
+    isFullyDownloaded: testsToDownload.length === 0,
+  };
+}
+
+function readExistingVersion(versionFile: string): string | null {
+  if (!fs.existsSync(versionFile)) {
+    return null;
+  }
+
+  return fs.readFileSync(versionFile, "utf8").trim();
+}
+
+function getDoneMarkerPath(stateDir: string, test: string): string {
+  return path.join(stateDir, `${encodeURIComponent(test)}.done`);
+}
+
+async function downloadAndExtractArchive({
+  outputDir,
+  stateDir,
+  test,
+  url,
+  progressReporter,
+}: DownloadAndExtractArchiveOpts): Promise<void> {
+  const tarball = path.join(outputDir, `${test}.tar.gz.part`);
+  const doneMarker = getDoneMarkerPath(stateDir, test);
+  const label = `${test}.tar.gz`;
+
+  await retry(
+    async () => {
+      fs.rmSync(tarball, {force: true});
+
+      const res = await fetch(url, {signal: AbortSignal.timeout(30 * 60 * 1000)});
+      if (!res.ok) {
+        throw new Error(`Failed to download file from ${url}: ${res.status} ${res.statusText}`);
+      }
+
+      if (!res.body) {
+        throw new Error("Response body is null");
+      }
+
+      const totalBytesHeader = res.headers.get("content-length");
+      const totalBytes = totalBytesHeader ? Number.parseInt(totalBytesHeader, 10) : null;
+      progressReporter.start(label, totalBytes);
+
+      let transferredBytes = 0;
+      const body = Readable.fromWeb(res.body as unknown as NodeReadableStream);
+      const progressStream = new Transform({
+        transform(chunk: Buffer, _encoding, callback) {
+          transferredBytes += chunk.length;
+          progressReporter.update(label, transferredBytes);
+          callback(null, chunk);
+        },
+      });
+
+      await pipeline(body, progressStream, fs.createWriteStream(tarball));
+      progressReporter.downloaded(label, transferredBytes);
+
+      await extractTarball(tarball, outputDir);
+      progressReporter.extracted(label, outputDir);
+
+      fs.closeSync(fs.openSync(doneMarker, "w"));
+      fs.rmSync(tarball, {force: true});
+    },
+    {
+      retries: 3,
+      onRetry: (e, attempt) => {
+        progressReporter.retry(label, attempt, e.message);
+      },
+    }
+  );
+}
+
+async function extractTarball(tarball: string, outputDir: string): Promise<void> {
+  await promisify(execFile)("tar", ["-xzf", tarball, "-C", outputDir, "--exclude=._*", "--exclude=*/._*"], {
+    maxBuffer: 1000 * 1024 * 1024, // 1 GB
+  });
 }

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -180,7 +180,7 @@ async function downloadAndExtractArchive({
       }
 
       const totalBytesHeader = res.headers.get("content-length");
-      const totalBytes = totalBytesHeader ? Number.parseInt(totalBytesHeader, 10) : null;
+      const totalBytes = parseContentLength(totalBytesHeader);
       progressReporter.start(label, totalBytes);
 
       let transferredBytes = 0;
@@ -215,4 +215,13 @@ async function extractTarball(tarball: string, outputDir: string): Promise<void>
   await promisify(execFile)("tar", ["-xzf", tarball, "-C", outputDir, "--exclude=._*", "--exclude=*/._*"], {
     maxBuffer: 1000 * 1024 * 1024, // 1 GB
   });
+}
+
+function parseContentLength(contentLengthHeader: string | null): number | null {
+  if (contentLengthHeader === null) {
+    return null;
+  }
+
+  const totalBytes = Number.parseInt(contentLengthHeader, 10);
+  return Number.isFinite(totalBytes) && totalBytes > 0 ? totalBytes : null;
 }

--- a/packages/spec-test-util/test/unit/downloadTests.test.ts
+++ b/packages/spec-test-util/test/unit/downloadTests.test.ts
@@ -1,0 +1,359 @@
+import {execFileSync} from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {fetch} from "@lodestar/utils";
+import {createDownloadProgressReporter} from "../../src/downloadProgress.js";
+import {downloadGenericSpecTests} from "../../src/downloadTests.js";
+
+vi.mock("@lodestar/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lodestar/utils")>();
+  return {
+    ...actual,
+    fetch: vi.fn(),
+  };
+});
+
+type TestConsoleWrite = typeof process.stdout.write;
+
+const fetchMock = vi.mocked(fetch);
+const createdDirs: string[] = [];
+const stdoutIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+
+describe("downloadGenericSpecTests", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    fetchMock.mockReset();
+    restoreStdoutIsTTY();
+
+    while (createdDirs.length > 0) {
+      const dir = createdDirs.pop();
+      if (dir) {
+        fs.rmSync(dir, {recursive: true, force: true});
+      }
+    }
+  });
+
+  it("downloads only missing archives when resuming the same version", async () => {
+    const outputDir = createTempDir();
+    const version = "v1.7.0-alpha.3";
+    const stateDir = path.join(outputDir, ".download-state");
+    fs.mkdirSync(stateDir, {recursive: true});
+    fs.writeFileSync(path.join(outputDir, "version.txt"), version);
+    fs.closeSync(fs.openSync(path.join(stateDir, "general.done"), "w"));
+    fs.mkdirSync(path.join(outputDir, "tests", "general"), {recursive: true});
+    fs.writeFileSync(path.join(outputDir, "tests", "general", "existing.txt"), "general");
+
+    const archiveFixtures = {
+      "mainnet.tar.gz": createArchiveFixture("mainnet", {"tests/mainnet/file.txt": "mainnet"}),
+      "minimal.tar.gz": createArchiveFixture("minimal", {"tests/minimal/file.txt": "minimal"}),
+    };
+    setFetchMock(archiveFixtures);
+
+    const logs: string[] = [];
+    await downloadGenericSpecTests(
+      {
+        specVersion: version,
+        outputDir,
+        specTestsRepoUrl: "https://example.test/specs",
+        testsToDownload: ["general", "mainnet", "minimal"],
+      },
+      (message) => logs.push(message)
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fs.readFileSync(path.join(outputDir, "tests", "general", "existing.txt"), "utf8")).toBe("general");
+    expect(fs.readFileSync(path.join(outputDir, "tests", "mainnet", "file.txt"), "utf8")).toBe("mainnet");
+    expect(fs.readFileSync(path.join(outputDir, "tests", "minimal", "file.txt"), "utf8")).toBe("minimal");
+    expect(fs.existsSync(path.join(stateDir, "general.done"))).toBe(true);
+    expect(fs.existsSync(path.join(stateDir, "mainnet.done"))).toBe(true);
+    expect(fs.existsSync(path.join(stateDir, "minimal.done"))).toBe(true);
+    expect(logs).toContain(`Resuming version ${version}`);
+  });
+
+  it("migrates a legacy complete download that only has version.txt", async () => {
+    const outputDir = createTempDir();
+    const version = "v1.7.0-alpha.3";
+    fs.mkdirSync(path.join(outputDir, "tests", "general"), {recursive: true});
+    fs.writeFileSync(path.join(outputDir, "tests", "general", "existing.txt"), "general");
+    fs.writeFileSync(path.join(outputDir, "version.txt"), version);
+
+    const logs: string[] = [];
+    await downloadGenericSpecTests(
+      {
+        specVersion: version,
+        outputDir,
+        specTestsRepoUrl: "https://example.test/specs",
+        testsToDownload: ["general"],
+      },
+      (message) => logs.push(message)
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(outputDir, ".download-state", "general.done"))).toBe(true);
+    expect(logs).toContain(`version ${version} already downloaded`);
+  });
+
+  it("cleans an existing directory when the version changes", async () => {
+    const outputDir = createTempDir();
+    fs.writeFileSync(path.join(outputDir, "version.txt"), "v1.6.0");
+    fs.writeFileSync(path.join(outputDir, "stale.txt"), "stale");
+
+    setFetchMock({
+      "general.tar.gz": createArchiveFixture("general", {"tests/general/file.txt": "fresh"}),
+    });
+
+    await downloadGenericSpecTests(
+      {
+        specVersion: "v1.7.0-alpha.3",
+        outputDir,
+        specTestsRepoUrl: "https://example.test/specs",
+        testsToDownload: ["general"],
+      },
+      () => {}
+    );
+
+    expect(fs.existsSync(path.join(outputDir, "stale.txt"))).toBe(false);
+    expect(fs.readFileSync(path.join(outputDir, "version.txt"), "utf8")).toBe("v1.7.0-alpha.3");
+    expect(fs.readFileSync(path.join(outputDir, "tests", "general", "file.txt"), "utf8")).toBe("fresh");
+  });
+
+  it("cleans an unknown partial directory when version.txt is missing", async () => {
+    const outputDir = createTempDir();
+    fs.writeFileSync(path.join(outputDir, "stale.txt"), "stale");
+
+    setFetchMock({
+      "general.tar.gz": createArchiveFixture("general", {"tests/general/file.txt": "fresh"}),
+    });
+
+    await downloadGenericSpecTests(
+      {
+        specVersion: "v1.7.0-alpha.3",
+        outputDir,
+        specTestsRepoUrl: "https://example.test/specs",
+        testsToDownload: ["general"],
+      },
+      () => {}
+    );
+
+    expect(fs.existsSync(path.join(outputDir, "stale.txt"))).toBe(false);
+    expect(fs.readFileSync(path.join(outputDir, "tests", "general", "file.txt"), "utf8")).toBe("fresh");
+  });
+
+  it("keeps completed archives when another archive fails", async () => {
+    const outputDir = createTempDir();
+    const invalidArchive = path.join(createTempDir(), "invalid.tar.gz");
+    fs.writeFileSync(invalidArchive, "not a tarball");
+
+    setFetchMock({
+      "general.tar.gz": createArchiveFixture("general", {"tests/general/file.txt": "general"}),
+      "mainnet.tar.gz": invalidArchive,
+    });
+
+    await expect(
+      downloadGenericSpecTests(
+        {
+          specVersion: "v1.7.0-alpha.3",
+          outputDir,
+          specTestsRepoUrl: "https://example.test/specs",
+          testsToDownload: ["general", "mainnet"],
+        },
+        () => {}
+      )
+    ).rejects.toThrow();
+
+    expect(fs.readFileSync(path.join(outputDir, "tests", "general", "file.txt"), "utf8")).toBe("general");
+    expect(fs.existsSync(path.join(outputDir, ".download-state", "general.done"))).toBe(true);
+    expect(fs.existsSync(path.join(outputDir, ".download-state", "mainnet.done"))).toBe(false);
+  });
+
+  it("retries a failed extraction and cleans up the temporary tarball", async () => {
+    const outputDir = createTempDir();
+    const invalidArchive = path.join(createTempDir(), "invalid.tar.gz");
+    fs.writeFileSync(invalidArchive, "not a tarball");
+
+    let attempts = 0;
+    fetchMock.mockImplementation(async (url) => {
+      const archiveName = getArchiveName(url);
+      attempts++;
+      if (archiveName !== "general.tar.gz") {
+        throw new Error(`Unexpected archive ${archiveName}`);
+      }
+
+      return createArchiveResponse(
+        attempts === 1 ? invalidArchive : createArchiveFixture("general", {"tests/general/file.txt": "general"})
+      );
+    });
+
+    await downloadGenericSpecTests(
+      {
+        specVersion: "v1.7.0-alpha.3",
+        outputDir,
+        specTestsRepoUrl: "https://example.test/specs",
+        testsToDownload: ["general"],
+      },
+      () => {}
+    );
+
+    expect(attempts).toBe(2);
+    expect(fs.readFileSync(path.join(outputDir, "tests", "general", "file.txt"), "utf8")).toBe("general");
+    expect(fs.existsSync(path.join(outputDir, "general.tar.gz.part"))).toBe(false);
+  });
+
+  it("does not write a done marker when extraction never succeeds", async () => {
+    const outputDir = createTempDir();
+    const invalidArchive = path.join(createTempDir(), "invalid.tar.gz");
+    fs.writeFileSync(invalidArchive, "not a tarball");
+
+    setFetchMock({
+      "general.tar.gz": invalidArchive,
+    });
+
+    await expect(
+      downloadGenericSpecTests(
+        {
+          specVersion: "v1.7.0-alpha.3",
+          outputDir,
+          specTestsRepoUrl: "https://example.test/specs",
+          testsToDownload: ["general"],
+        },
+        () => {}
+      )
+    ).rejects.toThrow();
+
+    expect(fs.existsSync(path.join(outputDir, ".download-state", "general.done"))).toBe(false);
+  });
+
+  it("logs plain progress milestones outside of TTY mode", async () => {
+    setStdoutIsTTY(false);
+    const outputDir = createTempDir();
+    const logs: string[] = [];
+
+    setFetchMock({
+      "general.tar.gz": createArchiveFixture("general", {"tests/general/file.txt": "general"}, 16),
+    });
+
+    await downloadGenericSpecTests(
+      {
+        specVersion: "v1.7.0-alpha.3",
+        outputDir,
+        specTestsRepoUrl: "https://example.test/specs",
+        testsToDownload: ["general"],
+      },
+      (message) => logs.push(message)
+    );
+
+    expect(logs.some((message) => message.startsWith("Downloading general.tar.gz -"))).toBe(true);
+    expect(logs.some((message) => message.includes("general.tar.gz 100%"))).toBe(true);
+    expect(logs.some((message) => message.startsWith("Downloaded general.tar.gz - "))).toBe(true);
+    expect(logs).toContain(`Extracted general.tar.gz to ${outputDir}`);
+    expect(logs.every((message) => !message.includes("\r"))).toBe(true);
+  });
+});
+
+describe("createDownloadProgressReporter", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    restoreStdoutIsTTY();
+  });
+
+  it("updates tty progress in place instead of logging a new line per update", () => {
+    vi.useFakeTimers();
+    setStdoutIsTTY(true);
+
+    const log = vi.fn();
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as TestConsoleWrite);
+    const reporter = createDownloadProgressReporter({log, enabled: true});
+
+    reporter.start("mainnet.tar.gz", 100);
+    vi.advanceTimersByTime(100);
+    reporter.update("mainnet.tar.gz", 50);
+    vi.advanceTimersByTime(100);
+    reporter.close();
+
+    expect(log).not.toHaveBeenCalled();
+    expect(writeSpy.mock.calls.some(([value]) => String(value).includes("mainnet.tar.gz ["))).toBe(true);
+    expect(writeSpy.mock.calls.some(([value]) => String(value).includes("\u001b["))).toBe(true);
+  });
+});
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lodestar-spec-test-util-"));
+  createdDirs.push(dir);
+  return dir;
+}
+
+function createArchiveFixture(archiveName: string, files: Record<string, string>, chunkSize = 32): string {
+  const fixtureDir = createTempDir();
+  const sourceDir = path.join(fixtureDir, `source-${archiveName}`);
+  fs.mkdirSync(sourceDir, {recursive: true});
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absolutePath = path.join(sourceDir, relativePath);
+    fs.mkdirSync(path.dirname(absolutePath), {recursive: true});
+    fs.writeFileSync(absolutePath, content);
+  }
+
+  const archivePath = path.join(fixtureDir, `${archiveName}.tar.gz`);
+  execFileSync("tar", ["-czf", archivePath, "-C", sourceDir, "."]);
+  fs.writeFileSync(`${archivePath}.chunk-size`, String(chunkSize));
+  return archivePath;
+}
+
+function setFetchMock(archivesByName: Record<string, string>): void {
+  fetchMock.mockImplementation(async (url) => {
+    const archiveName = getArchiveName(url);
+    const archivePath = archivesByName[archiveName];
+    if (!archivePath) {
+      throw new Error(`Unexpected archive ${archiveName}`);
+    }
+
+    return createArchiveResponse(archivePath);
+  });
+}
+
+function createArchiveResponse(archivePath: string): Response {
+  const bytes = fs.readFileSync(archivePath);
+  const chunkSizeFile = `${archivePath}.chunk-size`;
+  const chunkSize = fs.existsSync(chunkSizeFile) ? Number.parseInt(fs.readFileSync(chunkSizeFile, "utf8"), 10) : 32;
+
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let index = 0; index < bytes.length; index += chunkSize) {
+        controller.enqueue(bytes.subarray(index, Math.min(index + chunkSize, bytes.length)));
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(body, {
+    headers: {
+      "content-length": String(bytes.length),
+    },
+  });
+}
+
+function getArchiveName(url: string | URL | Request): string {
+  const href = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+  const pathname = new URL(href).pathname;
+  return pathname.slice(pathname.lastIndexOf("/") + 1);
+}
+
+function setStdoutIsTTY(isTTY: boolean): void {
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value: isTTY,
+  });
+}
+
+function restoreStdoutIsTTY(): void {
+  if (stdoutIsTTYDescriptor) {
+    Object.defineProperty(process.stdout, "isTTY", stdoutIsTTYDescriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(process.stdout as NodeJS.WriteStream & {isTTY?: boolean}, "isTTY");
+}

--- a/packages/spec-test-util/test/unit/downloadTests.test.ts
+++ b/packages/spec-test-util/test/unit/downloadTests.test.ts
@@ -251,6 +251,35 @@ describe("downloadGenericSpecTests", () => {
     expect(logs).toContain(`Extracted general.tar.gz to ${outputDir}`);
     expect(logs.every((message) => !message.includes("\r"))).toBe(true);
   });
+
+  it("treats invalid content-length as unknown size", async () => {
+    setStdoutIsTTY(true);
+    vi.useFakeTimers();
+
+    const outputDir = createTempDir();
+    const archivePath = createArchiveFixture("general", {"tests/general/file.txt": "general"});
+    setFetchMock(
+      {
+        "general.tar.gz": archivePath,
+      },
+      "not-a-number"
+    );
+
+    const downloadPromise = downloadGenericSpecTests(
+      {
+        specVersion: "v1.7.0-alpha.3",
+        outputDir,
+        specTestsRepoUrl: "https://example.test/specs",
+        testsToDownload: ["general"],
+      },
+      () => {}
+    );
+
+    vi.runAllTimers();
+    await downloadPromise;
+
+    expect(fs.readFileSync(path.join(outputDir, "tests", "general", "file.txt"), "utf8")).toBe("general");
+  });
 });
 
 describe("createDownloadProgressReporter", () => {
@@ -278,6 +307,24 @@ describe("createDownloadProgressReporter", () => {
     expect(writeSpy.mock.calls.some(([value]) => String(value).includes("mainnet.tar.gz ["))).toBe(true);
     expect(writeSpy.mock.calls.some(([value]) => String(value).includes("\u001b["))).toBe(true);
   });
+
+  it("treats non-finite totals as unknown size in tty mode", () => {
+    vi.useFakeTimers();
+    setStdoutIsTTY(true);
+
+    const log = vi.fn();
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as TestConsoleWrite);
+    const reporter = createDownloadProgressReporter({log, enabled: true});
+
+    reporter.start("mainnet.tar.gz", Number.NaN);
+    vi.advanceTimersByTime(100);
+    reporter.update("mainnet.tar.gz", 50);
+    vi.advanceTimersByTime(100);
+    reporter.close();
+
+    expect(writeSpy.mock.calls.some(([value]) => String(value).includes("mainnet.tar.gz 50 B"))).toBe(true);
+    expect(writeSpy.mock.calls.every(([value]) => !String(value).includes("NaN"))).toBe(true);
+  });
 });
 
 function createTempDir(): string {
@@ -303,7 +350,7 @@ function createArchiveFixture(archiveName: string, files: Record<string, string>
   return archivePath;
 }
 
-function setFetchMock(archivesByName: Record<string, string>): void {
+function setFetchMock(archivesByName: Record<string, string>, contentLengthHeader?: string): void {
   fetchMock.mockImplementation(async (url) => {
     const archiveName = getArchiveName(url);
     const archivePath = archivesByName[archiveName];
@@ -311,11 +358,11 @@ function setFetchMock(archivesByName: Record<string, string>): void {
       throw new Error(`Unexpected archive ${archiveName}`);
     }
 
-    return createArchiveResponse(archivePath);
+    return createArchiveResponse(archivePath, contentLengthHeader);
   });
 }
 
-function createArchiveResponse(archivePath: string): Response {
+function createArchiveResponse(archivePath: string, contentLengthHeader?: string): Response {
   const bytes = fs.readFileSync(archivePath);
   const chunkSizeFile = `${archivePath}.chunk-size`;
   const chunkSize = fs.existsSync(chunkSizeFile) ? Number.parseInt(fs.readFileSync(chunkSizeFile, "utf8"), 10) : 32;
@@ -331,7 +378,7 @@ function createArchiveResponse(archivePath: string): Response {
 
   return new Response(body, {
     headers: {
-      "content-length": String(bytes.length),
+      "content-length": contentLengthHeader ?? String(bytes.length),
     },
   });
 }


### PR DESCRIPTION
**Motivation**

  `download-spec-tests` still had the original `#6991` behavior on `unstable`:
  same-version interrupted runs were not resumable because completion was tracked
  only by a final root `version.txt`, and download progress was not shown in a
  useful way.

**Description**

This change fixes the downloader in `@lodestar/spec-test-util` by:

  - tracking completion per archive in a hidden `.download-state` directory
  - keeping the root `version.txt` for compatibility
  - resuming same-version interrupted runs by downloading only missing archives
  - downloading through `*.tar.gz.part` and only marking an archive complete after extraction succeeds
  - adding terminal-safe progress reporting for concurrent downloads
  - falling back to plain milestone logs outside TTY environments
  - ignoring `.download-state` during spec test iteration so existing spec discovery is unaffected

  It also adds targeted unit coverage for:
  - same-version resume
  - legacy `version.txt` migration
  - failure isolation between archives
  - TTY and non-TTY progress behavior

  Closes #6991

**AI Assistance Disclosure**

- [ ] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

I used Codex to inspect the existing downloader, compare it with the stale PR,
  design the fix, and generate the initial implementation and tests. I reviewed the final
  changes manually. 
