### PR TITLE
feat: trigger processExecutionPayload() once

### DIFF
--- a/packages/beacon-node/src/chain/GetBlobsTracker.ts
+++ b/packages/beacon-node/src/chain/GetBlobsTracker.ts
@@ -44,7 +44,7 @@ export class GetBlobsTracker {
     this.config = init.config;
   }
 
-  triggerGetBlobs(input: IBlockInput | PayloadEnvelopeInput, onComplete?: () => void): void {
+  triggerGetBlobs(input: IBlockInput | PayloadEnvelopeInput): void {
     if (this.activeReconstructions.has(input.blockRootHex)) {
       return;
     }
@@ -101,7 +101,6 @@ export class GetBlobsTracker {
         .then((result) => {
           this.logger.debug("getBlobsV2 result for block", {...logCtx, result});
           this.metrics?.dataColumns.dataColumnEngineResult.inc({result});
-          onComplete?.();
         })
         .catch((error) => {
           this.logger.debug("Error during getBlobsV2 for block", logCtx, error as Error);

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -161,17 +161,9 @@ export async function importBlock(
     // which is all the information we need so there is no reason to delay until execution payload arrives
     // TODO GLOAS: If we want EL retries after this initial attempt, add an explicit retry policy here
     // (for example later in the slot). Do not couple retries to incoming gossip columns.
-    this.getBlobsTracker.triggerGetBlobs(payloadInput, () => {
-      // TODO GLOAS: come up with a better mechanism to trigger processExecutionPayload after data becomes available,
-      // similar to how pre-gloas uses waitForBlockAndAllData with a cutoff timeout and incompleteBlockInput event
-      this.processExecutionPayload(payloadInput, {validSignature: true}).catch((e) => {
-        this.logger.debug(
-          "Error processing execution payload after getBlobs",
-          {slot: blockSlot, root: blockRootHex},
-          e as Error
-        );
-      });
-    });
+    // Columns fetched here feed payloadInput.addColumn, which resolves waitForAllData for any
+    // in-flight importExecutionPayload. No processExecutionPayload trigger needed from this path.
+    this.getBlobsTracker.triggerGetBlobs(payloadInput);
   }
 
   this.metrics?.importBlock.bySource.inc({source: source.source});

--- a/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
+++ b/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
@@ -9,6 +9,7 @@ import {BeaconChain} from "../chain.js";
 import {RegenCaller} from "../regen/interface.js";
 import {PayloadEnvelopeInput} from "../seenCache/seenPayloadEnvelopeInput.js";
 import {ImportPayloadOpts} from "./types.js";
+import {verifyPayloadsDataAvailability} from "./verifyPayloadsDataAvailability.js";
 
 const EVENTSTREAM_EMIT_RECENT_EXECUTION_PAYLOAD_SLOTS = 64;
 
@@ -84,6 +85,7 @@ function toForkChoiceExecutionStatus(status: ExecutionPayloadStatus): PayloadExe
 export async function importExecutionPayload(
   this: BeaconChain,
   payloadInput: PayloadEnvelopeInput,
+  signal: AbortSignal,
   opts: ImportPayloadOpts = {}
 ): Promise<void> {
   const signedEnvelope = payloadInput.getPayloadEnvelope();
@@ -112,11 +114,15 @@ export async function importExecutionPayload(
     });
   }
 
-  // 3. Apply backpressure from the write queue early, before doing verification work.
+  // 3. Wait for data columns to be available before claiming a write-queue slot.
+  // The helper is shared with future gloas sync services; take the single-item batch form here.
+  await verifyPayloadsDataAvailability([payloadInput], signal);
+
+  // 4. Apply backpressure from the write queue, before doing verification work.
   // The actual DB write is deferred until after verification succeeds.
   await this.unfinalizedPayloadEnvelopeWrites.waitForSpace();
 
-  // 4. Get pre-state for processExecutionPayloadEnvelope
+  // 5. Get pre-state for processExecutionPayloadEnvelope
   // We need the block state (post-block, pre-payload) to process the envelope
   const blockState = await this.regen.getBlockSlotState(
     protoBlock,
@@ -131,9 +137,7 @@ export async function importExecutionPayload(
     });
   }
 
-  // 5. Run verification steps in parallel
-  // Note: No data availability check needed here - importExecutionPayload is only
-  // called when payloadInput.isComplete() is true, so all data is already available.
+  // 6. Run verification steps in parallel
   const [execResult, signatureValid, postPayloadResult] = await Promise.all([
     this.executionEngine.notifyNewPayload(
       fork,

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
@@ -73,6 +73,7 @@ export class PayloadEnvelopeInput {
   private timeCreatedSec: number;
 
   private readonly payloadEnvelopeDataPromise: PromiseParts<gloas.SignedExecutionPayloadEnvelope>;
+  private readonly allDataPromise: PromiseParts<gloas.DataColumnSidecar[]>;
   private readonly columnsDataPromise: PromiseParts<gloas.DataColumnSidecar[]>;
 
   state: PayloadEnvelopeInputState;
@@ -97,6 +98,7 @@ export class PayloadEnvelopeInput {
     this.custodyColumns = props.custodyColumns;
     this.timeCreatedSec = props.timeCreatedSec;
     this.payloadEnvelopeDataPromise = createPromise();
+    this.allDataPromise = createPromise();
     this.columnsDataPromise = createPromise();
 
     const noBlobs = props.bid.blobKzgCommitments.length === 0;
@@ -105,6 +107,7 @@ export class PayloadEnvelopeInput {
 
     if (hasAllData) {
       this.state = {hasPayload: false, hasAllData: true, hasComputedAllData: true};
+      this.allDataPromise.resolve(this.getSampledColumns());
       this.columnsDataPromise.resolve(this.getSampledColumns());
     } else {
       this.state = {hasPayload: false, hasAllData: false, hasComputedAllData: false};
@@ -201,6 +204,12 @@ export class PayloadEnvelopeInput {
 
     if (!hasAllData) {
       return true;
+    }
+
+    // Resolve allDataPromise on the first transition to hasAllData (either sampled-complete or
+    // reconstruction-threshold branch). Guarded so it fires exactly once.
+    if (hasAllData) {
+      this.allDataPromise.resolve(sampledColumns);
     }
 
     if (hasComputedAllData) {
@@ -313,6 +322,13 @@ export class PayloadEnvelopeInput {
 
   hasComputedAllData(): boolean {
     return this.state.hasComputedAllData;
+  }
+
+  waitForAllData(timeout: number, signal?: AbortSignal): Promise<gloas.DataColumnSidecar[]> {
+    if (this.state.hasAllData) {
+      return Promise.resolve(this.getSampledColumns());
+    }
+    return withTimeout(() => this.allDataPromise.promise, timeout, signal);
   }
 
   waitForComputedAllData(timeout: number, signal?: AbortSignal): Promise<gloas.DataColumnSidecar[]> {

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
@@ -208,7 +208,7 @@ export class PayloadEnvelopeInput {
 
     // Resolve allDataPromise on the first transition to hasAllData (either sampled-complete or
     // reconstruction-threshold branch). Guarded so it fires exactly once.
-    if (hasAllData) {
+    if (!this.state.hasAllData && hasAllData) {
       this.allDataPromise.resolve(sampledColumns);
     }
 

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
@@ -331,6 +331,17 @@ export class PayloadEnvelopeInput {
     return withTimeout(() => this.allDataPromise.promise, timeout, signal);
   }
 
+  async waitForEnvelopeAndAllData(timeout: number, signal?: AbortSignal): Promise<this> {
+    if (!this.state.hasPayload || !this.state.hasAllData) {
+      await withTimeout(
+        () => Promise.all([this.payloadEnvelopeDataPromise.promise, this.allDataPromise.promise]),
+        timeout,
+        signal
+      );
+    }
+    return this;
+  }
+
   waitForComputedAllData(timeout: number, signal?: AbortSignal): Promise<gloas.DataColumnSidecar[]> {
     if (this.state.hasComputedAllData) {
       return Promise.resolve(this.getSampledColumns());

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeProcessor.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeProcessor.ts
@@ -16,6 +16,11 @@ enum PayloadEnvelopeImportStatus {
 
 /**
  * PayloadEnvelopeProcessor processes payload envelope jobs in a queued fashion, one after the other.
+ *
+ * Jobs are enqueued only on envelope arrival (gossip or API). The envelope may reach us before
+ * the sampled data columns; importExecutionPayload awaits `verifyPayloadsDataAvailability`
+ * internally, so a queued job can pend for up to `PAYLOAD_DATA_AVAILABILITY_TIMEOUT` while
+ * waiting for columns. Duplicate triggers for the same payloadInput are deduped via `importStatus`.
  */
 export class PayloadEnvelopeProcessor {
   readonly jobQueue: JobItemQueue<[PayloadEnvelopeInput, ImportPayloadOpts], void>;
@@ -25,7 +30,7 @@ export class PayloadEnvelopeProcessor {
     this.jobQueue = new JobItemQueue<[PayloadEnvelopeInput, ImportPayloadOpts], void>(
       (payloadInput, opts) => {
         this.importStatus.set(payloadInput, PayloadEnvelopeImportStatus.importing);
-        return importExecutionPayload.call(chain, payloadInput, opts);
+        return importExecutionPayload.call(chain, payloadInput, signal, opts);
       },
       {maxLength: QUEUE_MAX_LENGTH, noYieldIfOneItem: true, signal},
       metrics?.payloadEnvelopeProcessorQueue ?? undefined
@@ -33,10 +38,6 @@ export class PayloadEnvelopeProcessor {
   }
 
   async processPayloadEnvelopeJob(payloadInput: PayloadEnvelopeInput, opts: ImportPayloadOpts = {}): Promise<void> {
-    if (!payloadInput.isComplete()) {
-      return;
-    }
-
     if (this.importStatus.get(payloadInput) !== undefined) {
       return;
     }

--- a/packages/beacon-node/src/chain/blocks/verifyPayloadsDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyPayloadsDataAvailability.ts
@@ -1,0 +1,38 @@
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
+import {gloas} from "@lodestar/types";
+import {PayloadEnvelopeInput} from "../seenCache/seenPayloadEnvelopeInput.js";
+
+// we can now wait for full 12 seconds because sync and reconstruction will try pulling
+// the data columns from the network anyway while the envelope is being processed
+export const PAYLOAD_DATA_AVAILABILITY_TIMEOUT = 12_000;
+
+/**
+ * Verifies that all payload envelope inputs have their data columns available.
+ * - Waits a max of PAYLOAD_DATA_AVAILABILITY_TIMEOUT for all data to be available
+ * - Returns the time at which all data was available
+ * - Returns the data availability status for each payload input
+ */
+export async function verifyPayloadsDataAvailability(
+  payloadInputs: PayloadEnvelopeInput[],
+  signal: AbortSignal
+): Promise<{
+  dataAvailabilityStatuses: DataAvailabilityStatus[];
+  availableTime: number;
+}> {
+  const promises: Promise<gloas.DataColumnSidecar[]>[] = [];
+  for (const payloadInput of payloadInputs) {
+    if (!payloadInput.hasAllData()) {
+      promises.push(payloadInput.waitForAllData(PAYLOAD_DATA_AVAILABILITY_TIMEOUT, signal));
+    }
+  }
+  await Promise.all(promises);
+
+  const availableTime = Math.max(0, Math.max(...payloadInputs.map((payloadInput) => payloadInput.getTimeComplete())));
+  const dataAvailabilityStatuses: DataAvailabilityStatus[] = payloadInputs.map((payloadInput) =>
+    payloadInput.getBlobKzgCommitments().length === 0
+      ? DataAvailabilityStatus.NotRequired
+      : DataAvailabilityStatus.Available
+  );
+
+  return {dataAvailabilityStatuses, availableTime};
+}

--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -7,6 +7,7 @@ import {DataColumnSidecar, RootHex, deneb, phase0} from "@lodestar/types";
 import {SignedExecutionPayloadEnvelope} from "@lodestar/types/gloas";
 import {PeerIdStr} from "../util/peerId.js";
 import {BlockInputSource, IBlockInput} from "./blocks/blockInput/types.js";
+import {PayloadEnvelopeInput} from "./blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 
 /**
  * Important chain events that occur during normal chain operation.
@@ -76,6 +77,11 @@ export enum ChainEvent {
    * cut-off window passes for waiting on gossip
    */
   incompleteBlockInput = "incompleteBlockInput",
+  /**
+   * Post-gloas: trigger BlockInputSync for payload envelopes whose envelope and/or sampled columns are partially
+   * received via gossip but are not complete by time the cut-off window passes for waiting on gossip
+   */
+  incompletePayloadEnvelope = "incompletePayloadEnvelope",
 }
 
 export type HeadEventData = routes.events.EventData[routes.events.EventType.head];
@@ -93,6 +99,11 @@ export type ChainEventData = {
   };
   [ChainEvent.unknownBlockRoot]: {rootHex: RootHex; peer?: PeerIdStr; source: BlockInputSource};
   [ChainEvent.incompleteBlockInput]: {blockInput: IBlockInput; peer: PeerIdStr; source: BlockInputSource};
+  [ChainEvent.incompletePayloadEnvelope]: {
+    payloadInput: PayloadEnvelopeInput;
+    peer: PeerIdStr;
+    source: BlockInputSource;
+  };
   [ChainEvent.unknownEnvelopeBlockRoot]: {rootHex: RootHex; peer?: PeerIdStr; source: BlockInputSource};
 };
 
@@ -116,6 +127,7 @@ export type IChainEvents = ApiEvents & {
   [ChainEvent.envelopeUnknownBlock]: (data: ChainEventData[ChainEvent.envelopeUnknownBlock]) => void;
   [ChainEvent.unknownBlockRoot]: (data: ChainEventData[ChainEvent.unknownBlockRoot]) => void;
   [ChainEvent.incompleteBlockInput]: (data: ChainEventData[ChainEvent.incompleteBlockInput]) => void;
+  [ChainEvent.incompletePayloadEnvelope]: (data: ChainEventData[ChainEvent.incompletePayloadEnvelope]) => void;
   [ChainEvent.unknownEnvelopeBlockRoot]: (data: ChainEventData[ChainEvent.unknownEnvelopeBlockRoot]) => void;
 };
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -748,6 +748,26 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         // NOTE: we do NOT call chain.processExecutionPayload here. That is triggered only by
         // envelope arrival (gossip or API). An in-flight importExecutionPayload is awaiting
         // payloadInput.waitForAllData(); addColumn above will resolve it once hasAllData flips.
+
+        if (!payloadInput.isComplete()) {
+          const cutoffTimeMs = getCutoffTimeMs(chain, dataColumnSlot, BLOCK_AVAILABILITY_CUTOFF_MS);
+          // do not await here to not delay gossip validation
+          payloadInput.waitForEnvelopeAndAllData(cutoffTimeMs).catch((_e) => {
+            chain.logger.debug(
+              "Waited for envelope and data after receiving gossip column. Cut-off reached so emitting incompletePayloadEnvelope",
+              {
+                dataColumnIndex: index,
+                ...payloadInputMeta,
+              }
+            );
+            // TODO GLOAS: UnknownBlockSync to handle this event
+            chain.emitter.emit(ChainEvent.incompletePayloadEnvelope, {
+              payloadInput,
+              peer: peerIdStr,
+              source: BlockInputSource.gossip,
+            });
+          });
+        }
       } else {
         if (config.getForkSeq(dataColumnSlot) < ForkSeq.fulu) {
           throw new GossipActionError(GossipAction.REJECT, {code: "PRE_FULU_BLOCK"});

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -745,13 +745,9 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
           });
         }
 
-        chain.processExecutionPayload(payloadInput, {validSignature: true}).catch((e) => {
-          chain.logger.debug(
-            "Error processing execution payload from gossip data column",
-            {slot: dataColumnSlot, root: payloadInput.blockRootHex},
-            e as Error
-          );
-        });
+        // NOTE: we do NOT call chain.processExecutionPayload here. That is triggered only by
+        // envelope arrival (gossip or API). An in-flight importExecutionPayload is awaiting
+        // payloadInput.waitForAllData(); addColumn above will resolve it once hasAllData flips.
       } else {
         if (config.getForkSeq(dataColumnSlot) < ForkSeq.fulu) {
           throw new GossipActionError(GossipAction.REJECT, {code: "PRE_FULU_BLOCK"});

--- a/packages/beacon-node/test/unit/chain/blocks/verifyPayloadsDataAvailability.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyPayloadsDataAvailability.test.ts
@@ -1,0 +1,194 @@
+import {describe, expect, it} from "vitest";
+import {ForkName, NUMBER_OF_COLUMNS} from "@lodestar/params";
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
+import {ColumnIndex, SignedBeaconBlock, gloas, ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
+import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
+import {
+  PAYLOAD_DATA_AVAILABILITY_TIMEOUT,
+  verifyPayloadsDataAvailability,
+} from "../../../../src/chain/blocks/verifyPayloadsDataAvailability.js";
+
+function buildPayloadEnvelopeInput({blobCount, sampledColumns}: {blobCount: number; sampledColumns: ColumnIndex[]}): {
+  payloadInput: PayloadEnvelopeInput;
+  signedEnvelope: gloas.SignedExecutionPayloadEnvelope;
+} {
+  const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+  block.message.slot = 0;
+  const commitments = Array.from({length: blobCount}, () => Buffer.alloc(48, 0x77));
+  block.message.body.signedExecutionPayloadBid.message.blobKzgCommitments = commitments;
+
+  const blockRoot = ssz.gloas.BeaconBlock.hashTreeRoot(block.message);
+  const blockRootHex = toRootHex(blockRoot);
+
+  const payloadInput = PayloadEnvelopeInput.createFromBlock({
+    blockRootHex,
+    block: block as SignedBeaconBlock<typeof ForkName.gloas>,
+    forkName: ForkName.gloas,
+    sampledColumns,
+    custodyColumns: sampledColumns,
+    timeCreatedSec: Date.now() / 1000,
+  });
+
+  const signedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+  signedEnvelope.message.beaconBlockRoot = blockRoot;
+  signedEnvelope.message.slot = block.message.slot;
+
+  payloadInput.addPayloadEnvelope({
+    envelope: signedEnvelope,
+    source: PayloadEnvelopeInputSource.gossip,
+    seenTimestampSec: Date.now() / 1000,
+  });
+
+  return {payloadInput, signedEnvelope};
+}
+
+function buildColumnSidecar(index: ColumnIndex): gloas.DataColumnSidecar {
+  const columnSidecar = ssz.gloas.DataColumnSidecar.defaultValue();
+  columnSidecar.index = index;
+  return columnSidecar;
+}
+
+describe("verifyPayloadsDataAvailability", () => {
+  it("resolves immediately when payload has no blobs (NotRequired)", async () => {
+    const {payloadInput} = buildPayloadEnvelopeInput({blobCount: 0, sampledColumns: [0, 1, 2, 3]});
+
+    const controller = new AbortController();
+    const {dataAvailabilityStatuses, availableTime} = await verifyPayloadsDataAvailability(
+      [payloadInput],
+      controller.signal
+    );
+
+    expect(dataAvailabilityStatuses).toEqual([DataAvailabilityStatus.NotRequired]);
+    expect(availableTime).toBeGreaterThan(0);
+  });
+
+  it("resolves immediately when all sampled columns are already present", async () => {
+    const sampled = [0, 1, 2, 3];
+    const {payloadInput} = buildPayloadEnvelopeInput({blobCount: 1, sampledColumns: sampled});
+    for (const idx of sampled) {
+      payloadInput.addColumn({
+        columnSidecar: buildColumnSidecar(idx),
+        source: PayloadEnvelopeInputSource.gossip,
+        seenTimestampSec: Date.now() / 1000,
+      });
+    }
+    expect(payloadInput.hasAllData()).toBe(true);
+
+    const controller = new AbortController();
+    const {dataAvailabilityStatuses} = await verifyPayloadsDataAvailability([payloadInput], controller.signal);
+    expect(dataAvailabilityStatuses).toEqual([DataAvailabilityStatus.Available]);
+  });
+
+  it("waits for columns to arrive after envelope, then resolves", async () => {
+    const sampled = [0, 1];
+    const {payloadInput} = buildPayloadEnvelopeInput({blobCount: 1, sampledColumns: sampled});
+    expect(payloadInput.hasAllData()).toBe(false);
+
+    const controller = new AbortController();
+    const verifyPromise = verifyPayloadsDataAvailability([payloadInput], controller.signal);
+
+    // Columns arrive asynchronously
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    for (const idx of sampled) {
+      payloadInput.addColumn({
+        columnSidecar: buildColumnSidecar(idx),
+        source: PayloadEnvelopeInputSource.gossip,
+        seenTimestampSec: Date.now() / 1000,
+      });
+    }
+
+    const {dataAvailabilityStatuses} = await verifyPromise;
+    expect(dataAvailabilityStatuses).toEqual([DataAvailabilityStatus.Available]);
+  });
+
+  it("resolves when reconstruction threshold (>= NUMBER_OF_COLUMNS/2) is hit without any sampled column", async () => {
+    const sampled = [0, 1, 2, 3];
+    const {payloadInput} = buildPayloadEnvelopeInput({blobCount: 1, sampledColumns: sampled});
+
+    // Add NUMBER_OF_COLUMNS/2 non-sampled columns — none match sampled, but reconstruction is guaranteed
+    for (let i = 10; i < 10 + NUMBER_OF_COLUMNS / 2; i++) {
+      payloadInput.addColumn({
+        columnSidecar: buildColumnSidecar(i),
+        source: PayloadEnvelopeInputSource.gossip,
+        seenTimestampSec: Date.now() / 1000,
+      });
+    }
+
+    expect(payloadInput.hasAllData()).toBe(true);
+    expect(payloadInput.hasComputedAllData()).toBe(false);
+
+    const controller = new AbortController();
+    const {dataAvailabilityStatuses} = await verifyPayloadsDataAvailability([payloadInput], controller.signal);
+    expect(dataAvailabilityStatuses).toEqual([DataAvailabilityStatus.Available]);
+  });
+
+  it("rejects with timeout when columns never arrive", async () => {
+    const sampled = [0, 1];
+    const {payloadInput} = buildPayloadEnvelopeInput({blobCount: 1, sampledColumns: sampled});
+    expect(payloadInput.hasAllData()).toBe(false);
+
+    // Temporarily shorten the timeout by monkey-patching? Better: run with natural timeout but bound the test.
+    // Instead, call waitForAllData directly with a short timeout to verify the timeout behavior
+    // (the helper uses PAYLOAD_DATA_AVAILABILITY_TIMEOUT which is too long for a unit test).
+    const controller = new AbortController();
+    await expect(payloadInput.waitForAllData(10, controller.signal)).rejects.toThrow();
+    // Sanity: the helper constant is defined and positive.
+    expect(PAYLOAD_DATA_AVAILABILITY_TIMEOUT).toBeGreaterThan(0);
+  });
+
+  it("rejects promptly when signal is aborted", async () => {
+    const sampled = [0, 1];
+    const {payloadInput} = buildPayloadEnvelopeInput({blobCount: 1, sampledColumns: sampled});
+    expect(payloadInput.hasAllData()).toBe(false);
+
+    const controller = new AbortController();
+    const waitPromise = payloadInput.waitForAllData(60_000, controller.signal);
+    controller.abort();
+    await expect(waitPromise).rejects.toThrow();
+  });
+});
+
+describe("PayloadEnvelopeInput.waitForAllData", () => {
+  it("resolves on reconstruction threshold without resolving waitForComputedAllData", async () => {
+    const sampled = [0, 1, 2, 3];
+    const {payloadInput} = buildPayloadEnvelopeInput({blobCount: 1, sampledColumns: sampled});
+
+    let allDataResolved = false;
+    let computedAllDataResolved = false;
+    const controller = new AbortController();
+    payloadInput.waitForAllData(60_000, controller.signal).then(
+      () => {
+        allDataResolved = true;
+      },
+      () => {
+        /* ignore abort */
+      }
+    );
+    payloadInput.waitForComputedAllData(60_000, controller.signal).then(
+      () => {
+        computedAllDataResolved = true;
+      },
+      () => {
+        /* ignore abort */
+      }
+    );
+
+    for (let i = 10; i < 10 + NUMBER_OF_COLUMNS / 2; i++) {
+      payloadInput.addColumn({
+        columnSidecar: buildColumnSidecar(i),
+        source: PayloadEnvelopeInputSource.gossip,
+        seenTimestampSec: Date.now() / 1000,
+      });
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(allDataResolved).toBe(true);
+    expect(computedAllDataResolved).toBe(false);
+
+    controller.abort();
+    // Let the aborted computedAllData promise settle before the test exits
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  });
+});

--- a/packages/beacon-node/test/unit/chain/blocks/verifyPayloadsDataAvailability.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyPayloadsDataAvailability.test.ts
@@ -150,6 +150,114 @@ describe("verifyPayloadsDataAvailability", () => {
   });
 });
 
+describe("PayloadEnvelopeInput.waitForEnvelopeAndAllData", () => {
+  function buildPayloadInputNoEnvelope({
+    blobCount,
+    sampledColumns,
+  }: {
+    blobCount: number;
+    sampledColumns: ColumnIndex[];
+  }): {payloadInput: PayloadEnvelopeInput; signedEnvelope: gloas.SignedExecutionPayloadEnvelope} {
+    const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+    block.message.slot = 0;
+    const commitments = Array.from({length: blobCount}, () => Buffer.alloc(48, 0x77));
+    block.message.body.signedExecutionPayloadBid.message.blobKzgCommitments = commitments;
+
+    const blockRoot = ssz.gloas.BeaconBlock.hashTreeRoot(block.message);
+    const blockRootHex = toRootHex(blockRoot);
+
+    const payloadInput = PayloadEnvelopeInput.createFromBlock({
+      blockRootHex,
+      block: block as SignedBeaconBlock<typeof ForkName.gloas>,
+      forkName: ForkName.gloas,
+      sampledColumns,
+      custodyColumns: sampledColumns,
+      timeCreatedSec: Date.now() / 1000,
+    });
+
+    const signedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    signedEnvelope.message.beaconBlockRoot = blockRoot;
+    signedEnvelope.message.slot = block.message.slot;
+
+    return {payloadInput, signedEnvelope};
+  }
+
+  it("resolves immediately when already complete", async () => {
+    const {payloadInput} = buildPayloadEnvelopeInput({blobCount: 0, sampledColumns: [0, 1, 2, 3]});
+    expect(payloadInput.isComplete()).toBe(true);
+
+    await expect(payloadInput.waitForEnvelopeAndAllData(60_000)).resolves.toBe(payloadInput);
+  });
+
+  it("waits for envelope and columns, then resolves", async () => {
+    const sampled = [0, 1];
+    const {payloadInput, signedEnvelope} = buildPayloadInputNoEnvelope({blobCount: 1, sampledColumns: sampled});
+    expect(payloadInput.isComplete()).toBe(false);
+
+    const controller = new AbortController();
+    const waitPromise = payloadInput.waitForEnvelopeAndAllData(60_000, controller.signal);
+
+    // Envelope + columns arrive asynchronously
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    payloadInput.addPayloadEnvelope({
+      envelope: signedEnvelope,
+      source: PayloadEnvelopeInputSource.gossip,
+      seenTimestampSec: Date.now() / 1000,
+    });
+    for (const idx of sampled) {
+      payloadInput.addColumn({
+        columnSidecar: buildColumnSidecar(idx),
+        source: PayloadEnvelopeInputSource.gossip,
+        seenTimestampSec: Date.now() / 1000,
+      });
+    }
+
+    await expect(waitPromise).resolves.toBe(payloadInput);
+    expect(payloadInput.isComplete()).toBe(true);
+  });
+
+  it("rejects with timeout when envelope never arrives", async () => {
+    const sampled = [0, 1];
+    const {payloadInput} = buildPayloadInputNoEnvelope({blobCount: 1, sampledColumns: sampled});
+    // Columns complete, but no envelope
+    for (const idx of sampled) {
+      payloadInput.addColumn({
+        columnSidecar: buildColumnSidecar(idx),
+        source: PayloadEnvelopeInputSource.gossip,
+        seenTimestampSec: Date.now() / 1000,
+      });
+    }
+    expect(payloadInput.hasAllData()).toBe(true);
+    expect(payloadInput.isComplete()).toBe(false);
+
+    await expect(payloadInput.waitForEnvelopeAndAllData(10)).rejects.toThrow();
+  });
+
+  it("rejects with timeout when columns never arrive", async () => {
+    const sampled = [0, 1];
+    const {payloadInput, signedEnvelope} = buildPayloadInputNoEnvelope({blobCount: 1, sampledColumns: sampled});
+    payloadInput.addPayloadEnvelope({
+      envelope: signedEnvelope,
+      source: PayloadEnvelopeInputSource.gossip,
+      seenTimestampSec: Date.now() / 1000,
+    });
+    expect(payloadInput.hasAllData()).toBe(false);
+    expect(payloadInput.isComplete()).toBe(false);
+
+    await expect(payloadInput.waitForEnvelopeAndAllData(10)).rejects.toThrow();
+  });
+
+  it("rejects promptly when signal is aborted", async () => {
+    const sampled = [0, 1];
+    const {payloadInput} = buildPayloadInputNoEnvelope({blobCount: 1, sampledColumns: sampled});
+
+    const controller = new AbortController();
+    const waitPromise = payloadInput.waitForEnvelopeAndAllData(60_000, controller.signal);
+    controller.abort();
+    await expect(waitPromise).rejects.toThrow();
+  });
+});
+
 describe("PayloadEnvelopeInput.waitForAllData", () => {
   it("resolves on reconstruction threshold without resolving waitForComputedAllData", async () => {
     const sampled = [0, 1, 2, 3];


### PR DESCRIPTION
**Motivation**

Post-gloas, `chain.processExecutionPayload()` was being triggered from 4 sites, including one that fires on every data-column gossip sidecar — up to 128 times per slot. Each call reached the queue only to be silently dropped by a `!isComplete()` guard while waiting for the envelope or missing columns. A standing TODO in `importBlock.ts` tracked this same issue.

**Description**

Mirror the existing `BlockInput` / `verifyBlocksDataAvailability` pattern for payload envelopes.

- Triggers `chain.processExecutionPayload()` only on envelope arrival (gossip + API publish). Removes the per-column gossip trigger and the `getBlobsTracker.triggerGetBlobs` onComplete callback from block import.
- Adds `PayloadEnvelopeInput.waitForAllData(timeout, signal)` — mirrors `BlockInput.waitForAllData`; resolves once on the first `state.hasAllData` transition.
- Adds `verifyPayloadsDataAvailability(payloadInputs, signal)` — exact twin of `verifyBlocksDataAvailability` (array input, `PAYLOAD_DATA_AVAILABILITY_TIMEOUT = 12_000`). Reusable by future gloas sync services.
- `importExecutionPayload` awaits the helper after the ProtoBlock lookup and before claiming a write-queue slot.
- Removes the `!isComplete()` early return in `PayloadEnvelopeProcessor` — the `importStatus` WeakMap still dedupes duplicate triggers for the same `payloadInput`.
- Drops the now-unused `onComplete` parameter from `GetBlobsTracker.triggerGetBlobs`.
- Adds 7 unit tests covering NotRequired / Available / wait-for-columns / reconstruction-threshold / timeout / abort, plus the `waitForAllData` vs `waitForComputedAllData` distinction.

Closes #9150

**AI Assistance Disclosure**

Used Claude Code to assist with codebase exploration, planning, implementation, and tests. The design, code, and review were gone through by me before submission.