### PR TITLE
fix: ignore repeat proposal during block publishing

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -191,7 +191,10 @@ export function getBeaconBlockApi({
           try {
             await validateGossipBlock(config, chain, signedBlock, fork);
           } catch (error) {
-            if (error instanceof BlockGossipError && error.type.code === BlockErrorCode.ALREADY_KNOWN) {
+            if (
+              error instanceof BlockGossipError &&
+              (error.type.code === BlockErrorCode.ALREADY_KNOWN || error.type.code === BlockErrorCode.REPEAT_PROPOSAL)
+            ) {
               chain.logger.debug("Ignoring known block during publishing", valLogMeta);
               // Blocks might already be published by another node as part of a fallback setup or DVT cluster
               // and can reach our node by gossip before the api. The error can be ignored and should not result in a 500 response.

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -195,7 +195,7 @@ export function getBeaconBlockApi({
               error instanceof BlockGossipError &&
               (error.type.code === BlockErrorCode.ALREADY_KNOWN || error.type.code === BlockErrorCode.REPEAT_PROPOSAL)
             ) {
-              chain.logger.debug("Ignoring known block during publishing", valLogMeta);
+              chain.logger.debug("Ignoring block during publishing", {...valLogMeta, reason: error.type.code});
               // Blocks might already be published by another node as part of a fallback setup or DVT cluster
               // and can reach our node by gossip before the api. The error can be ignored and should not result in a 500 response.
               return;

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -198,8 +198,9 @@ export function getBeaconBlockApi({
                   chain.logger.debug("Ignoring already-known block during publishing", valLogMeta);
                   return;
                 case BlockErrorCode.REPEAT_PROPOSAL:
-                  // The proposer already produced a block for this slot. Surfaced at `warn` so operators
-                  // notice duplicate-proposal attempts; fallback / DVT setups can filter or rate-limit if needed.
+                  // The proposer already produced a block for this slot. For a solo setup this is a
+                  // notable signal (duplicate-proposal attempt). For fallback / DVT setups it is
+                  // expected on every block where another node published first.
                   chain.logger.warn("Ignoring repeat-proposal block during publishing", valLogMeta);
                   return;
               }

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -191,13 +191,16 @@ export function getBeaconBlockApi({
           try {
             await validateGossipBlock(config, chain, signedBlock, fork);
           } catch (error) {
-            if (
-              error instanceof BlockGossipError &&
-              (error.type.code === BlockErrorCode.ALREADY_KNOWN || error.type.code === BlockErrorCode.REPEAT_PROPOSAL)
-            ) {
-              chain.logger.debug("Ignoring block during publishing", {...valLogMeta, reason: error.type.code});
-              // Blocks might already be published by another node as part of a fallback setup or DVT cluster
-              // and can reach our node by gossip before the api. The error can be ignored and should not result in a 500 response.
+            if (error instanceof BlockGossipError && error.type.code === BlockErrorCode.ALREADY_KNOWN) {
+              // Block has already been seen, e.g. via gossip racing the publish API. Benign.
+              chain.logger.debug("Ignoring already-known block during publishing", valLogMeta);
+              return;
+            }
+            if (error instanceof BlockGossipError && error.type.code === BlockErrorCode.REPEAT_PROPOSAL) {
+              // The proposer already produced a block for this slot. Common in fallback / DVT setups
+              // where another node publishes first; for solo setups this signals a duplicate-proposal
+              // attempt worth surfacing at `verbose` without alarming `warn` noise on redundant nodes.
+              chain.logger.verbose("Ignoring repeat-proposal block during publishing", valLogMeta);
               return;
             }
 

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -191,16 +191,18 @@ export function getBeaconBlockApi({
           try {
             await validateGossipBlock(config, chain, signedBlock, fork);
           } catch (error) {
-            if (error instanceof BlockGossipError && error.type.code === BlockErrorCode.ALREADY_KNOWN) {
-              // Block has already been seen, e.g. via gossip racing the publish API. Benign.
-              chain.logger.debug("Ignoring already-known block during publishing", valLogMeta);
-              return;
-            }
-            if (error instanceof BlockGossipError && error.type.code === BlockErrorCode.REPEAT_PROPOSAL) {
-              // The proposer already produced a block for this slot. Surfaced at `warn` so operators
-              // notice duplicate-proposal attempts; fallback / DVT setups can filter or rate-limit if needed.
-              chain.logger.warn("Ignoring repeat-proposal block during publishing", valLogMeta);
-              return;
+            if (error instanceof BlockGossipError) {
+              switch (error.type.code) {
+                case BlockErrorCode.ALREADY_KNOWN:
+                  // Block has already been seen, e.g. via gossip racing the publish API. Benign.
+                  chain.logger.debug("Ignoring already-known block during publishing", valLogMeta);
+                  return;
+                case BlockErrorCode.REPEAT_PROPOSAL:
+                  // The proposer already produced a block for this slot. Surfaced at `warn` so operators
+                  // notice duplicate-proposal attempts; fallback / DVT setups can filter or rate-limit if needed.
+                  chain.logger.warn("Ignoring repeat-proposal block during publishing", valLogMeta);
+                  return;
+              }
             }
 
             chain.logger.error("Gossip validations failed while publishing the block", valLogMeta, error as Error);

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -197,10 +197,9 @@ export function getBeaconBlockApi({
               return;
             }
             if (error instanceof BlockGossipError && error.type.code === BlockErrorCode.REPEAT_PROPOSAL) {
-              // The proposer already produced a block for this slot. Common in fallback / DVT setups
-              // where another node publishes first; for solo setups this signals a duplicate-proposal
-              // attempt worth surfacing at `verbose` without alarming `warn` noise on redundant nodes.
-              chain.logger.verbose("Ignoring repeat-proposal block during publishing", valLogMeta);
+              // The proposer already produced a block for this slot. Surfaced at `warn` so operators
+              // notice duplicate-proposal attempts; fallback / DVT setups can filter or rate-limit if needed.
+              chain.logger.warn("Ignoring repeat-proposal block during publishing", valLogMeta);
               return;
             }
 


### PR DESCRIPTION
## Motivation

Fixes #9228.

In multi-node setups (e.g. DVT clusters or fallback configurations), the same block is often submitted to multiple beacon nodes. When one node receives the block via gossip slightly before the `POST eth/v2/beacon/blocks` REST call, the gossip validation raises `BLOCK_ERROR_REPEAT_PROPOSAL` from the `seenBlockProposers` check, which currently propagates as an unhandled exception and returns HTTP 500 to the caller. Nothing is actually wrong with the submitted block.

## Description

Extend the existing `ALREADY_KNOWN` handler in `publishBlock` to also swallow `REPEAT_PROPOSAL`. Both are thrown as `BlockGossipError` with `GossipAction.IGNORE`, so they share the same remediation — log at debug and return silently so the API caller sees a successful response.

This mirrors the handler added in #6457 for `ALREADY_KNOWN`.

Only the `gossip` broadcast-validation path is affected; `consensus` / `consensusAndEquivocation` paths use `verifyBlocksInEpoch` and do not go through `validateGossipBlock`, so they cannot hit `REPEAT_PROPOSAL`.

No new tests added — the existing handler for `ALREADY_KNOWN` was introduced without tests (#6457), and the underlying validation error is already tested at the gossip layer in `test/unit/chain/validation/block.test.ts`.