### PR TITLE
fix: revert anchor block PTC vote override

### DIFF
--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -109,13 +109,6 @@ export class ProtoArray {
       null
     );
 
-    // Anchor block PTC votes must be all-true per spec get_forkchoice_store:
-    // payload_timeliness_vote={anchor_root: Vector[boolean, PTC_SIZE](True for _ in range(PTC_SIZE))}
-    // Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.5/specs/gloas/fork-choice.md#modified-get_forkchoice_store
-    if (protoArray.ptcVotes.has(block.blockRoot)) {
-      protoArray.ptcVotes.set(block.blockRoot, BitArray.fromBoolArray(Array.from({length: PTC_SIZE}, () => true)));
-    }
-
     return protoArray;
   }
 


### PR DESCRIPTION
## Summary

Revert the anchor-block PTC vote all-true override added in #9188.

Upstream `consensus-specs` `master` fixed the underlying spec bug in:

- [`c7a0a8527`](https://github.com/ethereum/consensus-specs/commit/c7a0a8527) — **Remove incorrect anchor seed for payload votes (#5135)**

[`specs/gloas/fork-choice.md#get_forkchoice_store`](https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#modified-get_forkchoice_store) on `master` now initializes:

```python
payload_timeliness_vote={},
payload_data_availability_vote={},
```

So Lodestar should stop force-seeding the anchor block's PTC votes to all-true in `ProtoArray.initialize()` — anchor initialization returns to the default `onBlock()` behavior.

This PR removes the temporary 8-line override.

## Tag vs. master

\`v1.7.0-alpha.5\` (current spec-test target) still carries the old anchor all-true seed — #5135 landed on spec master **after** the alpha.5 cut. Aligning Lodestar with `master` now means:

- the fix is in place for the next spec tag (alpha.6+) picking up #5135
- fork-choice spec tests generated from alpha.5 may flag the anchor-seed boundary until `spec-tests-version.json` bumps to that next tag

Per direction from @nflaig to follow latest `master` of the spec.

## Context

- Supersedes closed PR #9244 (closed when alpha.5 was still the current tag and kept the old seed).
- Fixes #9239.

## AI assistance

Drafted and validated with AI assistance.