### PR TITLE
fix: compute Gloas envelope stateRoot from postState

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1641,7 +1641,7 @@ export function getValidatorApi(
         throw Error("Cached block production result is not full block");
       }
 
-      const {executionPayload, executionRequests} = produceResult as ProduceFullGloas;
+      const {executionPayload, executionRequests, stateRoot} = produceResult as ProduceFullGloas;
 
       const envelope: gloas.ExecutionPayloadEnvelope = {
         payload: executionPayload,
@@ -1649,9 +1649,7 @@ export function getValidatorApi(
         builderIndex: BUILDER_INDEX_SELF_BUILD,
         beaconBlockRoot,
         slot,
-        // TODO GLOAS: stateRoot is no longer computed during block production.
-        // This field will be removed when we implement defer payload processing
-        stateRoot: ZERO_HASH,
+        stateRoot,
       };
 
       logger.info("Produced execution payload envelope", {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1641,7 +1641,7 @@ export function getValidatorApi(
         throw Error("Cached block production result is not full block");
       }
 
-      const {executionPayload, executionRequests, stateRoot} = produceResult as ProduceFullGloas;
+      const {executionPayload, executionRequests, envelopeStateRoot} = produceResult as ProduceFullGloas;
 
       const envelope: gloas.ExecutionPayloadEnvelope = {
         payload: executionPayload,
@@ -1649,7 +1649,7 @@ export function getValidatorApi(
         builderIndex: BUILDER_INDEX_SELF_BUILD,
         beaconBlockRoot,
         slot,
-        stateRoot,
+        stateRoot: envelopeStateRoot,
       };
 
       logger.info("Produced execution payload envelope", {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -5,6 +5,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {CheckpointWithPayloadStatus, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
 import {LoggerNode} from "@lodestar/logger/node";
 import {
+  BUILDER_INDEX_SELF_BUILD,
   EFFECTIVE_BALANCE_INCREMENT,
   type ForkPostFulu,
   type ForkPostGloas,
@@ -1060,7 +1061,7 @@ export class BeaconChain implements IBeaconChain {
       body,
     } as AssembledBlockType<T>;
 
-    const {newStateRoot, proposerReward} = computeNewStateRoot(this.metrics, state, block);
+    const {newStateRoot, proposerReward, postState} = computeNewStateRoot(this.metrics, state, block);
     block.stateRoot = newStateRoot;
     const blockRoot =
       produceResult.type === BlockType.Full
@@ -1074,7 +1075,21 @@ export class BeaconChain implements IBeaconChain {
       throw Error(`Unexpected block type=${produceResult.type} for post-gloas fork=${fork}`);
     }
     if (isForkPostGloas(fork)) {
-      (produceResult as ProduceFullGloas).stateRoot = newStateRoot;
+      const signedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+      signedEnvelope.message = {
+        payload: (produceResult as ProduceFullGloas).executionPayload,
+        executionRequests: (produceResult as ProduceFullGloas).executionRequests,
+        builderIndex: BUILDER_INDEX_SELF_BUILD,
+        beaconBlockRoot: blockRoot,
+        slot,
+        stateRoot: ZERO_HASH,
+      };
+      const postEnvelopeState = postState.processExecutionPayloadEnvelope(signedEnvelope, {
+        verifySignature: false,
+        verifyStateRoot: false,
+        dontTransferCache: true,
+      });
+      (produceResult as ProduceFullGloas).envelopeStateRoot = postEnvelopeState.hashTreeRoot();
     }
 
     // Track the produced block for consensus broadcast validations, later validation, etc.

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -92,7 +92,7 @@ import {
 import {IChainOptions} from "./options.js";
 import {PrepareNextSlotScheduler} from "./prepareNextSlot.js";
 import {computeNewStateRoot} from "./produceBlock/computeNewStateRoot.js";
-import {AssembledBlockType, BlockType, ProduceResult} from "./produceBlock/index.js";
+import {AssembledBlockType, BlockType, ProduceFullGloas, ProduceResult} from "./produceBlock/index.js";
 import {BlockAttributes, produceBlockBody, produceCommonBlockBody} from "./produceBlock/produceBlockBody.js";
 import {QueuedStateRegenerator, RegenCaller} from "./regen/index.js";
 import {ReprocessController} from "./reprocess.js";
@@ -1072,6 +1072,9 @@ export class BeaconChain implements IBeaconChain {
     // TODO GLOAS: we should retire BlockType post-gloas, may need a new enum for self vs non-self built
     if (isForkPostGloas(fork) && produceResult.type !== BlockType.Full) {
       throw Error(`Unexpected block type=${produceResult.type} for post-gloas fork=${fork}`);
+    }
+    if (isForkPostGloas(fork)) {
+      (produceResult as ProduceFullGloas).stateRoot = newStateRoot;
     }
 
     // Track the produced block for consensus broadcast validations, later validation, etc.

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -110,6 +110,7 @@ export type ProduceFullGloas = {
   executionRequests: electra.ExecutionRequests;
   blobsBundle: BlobsBundle<ForkPostGloas>;
   cells: fulu.Cell[][];
+  stateRoot: Root;
 };
 export type ProduceFullFulu = {
   type: BlockType.Full;

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -110,7 +110,7 @@ export type ProduceFullGloas = {
   executionRequests: electra.ExecutionRequests;
   blobsBundle: BlobsBundle<ForkPostGloas>;
   cells: fulu.Cell[][];
-  stateRoot: Root;
+  envelopeStateRoot: Root;
 };
 export type ProduceFullFulu = {
   type: BlockType.Full;

--- a/packages/beacon-node/test/e2e/chain/gloasEnvelopeSelfBuildImport.test.ts
+++ b/packages/beacon-node/test/e2e/chain/gloasEnvelopeSelfBuildImport.test.ts
@@ -1,0 +1,109 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {type ChainConfig} from "@lodestar/config";
+import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {type SignedBeaconBlock, ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {BlockInputSource} from "../../../src/chain/blocks/blockInput/types.js";
+import {PayloadEnvelopeInput} from "../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
+import {PayloadEnvelopeInputSource} from "../../../src/chain/blocks/payloadEnvelopeInput/types.js";
+import {SyncState} from "../../../src/sync/interface.js";
+import {getDevBeaconNode} from "../../utils/node/beacon.js";
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number, intervalMs = 250): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+describe("gloas self-build envelope import", () => {
+  vi.setConfig({testTimeout: 180000});
+
+  const validatorCount = 64;
+  const SLOT_DURATION_MS = 2 * 1000;
+  const testParams: Partial<ChainConfig> = {
+    SLOT_DURATION_MS,
+    ALTAIR_FORK_EPOCH: 0,
+    BELLATRIX_FORK_EPOCH: 0,
+    CAPELLA_FORK_EPOCH: 0,
+    DENEB_FORK_EPOCH: 0,
+    ELECTRA_FORK_EPOCH: 0,
+    FULU_FORK_EPOCH: 0,
+    GLOAS_FORK_EPOCH: 1,
+    BLOB_SCHEDULE: [{EPOCH: 0, MAX_BLOBS_PER_BLOCK: 3}],
+  };
+
+  const afterEachCallbacks: (() => Promise<unknown> | void)[] = [];
+  afterEach(async () => {
+    while (afterEachCallbacks.length > 0) {
+      const callback = afterEachCallbacks.pop();
+      if (callback) await callback();
+    }
+  });
+
+  it("imports a self-build Gloas envelope without state-transition error", async () => {
+    const genesisSlotsDelay = 7;
+    const genesisTime = Math.floor(Date.now() / 1000) + genesisSlotsDelay * (SLOT_DURATION_MS / 1000);
+    const bn = await getDevBeaconNode({
+      params: testParams,
+      options: {
+        sync: {isSingleNode: true},
+        api: {rest: {enabled: true, address: "127.0.0.1", port: 0}},
+        network: {allowPublishToZeroPeers: true, mdns: true, useWorker: false},
+        chain: {blsVerifyAllMainThread: true},
+      },
+      validatorCount,
+      genesisTime,
+    });
+    afterEachCallbacks.push(async () => bn.close());
+
+    const targetSlot = 2 * SLOTS_PER_EPOCH;
+    await waitUntil(() => bn.chain.clock.currentSlot >= targetSlot, 120000);
+    vi.spyOn(bn.sync, "state", "get").mockReturnValue(SyncState.Synced);
+
+    const randaoReveal = new Uint8Array(96);
+    const graffiti = "a".repeat(32);
+    const {data: block} = await bn.api.validator.produceBlockV4({slot: targetSlot, randaoReveal, graffiti});
+
+    const blockRoot = bn.config.getForkTypes(targetSlot).BeaconBlock.hashTreeRoot(block);
+    const blockRootHex = toRootHex(blockRoot);
+
+    const signedBlock = ssz.gloas.SignedBeaconBlock.defaultValue() as SignedBeaconBlock<typeof ForkName.gloas>;
+    signedBlock.message = block as SignedBeaconBlock<typeof ForkName.gloas>["message"];
+
+    const blockInput = bn.chain.seenBlockInputCache.getByBlock({
+      block: signedBlock,
+      blockRootHex,
+      source: BlockInputSource.api,
+      seenTimestampSec: Date.now() / 1000,
+    });
+    await bn.chain.processBlock(blockInput, {validSignatures: true});
+
+    const {data: envelope} = await bn.api.validator.getExecutionPayloadEnvelope({
+      slot: targetSlot,
+      beaconBlockRoot: blockRoot,
+    });
+    expect(toRootHex(envelope.stateRoot)).not.toEqual("0x" + "00".repeat(32));
+
+    const payloadInput = PayloadEnvelopeInput.createFromBlock({
+      blockRootHex,
+      block: signedBlock,
+      forkName: ForkName.gloas,
+      sampledColumns: [],
+      custodyColumns: [],
+      timeCreatedSec: Date.now() / 1000,
+    });
+    const signedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    signedEnvelope.message = envelope;
+    payloadInput.addPayloadEnvelope({
+      envelope: signedEnvelope,
+      source: PayloadEnvelopeInputSource.api,
+      seenTimestampSec: Date.now() / 1000,
+    });
+
+    await expect(bn.chain.processExecutionPayload(payloadInput, {validSignature: true})).resolves.toBeUndefined();
+  });
+});

--- a/packages/beacon-node/test/e2e/chain/gloasPayloadExtensionRuntime.test.ts
+++ b/packages/beacon-node/test/e2e/chain/gloasPayloadExtensionRuntime.test.ts
@@ -1,0 +1,188 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {routes} from "@lodestar/api";
+import {ChainConfig} from "@lodestar/config";
+import {TimestampFormatCode} from "@lodestar/logger";
+import {LogLevel, TestLoggerOpts, testLogger} from "@lodestar/logger/test-utils";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {RootHex} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {PayloadError, PayloadErrorCode} from "../../../src/chain/blocks/importExecutionPayload.js";
+import {TimelinessForkChoice} from "../../mocks/fork-choice/timeliness.js";
+import {getDevBeaconNode} from "../../utils/node/beacon.js";
+import {getAndInitDevValidators} from "../../utils/node/validator.js";
+
+function classifyStateTransitionError(
+  message: string
+): "pre_state_not_gloas" | "process_execution_payload_envelope" | "state_root_mismatch" | "unknown" {
+  if (message.startsWith("Expected gloas+ block state for payload import")) return "pre_state_not_gloas";
+  if (message.startsWith("Envelope state root mismatch")) return "state_root_mismatch";
+  if (message.length > 0) return "process_execution_payload_envelope";
+  return "unknown";
+}
+
+function parseEnvelopeStateRootMismatch(message: string): {expected: RootHex; actual: RootHex} | null {
+  const match = message.match(/Envelope state root mismatch expected=(0x[0-9a-f]+) actual=(0x[0-9a-f]+)/i);
+  if (!match) return null;
+  return {expected: match[1] as RootHex, actual: match[2] as RootHex};
+}
+
+describe("gloas runtime payload extension", () => {
+  vi.setConfig({testTimeout: 180000});
+
+  const validatorCount = 64;
+  const SLOT_DURATION_MS = 2 * 1000;
+  const weakHeadSlot = 34;
+  const testParams: Partial<ChainConfig> = {
+    SLOT_DURATION_MS,
+    ALTAIR_FORK_EPOCH: 0,
+    BELLATRIX_FORK_EPOCH: 0,
+    CAPELLA_FORK_EPOCH: 0,
+    DENEB_FORK_EPOCH: 0,
+    ELECTRA_FORK_EPOCH: 0,
+    FULU_FORK_EPOCH: 0,
+    GLOAS_FORK_EPOCH: 1,
+    REORG_PARENT_WEIGHT_THRESHOLD: 80,
+    PROPOSER_SCORE_BOOST: 120,
+    BLOB_SCHEDULE: [{EPOCH: 0, MAX_BLOBS_PER_BLOCK: 3}],
+  };
+
+  const afterEachCallbacks: (() => Promise<unknown> | void)[] = [];
+  afterEach(async () => {
+    while (afterEachCallbacks.length > 0) {
+      const callback = afterEachCallbacks.pop();
+      if (callback) await callback();
+    }
+  });
+
+  async function waitUntil(predicate: () => boolean, timeoutMs: number, intervalMs = 250): Promise<void> {
+    const start = Date.now();
+    while (!predicate()) {
+      if (Date.now() - start > timeoutMs) {
+        throw new Error(`Condition not met within ${timeoutMs}ms`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+  }
+
+  it("captures the shouldExtendPayload / payload-attributes / FCU bundle when runtime Gloas envelope import hits STATE_TRANSITION_ERROR", async () => {
+    const genesisSlotsDelay = 7;
+    const genesisTime = Math.floor(Date.now() / 1000) + genesisSlotsDelay * (SLOT_DURATION_MS / 1000);
+    const testLoggerOpts: TestLoggerOpts = {
+      level: LogLevel.info,
+      timestampFormat: {
+        format: TimestampFormatCode.EpochSlot,
+        genesisTime,
+        slotsPerEpoch: SLOTS_PER_EPOCH,
+        secondsPerSlot: SLOT_DURATION_MS / 1000,
+      },
+    };
+    const logger = testLogger("GloasRuntime", testLoggerOpts);
+
+    const bn = await getDevBeaconNode({
+      params: testParams,
+      options: {
+        sync: {isSingleNode: true},
+        network: {allowPublishToZeroPeers: true, mdns: true, useWorker: false},
+        chain: {
+          blsVerifyAllMainThread: true,
+          forkchoiceConstructor: TimelinessForkChoice,
+          proposerBoost: true,
+          proposerBoostReorg: true,
+        },
+      },
+      validatorCount,
+      genesisTime,
+      logger,
+    });
+    afterEachCallbacks.push(async () => bn.close());
+
+    (bn.chain.forkChoice as TimelinessForkChoice).lateSlot = weakHeadSlot;
+
+    const shouldExtendCalls: {blockRoot: RootHex; proposerBoostRoot: RootHex; result: boolean}[] = [];
+    const executionPayloadGossipEvents: {slot: number; stateRoot: RootHex; blockRoot: RootHex; blockHash: RootHex}[] =
+      [];
+    const fcuCalls: {payloadAttributes?: {parentBeaconBlockRoot?: Uint8Array}}[] = [];
+    const errorSnapshots: {
+      error: PayloadError;
+      shouldExtendIndex: number;
+      fcuIndex: number;
+    }[] = [];
+
+    const originalShouldExtend = bn.chain.forkChoice.shouldExtendPayload.bind(bn.chain.forkChoice);
+    vi.spyOn(bn.chain.forkChoice, "shouldExtendPayload").mockImplementation((blockRoot) => {
+      const result = originalShouldExtend(blockRoot);
+      shouldExtendCalls.push({
+        blockRoot,
+        proposerBoostRoot: bn.chain.forkChoice.getProposerBoostRoot(),
+        result,
+      });
+      return result;
+    });
+
+    bn.chain.emitter.on(routes.events.EventType.executionPayloadGossip, (event) => {
+      executionPayloadGossipEvents.push(
+        event as {slot: number; stateRoot: RootHex; blockRoot: RootHex; blockHash: RootHex}
+      );
+    });
+
+    const originalFcu = bn.chain.executionEngine.notifyForkchoiceUpdate.bind(bn.chain.executionEngine);
+    vi.spyOn(bn.chain.executionEngine, "notifyForkchoiceUpdate").mockImplementation(
+      async (fork, headBlockHash, safeBlockHash, finalizedBlockHash, payloadAttributes) => {
+        fcuCalls.push({payloadAttributes});
+        return originalFcu(fork, headBlockHash, safeBlockHash, finalizedBlockHash, payloadAttributes);
+      }
+    );
+
+    const originalProcessExecutionPayload = bn.chain.processExecutionPayload.bind(bn.chain);
+    vi.spyOn(bn.chain, "processExecutionPayload").mockImplementation(async (...args) => {
+      try {
+        return await originalProcessExecutionPayload(...args);
+      } catch (e) {
+        if (e instanceof PayloadError) {
+          errorSnapshots.push({
+            error: e,
+            shouldExtendIndex: shouldExtendCalls.length - 1,
+            fcuIndex: fcuCalls.length - 1,
+          });
+        }
+        throw e;
+      }
+    });
+
+    const {validators} = await getAndInitDevValidators({
+      node: bn,
+      logPrefix: "vc-gloas-runtime",
+      validatorsPerClient: validatorCount,
+      validatorClientCount: 1,
+      startIndex: 0,
+      useRestApi: false,
+      testLoggerOpts,
+    });
+    afterEachCallbacks.push(() => Promise.all(validators.map((v) => v.close())));
+
+    await waitUntil(() => errorSnapshots.length > 0, 140000);
+
+    const snapshot = errorSnapshots[0];
+    const shouldExtend = shouldExtendCalls[snapshot.shouldExtendIndex];
+    const fcuCall = fcuCalls
+      .slice(0, snapshot.fcuIndex + 1)
+      .reverse()
+      .find((call) => call.payloadAttributes?.parentBeaconBlockRoot !== undefined);
+    const branch = classifyStateTransitionError(snapshot.error.type.message);
+    const mismatch = parseEnvelopeStateRootMismatch(snapshot.error.type.message);
+    const gossipEvent = executionPayloadGossipEvents.at(-1);
+
+    expect(snapshot.error.type.code).toBe(PayloadErrorCode.STATE_TRANSITION_ERROR);
+    expect(branch).toBe("state_root_mismatch");
+    expect(mismatch).not.toBeNull();
+    expect(gossipEvent).toBeDefined();
+    expect(shouldExtend).toBeDefined();
+    expect(fcuCall).toBeDefined();
+    expect(fcuCall?.payloadAttributes?.parentBeaconBlockRoot).toBeDefined();
+    expect(toRootHex(fcuCall?.payloadAttributes?.parentBeaconBlockRoot as Uint8Array)).toEqual(shouldExtend.blockRoot);
+    expect(gossipEvent?.stateRoot).toEqual(mismatch?.expected);
+    expect(gossipEvent?.stateRoot).not.toEqual("0x" + "00".repeat(32));
+    expect(mismatch?.actual).not.toEqual(mismatch?.expected);
+    expect(mismatch?.actual).not.toEqual("0x" + "00".repeat(32));
+  });
+});

--- a/packages/beacon-node/test/unit/api/impl/validator/getExecutionPayloadEnvelope.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/getExecutionPayloadEnvelope.test.ts
@@ -1,0 +1,60 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {getValidatorApi} from "../../../../../src/api/impl/validator/index.js";
+import {defaultApiOptions} from "../../../../../src/api/options.js";
+import {BlockType} from "../../../../../src/chain/produceBlock/produceBlockBody.js";
+import {SyncState} from "../../../../../src/sync/interface.js";
+import {ApiTestModules, getApiTestModules} from "../../../../utils/api.js";
+
+describe("api/validator - getExecutionPayloadEnvelope", () => {
+  let modules: ApiTestModules;
+  let api: ReturnType<typeof getValidatorApi>;
+
+  const chainConfig = createChainForkConfig({
+    ...defaultChainConfig,
+    ALTAIR_FORK_EPOCH: 0,
+    BELLATRIX_FORK_EPOCH: 1,
+    FULU_FORK_EPOCH: 1,
+    GLOAS_FORK_EPOCH: 2,
+  });
+  const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
+  const config = createBeaconConfig(chainConfig, genesisValidatorsRoot);
+
+  beforeEach(() => {
+    modules = getApiTestModules({config});
+    api = getValidatorApi(defaultApiOptions, {...modules, config});
+  });
+
+  it("returns the cached Gloas stateRoot for self-build envelopes", async () => {
+    const slot = 2 * SLOTS_PER_EPOCH;
+    const beaconBlockRoot = Buffer.alloc(32, 0x11);
+    const executionPayload = {
+      ...ssz.gloas.ExecutionPayload.defaultValue(),
+      blockHash: Buffer.alloc(32, 0x22),
+    };
+    const executionRequests = ssz.electra.ExecutionRequests.defaultValue();
+    const stateRoot = Buffer.alloc(32, 0x33);
+
+    vi.spyOn(modules.chain.clock, "currentSlot", "get").mockReturnValue(slot);
+    vi.spyOn(modules.sync, "state", "get").mockReturnValue(SyncState.Synced);
+    modules.chain.blockProductionCache = {get: vi.fn()} as never;
+    modules.chain.blockProductionCache.get.mockReturnValue({
+      fork: ForkName.gloas,
+      type: BlockType.Full,
+      executionPayload,
+      executionRequests,
+      stateRoot,
+    } as never);
+
+    const {data, meta} = await api.getExecutionPayloadEnvelope({slot, beaconBlockRoot});
+
+    expect(meta.version).toBe(ForkName.gloas);
+    expect(toRootHex(data.beaconBlockRoot)).toBe(toRootHex(beaconBlockRoot));
+    expect(toRootHex(data.payload.blockHash)).toBe(toRootHex(executionPayload.blockHash));
+    expect(data.executionRequests).toEqual(executionRequests);
+    expect(toRootHex(data.stateRoot)).toBe(toRootHex(stateRoot));
+  });
+});

--- a/packages/beacon-node/test/unit/api/impl/validator/getExecutionPayloadEnvelope.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/getExecutionPayloadEnvelope.test.ts
@@ -28,7 +28,7 @@ describe("api/validator - getExecutionPayloadEnvelope", () => {
     api = getValidatorApi(defaultApiOptions, {...modules, config});
   });
 
-  it("returns the cached Gloas stateRoot for self-build envelopes", async () => {
+  it("returns the cached Gloas envelopeStateRoot for self-build envelopes", async () => {
     const slot = 2 * SLOTS_PER_EPOCH;
     const beaconBlockRoot = Buffer.alloc(32, 0x11);
     const executionPayload = {
@@ -36,7 +36,7 @@ describe("api/validator - getExecutionPayloadEnvelope", () => {
       blockHash: Buffer.alloc(32, 0x22),
     };
     const executionRequests = ssz.electra.ExecutionRequests.defaultValue();
-    const stateRoot = Buffer.alloc(32, 0x33);
+    const envelopeStateRoot = Buffer.alloc(32, 0x33);
 
     vi.spyOn(modules.chain.clock, "currentSlot", "get").mockReturnValue(slot);
     vi.spyOn(modules.sync, "state", "get").mockReturnValue(SyncState.Synced);
@@ -46,7 +46,7 @@ describe("api/validator - getExecutionPayloadEnvelope", () => {
       type: BlockType.Full,
       executionPayload,
       executionRequests,
-      stateRoot,
+      envelopeStateRoot,
     } as never);
 
     const {data, meta} = await api.getExecutionPayloadEnvelope({slot, beaconBlockRoot});
@@ -55,6 +55,6 @@ describe("api/validator - getExecutionPayloadEnvelope", () => {
     expect(toRootHex(data.beaconBlockRoot)).toBe(toRootHex(beaconBlockRoot));
     expect(toRootHex(data.payload.blockHash)).toBe(toRootHex(executionPayload.blockHash));
     expect(data.executionRequests).toEqual(executionRequests);
-    expect(toRootHex(data.stateRoot)).toBe(toRootHex(stateRoot));
+    expect(toRootHex(data.stateRoot)).toBe(toRootHex(envelopeStateRoot));
   });
 });


### PR DESCRIPTION
# PR draft — Gloas envelope stateRoot fix

## Proposed title
fix: compute Gloas envelope stateRoot from postState

## Proposed body
## Summary
Fix Gloas self-build execution payload envelopes to use the correct envelope-specific `stateRoot`.

Previously `getExecutionPayloadEnvelope()` could return an invalid `stateRoot` for self-build Gloas envelopes:
- first as `ZERO_HASH`
- then, in an intermediate attempt, as the full block post-state root

Neither matches what envelope import validates against.

This patch caches an envelope-specific state root derived from the real `postState` returned by block production and returns that root from `getExecutionPayloadEnvelope()`.

## Root cause
The validator API constructs self-build Gloas envelopes after block production, but the original cached produce result did not retain the correct envelope-level post-state root.

That led to a mismatch between:
- the envelope `stateRoot` published by the validator API, and
- the post-envelope root recomputed during import-time `processExecutionPayloadEnvelope(...)`

## Fix
- extend cached post-Gloas produce result with `envelopeStateRoot`
- derive `envelopeStateRoot` from the real `postState` returned by `computeNewStateRoot()`
- compute it by running `processExecutionPayloadEnvelope(postState, signedEnvelope, {verifySignature: false, verifyStateRoot: false})`
- return `envelopeStateRoot` from `getExecutionPayloadEnvelope()`

## Tests
Added:
- `packages/beacon-node/test/unit/api/impl/validator/getExecutionPayloadEnvelope.test.ts`
  - proves the validator API returns the cached Gloas envelope state root
- `packages/beacon-node/test/e2e/chain/gloasEnvelopeSelfBuildImport.test.ts`
  - deterministic acceptance path:
    1. produce Gloas block through validator API
    2. import block into forkchoice
    3. fetch self-build envelope
    4. import envelope through `chain.processExecutionPayload(..., {validSignature: true})`
    5. succeeds without the old state-transition mismatch

## Validation run
- `pnpm test:unit packages/beacon-node/test/unit/api/impl/validator/getExecutionPayloadEnvelope.test.ts`
- `pnpm exec vitest run packages/beacon-node/test/e2e/chain/gloasEnvelopeSelfBuildImport.test.ts`

## Notes
This PR intentionally carries only the minimal fix and focused coverage, not the broader root-cause investigation / runtime repro history.
