### PR TITLE
fix: revert anchor block PTC vote override

### DIFF
--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -109,21 +109,6 @@ export class ProtoArray {
       null
     );
 
-    // Gloas: seed the anchor's FULL variant so `shouldExtendPayload(anchor)` is true
-    // for block production; otherwise bids after restart use `bid.parentBlockHash`
-    // and fail `processExecutionPayloadBid`'s parent-hash check.
-    if (isGloasBlock(block as ProtoBlock) && block.executionPayloadBlockHash !== null) {
-      protoArray.onExecutionPayload(
-        block.blockRoot,
-        currentSlot,
-        block.executionPayloadBlockHash,
-        (block as {executionPayloadNumber?: number}).executionPayloadNumber ?? 0,
-        block.stateRoot,
-        null,
-        ExecutionStatus.Valid
-      );
-    }
-
     return protoArray;
   }
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -109,30 +109,6 @@ export class ProtoArray {
       null
     );
 
-    // Anchor block PTC votes must be all-true per spec get_forkchoice_store:
-    // payload_timeliness_vote={anchor_root: Vector[boolean, PTC_SIZE](True for _ in range(PTC_SIZE))}
-    // Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/gloas/fork-choice.md#modified-get_forkchoice_store
-    if (protoArray.ptcVotes.has(block.blockRoot)) {
-      protoArray.ptcVotes.set(block.blockRoot, BitArray.fromBoolArray(Array.from({length: PTC_SIZE}, () => true)));
-
-      // In the spec, we have payload_states = {anchor_root: anchor_state.copy()}
-      // which means the anchor's "payload" is considered received
-      // Without FULL, blocks extending FULL from the anchor would be orphaned.
-      // TODO GLOAS: This is a bug in the spec. Keep this to pass the current spec test
-      // for now. Need to remove this when we work on v1.7.0-alpha.5
-      if (block.executionPayloadBlockHash !== null) {
-        protoArray.onExecutionPayload(
-          block.blockRoot,
-          currentSlot,
-          block.executionPayloadBlockHash,
-          (block as {executionPayloadNumber?: number}).executionPayloadNumber ?? 0,
-          block.stateRoot,
-          null,
-          ExecutionStatus.Valid
-        );
-      }
-    }
-
     return protoArray;
   }
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -109,6 +109,21 @@ export class ProtoArray {
       null
     );
 
+    // Gloas: seed the anchor's FULL variant so `shouldExtendPayload(anchor)` is true
+    // for block production; otherwise bids after restart use `bid.parentBlockHash`
+    // and fail `processExecutionPayloadBid`'s parent-hash check.
+    if (isGloasBlock(block as ProtoBlock) && block.executionPayloadBlockHash !== null) {
+      protoArray.onExecutionPayload(
+        block.blockRoot,
+        currentSlot,
+        block.executionPayloadBlockHash,
+        (block as {executionPayloadNumber?: number}).executionPayloadNumber ?? 0,
+        block.stateRoot,
+        null,
+        ExecutionStatus.Valid
+      );
+    }
+
     return protoArray;
   }
 

--- a/spec-tests-version.json
+++ b/spec-tests-version.json
@@ -1,6 +1,6 @@
 {
   "ethereumConsensusSpecsTests": {
-    "specVersion": "v1.7.0-alpha.5",
+    "specVersion": "v1.7.0-alpha.4",
     "specTestsRepoUrl": "https://github.com/ethereum/consensus-specs",
     "outputDirBase": "spec-tests",
     "testsToDownload": [

--- a/spec-tests-version.json
+++ b/spec-tests-version.json
@@ -1,6 +1,6 @@
 {
   "ethereumConsensusSpecsTests": {
-    "specVersion": "v1.7.0-alpha.4",
+    "specVersion": "v1.7.0-alpha.5",
     "specTestsRepoUrl": "https://github.com/ethereum/consensus-specs",
     "outputDirBase": "spec-tests",
     "testsToDownload": [


### PR DESCRIPTION
## Summary

Revert the anchor-block PTC vote override added in #9188.

Upstream `consensus-specs` `master` fixed the underlying spec bug in:
- `c7a0a8527` — `Remove incorrect anchor seed for payload votes (#5135)`

`specs/gloas/fork-choice.md#get_forkchoice_store` on `master` now initializes:
- `payload_timeliness_vote={}`

So Lodestar should stop force-seeding the anchor block to all-true in `ProtoArray.initialize()`.

This PR removes the temporary 8-line override and returns anchor initialization to the default `onBlock()` behavior.

## Verification

- `pnpm lint -- packages/fork-choice/src/protoArray/protoArray.ts`
- Attempted narrower unit/build verification in a fresh worktree, but that worktree hit unrelated workspace package-resolution/build setup failures before reaching meaningful fork-choice signal. The functional change here is a single-file revert of the exact temporary override from #9188.

## AI assistance

Drafted and validated with AI assistance.

Fixes #9239