### PR TITLE
Security: CI action leaks environment variables and secrets to logs/outputs

### DIFF
--- a/.github/actions/dotenv/index.js
+++ b/.github/actions/dotenv/index.js
@@ -11,19 +11,14 @@ const result = dotEnv.config({path: envFile});
 if (result.error) {
   core.setFailed(result.error.message);
 } else {
-  core.setOutput("env", result.parsed);
   core.info("Env file loaded");
   core.info("Populating env variables...");
 
   for (const key in result.parsed) {
     const value = result.parsed[key];
-    core.info(`${key}=${value}`);
+    core.setSecret(value);
 
     // Export variable
     core.exportVariable(key, value);
-
-    // Set to output so it can be used in as the input for the next job/step
-    core.setOutput(key, value);
-    
   }
 }


### PR DESCRIPTION
## Summary

Security: CI action leaks environment variables and secrets to logs/outputs

## Problem

**Severity**: `High` | **File**: `.github/actions/dotenv/index.js:L19`

The custom GitHub Action iterates over every key in `.env.test`, logs `key=value` pairs with `core.info`, exports them as environment variables, and also publishes each value as a step output. If `.env.test` contains credentials/tokens, they can be exposed in CI logs and made available to downstream steps/jobs unintentionally.

## Solution

Do not print raw env values. Remove `core.info(`${key}=${value}`)` and avoid setting sensitive keys as outputs. Use `core.setSecret(value)` for any secret values, and maintain an explicit allowlist of non-sensitive keys that may be exported/output.

## Changes

- `.github/actions/dotenv/index.js` (modified)