### PR TITLE
perf(state-transition): add caches for  indexed pending deposits by pubkey and verified counts

### DIFF
--- a/packages/state-transition/src/block/processDepositRequest.ts
+++ b/packages/state-transition/src/block/processDepositRequest.ts
@@ -2,6 +2,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {FAR_FUTURE_EPOCH, ForkSeq, UNSET_DEPOSIT_REQUESTS_START_INDEX} from "@lodestar/params";
 import {BLSPubkey, Bytes32, PubkeyHex, UintNum64, electra, ssz} from "@lodestar/types";
 import {toPubkeyHex} from "@lodestar/utils";
+import {type PendingDepositPubkeyIndex, type PendingValidatorVerifiedCount} from "../cache/epochCache.js";
 import {CachedBeaconStateElectra, CachedBeaconStateGloas} from "../types.js";
 import {findBuilderIndexByPubkey, isBuilderWithdrawalCredential} from "../util/gloas.js";
 import {computeEpochAtSlot, isValidatorKnown} from "../util/index.js";
@@ -76,23 +77,16 @@ function addBuilderToRegistry(
   }
 }
 
-// TODO GLOAS: pendingValidatorPubkeys cache is currently naive and has room for improvement.
-// Currently the cache lives in process_block, but we should put it in epochCache or elsewhere that has longer
-// lifetime to avoid duplicated deposit signature computation
-// See https://github.com/ChainSafe/lodestar/issues/9181
 export function processDepositRequest(
   fork: ForkSeq,
   state: CachedBeaconStateElectra | CachedBeaconStateGloas,
-  depositRequest: electra.DepositRequest,
-  pendingValidatorPubkeysCache?: Set<PubkeyHex>
+  depositRequest: electra.DepositRequest
 ): void {
   const {pubkey, withdrawalCredentials, amount, signature} = depositRequest;
 
   // Check if this is a builder or validator deposit
   if (fork >= ForkSeq.gloas) {
     const stateGloas = state as CachedBeaconStateGloas;
-    const pendingValidatorPubkeys =
-      pendingValidatorPubkeysCache ?? getPendingValidatorPubkeys(state.config, stateGloas);
     const pubkeyHex = toPubkeyHex(pubkey);
     const builderIndex = findBuilderIndexByPubkey(stateGloas, pubkey);
     const validatorIndex = state.epochCtx.getValidatorIndex(pubkey);
@@ -101,23 +95,12 @@ export function processDepositRequest(
     // already exists with this pubkey, apply the deposit to their balance
     const isBuilder = builderIndex !== null;
     const isValidator = isValidatorKnown(state, validatorIndex);
-    const isPendingValidator = pendingValidatorPubkeys.has(pubkeyHex);
+    const isPendingValidator = getVerifiedPendingValidatorCountForPubkey(stateGloas, pubkeyHex) > 0;
 
     if (isBuilder || (isBuilderWithdrawalCredential(withdrawalCredentials) && !isValidator && !isPendingValidator)) {
       // Apply builder deposits immediately
       applyDepositForBuilder(stateGloas, pubkey, withdrawalCredentials, amount, signature, state.slot);
       return;
-    }
-
-    // Keep the shared cache in sync: if this deposit has a valid signature, subsequent
-    // deposit requests for the same pubkey in this envelope must see it as a pending validator
-    if (
-      pendingValidatorPubkeysCache &&
-      !isValidator &&
-      !isPendingValidator &&
-      isValidDepositSignature(state.config, pubkey, withdrawalCredentials, amount, signature)
-    ) {
-      pendingValidatorPubkeys.add(pubkeyHex);
     }
   }
 
@@ -135,6 +118,95 @@ export function processDepositRequest(
     slot: state.slot,
   });
   state.pendingDeposits.push(pendingDeposit);
+
+  if (fork >= ForkSeq.gloas) {
+    const stateGloas = state as CachedBeaconStateGloas;
+    const pubkeyHex = toPubkeyHex(pubkey);
+    const pendingDepositPubkeyIndex = ensurePendingDepositPubkeyIndex(stateGloas);
+    const newPendingDepositIndex = state.pendingDeposits.length - 1;
+    const bucket = pendingDepositPubkeyIndex.get(pubkeyHex);
+
+    if (bucket) {
+      bucket.push(newPendingDepositIndex);
+    } else {
+      pendingDepositPubkeyIndex.set(pubkeyHex, [newPendingDepositIndex]);
+    }
+
+    const verifiedPendingValidatorCount = getPendingValidatorVerifiedCount(stateGloas);
+    const cachedCount = verifiedPendingValidatorCount.get(pubkeyHex);
+    if (
+      cachedCount !== undefined &&
+      isValidDepositSignature(state.config, pubkey, withdrawalCredentials, amount, signature)
+    ) {
+      verifiedPendingValidatorCount.set(pubkeyHex, cachedCount + 1);
+    }
+  }
+}
+
+export function ensurePendingDepositPubkeyIndex(state: CachedBeaconStateGloas): PendingDepositPubkeyIndex {
+  if (state.epochCtx.pendingDepositPubkeyIndex !== null) {
+    return state.epochCtx.pendingDepositPubkeyIndex;
+  }
+
+  const pendingDepositPubkeyIndex: PendingDepositPubkeyIndex = new Map();
+  for (let i = 0; i < state.pendingDeposits.length; i++) {
+    const pubkeyHex = toPubkeyHex(state.pendingDeposits.getReadonly(i).pubkey);
+    const bucket = pendingDepositPubkeyIndex.get(pubkeyHex);
+
+    if (bucket) {
+      bucket.push(i);
+    } else {
+      pendingDepositPubkeyIndex.set(pubkeyHex, [i]);
+    }
+  }
+
+  state.epochCtx.pendingDepositPubkeyIndex = pendingDepositPubkeyIndex;
+  if (state.epochCtx.pendingValidatorVerifiedCount === null) {
+    state.epochCtx.pendingValidatorVerifiedCount = new Map();
+  }
+
+  return pendingDepositPubkeyIndex;
+}
+
+function getPendingValidatorVerifiedCount(state: CachedBeaconStateGloas): PendingValidatorVerifiedCount {
+  if (state.epochCtx.pendingValidatorVerifiedCount === null) {
+    state.epochCtx.pendingValidatorVerifiedCount = new Map();
+  }
+
+  return state.epochCtx.pendingValidatorVerifiedCount;
+}
+
+function getVerifiedPendingValidatorCountForPubkey(state: CachedBeaconStateGloas, pubkeyHex: PubkeyHex): number {
+  const verifiedPendingValidatorCount = getPendingValidatorVerifiedCount(state);
+  const cachedCount = verifiedPendingValidatorCount.get(pubkeyHex);
+  if (cachedCount !== undefined) {
+    return cachedCount;
+  }
+
+  const bucket = ensurePendingDepositPubkeyIndex(state).get(pubkeyHex);
+  if (!bucket) {
+    verifiedPendingValidatorCount.set(pubkeyHex, 0);
+    return 0;
+  }
+
+  let validCount = 0;
+  for (const pendingDepositIndex of bucket) {
+    const pendingDeposit = state.pendingDeposits.getReadonly(pendingDepositIndex);
+    if (
+      isValidDepositSignature(
+        state.config,
+        pendingDeposit.pubkey,
+        pendingDeposit.withdrawalCredentials,
+        pendingDeposit.amount,
+        pendingDeposit.signature
+      )
+    ) {
+      validCount++;
+    }
+  }
+
+  verifiedPendingValidatorCount.set(pubkeyHex, validCount);
+  return validCount;
 }
 
 /**

--- a/packages/state-transition/src/block/processDepositRequest.ts
+++ b/packages/state-transition/src/block/processDepositRequest.ts
@@ -83,11 +83,11 @@ export function processDepositRequest(
   depositRequest: electra.DepositRequest
 ): void {
   const {pubkey, withdrawalCredentials, amount, signature} = depositRequest;
+  const stateGloas = fork >= ForkSeq.gloas ? (state as CachedBeaconStateGloas) : null;
+  const pubkeyHex = stateGloas !== null ? toPubkeyHex(pubkey) : null;
 
   // Check if this is a builder or validator deposit
-  if (fork >= ForkSeq.gloas) {
-    const stateGloas = state as CachedBeaconStateGloas;
-    const pubkeyHex = toPubkeyHex(pubkey);
+  if (stateGloas !== null && pubkeyHex !== null) {
     const builderIndex = findBuilderIndexByPubkey(stateGloas, pubkey);
     const validatorIndex = state.epochCtx.getValidatorIndex(pubkey);
 
@@ -119,15 +119,13 @@ export function processDepositRequest(
   });
   state.pendingDeposits.push(pendingDeposit);
 
-  if (fork >= ForkSeq.gloas) {
-    const stateGloas = state as CachedBeaconStateGloas;
-    const pubkeyHex = toPubkeyHex(pubkey);
-    const pendingDepositPubkeyIndex = ensurePendingDepositPubkeyIndex(stateGloas);
+  if (stateGloas !== null && pubkeyHex !== null) {
+    const pendingDepositPubkeyIndex = ensurePendingDepositPubkeyIndexWritable(stateGloas);
     const newPendingDepositIndex = state.pendingDeposits.length - 1;
     const bucket = pendingDepositPubkeyIndex.get(pubkeyHex);
 
     if (bucket) {
-      bucket.push(newPendingDepositIndex);
+      pendingDepositPubkeyIndex.set(pubkeyHex, [...bucket, newPendingDepositIndex]);
     } else {
       pendingDepositPubkeyIndex.set(pubkeyHex, [newPendingDepositIndex]);
     }
@@ -138,7 +136,7 @@ export function processDepositRequest(
       cachedCount !== undefined &&
       isValidDepositSignature(state.config, pubkey, withdrawalCredentials, amount, signature)
     ) {
-      verifiedPendingValidatorCount.set(pubkeyHex, cachedCount + 1);
+      ensurePendingValidatorVerifiedCountWritable(stateGloas).set(pubkeyHex, cachedCount + 1);
     }
   }
 }
@@ -161,8 +159,22 @@ export function ensurePendingDepositPubkeyIndex(state: CachedBeaconStateGloas): 
   }
 
   state.epochCtx.pendingDepositPubkeyIndex = pendingDepositPubkeyIndex;
+  state.epochCtx.pendingDepositPubkeyIndexShared = false;
   if (state.epochCtx.pendingValidatorVerifiedCount === null) {
     state.epochCtx.pendingValidatorVerifiedCount = new Map();
+    state.epochCtx.pendingValidatorVerifiedCountShared = false;
+  }
+
+  return pendingDepositPubkeyIndex;
+}
+
+function ensurePendingDepositPubkeyIndexWritable(state: CachedBeaconStateGloas): PendingDepositPubkeyIndex {
+  let pendingDepositPubkeyIndex = ensurePendingDepositPubkeyIndex(state);
+
+  if (state.epochCtx.pendingDepositPubkeyIndexShared) {
+    pendingDepositPubkeyIndex = new Map(pendingDepositPubkeyIndex);
+    state.epochCtx.pendingDepositPubkeyIndex = pendingDepositPubkeyIndex;
+    state.epochCtx.pendingDepositPubkeyIndexShared = false;
   }
 
   return pendingDepositPubkeyIndex;
@@ -171,9 +183,22 @@ export function ensurePendingDepositPubkeyIndex(state: CachedBeaconStateGloas): 
 function getPendingValidatorVerifiedCount(state: CachedBeaconStateGloas): PendingValidatorVerifiedCount {
   if (state.epochCtx.pendingValidatorVerifiedCount === null) {
     state.epochCtx.pendingValidatorVerifiedCount = new Map();
+    state.epochCtx.pendingValidatorVerifiedCountShared = false;
   }
 
   return state.epochCtx.pendingValidatorVerifiedCount;
+}
+
+function ensurePendingValidatorVerifiedCountWritable(state: CachedBeaconStateGloas): PendingValidatorVerifiedCount {
+  let verifiedPendingValidatorCount = getPendingValidatorVerifiedCount(state);
+
+  if (state.epochCtx.pendingValidatorVerifiedCountShared) {
+    verifiedPendingValidatorCount = new Map(verifiedPendingValidatorCount);
+    state.epochCtx.pendingValidatorVerifiedCount = verifiedPendingValidatorCount;
+    state.epochCtx.pendingValidatorVerifiedCountShared = false;
+  }
+
+  return verifiedPendingValidatorCount;
 }
 
 function getVerifiedPendingValidatorCountForPubkey(state: CachedBeaconStateGloas, pubkeyHex: PubkeyHex): number {
@@ -185,7 +210,7 @@ function getVerifiedPendingValidatorCountForPubkey(state: CachedBeaconStateGloas
 
   const bucket = ensurePendingDepositPubkeyIndex(state).get(pubkeyHex);
   if (!bucket) {
-    verifiedPendingValidatorCount.set(pubkeyHex, 0);
+    ensurePendingValidatorVerifiedCountWritable(state).set(pubkeyHex, 0);
     return 0;
   }
 
@@ -205,7 +230,7 @@ function getVerifiedPendingValidatorCountForPubkey(state: CachedBeaconStateGloas
     }
   }
 
-  verifiedPendingValidatorCount.set(pubkeyHex, validCount);
+  ensurePendingValidatorVerifiedCountWritable(state).set(pubkeyHex, validCount);
   return validCount;
 }
 

--- a/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
@@ -7,7 +7,7 @@ import {CachedBeaconStateGloas} from "../types.js";
 import {computeTimeAtSlot} from "../util/index.js";
 import {verifySignatureSet} from "../util/signatureSets.js";
 import {processConsolidationRequest} from "./processConsolidationRequest.js";
-import {getPendingValidatorPubkeys, processDepositRequest} from "./processDepositRequest.js";
+import {ensurePendingDepositPubkeyIndex, processDepositRequest} from "./processDepositRequest.js";
 import {processWithdrawalRequest} from "./processWithdrawalRequest.js";
 
 export type ProcessExecutionPayloadEnvelopeOpts = {
@@ -33,19 +33,20 @@ export function processExecutionPayloadEnvelope(
     throw Error(`Execution payload envelope has invalid signature builderIndex=${envelope.builderIndex}`);
   }
 
+  const requests = envelope.executionRequests;
+
+  if (requests.deposits.length > 0) {
+    ensurePendingDepositPubkeyIndex(state);
+  }
+
   // .clone() before mutating state, similar to stateTransition()
   const postState = state.clone(opts?.dontTransferCache) as CachedBeaconStateGloas;
 
   validateExecutionPayloadEnvelope(postState, envelope);
 
-  const requests = envelope.executionRequests;
-
   if (requests.deposits.length > 0) {
-    // Build cache of pending validator pubkeys once, shared across all deposit requests
-    const pendingValidatorPubkeys = getPendingValidatorPubkeys(postState.config, postState);
-
     for (const deposit of requests.deposits) {
-      processDepositRequest(fork, postState, deposit, pendingValidatorPubkeys);
+      processDepositRequest(fork, postState, deposit);
     }
   }
 

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -235,6 +235,11 @@ export class EpochCache {
    * Starts as `null` on states created from bytes and is built when needed.
    */
   pendingDepositPubkeyIndex: PendingDepositPubkeyIndex | null;
