### PR TITLE
fix: gate loadOtherState validators/balances preload behind opt-in

### DIFF
--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -226,7 +226,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       }
       sszTimer?.();
       const timer = this.metrics?.cpStateCache.stateReloadDuration.startTimer();
-      // CP state will drive block replay — preload pays off.
+      // preload validators and balances for faster state transition
       const newCachedState = seedState.loadOtherState(stateBytes, validatorsBytes, {
         preloadValidatorsAndBalances: true,
       });

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -226,7 +226,10 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       }
       sszTimer?.();
       const timer = this.metrics?.cpStateCache.stateReloadDuration.startTimer();
-      const newCachedState = seedState.loadOtherState(stateBytes, validatorsBytes);
+      // CP state will drive block replay — preload pays off.
+      const newCachedState = seedState.loadOtherState(stateBytes, validatorsBytes, {
+        preloadValidatorsAndBalances: true,
+      });
       // hashTreeRoot() calls the commit() inside
       // there is no modification inside the state, it's just that we want to compute and cache all roots
       const stateRoot = toRootHex(newCachedState.hashTreeRoot());

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -704,7 +704,11 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
 
   // Serialization
 
-  loadOtherState(stateBytes: Uint8Array, seedValidatorsBytes?: Uint8Array): IBeaconStateView {
+  loadOtherState(
+    stateBytes: Uint8Array,
+    seedValidatorsBytes?: Uint8Array,
+    opts?: {preloadValidatorsAndBalances?: boolean}
+  ): IBeaconStateView {
     const {state} = loadState(this.config, this.cachedState, stateBytes, seedValidatorsBytes);
 
     const cachedState = createCachedBeaconState(
@@ -719,9 +723,10 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
       }
     );
 
-    // load all cache in order for consumers (usually regen.getState()) to process blocks faster
-    cachedState.validators.getAllReadonlyValues();
-    cachedState.balances.getAll();
+    if (opts?.preloadValidatorsAndBalances) {
+      cachedState.validators.getAllReadonlyValues();
+      cachedState.balances.getAll();
+    }
 
     return new BeaconStateView(cachedState);
   }

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -138,7 +138,13 @@ export interface IBeaconStateView {
   isStateValidatorsNodesPopulated(): boolean;
 
   // Serialization
-  loadOtherState(stateBytes: Uint8Array, seedValidatorsBytes?: Uint8Array): IBeaconStateView;
+  /** Set `preloadValidatorsAndBalances` only when the whole state will be consumed
+   *  immediately (e.g. CP reload before block replay). Costs hundreds of MB per call. */
+  loadOtherState(
+    stateBytes: Uint8Array,
+    seedValidatorsBytes?: Uint8Array,
+    opts?: {preloadValidatorsAndBalances?: boolean}
+  ): IBeaconStateView;
   toValue(): BeaconState;
   serialize(): Uint8Array;
   serializedSize(): number;

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -139,7 +139,7 @@ export interface IBeaconStateView {
 
   // Serialization
   /** Set `preloadValidatorsAndBalances` only when the whole state will be consumed
-   *  immediately (e.g. CP reload before block replay). Costs hundreds of MB per call. */
+   *  immediately (e.g. CP reload before block replay). */
   loadOtherState(
     stateBytes: Uint8Array,
     seedValidatorsBytes?: Uint8Array,


### PR DESCRIPTION
**Motivation**

Main-thread memory spike on `serveHistoricalState: true` nodes after #8857

#8857 rerouted the API path through `getState()` in
`packages/beacon-node/src/api/impl/beacon/state/index.ts` from the lightweight
`loadState(...)` to `BeaconStateView.loadOtherState()`, which eagerly materializes
all validators and balances. That is only needed for `persistentCheckpointsCache`.

**Description**

- Make the preload in `loadOtherState()` opt-in via `{preloadValidatorsAndBalances: true}`. Default is lazy, matching pre-#8857 semantics.
- only `persistentCheckpointsCache` passes in this flag as true
- API call sites https://github.com/ChainSafe/lodestar/blob/9fa9f08ef6837ffee69553350b0bc6c6bb2053e0/packages/beacon-node/src/api/impl/beacon/state/index.ts#L34 leave the opt off → restored lazy-load on the API path.

**AI Assistance Disclosure**

This PR was developed with AI assistance (Claude Code).