### PR TITLE
chore: bump kurtosis-assertoor action to v1.0.1 to fix nightly sim

### DIFF
--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -22,6 +22,6 @@ jobs:
             --tag chainsafe/lodestar:kurtosis-ci \
             --build-arg COMMIT=$(git rev-parse HEAD)
       - name: Run test
-        uses: ethpandaops/kurtosis-assertoor-github-action@5932604b244dbd2ddb811516b516a9094f4d2c2f # v1
+        uses: ethpandaops/kurtosis-assertoor-github-action@f64942cbc780df731a731ea9f45765b161d2c8df # v1.0.1
         with:
           ethereum_package_args: ".github/workflows/assets/kurtosis_sim_test_config.yaml"


### PR DESCRIPTION
## Summary

Nightly Kurtosis sim on `unstable` has been failing since 2026-04-15 with:

```
at [github.com/ethpandaops/ethereum-package/src/zkboost/zkboost_launcher.star:272:17]:
  undefined: GpuConfig (did you mean get_config?)
at [github.com/ethpandaops/ethereum-package/main.star:67:24]: <toplevel>
```

Ref: https://github.com/ChainSafe/lodestar/actions/runs/24865616925/job/72800866667

## Root cause

- `ethpandaops/ethereum-package#1353` (merged 2026-04-15) introduced `GpuConfig` in `src/zkboost/zkboost_launcher.star`. That predeclared global was added in [Kurtosis 1.18.1](https://github.com/kurtosis-tech/kurtosis/releases/tag/1.18.1).
- Kurtosis's Starlark resolver checks predeclared names at module load time, and `main.star` imports `zkboost_launcher.star` unconditionally — so any Kurtosis < 1.18.1 hits this error even when zkboost is not enabled.
- We pin `ethpandaops/kurtosis-assertoor-github-action@5932604b # v1`. At that sha the action installs via `apt.fury.io/kurtosis-tech`, which caps out at `1.15.2`. Even with `kurtosis_version: latest`, apt resolves to `1.15.2`.

## Fix

Bump to `v1.0.1` (`f64942cb`), which switches the apt source to `sdk.kurtosis.com/kurtosis-cli-release-artifacts` ([action PR #9](https://github.com/ethpandaops/kurtosis-assertoor-github-action/pull/9)). That repo has `1.18.1` available; `kurtosis_version: latest` then picks it up and the Starlark resolves.

## Test plan

- [ ] Trigger the workflow manually on this PR's branch via `workflow_dispatch` and confirm the sim runs past Starlark evaluation.

🤖 Generated with AI assistance