### PR TITLE
fix: align SSE parent root with predicted proposer head

### DIFF
--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -213,7 +213,7 @@ export class PrepareNextSlotScheduler {
           const data = getPayloadAttributesForSSE(fork as ForkPostBellatrix, this.chain, {
             prepareState: updatedPrepareState,
             prepareSlot,
-            parentBlockRoot: fromHex(headRoot),
+            parentBlockRoot: fromHex(updatedHeadRoot),
             parentBlockHash,
             // The likely consumers of this API are builders and will anyway ignore the
             // feeRecipient, so just pass zero hash for now till a real use case arises

--- a/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
+++ b/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
@@ -4,6 +4,8 @@ import {config} from "@lodestar/config/default";
 import {ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {BeaconStateView} from "@lodestar/state-transition";
+import {capella} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
 import {IChainOptions} from "../../../src/chain/options.js";
 import {PrepareNextSlotScheduler} from "../../../src/chain/prepareNextSlot.js";
 import {PayloadIdCache} from "../../../src/execution/engine/payloadIdCache.js";
@@ -143,5 +145,212 @@ describe("PrepareNextSlot scheduler", () => {
     expect(forkChoiceStub.getFinalizedBlock).toHaveBeenCalledOnce();
     expect(executionEngineStub.notifyForkchoiceUpdate).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("gloas - should prepare payload using latestExecutionPayloadBid.blockHash when shouldExtendPayload is true", async () => {
+    const payloadAttributesSpy = vi.fn();
+    const freshWithdrawals: capella.Withdrawal[] = [
+      {index: 1, validatorIndex: 2, address: new Uint8Array(20).fill(0x11), amount: 3n},
+    ];
+    const staleWithdrawals: capella.Withdrawal[] = [
+      {index: 9, validatorIndex: 8, address: new Uint8Array(20).fill(0x22), amount: 7n},
+    ];
+
+    chainStub.emitter.on(routes.events.EventType.payloadAttributes, payloadAttributesSpy);
+    getForkStub.mockReturnValue(ForkName.gloas);
+    chainStub.recomputeForkChoiceHead.mockReturnValue({...zeroProtoBlock, slot: SLOTS_PER_EPOCH - 3} as ProtoBlock);
+    chainStub.predictProposerHead.mockReturnValue({...zeroProtoBlock, slot: SLOTS_PER_EPOCH - 3} as ProtoBlock);
+    forkChoiceStub.getJustifiedBlock.mockReturnValue({
+      executionPayloadBlockHash: zeroProtoBlock.blockRoot,
+    } as ProtoBlock);
+    forkChoiceStub.getFinalizedBlock.mockReturnValue({
+      executionPayloadBlockHash: zeroProtoBlock.blockRoot,
+    } as ProtoBlock);
+    forkChoiceStub.getBlockHexAndBlockHash.mockReturnValue({
+      executionPayloadBlockHash: toRootHex(new Uint8Array(32).fill(0xaa)),
+      executionPayloadNumber: 99,
+    } as ProtoBlock);
+    (forkChoiceStub as MockedBeaconChain["forkChoice"] & {shouldExtendPayload: Mock}).shouldExtendPayload = vi
+      .fn()
+      .mockReturnValue(true);
+    updateBuilderStatus.mockReturnValue(void 0);
+
+    const blockHash = new Uint8Array(32).fill(0xaa);
+    const parentBlockHash = new Uint8Array(32).fill(0xbb);
+    const state = {
+      forkName: ForkName.gloas,
+      slot: SLOTS_PER_EPOCH - 1,
+      genesisTime: 0,
+      epoch: 0,
+      latestExecutionPayloadBid: {blockHash, parentBlockHash},
+      payloadExpectedWithdrawals: staleWithdrawals,
+      getExpectedWithdrawals: vi.fn().mockReturnValue({expectedWithdrawals: freshWithdrawals}),
+      getRandaoMix: vi.fn().mockReturnValue(new Uint8Array(32).fill(0xdd)),
+      getBeaconProposer: vi.fn().mockReturnValue(proposerIndex),
+      hashTreeRoot: vi.fn().mockReturnValue(new Uint8Array(32)),
+    };
+
+    regenStub.getBlockSlotState.mockResolvedValue(state as never);
+    beaconProposerCacheStub.get.mockReturnValue("0x fee recipient address");
+    (executionEngineStub as unknown as {payloadIdCache: PayloadIdCache}).payloadIdCache = new PayloadIdCache();
+    executionEngineStub.notifyForkchoiceUpdate.mockResolvedValue("0x");
+
+    await Promise.all([
+      scheduler.prepareForNextSlot(SLOTS_PER_EPOCH - 2),
+      vi.advanceTimersByTimeAsync((config.SLOT_DURATION_MS * 2) / 3),
+    ]);
+
+    expect(executionEngineStub.notifyForkchoiceUpdate).toHaveBeenCalledWith(
+      ForkName.gloas,
+      toRootHex(blockHash),
+      zeroProtoBlock.blockRoot,
+      zeroProtoBlock.blockRoot,
+      expect.any(Object)
+    );
+    expect(payloadAttributesSpy).toHaveBeenCalledOnce();
+    expect(payloadAttributesSpy).toHaveBeenCalledWith({
+      version: ForkName.gloas,
+      data: expect.objectContaining({
+        parentBlockHash: blockHash,
+        parentBlockNumber: 99,
+        payloadAttributes: expect.objectContaining({withdrawals: freshWithdrawals}),
+      }),
+    });
+    expect(state.getExpectedWithdrawals).toHaveBeenCalledTimes(2);
+  });
+
+  it("gloas - should emit payloadAttributes with parentBeaconBlockRoot aligned to updatedHeadRoot", async () => {
+    const spy = vi.fn();
+    chainStub.emitter.on(routes.events.EventType.payloadAttributes, spy);
+    getForkStub.mockReturnValue(ForkName.gloas);
+
+    const headRoot = toRootHex(new Uint8Array(32).fill(0x11));
+    const proposerHeadRoot = toRootHex(new Uint8Array(32).fill(0x22));
+
+    chainStub.recomputeForkChoiceHead.mockReturnValue({
+      ...zeroProtoBlock,
+      slot: SLOTS_PER_EPOCH - 3,
+      blockRoot: headRoot,
+    } as ProtoBlock);
+    chainStub.predictProposerHead.mockReturnValue({
+      ...zeroProtoBlock,
+      slot: SLOTS_PER_EPOCH - 3,
+      blockRoot: proposerHeadRoot,
+    } as ProtoBlock);
+    forkChoiceStub.getJustifiedBlock.mockReturnValue({
+      executionPayloadBlockHash: zeroProtoBlock.blockRoot,
+    } as ProtoBlock);
+    forkChoiceStub.getFinalizedBlock.mockReturnValue({
+      executionPayloadBlockHash: zeroProtoBlock.blockRoot,
+    } as ProtoBlock);
+    (forkChoiceStub as MockedBeaconChain["forkChoice"] & {shouldExtendPayload: Mock}).shouldExtendPayload = vi
+      .fn()
+      .mockReturnValue(true);
+    updateBuilderStatus.mockReturnValue(void 0);
+
+    const blockHash = new Uint8Array(32).fill(0xaa);
+    const parentBlockHash = new Uint8Array(32).fill(0xbb);
+    (forkChoiceStub as MockedBeaconChain["forkChoice"] & {getBlockHexAndBlockHash: Mock}).getBlockHexAndBlockHash = vi
+      .fn()
+      .mockReturnValue({executionPayloadBlockHash: toRootHex(blockHash), executionPayloadNumber: 99});
+    const state = {
+      forkName: ForkName.gloas,
+      slot: SLOTS_PER_EPOCH - 1,
+      genesisTime: 0,
+      epoch: 0,
+      latestExecutionPayloadBid: {blockHash, parentBlockHash},
+      payloadExpectedWithdrawals: [],
+      getExpectedWithdrawals: vi.fn().mockReturnValue({expectedWithdrawals: []}),
+      getRandaoMix: vi.fn().mockReturnValue(new Uint8Array(32).fill(0xdd)),
+      getBeaconProposer: vi.fn().mockReturnValue(proposerIndex),
+      hashTreeRoot: vi.fn().mockReturnValue(new Uint8Array(32)),
+    };
+
+    regenStub.getBlockSlotState.mockResolvedValue(state as never);
+    beaconProposerCacheStub.get.mockReturnValue("0x fee recipient address");
+    (executionEngineStub as unknown as {payloadIdCache: PayloadIdCache}).payloadIdCache = new PayloadIdCache();
+    executionEngineStub.notifyForkchoiceUpdate.mockResolvedValue("0x");
+
+    await Promise.all([
+      scheduler.prepareForNextSlot(SLOTS_PER_EPOCH - 2),
+      vi.advanceTimersByTimeAsync((config.SLOT_DURATION_MS * 2) / 3),
+    ]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const event = spy.mock.calls[0][0];
+    expect(event.data.parentBlockRoot).toEqual(new Uint8Array(32).fill(0x22));
+    expect(event.data.payloadAttributes.parentBeaconBlockRoot).toEqual(new Uint8Array(32).fill(0x22));
+  });
+
+  it("gloas - should prepare payload using latestExecutionPayloadBid.parentBlockHash when shouldExtendPayload is false", async () => {
+    const payloadAttributesSpy = vi.fn();
+    const freshWithdrawals: capella.Withdrawal[] = [
+      {index: 1, validatorIndex: 2, address: new Uint8Array(20).fill(0x11), amount: 3n},
+    ];
+    const staleWithdrawals: capella.Withdrawal[] = [
+      {index: 9, validatorIndex: 8, address: new Uint8Array(20).fill(0x22), amount: 7n},
+    ];
+
+    chainStub.emitter.on(routes.events.EventType.payloadAttributes, payloadAttributesSpy);
+    getForkStub.mockReturnValue(ForkName.gloas);
+    chainStub.recomputeForkChoiceHead.mockReturnValue({...zeroProtoBlock, slot: SLOTS_PER_EPOCH - 3} as ProtoBlock);
+    chainStub.predictProposerHead.mockReturnValue({...zeroProtoBlock, slot: SLOTS_PER_EPOCH - 3} as ProtoBlock);
+    forkChoiceStub.getJustifiedBlock.mockReturnValue({
+      executionPayloadBlockHash: zeroProtoBlock.blockRoot,
+    } as ProtoBlock);
+    forkChoiceStub.getFinalizedBlock.mockReturnValue({
+      executionPayloadBlockHash: zeroProtoBlock.blockRoot,
+    } as ProtoBlock);
+    forkChoiceStub.getBlockHexAndBlockHash.mockReturnValue({
+      executionPayloadBlockHash: toRootHex(new Uint8Array(32).fill(0xbb)),
+      executionPayloadNumber: 99,
+    } as ProtoBlock);
+    (forkChoiceStub as MockedBeaconChain["forkChoice"] & {shouldExtendPayload: Mock}).shouldExtendPayload = vi
+      .fn()
+      .mockReturnValue(false);
+    updateBuilderStatus.mockReturnValue(void 0);
+
+    const blockHash = new Uint8Array(32).fill(0xaa);
+    const parentBlockHash = new Uint8Array(32).fill(0xbb);
+    const state = {
+      forkName: ForkName.gloas,
+      slot: SLOTS_PER_EPOCH - 1,
+      genesisTime: 0,
+      epoch: 0,
+      latestExecutionPayloadBid: {blockHash, parentBlockHash},
+      payloadExpectedWithdrawals: staleWithdrawals,
+      getExpectedWithdrawals: vi.fn().mockReturnValue({expectedWithdrawals: freshWithdrawals}),
+      getRandaoMix: vi.fn().mockReturnValue(new Uint8Array(32).fill(0xdd)),
+      getBeaconProposer: vi.fn().mockReturnValue(proposerIndex),
+      hashTreeRoot: vi.fn().mockReturnValue(new Uint8Array(32)),
+    };
+
+    regenStub.getBlockSlotState.mockResolvedValue(state as never);
+    beaconProposerCacheStub.get.mockReturnValue("0x fee recipient address");
+    (executionEngineStub as unknown as {payloadIdCache: PayloadIdCache}).payloadIdCache = new PayloadIdCache();
+    executionEngineStub.notifyForkchoiceUpdate.mockResolvedValue("0x");
+
+    await Promise.all([
+      scheduler.prepareForNextSlot(SLOTS_PER_EPOCH - 2),
+      vi.advanceTimersByTimeAsync((config.SLOT_DURATION_MS * 2) / 3),
+    ]);
+
+    expect(executionEngineStub.notifyForkchoiceUpdate).toHaveBeenCalledWith(
+      ForkName.gloas,
+      toRootHex(parentBlockHash),
+      zeroProtoBlock.blockRoot,
+      zeroProtoBlock.blockRoot,
+      expect.any(Object)
+    );
+    expect(payloadAttributesSpy).toHaveBeenCalledOnce();
+    expect(payloadAttributesSpy).toHaveBeenCalledWith({
+      version: ForkName.gloas,
+      data: expect.objectContaining({
+        parentBlockHash,
+        parentBlockNumber: 99,
+        payloadAttributes: expect.objectContaining({withdrawals: staleWithdrawals}),
+      }),
+    });
+    expect(state.getExpectedWithdrawals).not.toHaveBeenCalled();
   });
 });

--- a/packages/beacon-node/test/unit/chain/produceBlock/getPayloadAttributesForSSE.test.ts
+++ b/packages/beacon-node/test/unit/chain/produceBlock/getPayloadAttributesForSSE.test.ts
@@ -1,0 +1,89 @@
+import {describe, expect, it, vi} from "vitest";
+import {createChainForkConfig} from "@lodestar/config";
+import {ForkName} from "@lodestar/params";
+import {capella} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {getPayloadAttributesForSSE} from "../../../../src/chain/produceBlock/produceBlockBody.js";
+
+const config = createChainForkConfig({
+  ALTAIR_FORK_EPOCH: 0,
+  BELLATRIX_FORK_EPOCH: 0,
+  CAPELLA_FORK_EPOCH: 0,
+  DENEB_FORK_EPOCH: 0,
+  ELECTRA_FORK_EPOCH: 0,
+  FULU_FORK_EPOCH: 0,
+  GLOAS_FORK_EPOCH: 0,
+});
+
+describe("getPayloadAttributesForSSE", () => {
+  it("uses fresh expected withdrawals when extending the parent payload, otherwise preserves stale payloadExpectedWithdrawals", () => {
+    const freshWithdrawals: capella.Withdrawal[] = [
+      {index: 1, validatorIndex: 2, address: new Uint8Array(20).fill(0x11), amount: 3n},
+    ];
+    const staleWithdrawals: capella.Withdrawal[] = [
+      {index: 9, validatorIndex: 8, address: new Uint8Array(20).fill(0x22), amount: 7n},
+    ];
+
+    const parentBlockRoot = new Uint8Array(32).fill(0xcc);
+    const extendingParentBlockHash = new Uint8Array(32).fill(0xaa);
+    const nonExtendingParentBlockHash = new Uint8Array(32).fill(0xbb);
+
+    const prepareState = {
+      forkName: ForkName.gloas,
+      genesisTime: 0,
+      epoch: 0,
+      latestExecutionPayloadBid: {
+        blockHash: extendingParentBlockHash,
+        parentBlockHash: nonExtendingParentBlockHash,
+      },
+      payloadExpectedWithdrawals: staleWithdrawals,
+      getExpectedWithdrawals: vi.fn().mockReturnValue({expectedWithdrawals: freshWithdrawals}),
+      getRandaoMix: vi.fn().mockReturnValue(new Uint8Array(32).fill(0xdd)),
+      getBeaconProposer: vi.fn().mockReturnValue(123),
+    };
+
+    const getBlockHexAndBlockHash = vi.fn().mockReturnValue({
+      executionPayloadBlockHash: toRootHex(extendingParentBlockHash),
+      executionPayloadNumber: 99,
+    });
+
+    const chain = {
+      config,
+      forkChoice: {
+        getBlockHexAndBlockHash,
+      },
+    };
+
+    const extending = getPayloadAttributesForSSE(ForkName.gloas, chain as never, {
+      prepareState: prepareState as never,
+      prepareSlot: 1,
+      parentBlockRoot,
+      parentBlockHash: extendingParentBlockHash,
+      feeRecipient: "0x" + "00".repeat(32),
+    });
+
+    const carryingStale = getPayloadAttributesForSSE(ForkName.gloas, chain as never, {
+      prepareState: prepareState as never,
+      prepareSlot: 1,
+      parentBlockRoot,
+      parentBlockHash: nonExtendingParentBlockHash,
+      feeRecipient: "0x" + "00".repeat(32),
+    });
+
+    expect(extending.payloadAttributes.withdrawals).toEqual(freshWithdrawals);
+    expect(carryingStale.payloadAttributes.withdrawals).toEqual(staleWithdrawals);
+    expect(extending.parentBlockNumber).toBe(99);
+    expect(carryingStale.parentBlockNumber).toBe(99);
+    expect(prepareState.getExpectedWithdrawals).toHaveBeenCalledTimes(1);
+    expect(getBlockHexAndBlockHash).toHaveBeenNthCalledWith(
+      1,
+      toRootHex(parentBlockRoot),
+      toRootHex(extendingParentBlockHash)
+    );
+    expect(getBlockHexAndBlockHash).toHaveBeenNthCalledWith(
+      2,
+      toRootHex(parentBlockRoot),
+      toRootHex(nonExtendingParentBlockHash)
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #9209. Aligns the `parentBlockRoot` on the `payload_attributes` SSE event with `updatedHeadRoot`, so the event emits a consistent `(prepareState, parentBlockRoot)` pair when the predicted proposer differs from the canonical head.

Current behavior on `unstable`:

```ts
const data = getPayloadAttributesForSSE(fork as ForkPostBellatrix, this.chain, {
  prepareState: updatedPrepareState, // predicted-proposer state
  prepareSlot,
  parentBlockRoot: fromHex(headRoot), // canonical head root
  ...
});
```

When `updatedHeadRoot !== headRoot` (predicted proposer path in ePBS), `prepareState` reflects the *updated* head while `parentBlockRoot` still points at the *original* head. Downstream SSE consumers (builders, relays) see a mismatch between the state's slot/parent and the advertised `parentBlockRoot`.

This PR changes `parentBlockRoot: fromHex(headRoot)` → `parentBlockRoot: fromHex(updatedHeadRoot)` so both fields come from the same predicted head.

## Context

While investigating the v1.42.0 \"Withdrawal mismatch at index=0\" regression, I found this inconsistency neighboring the SSE emit path. It was deliberately left out of #9209 (which converged on keeping the original `headRoot` there). The fix here is a separate latent-semantics alignment, independent of the actual mismatch root cause (addressed in #9246).

Happy to close this if the current SSE semantics are intentional and external consumers rely on `headRoot` specifically.

## Test plan

- [x] New unit: `gloas - should emit payloadAttributes with parentBeaconBlockRoot aligned to updatedHeadRoot` in `prepareNextSlot.test.ts`
- [x] New unit: `getPayloadAttributesForSSE.test.ts` covering the extend-vs-fresh-withdrawal path
- [x] Existing prepareNextSlot tests green (10/10)
- [x] Lint + type-check clean

## AI assistance

Drafted and validated with AI assistance.