+  /**
+   * True when `pendingDepositPubkeyIndex` is shared with another cloned state and must be detached
+   * before mutating the map itself.
+   */
+  pendingDepositPubkeyIndexShared: boolean;
 
   /**
    * Caches the number of signature-valid pending deposits for each pubkey.
@@ -242,6 +247,11 @@ export class EpochCache {
    * that pubkey has not been checked for the current state yet.
    */
   pendingValidatorVerifiedCount: PendingValidatorVerifiedCount | null;
+  /**
+   * True when `pendingValidatorVerifiedCount` is shared with another cloned state and must be detached
+   * before mutating the map itself.
+   */
+  pendingValidatorVerifiedCountShared: boolean;
 
   // TODO GLOAS: See if we need to cache PTC for next epoch
   // PTC for previous epoch, required for slot N block validating slot N-1 attestations
@@ -286,7 +296,9 @@ export class EpochCache {
     currentSyncCommitteeIndexed: SyncCommitteeCache;
     nextSyncCommitteeIndexed: SyncCommitteeCache;
     pendingDepositPubkeyIndex: PendingDepositPubkeyIndex | null;
+    pendingDepositPubkeyIndexShared: boolean;
     pendingValidatorVerifiedCount: PendingValidatorVerifiedCount | null;
+    pendingValidatorVerifiedCountShared: boolean;
     previousPayloadTimelinessCommittees: Uint32Array[];
     payloadTimelinessCommittees: Uint32Array[];
     epoch: Epoch;
@@ -319,7 +331,9 @@ export class EpochCache {
     this.currentSyncCommitteeIndexed = data.currentSyncCommitteeIndexed;
     this.nextSyncCommitteeIndexed = data.nextSyncCommitteeIndexed;
     this.pendingDepositPubkeyIndex = data.pendingDepositPubkeyIndex;
+    this.pendingDepositPubkeyIndexShared = data.pendingDepositPubkeyIndexShared;
     this.pendingValidatorVerifiedCount = data.pendingValidatorVerifiedCount;
+    this.pendingValidatorVerifiedCountShared = data.pendingValidatorVerifiedCountShared;
     this.previousPayloadTimelinessCommittees = data.previousPayloadTimelinessCommittees;
     this.payloadTimelinessCommittees = data.payloadTimelinessCommittees;
     this.epoch = data.epoch;
@@ -566,7 +580,9 @@ export class EpochCache {
       currentSyncCommitteeIndexed,
       nextSyncCommitteeIndexed,
       pendingDepositPubkeyIndex: null,
+      pendingDepositPubkeyIndexShared: false,
       pendingValidatorVerifiedCount: null,
+      pendingValidatorVerifiedCountShared: false,
       previousPayloadTimelinessCommittees,
       payloadTimelinessCommittees,
       epoch: currentEpoch,
@@ -581,6 +597,13 @@ export class EpochCache {
     // warning: pubkey cache is not copied, it is shared, as eth1 is not expected to reorder validators.
     // Shallow copy all data from current epoch context to the next
     // All data is completely replaced, or only-appended
+    if (this.pendingDepositPubkeyIndex !== null) {
+      this.pendingDepositPubkeyIndexShared = true;
+    }
+    if (this.pendingValidatorVerifiedCount !== null) {
+      this.pendingValidatorVerifiedCountShared = true;
+    }
+
     return new EpochCache({
       config: this.config,
       // Common append-only structures shared with all states, no need to clone
@@ -613,14 +636,10 @@ export class EpochCache {
       currentTargetUnslashedBalanceIncrements: this.currentTargetUnslashedBalanceIncrements,
       currentSyncCommitteeIndexed: this.currentSyncCommitteeIndexed,
       nextSyncCommitteeIndexed: this.nextSyncCommitteeIndexed,
-      pendingDepositPubkeyIndex:
-        this.pendingDepositPubkeyIndex !== null
-          ? new Map(
-              Array.from(this.pendingDepositPubkeyIndex, ([pubkeyHex, indexes]) => [pubkeyHex, [...indexes]] as const)
-            )
-          : null,
-      pendingValidatorVerifiedCount:
-        this.pendingValidatorVerifiedCount !== null ? new Map(this.pendingValidatorVerifiedCount) : null,
+      pendingDepositPubkeyIndex: this.pendingDepositPubkeyIndex,
+      pendingDepositPubkeyIndexShared: this.pendingDepositPubkeyIndex !== null,
+      pendingValidatorVerifiedCount: this.pendingValidatorVerifiedCount,
+      pendingValidatorVerifiedCountShared: this.pendingValidatorVerifiedCount !== null,
       previousPayloadTimelinessCommittees: this.previousPayloadTimelinessCommittees,
       payloadTimelinessCommittees: this.payloadTimelinessCommittees,
       epoch: this.epoch,

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -17,6 +17,7 @@ import {
   CommitteeIndex,
   Epoch,
   IndexedAttestation,
+  PubkeyHex,
   RootHex,
   Slot,
   SubnetID,
@@ -78,6 +79,9 @@ export type EpochCacheOpts = {
   skipSyncPubkeys?: boolean;
   shufflingGetter?: ShufflingGetter;
 };
+
+export type PendingDepositPubkeyIndex = Map<PubkeyHex, number[]>;
+export type PendingValidatorVerifiedCount = Map<PubkeyHex, number>;
 
 /** Defers computing proposers by persisting only the seed, and dropping it once indexes are computed */
 type ProposersDeferred = {computed: false; seed: Uint8Array} | {computed: true; indexes: ValidatorIndex[]};
@@ -226,6 +230,19 @@ export class EpochCache {
   /** TODO: Indexed SyncCommitteeCache */
   nextSyncCommitteeIndexed: SyncCommitteeCache;
 
+  /**
+   * Maps each pending-deposit pubkey to the indices where it appears in `state.pendingDeposits`.
+   * Starts as `null` on states created from bytes and is built when needed.
+   */
+  pendingDepositPubkeyIndex: PendingDepositPubkeyIndex | null;
+
+  /**
+   * Caches the number of signature-valid pending deposits for each pubkey.
+   * Starts as `null` on states created from bytes and is built when needed. a missing map entry means
+   * that pubkey has not been checked for the current state yet.
+   */
+  pendingValidatorVerifiedCount: PendingValidatorVerifiedCount | null;
+
   // TODO GLOAS: See if we need to cache PTC for next epoch
   // PTC for previous epoch, required for slot N block validating slot N-1 attestations
   previousPayloadTimelinessCommittees: Uint32Array[];
@@ -268,6 +285,8 @@ export class EpochCache {
     previousTargetUnslashedBalanceIncrements: number;
     currentSyncCommitteeIndexed: SyncCommitteeCache;
     nextSyncCommitteeIndexed: SyncCommitteeCache;
+    pendingDepositPubkeyIndex: PendingDepositPubkeyIndex | null;
+    pendingValidatorVerifiedCount: PendingValidatorVerifiedCount | null;
     previousPayloadTimelinessCommittees: Uint32Array[];
     payloadTimelinessCommittees: Uint32Array[];
     epoch: Epoch;
@@ -299,6 +318,8 @@ export class EpochCache {
     this.previousTargetUnslashedBalanceIncrements = data.previousTargetUnslashedBalanceIncrements;
     this.currentSyncCommitteeIndexed = data.currentSyncCommitteeIndexed;
     this.nextSyncCommitteeIndexed = data.nextSyncCommitteeIndexed;
+    this.pendingDepositPubkeyIndex = data.pendingDepositPubkeyIndex;
+    this.pendingValidatorVerifiedCount = data.pendingValidatorVerifiedCount;
     this.previousPayloadTimelinessCommittees = data.previousPayloadTimelinessCommittees;
     this.payloadTimelinessCommittees = data.payloadTimelinessCommittees;
     this.epoch = data.epoch;
@@ -544,6 +565,8 @@ export class EpochCache {
       currentTargetUnslashedBalanceIncrements,
       currentSyncCommitteeIndexed,
       nextSyncCommitteeIndexed,
+      pendingDepositPubkeyIndex: null,
+      pendingValidatorVerifiedCount: null,
       previousPayloadTimelinessCommittees,
       payloadTimelinessCommittees,
       epoch: currentEpoch,
@@ -590,6 +613,14 @@ export class EpochCache {
       currentTargetUnslashedBalanceIncrements: this.currentTargetUnslashedBalanceIncrements,
       currentSyncCommitteeIndexed: this.currentSyncCommitteeIndexed,
       nextSyncCommitteeIndexed: this.nextSyncCommitteeIndexed,
+      pendingDepositPubkeyIndex:
+        this.pendingDepositPubkeyIndex !== null
+          ? new Map(
+              Array.from(this.pendingDepositPubkeyIndex, ([pubkeyHex, indexes]) => [pubkeyHex, [...indexes]] as const)
+            )
+          : null,
+      pendingValidatorVerifiedCount:
+        this.pendingValidatorVerifiedCount !== null ? new Map(this.pendingValidatorVerifiedCount) : null,
       previousPayloadTimelinessCommittees: this.previousPayloadTimelinessCommittees,
       payloadTimelinessCommittees: this.payloadTimelinessCommittees,
       epoch: this.epoch,

--- a/packages/state-transition/src/epoch/processPendingDeposits.ts
+++ b/packages/state-transition/src/epoch/processPendingDeposits.ts
@@ -97,7 +97,9 @@ export function processPendingDeposits(state: CachedBeaconStateElectra, cache: E
   }
 
   state.epochCtx.pendingDepositPubkeyIndex = null;
+  state.epochCtx.pendingDepositPubkeyIndexShared = false;
   state.epochCtx.pendingValidatorVerifiedCount = null;
+  state.epochCtx.pendingValidatorVerifiedCountShared = false;
 
   // Accumulate churn only if the churn limit has been hit.
   if (isChurnLimitReached) {

--- a/packages/state-transition/src/epoch/processPendingDeposits.ts
+++ b/packages/state-transition/src/epoch/processPendingDeposits.ts
@@ -96,6 +96,9 @@ export function processPendingDeposits(state: CachedBeaconStateElectra, cache: E
     state.pendingDeposits.push(deposit);
   }
 
+  state.epochCtx.pendingDepositPubkeyIndex = null;
+  state.epochCtx.pendingValidatorVerifiedCount = null;
+
   // Accumulate churn only if the churn limit has been hit.
   if (isChurnLimitReached) {
     state.depositBalanceToConsume = availableForProcessing - BigInt(processedAmount);


### PR DESCRIPTION
**Motivation**

Gloas deposit request processing needs to determine whether a pubkey already has a valid pending validator deposit. The previous approach requires scanning `state.pendingDeposits` and BLS-verifying every pending deposit signature to build a global set of pending validator pubkeys . The pr reeduces the overhead by caching pubkey-indexed pending deposit lookups and verified counts on the epoch cache.

**Description**

This PR replaces the eager pending-validator pubkey lookup in Gloas deposit request processing with two caches stored on state.epochCtx: 
- pubkey -> pending deposit indices index
- pubkey -> verified pending deposit count

With these caches, lodestar can jump directly to the pending deposits for one pubkey and verify only those entries instead of scanning and verifying the full queue. The caches are updated when new pending deposits are appended.

Addresses #9181 

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

<!-- Insert any AI assistance disclosure here -->
Claude was used for this optimisation