### PR TITLE
feat: range sync for gloas

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -655,7 +655,6 @@ export function getBeaconBlockApi({
       const fork = config.getForkName(slot);
       const blockRootHex = toRootHex(envelope.beaconBlockRoot);
       const blockHashHex = toRootHex(envelope.payload.blockHash);
-      // stateRoot removed from envelope in consensus-specs#5094
 
       if (!isForkPostGloas(fork)) {
         throw new ApiError(400, `publishExecutionPayloadEnvelope not supported for pre-gloas fork=${fork}`);

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -234,7 +234,7 @@ export function getBeaconBlockApi({
           }
 
           try {
-            await verifyBlocksInEpoch.call(chain as BeaconChain, parentBlock, [blockForImport], {
+            await verifyBlocksInEpoch.call(chain as BeaconChain, parentBlock, [blockForImport], null, {
               ...opts,
               verifyOnly: true,
               skipVerifyBlockSignatures: true,
@@ -655,6 +655,7 @@ export function getBeaconBlockApi({
       const fork = config.getForkName(slot);
       const blockRootHex = toRootHex(envelope.beaconBlockRoot);
       const blockHashHex = toRootHex(envelope.payload.blockHash);
+      // stateRoot removed from envelope in consensus-specs#5094
 
       if (!isForkPostGloas(fork)) {
         throw new ApiError(400, `publishExecutionPayloadEnvelope not supported for pre-gloas fork=${fork}`);

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -118,7 +118,7 @@ export function getLodestarApi({
       return {
         // biome-ignore lint/complexity/useLiteralKeys: The `blockProcessor` is a protected attribute
         data: (chain as BeaconChain)["blockProcessor"].jobQueue.getItems().map((item) => {
-          const [blockInputs, opts] = item.args;
+          const [blockInputs, _payloadEnvelopes, opts] = item.args;
           return {
             blockSlots: blockInputs.map((blockInput) => blockInput.slot),
             jobOpts: opts,

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -128,6 +128,7 @@ export async function importBlock(
     blockDelaySec,
     currentSlot,
     fork >= ForkSeq.gloas ? ExecutionStatus.PayloadSeparated : executionStatus,
+    // TODO GLOAS: this is not useful post-gloas, may need to remove it?
     dataAvailabilityStatus
   );
 
@@ -135,8 +136,9 @@ export async function importBlock(
   // Some block event handlers require state being in state cache so need to do this before emitting EventType.block
   this.regen.processState(blockRootHex, postState);
 
-  // For Gloas blocks, create PayloadEnvelopeInput so it's available for later payload import
-  if (fork >= ForkSeq.gloas) {
+  // For range sync, PayloadEnvelope is created before reaching this
+  // we also don't need to trigger getBlobs() in that case
+  if (fork >= ForkSeq.gloas && !opts.fromRangeSync) {
     const payloadInput = this.seenPayloadEnvelopeInputCache.add({
       blockRootHex,
       block: block as SignedBeaconBlock<ForkPostGloas>,

--- a/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
+++ b/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
@@ -75,21 +75,22 @@ function toForkChoiceExecutionStatus(status: ExecutionPayloadStatus): PayloadExe
  * The envelope is only verified here, no state mutation. State effects from the payload
  * are applied on the next block via processParentExecutionPayload.
  *
+ * The DA wait must have run upstream (range sync awaits DA in `verifyBlocksInEpoch` for the
+ * whole segment; gossip / API path uses the `processExecutionPayload` wrapper below).
+ *
  * Steps:
  * 1. Emit `execution_payload_available` event for payload attestation
  * 2. Get the ProtoBlock from fork choice
- * 3. Wait for data columns to be available
- * 4. Regenerate state for envelope verification
- * 5. Verify envelope (fields against state, signature, and EL in parallel where possible)
- * 6. Persist verified payload envelope to hot DB (waits for write-queue space for backpressure)
- * 7. Update fork choice (transitions the block's PENDING variant to FULL)
- * 8. Record metrics for payload envelope and column sources
- * 9. Emit `execution_payload` event
+ * 3. Regenerate state for envelope verification
+ * 4. Verify envelope (fields against state, signature, and EL in parallel where possible)
+ * 5. Persist verified payload envelope to hot DB (waits for write-queue space for backpressure)
+ * 6. Update fork choice (transitions the block's PENDING variant to FULL)
+ * 7. Record metrics for payload envelope and column sources
+ * 8. Emit `execution_payload` event
  */
 export async function importExecutionPayload(
   this: BeaconChain,
   payloadInput: PayloadEnvelopeInput,
-  signal: AbortSignal,
   opts: ImportPayloadOpts = {}
 ): Promise<void> {
   const signedEnvelope = payloadInput.getPayloadEnvelope();
@@ -119,11 +120,7 @@ export async function importExecutionPayload(
     });
   }
 
-  // 3. Wait for data columns to be available.
-  // The helper is shared with future gloas sync services; take the single-item batch form here.
-  await verifyPayloadsDataAvailability([payloadInput], signal);
-
-  // 4. Regenerate state for envelope verification
+  // 3. Regenerate state for envelope verification
   const blockState = await this.regen.getBlockSlotState(
     protoBlock,
     protoBlock.slot,
@@ -137,7 +134,7 @@ export async function importExecutionPayload(
     });
   }
 
-  // 5. Verify envelope fields against state first to fail fast before the EL + BLS work.
+  // 4. Verify envelope fields against state first to fail fast before the EL + BLS work.
   // When validSignature is true, gossip/API has already verified both the signature and the
   // executionRequestsRoot, so we skip those checks here.
   try {
@@ -154,7 +151,7 @@ export async function importExecutionPayload(
     );
   }
 
-  // 5a. Run EL and signature verification in parallel
+  // 4a. Run EL and signature verification in parallel
   const [execResult, signatureValid] = await Promise.all([
     this.executionEngine.notifyNewPayload(
       fork,
@@ -176,12 +173,12 @@ export async function importExecutionPayload(
         ),
   ]);
 
-  // 5b. Check signature verification result
+  // 4b. Check signature verification result
   if (!signatureValid) {
     throw new PayloadError({code: PayloadErrorCode.INVALID_SIGNATURE});
   }
 
-  // 5c. Handle EL response
+  // 4c. Handle EL response
   switch (execResult.status) {
     case ExecutionPayloadStatus.VALID:
       break;
@@ -207,7 +204,7 @@ export async function importExecutionPayload(
       });
   }
 
-  // 6. Persist payload envelope to hot DB. Wait for write-queue space here to apply backpressure
+  // 5. Persist payload envelope to hot DB. Wait for write-queue space here to apply backpressure
   // on the import pipeline during sync, then perform the write asynchronously to avoid blocking.
   await this.unfinalizedPayloadEnvelopeWrites.waitForSpace();
   this.unfinalizedPayloadEnvelopeWrites.push(payloadInput).catch((e) => {
@@ -220,17 +217,17 @@ export async function importExecutionPayload(
     }
   });
 
-  // 7. Update fork choice, transitions the block's PENDING variant to FULL
+  // 6. Update fork choice, transitions the block's PENDING variant to FULL
   const execStatus = toForkChoiceExecutionStatus(execResult.status);
   this.forkChoice.onExecutionPayload(blockRootHex, blockHashHex, envelope.payload.blockNumber, execStatus);
 
-  // 8. Record metrics for payload envelope and column sources
+  // 7. Record metrics for payload envelope and column sources
   this.metrics?.importPayload.bySource.inc({source: payloadInput.getPayloadEnvelopeSource().source});
   for (const {source} of payloadInput.getSampledColumnsWithSource()) {
     this.metrics?.importPayload.columnsBySource.inc({source});
   }
 
-  // 9. Emit event after payload is fully verified and imported to fork choice, only for recent enough payloads
+  // 8. Emit event after payload is fully verified and imported to fork choice, only for recent enough payloads
   if (this.clock.currentSlot - slot < EVENTSTREAM_EMIT_RECENT_EXECUTION_PAYLOAD_SLOTS) {
     this.emitter.emit(routes.events.EventType.executionPayload, {
       slot,
@@ -248,4 +245,22 @@ export async function importExecutionPayload(
     blockRoot: blockRootHex,
     blockHash: blockHashHex,
   });
+}
+
+/**
+ * Process an execution payload envelope end-to-end: wait for DA, then import.
+ *
+ * Used by the PayloadEnvelopeProcessor queue (gossip / API / unknown-payload sync) — i.e.
+ * callers that have NOT already awaited DA themselves. Range sync's inline dispatch in
+ * processBlocks skips this wrapper and calls `importExecutionPayload` directly, since
+ * `verifyBlocksInEpoch` already awaited DA for the segment.
+ */
+export async function processExecutionPayload(
+  this: BeaconChain,
+  payloadInput: PayloadEnvelopeInput,
+  signal: AbortSignal,
+  opts: ImportPayloadOpts = {}
+): Promise<void> {
+  await verifyPayloadsDataAvailability([payloadInput], signal);
+  await importExecutionPayload.call(this, payloadInput, opts);
 }

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -1,4 +1,4 @@
-import {SignedBeaconBlock} from "@lodestar/types";
+import {SignedBeaconBlock, Slot} from "@lodestar/types";
 import {isErrorAborted, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {nextEventLoop} from "../../util/eventLoop.js";
@@ -8,6 +8,8 @@ import {BlockError, BlockErrorCode, isBlockErrorAborted} from "../errors/index.j
 import {BlockProcessOpts} from "../options.js";
 import {IBlockInput} from "./blockInput/types.js";
 import {importBlock} from "./importBlock.js";
+import {importExecutionPayload} from "./importExecutionPayload.js";
+import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {FullyVerifiedBlock, ImportBlockOpts} from "./types.js";
 import {assertLinearChainSegment} from "./utils/chainSegment.js";
 import {verifyBlocksInEpoch} from "./verifyBlock.js";
@@ -21,20 +23,24 @@ const QUEUE_MAX_LENGTH = 256;
  * BlockProcessor processes block jobs in a queued fashion, one after the other.
  */
 export class BlockProcessor {
-  readonly jobQueue: JobItemQueue<[IBlockInput[], ImportBlockOpts], void>;
+  readonly jobQueue: JobItemQueue<[IBlockInput[], Map<Slot, PayloadEnvelopeInput> | null, ImportBlockOpts], void>;
 
   constructor(chain: BeaconChain, metrics: Metrics | null, opts: BlockProcessOpts, signal: AbortSignal) {
-    this.jobQueue = new JobItemQueue<[IBlockInput[], ImportBlockOpts], void>(
-      (job, importOpts) => {
-        return processBlocks.call(chain, job, {...opts, ...importOpts});
+    this.jobQueue = new JobItemQueue<[IBlockInput[], Map<Slot, PayloadEnvelopeInput> | null, ImportBlockOpts], void>(
+      (job, payloadEnvelopes, importOpts) => {
+        return processBlocks.call(chain, job, payloadEnvelopes, {...opts, ...importOpts});
       },
       {maxLength: QUEUE_MAX_LENGTH, noYieldIfOneItem: true, signal},
       metrics?.blockProcessorQueue ?? undefined
     );
   }
 
-  async processBlocksJob(job: IBlockInput[], opts: ImportBlockOpts = {}): Promise<void> {
-    await this.jobQueue.push(job, opts);
+  async processBlocksJob(
+    job: IBlockInput[],
+    payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
+    opts: ImportBlockOpts = {}
+  ): Promise<void> {
+    await this.jobQueue.push(job, payloadEnvelopes, opts);
   }
 }
 
@@ -51,14 +57,11 @@ export class BlockProcessor {
 export async function processBlocks(
   this: BeaconChain,
   blocks: IBlockInput[],
+  payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<void> {
   if (blocks.length === 0) {
     return; // TODO: or throw?
-  }
-
-  if (blocks.length > 1) {
-    assertLinearChainSegment(this.config, blocks);
   }
 
   try {
@@ -70,10 +73,25 @@ export async function processBlocks(
       return;
     }
 
+    const {warnings: orphanedPayloads} = assertLinearChainSegment(
+      this.config,
+      relevantBlocks,
+      payloadEnvelopes,
+      parentBlock
+    );
+    if (orphanedPayloads != null) {
+      for (const orphaned of orphanedPayloads) {
+        this.logger.debug("Orphaned payload envelope in chain segment", {
+          slot: orphaned.slot,
+          blockRoot: orphaned.payloadEnvelopeInput.blockRootHex,
+        });
+      }
+    }
+
     // Fully verify a block to be imported immediately after. Does not produce any side-effects besides adding intermediate
     // states in the state cache through regen.
     const {postStates, dataAvailabilityStatuses, proposerBalanceDeltas, segmentExecStatus, indexedAttestationsByBlock} =
-      await verifyBlocksInEpoch.call(this, parentBlock, relevantBlocks, opts);
+      await verifyBlocksInEpoch.call(this, parentBlock, relevantBlocks, payloadEnvelopes, opts);
 
     // If segmentExecStatus has lvhForkchoice then, the entire segment should be invalid
     // and we need to further propagate
@@ -103,6 +121,16 @@ export async function processBlocks(
     for (const fullyVerifiedBlock of fullyVerifiedBlocks) {
       // TODO: Consider batching importBlock too if it takes significant time
       await importBlock.call(this, fullyVerifiedBlock, opts);
+
+      const slot = fullyVerifiedBlock.blockInput.getBlock().message.slot;
+      const payloadInput = payloadEnvelopes?.get(slot);
+      if (payloadInput?.hasPayloadEnvelope() && payloadInput.isComplete()) {
+        // we already awaited DA in verifyBlocksInEpoch for this segment
+        // TODO GLOAS: may need FullyVerifiedPayload here with DatAvailabilityStatus added from here
+        // the current flow use that data from the forkchoice pending node which is not correct
+        await importExecutionPayload.call(this, payloadInput, {validSignature: false});
+      }
+
       await nextEventLoop();
     }
   } catch (e) {

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -124,7 +124,11 @@ export async function processBlocks(
 
       const slot = fullyVerifiedBlock.blockInput.getBlock().message.slot;
       const payloadInput = payloadEnvelopes?.get(slot);
-      if (payloadInput?.hasPayloadEnvelope() && payloadInput.isComplete()) {
+      if (payloadInput?.hasPayloadEnvelope()) {
+        if (!payloadInput.isComplete()) {
+          // we validated DA before reaching this
+          throw new Error(`Payload envelope for slot ${slot} not complete after DA verification`);
+        }
         // we already awaited DA in verifyBlocksInEpoch for this segment
         // TODO GLOAS: may need FullyVerifiedPayload here with DatAvailabilityStatus added from here
         // the current flow use that data from the forkchoice pending node which is not correct

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeProcessor.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeProcessor.ts
@@ -2,7 +2,7 @@ import {Metrics} from "../../metrics/metrics.js";
 import {JobItemQueue} from "../../util/queue/index.js";
 import type {BeaconChain} from "../chain.js";
 import {PayloadEnvelopeInput} from "../seenCache/seenPayloadEnvelopeInput.js";
-import {importExecutionPayload} from "./importExecutionPayload.js";
+import {processExecutionPayload} from "./importExecutionPayload.js";
 import {ImportPayloadOpts} from "./types.js";
 
 // TODO GLOAS: Set to be equal to DEFAULT_MAX_PENDING_UNFINALIZED_PAYLOAD_ENVELOPE_WRITES for now
@@ -30,7 +30,7 @@ export class PayloadEnvelopeProcessor {
     this.jobQueue = new JobItemQueue<[PayloadEnvelopeInput, ImportPayloadOpts], void>(
       (payloadInput, opts) => {
         this.importStatus.set(payloadInput, PayloadEnvelopeImportStatus.importing);
-        return importExecutionPayload.call(chain, payloadInput, signal, opts);
+        return processExecutionPayload.call(chain, payloadInput, signal, opts);
       },
       {maxLength: QUEUE_MAX_LENGTH, noYieldIfOneItem: true, signal},
       metrics?.payloadEnvelopeProcessorQueue ?? undefined

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -106,6 +106,6 @@ export type FullyVerifiedBlock = {
   indexedAttestations: IndexedAttestation[];
   /** Seen timestamp seconds */
   seenTimestampSec: number;
-  /** If the execution payload couldn't be verified because of EL syncing status, used in optimistic sync or for merge block */
+  /** If the execution payload couldn't be verified because of EL syncing status, used in optimistic sync */
   executionStatus: BlockExecutionStatus | PayloadExecutionStatus;
 };

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -1,5 +1,5 @@
 import type {ChainForkConfig} from "@lodestar/config";
-import {BlockExecutionStatus} from "@lodestar/fork-choice";
+import type {BlockExecutionStatus, PayloadExecutionStatus} from "@lodestar/fork-choice";
 import {ForkSeq} from "@lodestar/params";
 import {DataAvailabilityStatus, IBeaconStateView, computeEpochAtSlot} from "@lodestar/state-transition";
 import type {IndexedAttestation, Slot, fulu} from "@lodestar/types";
@@ -106,6 +106,6 @@ export type FullyVerifiedBlock = {
   indexedAttestations: IndexedAttestation[];
   /** Seen timestamp seconds */
   seenTimestampSec: number;
-  /** If the execution payload couldn't be verified because of EL syncing status, used in optimistic sync */
-  executionStatus: BlockExecutionStatus;
+  /** If the execution payload couldn't be verified because of EL syncing status, used in optimistic sync or for merge block */
+  executionStatus: BlockExecutionStatus | PayloadExecutionStatus;
 };

--- a/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
+++ b/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
@@ -1,29 +1,110 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ssz} from "@lodestar/types";
+import {ProtoBlock} from "@lodestar/fork-choice";
+import {Slot, isGloasBeaconBlock, ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
 import {BlockError, BlockErrorCode} from "../../errors/index.js";
 import {IBlockInput} from "../blockInput/types.js";
+import {PayloadEnvelopeInput} from "../payloadEnvelopeInput/payloadEnvelopeInput.js";
+
+export type OrphanedPayloadEnvelope = {
+  slot: Slot;
+  payloadEnvelopeInput: PayloadEnvelopeInput;
+};
+
+export type ChainSegmentResult = {warnings: OrphanedPayloadEnvelope[] | null};
 
 /**
- * Assert this chain segment of blocks is linear with slot numbers and hashes
+ * Assert this chain segment of blocks is linear with slot numbers and hashes,
+ * and that the provided envelopes are consistent with their respective blocks.
+ *
+ * Must be called after verifyBlocksSanityChecks so that parentBlock (from forkchoice)
+ * is available to seed the execution hash chain.
+ *
+ * For each block:
+ * - Verifies parent root + slot linearity
+ * - For gloas: verifies bid.parentBlockHash matches the tracked execution hash; if not, the
+ *   previous FULL envelope is treated as orphaned (segment continues as if previous slot was EMPTY)
+ * - If an envelope exists for this slot: verifies it references this block's root
+ * - Advances the tracked execution hash (FULL if envelope present, EMPTY if not)
  */
+export function assertLinearChainSegment(
+  config: ChainForkConfig,
+  blocks: IBlockInput[],
+  payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
+  parentBlock: ProtoBlock
+): ChainSegmentResult {
+  const warnings: OrphanedPayloadEnvelope[] = [];
 
-export function assertLinearChainSegment(config: ChainForkConfig, blocks: IBlockInput[]): void {
-  for (let i = 0; i < blocks.length - 1; i++) {
+  // Track the expected execution payload block hash through the segment.
+  // Starts from the known forkchoice parent's execution hash.
+  // - FULL variant (envelope present for slot): advances to envelope.payload.blockHash
+  // - EMPTY variant (no envelope for slot): execution hash is unchanged
+  // null only for pre-merge parents, which cannot precede gloas blocks.
+  let currentExecHash: string | null = parentBlock.executionPayloadBlockHash;
+  // Track the execution hash before the last FULL advancement so we can recover
+  // if the next block reveals that envelope was orphaned.
+  let prevExecHash: string | null = currentExecHash;
+  // The slot whose envelope last advanced currentExecHash (for warning context).
+  let lastFullSlot: Slot | null = null;
+
+  for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i].getBlock();
-    const child = blocks[i + 1].getBlock();
-    // If this block has a child in this chain segment, ensure that its parent root matches
-    // the root of this block.
-    if (
-      !ssz.Root.equals(
-        config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message),
-        child.message.parentRoot
-      )
-    ) {
-      throw new BlockError(block, {code: BlockErrorCode.NON_LINEAR_PARENT_ROOTS});
+    const slot = block.message.slot;
+
+    if (i > 0) {
+      const prevBlock = blocks[i - 1].getBlock();
+      // Ensure parent root matches the previous block's root
+      if (
+        !ssz.Root.equals(
+          config.getForkTypes(prevBlock.message.slot).BeaconBlock.hashTreeRoot(prevBlock.message),
+          block.message.parentRoot
+        )
+      ) {
+        throw new BlockError(block, {code: BlockErrorCode.NON_LINEAR_PARENT_ROOTS});
+      }
+      // Ensure slots are strictly increasing
+      if (slot <= prevBlock.message.slot) {
+        throw new BlockError(block, {code: BlockErrorCode.NON_LINEAR_SLOTS});
+      }
     }
-    // Ensure that the slots are strictly increasing throughout the chain segment.
-    if (child.message.slot <= block.message.slot) {
-      throw new BlockError(block, {code: BlockErrorCode.NON_LINEAR_SLOTS});
+
+    if (isGloasBeaconBlock(block.message) && currentExecHash !== null) {
+      // Verify the bid's parentBlockHash matches the tracked execution hash.
+      // This ensures the block was built on the correct FULL or EMPTY variant of its parent.
+      const bidParentHash = toRootHex(block.message.body.signedExecutionPayloadBid.message.parentBlockHash);
+      if (bidParentHash !== currentExecHash) {
+        // The previous slot's envelope was orphaned — fall back to prevExecHash
+        if (lastFullSlot !== null && payloadEnvelopes !== null) {
+          const orphanedInput = payloadEnvelopes.get(lastFullSlot);
+          if (orphanedInput != null) {
+            warnings.push({slot: lastFullSlot, payloadEnvelopeInput: orphanedInput});
+          }
+        }
+        currentExecHash = prevExecHash;
+      }
+
+      const payloadInput = payloadEnvelopes?.get(slot) ?? null;
+      const payloadEnvelope = payloadInput?.hasPayloadEnvelope() ? payloadInput.getPayloadEnvelope() : null;
+      if (payloadEnvelope !== null) {
+        // Verify the envelope references this block's root
+        const blockRoot = toRootHex(config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block.message));
+        const envelopeBlockRoot = toRootHex(payloadEnvelope.message.beaconBlockRoot);
+        if (blockRoot !== envelopeBlockRoot) {
+          throw new BlockError(block, {
+            code: BlockErrorCode.ENVELOPE_BLOCK_ROOT_MISMATCH,
+            envelopeBlockRoot,
+            blockRoot,
+          });
+        }
+
+        // FULL variant: save state before advancing, then advance
+        prevExecHash = currentExecHash;
+        lastFullSlot = slot;
+        currentExecHash = toRootHex(payloadEnvelope.message.payload.blockHash);
+      }
+      // EMPTY variant: currentExecHash unchanged
     }
   }
+
+  return {warnings: warnings.length > 0 ? warnings : null};
 }

--- a/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
+++ b/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
@@ -73,7 +73,15 @@ export function assertLinearChainSegment(
       // This ensures the block was built on the correct FULL or EMPTY variant of its parent.
       const bidParentHash = toRootHex(block.message.body.signedExecutionPayloadBid.message.parentBlockHash);
       if (bidParentHash !== currentExecHash) {
-        // The previous slot's envelope was orphaned — fall back to prevExecHash
+        // Maybe the previous slot's FULL envelope was orphaned — try falling back.
+        // If even prevExecHash doesn't match, the segment is non-linear.
+        if (bidParentHash !== prevExecHash) {
+          throw new BlockError(block, {
+            code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
+            parentRoot: toRootHex(block.message.parentRoot),
+            parentBlockHash: bidParentHash,
+          });
+        }
         if (lastFullSlot !== null && payloadEnvelopes !== null) {
           const orphanedInput = payloadEnvelopes.get(lastFullSlot);
           if (orphanedInput != null) {

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -1,12 +1,14 @@
 import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
-import {ForkName, isForkPostFulu} from "@lodestar/params";
+import {ForkName, ForkSeq, isForkPostFulu} from "@lodestar/params";
 import {DataAvailabilityStatus, IBeaconStateView, computeEpochAtSlot} from "@lodestar/state-transition";
-import {IndexedAttestation, deneb} from "@lodestar/types";
+import {IndexedAttestation, Slot, deneb} from "@lodestar/types";
+import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import type {BeaconChain} from "../chain.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
 import {BlockProcessOpts} from "../options.js";
 import {RegenCaller} from "../regen/index.js";
 import {DAType, IBlockInput} from "./blockInput/index.js";
+import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {ImportBlockOpts} from "./types.js";
 import {DENEB_BLOWFISH_BANNER} from "./utils/blowfishBanner.js";
 import {ELECTRA_GIRAFFE_BANNER} from "./utils/giraffeBanner.js";
@@ -16,6 +18,7 @@ import {verifyBlocksDataAvailability} from "./verifyBlocksDataAvailability.js";
 import {SegmentExecStatus, verifyBlocksExecutionPayload} from "./verifyBlocksExecutionPayloads.js";
 import {verifyBlocksSignatures} from "./verifyBlocksSignatures.js";
 import {verifyBlocksStateTransitionOnly} from "./verifyBlocksStateTransitionOnly.js";
+import {verifyPayloadsDataAvailability} from "./verifyPayloadsDataAvailability.js";
 
 /**
  * Verifies 1 or more blocks are fully valid; from a linear sequence of blocks.
@@ -32,6 +35,7 @@ export async function verifyBlocksInEpoch(
   this: BeaconChain,
   parentBlock: ProtoBlock,
   blockInputs: IBlockInput[],
+  payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<{
   postStates: IBeaconStateView[];
@@ -110,6 +114,26 @@ export async function verifyBlocksInEpoch(
       });
     }
 
+    // Pick the data-availability source by fork:
+    // - Pre-Gloas: blob/Fulu-column data lives in IBlockInput → verifyBlocksDataAvailability.
+    // - Post-Gloas: verifyPayloadsDataAvailability
+    const daAvailabilityPromise =
+      fork >= ForkSeq.gloas
+        ? (async () => {
+            const payloadInputsForDa: PayloadEnvelopeInput[] = [];
+            for (const input of blockInputs) {
+              const pi = payloadEnvelopes?.get(input.slot);
+              if (pi !== undefined) payloadInputsForDa.push(pi);
+            }
+            await verifyPayloadsDataAvailability(payloadInputsForDa, abortController.signal);
+            return {
+              // post-gloas, DataAvailabilityStatus is NotRequired for forkChoice.onBlock() ProtoBlock
+              dataAvailabilityStatuses: blockInputs.map(() => DataAvailabilityStatus.NotRequired),
+              availableTime: Date.now(),
+            };
+          })()
+        : verifyBlocksDataAvailability(blockInputs, abortController.signal);
+
     // batch all I/O operations to reduce overhead
     const [
       segmentExecStatus,
@@ -119,8 +143,8 @@ export async function verifyBlocksInEpoch(
     ] = await Promise.all([
       verifyExecutionPayloadsPromise,
 
-      // data availability for the blobs
-      verifyBlocksDataAvailability(blockInputs, abortController.signal),
+      // data availability (fork-specific; see daAvailabilityPromise above)
+      daAvailabilityPromise,
 
       // Run state transition only
       // TODO: Ensure it yields to allow flushing to workers and engine API
@@ -200,7 +224,9 @@ export async function verifyBlocksInEpoch(
         blockInputs.length === 1 &&
         // gossip blocks have seenTimestampSec
         opts.seenTimestampSec !== undefined &&
+        // PreData (pre-deneb) and NoData (gloas) carry no blob data on the block — skip metric
         blockInputs[0].type !== DAType.PreData &&
+        blockInputs[0].type !== DAType.NoData &&
         executionStatuses[0] === ExecutionStatus.Valid
       ) {
         // Find the max time when the block was actually verified
@@ -209,8 +235,8 @@ export async function verifyBlocksInEpoch(
         this.metrics?.gossipBlock.receivedToFullyVerifiedTime.observe(recvTofullyVerifedTime);
 
         const verifiedToBlobsAvailabiltyTime = Math.max(availableTime - fullyVerifiedTime, 0) / 1000;
-        const block = blockInputs[0].getBlock() as deneb.SignedBeaconBlock;
-        const numBlobs = block.message.body.blobKzgCommitments.length;
+        const block = blockInputs[0].getBlock();
+        const numBlobs = getBlobKzgCommitments(blockInputs[0].forkName, block as deneb.SignedBeaconBlock).length;
 
         this.metrics?.gossipBlock.verifiedToBlobsAvailabiltyTime.observe({numBlobs}, verifiedToBlobsAvailabiltyTime);
         this.logger.verbose("Verified blockInput fully with blobs availability", {

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -173,6 +173,9 @@ export async function verifyBlocksInEpoch(
             opts
           )
         : Promise.resolve({verifySignaturesTime: Date.now()}),
+
+      // TODO GLOAS: can verify payload signatures in batch too
+      // maybe chain with the above verifyBlocksSignatures()
     ]);
 
     if (opts.verifyOnly !== true) {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -891,7 +891,7 @@ export class BeaconChain implements IBeaconChain {
     parentBlockSlot: Slot,
     parentBlockRootHex: RootHex
   ): Promise<electra.ExecutionRequests> {
-    // handle the fork boundary where parent could be pre-gloas
+    // at the fork boundary, parent is pre-gloas
     if (!isForkPostGloas(this.config.getForkName(parentBlockSlot))) {
       return ssz.electra.ExecutionRequests.defaultValue();
     }

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -891,6 +891,10 @@ export class BeaconChain implements IBeaconChain {
     parentBlockSlot: Slot,
     parentBlockRootHex: RootHex
   ): Promise<electra.ExecutionRequests> {
+    // handle the fork boundary where parent could be pre-gloas
+    if (!isForkPostGloas(this.config.getForkName(parentBlockSlot))) {
+      return ssz.electra.ExecutionRequests.defaultValue();
+    }
     const envelope = await this.getExecutionPayloadEnvelope(parentBlockSlot, parentBlockRootHex);
     if (envelope === null) {
       throw Error(`Parent execution payload envelope not found slot=${parentBlockSlot}, root=${parentBlockRootHex}`);
@@ -1094,11 +1098,15 @@ export class BeaconChain implements IBeaconChain {
   }
 
   async processBlock(block: IBlockInput, opts?: ImportBlockOpts): Promise<void> {
-    return this.blockProcessor.processBlocksJob([block], opts);
+    return this.blockProcessor.processBlocksJob([block], null, opts);
   }
 
-  async processChainSegment(blocks: IBlockInput[], opts?: ImportBlockOpts): Promise<void> {
-    return this.blockProcessor.processBlocksJob(blocks, opts);
+  async processChainSegment(
+    blocks: IBlockInput[],
+    payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
+    opts?: ImportBlockOpts
+  ): Promise<void> {
+    await this.blockProcessor.processBlocksJob(blocks, payloadEnvelopes, opts);
   }
 
   async processExecutionPayload(payloadInput: PayloadEnvelopeInput, opts?: ImportPayloadOpts): Promise<void> {

--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -74,6 +74,8 @@ export enum BlockErrorCode {
   PARENT_EXECUTION_INVALID = "BLOCK_ERROR_PARENT_EXECUTION_INVALID",
   /** The block's parent execution payload (defined by bid.parent_block_hash) has not been seen */
   PARENT_PAYLOAD_UNKNOWN = "BLOCK_ERROR_PARENT_PAYLOAD_UNKNOWN",
+  /** An execution payload envelope in the chain segment references a block root that does not match its slot's block */
+  ENVELOPE_BLOCK_ROOT_MISMATCH = "BLOCK_ERROR_ENVELOPE_BLOCK_ROOT_MISMATCH",
 }
 
 type ExecutionErrorStatus = Exclude<
@@ -107,6 +109,7 @@ export type BlockErrorType =
   | {code: BlockErrorCode.NOT_LATER_THAN_PARENT; parentSlot: Slot; slot: Slot}
   | {code: BlockErrorCode.NON_LINEAR_PARENT_ROOTS}
   | {code: BlockErrorCode.NON_LINEAR_SLOTS}
+  | {code: BlockErrorCode.ENVELOPE_BLOCK_ROOT_MISMATCH; envelopeBlockRoot: RootHex; blockRoot: RootHex}
   | {code: BlockErrorCode.PER_BLOCK_PROCESSING_ERROR; error: Error}
   | {code: BlockErrorCode.BEACON_CHAIN_ERROR; error: Error}
   | {code: BlockErrorCode.KNOWN_BAD_BLOCK}
@@ -120,7 +123,7 @@ export type BlockErrorType =
   | {code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS; blobKzgCommitmentsLen: number; commitmentLimit: number}
   | {code: BlockErrorCode.BID_PARENT_ROOT_MISMATCH; bidParentRoot: RootHex; blockParentRoot: RootHex}
   | {code: BlockErrorCode.PARENT_EXECUTION_INVALID; parentRoot: RootHex}
-  | {code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN; parentBlockHash: RootHex};
+  | {code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN; parentRoot: RootHex; parentBlockHash: RootHex};
 
 export class BlockGossipError extends GossipActionError<BlockErrorType> {}
 

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -250,7 +250,11 @@ export interface IBeaconChain {
   /** Process a block until complete */
   processBlock(block: IBlockInput, opts?: ImportBlockOpts): Promise<void>;
   /** Process a chain of blocks until complete */
-  processChainSegment(blocks: IBlockInput[], opts?: ImportBlockOpts): Promise<void>;
+  processChainSegment(
+    blocks: IBlockInput[],
+    payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
+    opts?: ImportBlockOpts
+  ): Promise<void>;
 
   /** Process execution payload envelope: verify, import to fork choice, and persist to DB */
   processExecutionPayload(payloadInput: PayloadEnvelopeInput, opts?: ImportPayloadOpts): Promise<void>;

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -18,6 +18,7 @@ import {
   G2_POINT_AT_INFINITY,
   IBeaconStateView,
   type IBeaconStateViewBellatrix,
+  type IBeaconStateViewGloas,
   computeTimeAtSlot,
   isStatePostBellatrix,
   isStatePostCapella,
@@ -263,9 +264,16 @@ export async function produceBlockBody<T extends BlockType>(
     }
 
     // Create self-build execution payload bid
+    // IMPORTANT: bid.parentBlockHash must match the EL-block that the payload was built on (i.e.
+    // executionPayload.parentHash). Using currentState.latestBlockHash would always yield the
+    // EMPTY-parent hash (state.latestBlockHash is only advanced on the FULL path once the next
+    // block applies parent envelope in process_parent_execution_payload), so FULL-parent
+    // self-builds would be mis-encoded as EMPTY and the canonical chain would never pick up
+    // envelope variants. See gloas/beacon-chain.md::process_execution_payload_bid which checks
+    // bid.parent_block_hash against the selected parent payload.
     const bid: gloas.ExecutionPayloadBid = {
-      parentBlockHash,
-      parentBlockRoot,
+      parentBlockHash: executionPayload.parentHash,
+      parentBlockRoot: parentBlockRoot,
       blockHash: executionPayload.blockHash,
       prevRandao: currentState.getRandaoMix(currentState.epoch),
       feeRecipient: executionPayload.feeRecipient,
@@ -616,6 +624,7 @@ export async function prepareExecutionPayload(
   chain: {
     executionEngine: IExecutionEngine;
     config: ChainForkConfig;
+    forkChoice?: IForkChoice;
   },
   logger: Logger,
   fork: ForkPostBellatrix,
@@ -731,6 +740,9 @@ export function getPayloadAttributesForSSE(
     parentExecutionRequests?: electra.ExecutionRequests;
   }
 ): SSEPayloadAttributes {
+  const parentHash = isForkPostGloas(fork)
+    ? (prepareState as unknown as IBeaconStateViewGloas).latestBlockHash
+    : prepareState.latestExecutionPayloadHeader.blockHash;
   const payloadAttributes = preparePayloadAttributes(fork, chain, {
     prepareState,
     prepareSlot,
@@ -742,10 +754,7 @@ export function getPayloadAttributesForSSE(
 
   let parentBlockNumber: number;
   if (isForkPostGloas(fork)) {
-    const parentBlock = chain.forkChoice.getBlockHexAndBlockHash(
-      toRootHex(parentBlockRoot),
-      toRootHex(parentBlockHash)
-    );
+    const parentBlock = chain.forkChoice.getBlockHexAndBlockHash(toRootHex(parentBlockRoot), toRootHex(parentHash));
     if (parentBlock?.executionPayloadBlockHash == null) {
       throw Error(`Parent block not found in fork choice root=${toRootHex(parentBlockRoot)}`);
     }
@@ -759,7 +768,7 @@ export function getPayloadAttributesForSSE(
     proposalSlot: prepareSlot,
     parentBlockNumber,
     parentBlockRoot,
-    parentBlockHash,
+    parentBlockHash: parentHash,
     payloadAttributes,
   };
   return ssePayloadAttributes;
@@ -816,7 +825,7 @@ function preparePayloadAttributes(
           prepareState.payloadExpectedWithdrawals;
       }
     } else {
-      // withdrawals logic is now fork aware as it changes on electra fork post capella
+      // Pre-Gloas or Gloas with full parent but no override (shouldn't happen in normal flow)
       (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
         prepareState.getExpectedWithdrawals().expectedWithdrawals;
     }

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -18,7 +18,6 @@ import {
   G2_POINT_AT_INFINITY,
   IBeaconStateView,
   type IBeaconStateViewBellatrix,
-  type IBeaconStateViewGloas,
   computeTimeAtSlot,
   isStatePostBellatrix,
   isStatePostCapella,
@@ -264,16 +263,9 @@ export async function produceBlockBody<T extends BlockType>(
     }
 
     // Create self-build execution payload bid
-    // IMPORTANT: bid.parentBlockHash must match the EL-block that the payload was built on (i.e.
-    // executionPayload.parentHash). Using currentState.latestBlockHash would always yield the
-    // EMPTY-parent hash (state.latestBlockHash is only advanced on the FULL path once the next
-    // block applies parent envelope in process_parent_execution_payload), so FULL-parent
-    // self-builds would be mis-encoded as EMPTY and the canonical chain would never pick up
-    // envelope variants. See gloas/beacon-chain.md::process_execution_payload_bid which checks
-    // bid.parent_block_hash against the selected parent payload.
     const bid: gloas.ExecutionPayloadBid = {
-      parentBlockHash: executionPayload.parentHash,
-      parentBlockRoot: parentBlockRoot,
+      parentBlockHash,
+      parentBlockRoot,
       blockHash: executionPayload.blockHash,
       prevRandao: currentState.getRandaoMix(currentState.epoch),
       feeRecipient: executionPayload.feeRecipient,
@@ -624,7 +616,6 @@ export async function prepareExecutionPayload(
   chain: {
     executionEngine: IExecutionEngine;
     config: ChainForkConfig;
-    forkChoice?: IForkChoice;
   },
   logger: Logger,
   fork: ForkPostBellatrix,
@@ -740,9 +731,6 @@ export function getPayloadAttributesForSSE(
     parentExecutionRequests?: electra.ExecutionRequests;
   }
 ): SSEPayloadAttributes {
-  const parentHash = isForkPostGloas(fork)
-    ? (prepareState as unknown as IBeaconStateViewGloas).latestBlockHash
-    : prepareState.latestExecutionPayloadHeader.blockHash;
   const payloadAttributes = preparePayloadAttributes(fork, chain, {
     prepareState,
     prepareSlot,
@@ -754,7 +742,10 @@ export function getPayloadAttributesForSSE(
 
   let parentBlockNumber: number;
   if (isForkPostGloas(fork)) {
-    const parentBlock = chain.forkChoice.getBlockHexAndBlockHash(toRootHex(parentBlockRoot), toRootHex(parentHash));
+    const parentBlock = chain.forkChoice.getBlockHexAndBlockHash(
+      toRootHex(parentBlockRoot),
+      toRootHex(parentBlockHash)
+    );
     if (parentBlock?.executionPayloadBlockHash == null) {
       throw Error(`Parent block not found in fork choice root=${toRootHex(parentBlockRoot)}`);
     }
@@ -768,7 +759,7 @@ export function getPayloadAttributesForSSE(
     proposalSlot: prepareSlot,
     parentBlockNumber,
     parentBlockRoot,
-    parentBlockHash: parentHash,
+    parentBlockHash,
     payloadAttributes,
   };
   return ssePayloadAttributes;
@@ -825,7 +816,7 @@ function preparePayloadAttributes(
           prepareState.payloadExpectedWithdrawals;
       }
     } else {
-      // Pre-Gloas or Gloas with full parent but no override (shouldn't happen in normal flow)
+      // withdrawals logic is now fork aware as it changes on electra fork post capella
       (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
         prepareState.getExpectedWithdrawals().expectedWithdrawals;
     }

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -103,6 +103,7 @@ export async function validateGossipBlock(
     if (chain.forkChoice.getBlockHexAndBlockHash(parentRoot, parentBlockHashHex) === null) {
       throw new BlockGossipError(GossipAction.IGNORE, {
         code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
+        parentRoot,
         parentBlockHash: parentBlockHashHex,
       });
     }

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -51,14 +51,14 @@ export async function* onBeaconBlocksByRange(
     const headRoot = headBlock.blockRoot;
     // TODO DENEB: forkChoice should mantain an array of canonical blocks, and change only on reorg
     const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot, headBlock.payloadStatus);
-    // getAllAncestorBlocks response includes the head node, so it's the full chain.
+    // `getAllAncestorBlocks` includes both the head and the previous-finalized boundary.
 
     // Iterate head chain with ascending block numbers
     for (let i = headChain.length - 1; i >= 0; i--) {
       const block = headChain[i];
 
       // Must include only blocks in the range requested
-      if (block.slot >= startSlot && block.slot < endSlot) {
+      if (block.slot > finalizedSlot && block.slot >= startSlot && block.slot < endSlot) {
         // Note: Here the forkChoice head may change due to a re-org, so the headChain reflects the canonical chain
         // at the time of the start of the request. Spec is clear the chain of blobs must be consistent, but on
         // re-org there's no need to abort the request

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -24,6 +24,10 @@ export async function* onBeaconBlocksByRange(
   // in the case of initializing from a non-finalized state, we don't have the finalized block so this api does not work
   // chain.forkChoice.getFinalizeBlock().slot
   const finalizedSlot = chain.forkChoice.getFinalizedCheckpointSlot();
+  // Blocks are migrated to blockArchive at finalization (including the finalized block itself),
+  // so the archive loop serves up to AND INCLUDING finalizedSlot and the headChain loop
+  // starts above it to avoid duplicate yields. See archiveBlocks.ts for the migration logic.
+  const archiveMaxSlot = finalizedSlot;
 
   const forkName = chain.config.getForkName(startSlot);
   if (isForkPostFulu(forkName) && startSlot < chain.earliestAvailableSlot) {
@@ -35,9 +39,12 @@ export async function* onBeaconBlocksByRange(
   }
 
   // Finalized range of blocks
-  if (startSlot <= finalizedSlot) {
+  if (startSlot <= archiveMaxSlot) {
     // Chain of blobs won't change
-    for await (const {key, value} of finalized.binaryEntriesStream({gte: startSlot, lt: endSlot})) {
+    for await (const {key, value} of finalized.binaryEntriesStream({
+      gte: startSlot,
+      lt: Math.min(endSlot, archiveMaxSlot + 1),
+    })) {
       yield {
         data: value,
         boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(finalized.decodeKey(key))),
@@ -46,7 +53,7 @@ export async function* onBeaconBlocksByRange(
   }
 
   // Non-finalized range of blocks
-  if (endSlot > finalizedSlot) {
+  if (endSlot > archiveMaxSlot) {
     const headBlock = chain.forkChoice.getHead();
     const headRoot = headBlock.blockRoot;
     // TODO DENEB: forkChoice should mantain an array of canonical blocks, and change only on reorg
@@ -57,8 +64,9 @@ export async function* onBeaconBlocksByRange(
     for (let i = headChain.length - 1; i >= 0; i--) {
       const block = headChain[i];
 
-      // Must include only blocks in the range requested
-      if (block.slot > finalizedSlot && block.slot >= startSlot && block.slot < endSlot) {
+      // Must include only blocks in the range requested, and skip anything the archive loop
+      // above already served via the block.slot > archiveMaxSlot filter.
+      if (block.slot > archiveMaxSlot && block.slot >= startSlot && block.slot < endSlot) {
         // Note: Here the forkChoice head may change due to a re-org, so the headChain reflects the canonical chain
         // at the time of the start of the request. Spec is clear the chain of blobs must be consistent, but on
         // re-org there's no need to abort the request

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
@@ -38,13 +38,14 @@ export async function* onBlobSidecarsByRange(
     const headRoot = headBlock.blockRoot;
     // TODO DENEB: forkChoice should mantain an array of canonical blocks, and change only on reorg
     const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot, headBlock.payloadStatus);
+    // `getAllAncestorBlocks` includes both the head and the previous-finalized boundary.
 
     // Iterate head chain with ascending block numbers
     for (let i = headChain.length - 1; i >= 0; i--) {
       const block = headChain[i];
 
       // Must include only blobs in the range requested
-      if (block.slot >= startSlot && block.slot < endSlot) {
+      if (block.slot > finalizedSlot && block.slot >= startSlot && block.slot < endSlot) {
         // Note: Here the forkChoice head may change due to a re-org, so the headChain reflects the canonical chain
         // at the time of the start of the request. Spec is clear the chain of blobs must be consistent, but on
         // re-org there's no need to abort the request

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
@@ -20,20 +20,24 @@ export async function* onBlobSidecarsByRange(
   const finalized = db.blobSidecarsArchive;
   const unfinalized = db.blobSidecars;
   const finalizedSlot = chain.forkChoice.getFinalizedBlock().slot;
+  // Blobs are migrated to blobSidecarsArchive at finalization (including the finalized block
+  // itself), so the archive loop serves up to AND INCLUDING finalizedSlot and the headChain
+  // loop starts above it to avoid duplicate yields. See archiveBlocks.ts for the migration logic.
+  const archiveMaxSlot = finalizedSlot;
 
   // Finalized range of blobs
-  if (startSlot <= finalizedSlot) {
+  if (startSlot <= archiveMaxSlot) {
     // Chain of blobs won't change
     for await (const {key, value: blobSideCarsBytesWrapped} of finalized.binaryEntriesStream({
       gte: startSlot,
-      lt: endSlot,
+      lt: Math.min(endSlot, archiveMaxSlot + 1),
     })) {
       yield* iterateBlobBytesFromWrapper(chain, blobSideCarsBytesWrapped, finalized.decodeKey(key));
     }
   }
 
   // Non-finalized range of blobs
-  if (endSlot > finalizedSlot) {
+  if (endSlot > archiveMaxSlot) {
     const headBlock = chain.forkChoice.getHead();
     const headRoot = headBlock.blockRoot;
     // TODO DENEB: forkChoice should mantain an array of canonical blocks, and change only on reorg
@@ -44,8 +48,9 @@ export async function* onBlobSidecarsByRange(
     for (let i = headChain.length - 1; i >= 0; i--) {
       const block = headChain[i];
 
-      // Must include only blobs in the range requested
-      if (block.slot > finalizedSlot && block.slot >= startSlot && block.slot < endSlot) {
+      // Must include only blobs in the range requested, and skip anything the archive loop
+      // above already served via the block.slot > archiveMaxSlot filter.
+      if (block.slot > archiveMaxSlot && block.slot >= startSlot && block.slot < endSlot) {
         // Note: Here the forkChoice head may change due to a re-org, so the headChain reflects the canonical chain
         // at the time of the start of the request. Spec is clear the chain of blobs must be consistent, but on
         // re-org there's no need to abort the request

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
@@ -1,6 +1,6 @@
 import {PeerId} from "@libp2p/interface";
 import {ChainConfig} from "@lodestar/config";
-import {GENESIS_SLOT} from "@lodestar/params";
+import {ForkSeq, GENESIS_SLOT} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {ColumnIndex, Epoch, fulu} from "@lodestar/types";
@@ -43,10 +43,19 @@ export async function* onDataColumnSidecarsByRange(
 
   const finalized = db.dataColumnSidecarArchive;
   const finalizedSlot = chain.forkChoice.getFinalizedBlock().slot;
+  // Columns of the last finalized block live in different DBs depending on fork:
+  // - Pre-gloas (fulu): migrated to dataColumnSidecarArchive in the same finalization run.
+  // - Post-gloas: stay in the hot db (db.dataColumnSidecar) until the next finalization run,
+  //   because the migration filter requires payloadStatus === FULL for gloas blocks.
+  // archiveMaxSlot is the last slot whose columns are served by the archive loop below;
+  // anything above it is served by the headChain loop.
+  const isPostGloasFinalized = chain.config.getForkSeq(finalizedSlot) >= ForkSeq.gloas;
+  const archiveMaxSlot = isPostGloasFinalized ? finalizedSlot - 1 : finalizedSlot;
 
   // Finalized range of columns
-  if (startSlot <= finalizedSlot) {
-    for (let slot = startSlot; slot < endSlot; slot++) {
+  if (startSlot <= archiveMaxSlot) {
+    const archiveEnd = Math.min(endSlot, archiveMaxSlot + 1);
+    for (let slot = startSlot; slot < archiveEnd; slot++) {
       const dataColumnSidecars = await finalized.getManyBinary(slot, availableColumns);
 
       const unavailableColumnIndices: ColumnIndex[] = [];
@@ -81,9 +90,12 @@ export async function* onDataColumnSidecarsByRange(
   }
 
   // Non-finalized range of columns
-  if (endSlot > finalizedSlot) {
+  if (endSlot > archiveMaxSlot) {
     const headBlock = chain.forkChoice.getHead();
     const headRoot = headBlock.blockRoot;
+    // getAllAncestorBlocks includes the last finalized block as its final element.
+    // Skip anything the archive loop above already served via the block.slot > archiveMaxSlot
+    // filter below (pre-gloas this skips finalizedSlot, post-gloas it keeps it).
     const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot, headBlock.payloadStatus);
 
     // Iterate head chain with ascending block numbers
@@ -91,7 +103,7 @@ export async function* onDataColumnSidecarsByRange(
       const block = headChain[i];
 
       // Must include only columns in the range requested
-      if (block.slot >= startSlot && block.slot < endSlot) {
+      if (block.slot > archiveMaxSlot && block.slot >= startSlot && block.slot < endSlot) {
         // Note: Here the forkChoice head may change due to a re-org, so the headChain reflects the canonical chain
         // at the time of the start of the request. Spec is clear the chain of columns must be consistent, but on
         // re-org there's no need to abort the request

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
@@ -21,12 +21,15 @@ export async function* onExecutionPayloadEnvelopesByRange(
 
   const finalized = db.executionPayloadEnvelopeArchive;
   const finalizedSlot = chain.forkChoice.getFinalizedCheckpointSlot();
+  // The current finalized block's envelope is still in the hot db; archive migration happens
+  // in the next finalization run (see migrateExecutionPayloadEnvelopesFromHotToColdDb).
+  const archiveMaxSlot = finalizedSlot - 1;
 
   // Finalized range of envelopes
-  if (startSlot <= finalizedSlot) {
+  if (startSlot <= archiveMaxSlot) {
     for await (const {key, value: envelopeBytes} of finalized.binaryEntriesStream({
       gte: startSlot,
-      lt: endSlot,
+      lt: Math.min(endSlot, archiveMaxSlot + 1),
     })) {
       const slot = finalized.decodeKey(key);
       yield {
@@ -37,7 +40,7 @@ export async function* onExecutionPayloadEnvelopesByRange(
   }
 
   // Non-finalized range of envelopes
-  if (endSlot > finalizedSlot) {
+  if (endSlot > archiveMaxSlot) {
     const headBlock = chain.forkChoice.getHead();
     const headRoot = headBlock.blockRoot;
     const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot, headBlock.payloadStatus);
@@ -46,7 +49,7 @@ export async function* onExecutionPayloadEnvelopesByRange(
     for (let i = headChain.length - 1; i >= 0; i--) {
       const block = headChain[i];
 
-      if (block.slot >= startSlot && block.slot < endSlot) {
+      if (block.slot > archiveMaxSlot && block.slot >= startSlot && block.slot < endSlot) {
         // Skip EMPTY blocks
         if (block.payloadStatus !== PayloadStatus.FULL) {
           continue;

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -1,10 +1,11 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, isForkPostDeneb, isForkPostFulu} from "@lodestar/params";
+import {ForkName, isForkPostDeneb, isForkPostFulu, isForkPostGloas} from "@lodestar/params";
 import {Epoch, RootHex, Slot, phase0} from "@lodestar/types";
 import {LodestarError} from "@lodestar/utils";
 import {isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {IBlockInput} from "../../chain/blocks/blockInput/types.js";
 import {isDaOutOfRange} from "../../chain/blocks/blockInput/utils.js";
+import {PayloadEnvelopeInput} from "../../chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {BlockError, BlockErrorCode} from "../../chain/errors/index.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
 import {IClock} from "../../util/clock.js";
@@ -46,19 +47,36 @@ export type Attempt = {
 export type AwaitingDownloadState = {
   status: BatchStatus.AwaitingDownload;
   blocks: IBlockInput[];
+  payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null;
 };
 
 export type DownloadSuccessState = {
   status: BatchStatus.AwaitingProcessing;
   blocks: IBlockInput[];
+  payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null;
 };
 
 export type BatchState =
   | AwaitingDownloadState
-  | {status: BatchStatus.Downloading; peer: PeerIdStr; blocks: IBlockInput[]}
+  | {
+      status: BatchStatus.Downloading;
+      peer: PeerIdStr;
+      blocks: IBlockInput[];
+      payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null;
+    }
   | DownloadSuccessState
-  | {status: BatchStatus.Processing; blocks: IBlockInput[]; attempt: Attempt}
-  | {status: BatchStatus.AwaitingValidation; blocks: IBlockInput[]; attempt: Attempt};
+  | {
+      status: BatchStatus.Processing;
+      blocks: IBlockInput[];
+      payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null;
+      attempt: Attempt;
+    }
+  | {
+      status: BatchStatus.AwaitingValidation;
+      blocks: IBlockInput[];
+      payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null;
+      attempt: Attempt;
+    };
 
 export type BatchMetadata = {
   startEpoch: Epoch;
@@ -85,7 +103,7 @@ export class Batch {
   /** Block, blob and column requests that are used to determine the best peer and are used in downloadByRange */
   requests: DownloadByRangeRequests;
   /** State of the batch. */
-  state: BatchState = {status: BatchStatus.AwaitingDownload, blocks: []};
+  state: BatchState = {status: BatchStatus.AwaitingDownload, blocks: [], payloadEnvelopes: null};
   /** Peers that provided good data */
   goodPeers: PeerIdStr[] = [];
   /** The `Attempts` that have been made and failed to send us this batch. */
@@ -129,35 +147,33 @@ export class Batch {
         count: this.count,
         step: 1,
       };
+      const requests: DownloadByRangeRequests = {blocksRequest};
+
+      // Post-Gloas envelopes are required for block processing, independent of DA retention window.
+      if (isForkPostGloas(this.forkName)) {
+        requests.envelopesRequest = {startSlot: this.startSlot, count: this.count};
+      }
+
       if (isForkPostFulu(this.forkName) && withinValidRequestWindow) {
-        return {
-          blocksRequest,
-          columnsRequest: {
-            startSlot: this.startSlot,
-            count: this.count,
-            columns: this.custodyConfig.sampledColumns,
-          },
+        requests.columnsRequest = {
+          startSlot: this.startSlot,
+          count: this.count,
+          columns: this.custodyConfig.sampledColumns,
         };
+      } else if (isForkPostDeneb(this.forkName) && withinValidRequestWindow) {
+        requests.blobsRequest = {startSlot: this.startSlot, count: this.count};
       }
-      if (isForkPostDeneb(this.forkName) && withinValidRequestWindow) {
-        return {
-          blocksRequest,
-          blobsRequest: {
-            startSlot: this.startSlot,
-            count: this.count,
-          },
-        };
-      }
-      return {
-        blocksRequest,
-      };
+
+      return requests;
     }
 
     // subsequent request where part of the epoch has already been downloaded. Need to figure out what is the beginning
     // of the range where download needs to resume
     let blockStartSlot = this.startSlot;
     let dataStartSlot = this.startSlot;
+    let envelopeStartSlot = this.startSlot;
     const neededColumns = new Set<number>();
+    const envelopesBySlot = this.state.payloadEnvelopes ?? new Map<Slot, PayloadEnvelopeInput>();
 
     // ensure blocks are in slot-wise order
     for (const blockInput of blocks) {
@@ -174,6 +190,9 @@ export class Batch {
       // the desired end slot
       if (blockInput.hasBlock() && blockStartSlot === blockSlot) {
         blockStartSlot = blockSlot + 1;
+      }
+      if (blockInput.hasBlock() && envelopeStartSlot === blockSlot && envelopesBySlot.has(blockSlot)) {
+        envelopeStartSlot = blockSlot + 1;
       }
       if (!blockInput.hasAllData()) {
         if (isBlockInputColumns(blockInput)) {
@@ -214,6 +233,13 @@ export class Batch {
         };
       }
       // dataSlot will still have a value but do not create a request for preDeneb forks
+    }
+
+    if (isForkPostGloas(this.forkName) && envelopeStartSlot <= endSlot) {
+      requests.envelopesRequest = {
+        startSlot: envelopeStartSlot,
+        count: endSlot - envelopeStartSlot + 1,
+      };
     }
 
     return requests;
@@ -263,6 +289,10 @@ export class Batch {
     return this.state.blocks;
   }
 
+  getPayloadEnvelopes(): Map<Slot, PayloadEnvelopeInput> | null {
+    return this.state.payloadEnvelopes;
+  }
+
   /**
    * AwaitingDownload -> Downloading
    */
@@ -271,13 +301,22 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.AwaitingDownload));
     }
 
-    this.state = {status: BatchStatus.Downloading, peer, blocks: this.state.blocks};
+    this.state = {
+      status: BatchStatus.Downloading,
+      peer,
+      blocks: this.state.blocks,
+      payloadEnvelopes: this.state.payloadEnvelopes,
+    };
   }
 
   /**
    * Downloading -> AwaitingProcessing
    */
-  downloadingSuccess(peer: PeerIdStr, blocks: IBlockInput[]): DownloadSuccessState {
+  downloadingSuccess(
+    peer: PeerIdStr,
+    blocks: IBlockInput[],
+    payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null
+  ): DownloadSuccessState {
     if (this.state.status !== BatchStatus.Downloading) {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.Downloading));
     }
@@ -305,11 +344,13 @@ export class Batch {
         status: this.state.status,
       });
     }
+    const newPayloadEnvelopes = payloadEnvelopes ?? this.state.payloadEnvelopes;
+
     if (allComplete) {
-      this.state = {status: BatchStatus.AwaitingProcessing, blocks};
+      this.state = {status: BatchStatus.AwaitingProcessing, blocks, payloadEnvelopes: newPayloadEnvelopes};
     } else {
       this.requests = this.getRequests(blocks);
-      this.state = {status: BatchStatus.AwaitingDownload, blocks};
+      this.state = {status: BatchStatus.AwaitingDownload, blocks, payloadEnvelopes: newPayloadEnvelopes};
     }
 
     return this.state as DownloadSuccessState;
@@ -328,25 +369,30 @@ export class Batch {
       throw new BatchError(this.errorType({code: BatchErrorCode.MAX_DOWNLOAD_ATTEMPTS}));
     }
 
-    this.state = {status: BatchStatus.AwaitingDownload, blocks: this.state.blocks};
+    this.state = {
+      status: BatchStatus.AwaitingDownload,
+      blocks: this.state.blocks,
+      payloadEnvelopes: this.state.payloadEnvelopes,
+    };
   }
 
   /**
    * AwaitingProcessing -> Processing
    */
-  startProcessing(): IBlockInput[] {
+  startProcessing(): {blocks: IBlockInput[]; payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null} {
     if (this.state.status !== BatchStatus.AwaitingProcessing) {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.AwaitingProcessing));
     }
 
     const blocks = this.state.blocks;
+    const payloadEnvelopes = this.state.payloadEnvelopes;
     const hash = hashBlocks(blocks, this.config); // tracks blocks to report peer on processing error
     // Reset goodPeers in case another download attempt needs to be made.  When Attempt is successful or not the peers
     // that the data came from will be handled by the Attempt that goes for processing
     const peers = this.goodPeers;
     this.goodPeers = [];
-    this.state = {status: BatchStatus.Processing, blocks, attempt: {peers, hash}};
-    return blocks;
+    this.state = {status: BatchStatus.Processing, blocks, payloadEnvelopes, attempt: {peers, hash}};
+    return {blocks, payloadEnvelopes};
   }
 
   /**
@@ -357,7 +403,12 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.Processing));
     }
 
-    this.state = {status: BatchStatus.AwaitingValidation, blocks: this.state.blocks, attempt: this.state.attempt};
+    this.state = {
+      status: BatchStatus.AwaitingValidation,
+      blocks: this.state.blocks,
+      payloadEnvelopes: this.state.payloadEnvelopes,
+      attempt: this.state.attempt,
+    };
   }
 
   /**
@@ -408,7 +459,7 @@ export class Batch {
 
     // remove any downloaded blocks and re-attempt
     // TODO(fulu): need to remove the bad blocks from the SeenBlockInputCache
-    this.state = {status: BatchStatus.AwaitingDownload, blocks: []};
+    this.state = {status: BatchStatus.AwaitingDownload, blocks: [], payloadEnvelopes: null};
   }
 
   private onProcessingError(attempt: Attempt): void {
@@ -419,7 +470,7 @@ export class Batch {
 
     // remove any downloaded blocks and re-attempt
     // TODO(fulu): need to remove the bad blocks from the SeenBlockInputCache
-    this.state = {status: BatchStatus.AwaitingDownload, blocks: []};
+    this.state = {status: BatchStatus.AwaitingDownload, blocks: [], payloadEnvelopes: null};
   }
 
   /** Helper to construct typed BatchError. Stack traces are correct as the error is thrown above */

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -191,7 +191,11 @@ export class Batch {
       if (blockInput.hasBlock() && blockStartSlot === blockSlot) {
         blockStartSlot = blockSlot + 1;
       }
-      if (blockInput.hasBlock() && envelopeStartSlot === blockSlot && envelopesBySlot.has(blockSlot)) {
+      if (
+        blockInput.hasBlock() &&
+        envelopeStartSlot === blockSlot &&
+        envelopesBySlot.get(blockSlot)?.hasPayloadEnvelope()
+      ) {
         envelopeStartSlot = blockSlot + 1;
       }
       if (!blockInput.hasAllData()) {

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -4,6 +4,7 @@ import {ErrorAborted, LodestarError, Logger, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {BlockInputErrorCode} from "../../chain/blocks/blockInput/errors.js";
 import {IBlockInput} from "../../chain/blocks/blockInput/types.js";
+import {PayloadEnvelopeInput} from "../../chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {BlobSidecarErrorCode} from "../../chain/errors/blobSidecarError.js";
 import {DataColumnSidecarErrorCode} from "../../chain/errors/dataColumnSidecarError.js";
 import {Metrics} from "../../metrics/metrics.js";
@@ -44,13 +45,19 @@ export type SyncChainFns = {
    * Must return if ALL blocks are processed successfully
    * If SOME blocks are processed must throw BlockProcessorError()
    */
-  processChainSegment: (blocks: IBlockInput[], syncType: RangeSyncType) => Promise<void>;
+  processChainSegment: (
+    blocks: IBlockInput[],
+    payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
+    syncType: RangeSyncType
+  ) => Promise<void>;
   /** Must download blocks, and validate their range */
   downloadByRange: (
     peer: PeerSyncMeta,
     batch: Batch,
     syncType: RangeSyncType
-  ) => Promise<WarnResult<IBlockInput[], DownloadByRangeError>>;
+  ) => Promise<
+    WarnResult<{blocks: IBlockInput[]; payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null}, DownloadByRangeError>
+  >;
   /** Report peer for negative actions. Decouples from the full network instance */
   reportPeer: (peer: PeerIdStr, action: PeerAction, actionName: string) => void;
   /** Gets current peer custodyColumns and earliestAvailableSlot */
@@ -516,7 +523,8 @@ export class SyncChain {
         });
         this.metrics?.syncRange.downloadByRange.success.inc();
         const {warnings, result} = res.result;
-        const downloadSuccessOutput = batch.downloadingSuccess(peer.peerId, result);
+        const {blocks: downloadedBlocks, payloadEnvelopes} = result;
+        const downloadSuccessOutput = batch.downloadingSuccess(peer.peerId, downloadedBlocks, payloadEnvelopes);
         const logMeta: Record<string, number> = {
           blockCount: downloadSuccessOutput.blocks.length,
         };
@@ -578,10 +586,10 @@ export class SyncChain {
    * Sends `batch` to the processor. Note: batch may be empty
    */
   private async processBatch(batch: Batch): Promise<void> {
-    const blocks = batch.startProcessing();
+    const {blocks, payloadEnvelopes} = batch.startProcessing();
 
     // wrapError ensures to never call both batch success() and batch error()
-    const res = await wrapError(this.processChainSegment(blocks, this.syncType));
+    const res = await wrapError(this.processChainSegment(blocks, payloadEnvelopes, this.syncType));
 
     if (!res.err) {
       batch.processingSuccess();

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -172,7 +172,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
   }
 
   /** Convenience method for `SyncChain` */
-  private processChainSegment: SyncChainFns["processChainSegment"] = async (blocks, syncType) => {
+  private processChainSegment: SyncChainFns["processChainSegment"] = async (blocks, payloadEnvelopes, syncType) => {
     // Not trusted, verify signatures
     const flags: ImportBlockOpts = {
       // Only skip importing attestations for finalized sync. For head sync attestation are valuable.
@@ -194,7 +194,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       // Should only be used for debugging or testing
       for (const block of blocks) await this.chain.processBlock(block, flags);
     } else {
-      await this.chain.processChainSegment(blocks, flags);
+      await this.chain.processChainSegment(blocks, payloadEnvelopes, flags);
     }
   };
 
@@ -209,13 +209,19 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       peerDasMetrics: this.chain.metrics?.peerDas,
       ...batch.getRequestsForPeer(peer),
     });
-    const cached = cacheByRangeResponses({
+    const {responses, payloadEnvelopes: downloadedPayloadEnvelopes} = result;
+    const {blocks, payloadEnvelopes} = cacheByRangeResponses({
       cache: this.chain.seenBlockInputCache,
+      seenPayloadEnvelopeInputCache: this.chain.seenPayloadEnvelopeInputCache,
       peerIdStr: peer.peerId,
-      responses: result,
+      responses,
       batchBlocks,
+      downloadedPayloadEnvelopes,
+      existingPayloadEnvelopes: batch.getPayloadEnvelopes(),
+      custodyConfig: this.chain.custodyConfig,
+      seenTimestampSec: Date.now() / 1000,
     });
-    return {result: cached, warnings};
+    return {result: {blocks, payloadEnvelopes}, warnings};
   };
 
   private pruneBlockInputs: SyncChainFns["pruneBlockInputs"] = (blocks: IBlockInput[]) => {

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -192,7 +192,13 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
 
     if (this.opts?.disableProcessAsChainSegment) {
       // Should only be used for debugging or testing
-      for (const block of blocks) await this.chain.processBlock(block, flags);
+      for (const block of blocks) {
+        await this.chain.processBlock(block, flags);
+        const payloadEnvelope = payloadEnvelopes?.get(block.slot);
+        if (payloadEnvelope) {
+          await this.chain.processExecutionPayload(payloadEnvelope);
+        }
+      }
     } else {
       await this.chain.processChainSegment(blocks, payloadEnvelopes, flags);
     }

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -1,6 +1,22 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkPostDeneb, ForkPostFulu, ForkPreFulu, isForkPostFulu} from "@lodestar/params";
-import {SignedBeaconBlock, Slot, deneb, fulu, phase0} from "@lodestar/types";
+import {
+  ForkPostDeneb,
+  ForkPostFulu,
+  ForkPostGloas,
+  ForkPreFulu,
+  isForkPostFulu,
+  isForkPostGloas,
+} from "@lodestar/params";
+import {
+  DataColumnSidecar,
+  SignedBeaconBlock,
+  Slot,
+  deneb,
+  fulu,
+  gloas,
+  isGloasDataColumnSidecar,
+  phase0,
+} from "@lodestar/types";
 import {LodestarError, Logger, byteArrayEquals, fromHex, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {
   BlockInputSource,
@@ -9,12 +25,18 @@ import {
   isBlockInputBlobs,
   isBlockInputColumns,
 } from "../../chain/blocks/blockInput/index.js";
+import {PayloadEnvelopeInput} from "../../chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
+import {PayloadEnvelopeInputSource} from "../../chain/blocks/payloadEnvelopeInput/types.js";
 import {SeenBlockInput} from "../../chain/seenCache/seenGossipBlockInput.js";
+import {SeenPayloadEnvelopeInput} from "../../chain/seenCache/seenPayloadEnvelopeInput.js";
 import {validateBlockBlobSidecars} from "../../chain/validation/blobSidecar.js";
-import {validateFuluBlockDataColumnSidecars} from "../../chain/validation/dataColumnSidecar.js";
+import {
+  validateFuluBlockDataColumnSidecars,
+  validateGloasBlockDataColumnSidecars,
+} from "../../chain/validation/dataColumnSidecar.js";
 import {BeaconMetrics} from "../../metrics/metrics/beacon.js";
 import {INetwork} from "../../network/index.js";
-import {getBlobKzgCommitments} from "../../util/dataColumns.js";
+import {CustodyConfig, getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {WarnResult} from "../../util/wrapError.js";
 
@@ -22,12 +44,14 @@ export type DownloadByRangeRequests = {
   blocksRequest?: phase0.BeaconBlocksByRangeRequest;
   blobsRequest?: deneb.BlobSidecarsByRangeRequest;
   columnsRequest?: fulu.DataColumnSidecarsByRangeRequest;
+  envelopesRequest?: gloas.ExecutionPayloadEnvelopesByRangeRequest;
 };
 
 export type DownloadByRangeResponses = {
   blocks?: SignedBeaconBlock[];
   blobSidecars?: deneb.BlobSidecars;
-  columnSidecars?: fulu.DataColumnSidecar[];
+  columnSidecars?: DataColumnSidecar[];
+  payloadEnvelopes?: gloas.SignedExecutionPayloadEnvelope[];
 };
 
 export type DownloadAndCacheByRangeProps = DownloadByRangeRequests & {
@@ -41,9 +65,17 @@ export type DownloadAndCacheByRangeProps = DownloadByRangeRequests & {
 
 export type CacheByRangeResponsesProps = {
   cache: SeenBlockInput;
+  seenPayloadEnvelopeInputCache: SeenPayloadEnvelopeInput;
   peerIdStr: string;
   responses: ValidatedResponses;
   batchBlocks: IBlockInput[];
+  /** Raw envelopes downloaded in this batch, keyed by slot (from downloadByRange return) */
+  downloadedPayloadEnvelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null;
+  /** Envelopes already wrapped from previous partial downloads on this batch */
+  existingPayloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null;
+  /** Sampled/custody column indices for building PayloadEnvelopeInputs */
+  custodyConfig: Pick<CustodyConfig, "sampledColumns" | "custodyColumns">;
+  seenTimestampSec: number;
 };
 
 export type ValidatedBlock = {
@@ -58,7 +90,7 @@ export type ValidatedBlobSidecars = {
 
 export type ValidatedColumnSidecars = {
   blockRoot: Uint8Array;
-  columnSidecars: fulu.DataColumnSidecar[];
+  columnSidecars: DataColumnSidecar[];
 };
 
 export type ValidatedResponses = {
@@ -72,12 +104,16 @@ export type ValidatedResponses = {
  */
 export function cacheByRangeResponses({
   cache,
+  seenPayloadEnvelopeInputCache,
   peerIdStr,
   responses,
   batchBlocks,
-}: CacheByRangeResponsesProps): IBlockInput[] {
+  downloadedPayloadEnvelopes,
+  existingPayloadEnvelopes,
+  custodyConfig,
+  seenTimestampSec,
+}: CacheByRangeResponsesProps): {blocks: IBlockInput[]; payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null} {
   const source = BlockInputSource.byRange;
-  const seenTimestampSec = Date.now() / 1000;
   const updatedBatchBlocks = new Map<Slot, IBlockInput>(batchBlocks.map((block) => [block.slot, block]));
 
   const blocks = responses.validatedBlocks ?? [];
@@ -149,15 +185,81 @@ export function cacheByRangeResponses({
     }
   }
 
+  // Build payloadEnvelopes map for gloas: start from existing (partial download) state.
+  // The entries are wrappers around (block + envelope + sampled columns) and also seeded into
+  // seenPayloadEnvelopeInputCache so importBlock can find them without creating a duplicate.
+  let payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null = null;
+  if (downloadedPayloadEnvelopes !== null) {
+    payloadEnvelopes = new Map(existingPayloadEnvelopes ?? []);
+
+    for (const [slot, envelope] of downloadedPayloadEnvelopes) {
+      const blockInput = updatedBatchBlocks.get(slot);
+      if (!blockInput?.hasBlock() || !isForkPostGloas(blockInput.forkName)) {
+        // No block to pair this envelope with; drop silently
+        continue;
+      }
+      const {blockRootHex} = blockInput;
+
+      // Reuse any existing PayloadEnvelopeInput (e.g. gossip arrived first) to avoid
+      // duplicate cache entries. If missing, create a fresh one from the block's bid.
+      let payloadInput = seenPayloadEnvelopeInputCache.get(blockRootHex);
+      if (payloadInput === undefined) {
+        payloadInput = seenPayloadEnvelopeInputCache.add({
+          blockRootHex,
+          block: blockInput.getBlock() as SignedBeaconBlock<ForkPostGloas>,
+          forkName: blockInput.forkName,
+          sampledColumns: custodyConfig.sampledColumns,
+          custodyColumns: custodyConfig.custodyColumns,
+          timeCreatedSec: seenTimestampSec,
+        });
+      }
+
+      if (!payloadInput.hasPayloadEnvelope()) {
+        payloadInput.addPayloadEnvelope({
+          envelope,
+          source: PayloadEnvelopeInputSource.byRange,
+          seenTimestampSec,
+          peerIdStr,
+        });
+      }
+
+      payloadEnvelopes.set(slot, payloadInput);
+    }
+  }
+
   for (const {blockRoot, columnSidecars} of responses.validatedColumnSidecars ?? []) {
-    const dataSlot = columnSidecars.at(0)?.signedBlockHeader.message.slot;
-    if (dataSlot === undefined) {
+    const firstColumn = columnSidecars[0];
+    if (!firstColumn) {
       throw new Error(
         `Coding Error: empty columnSidecars returned for blockRoot=${toRootHex(blockRoot)} from validation functions`
       );
     }
-    const existing = updatedBatchBlocks.get(dataSlot);
+
     const blockRootHex = toRootHex(blockRoot);
+
+    if (isGloasDataColumnSidecar(firstColumn)) {
+      // Gloas columns are attached to the matching PayloadEnvelopeInput, NOT to IBlockInput.
+      // Gloas DataColumnSidecar has `slot` directly (no signedBlockHeader).
+      const dataSlot = firstColumn.slot;
+      const payloadInput = payloadEnvelopes?.get(dataSlot);
+      if (!payloadInput) {
+        // Should not happen: we built payloadInputs for all gloas blocks above
+        continue;
+      }
+      for (const columnSidecar of columnSidecars as gloas.DataColumnSidecar[]) {
+        payloadInput.addColumn({
+          columnSidecar,
+          seenTimestampSec,
+          peerIdStr,
+          source: PayloadEnvelopeInputSource.byRange,
+        });
+      }
+      continue;
+    }
+
+    const fuluColumns = columnSidecars as fulu.DataColumnSidecar[];
+    const dataSlot = fuluColumns[0].signedBlockHeader.message.slot;
+    const existing = updatedBatchBlocks.get(dataSlot);
 
     if (!existing) {
       throw new Error("Coding error: blockInput must exist when adding columns");
@@ -172,7 +274,7 @@ export function cacheByRangeResponses({
         actual: existing.type,
       });
     }
-    for (const columnSidecar of columnSidecars) {
+    for (const columnSidecar of fuluColumns) {
       // will throw if root hex does not match (meaning we are following the wrong chain)
       existing.addColumn(
         {
@@ -187,7 +289,7 @@ export function cacheByRangeResponses({
     }
   }
 
-  return Array.from(updatedBatchBlocks.values());
+  return {blocks: Array.from(updatedBatchBlocks.values()), payloadEnvelopes};
 }
 
 export async function downloadByRange({
@@ -198,8 +300,14 @@ export async function downloadByRange({
   blocksRequest,
   blobsRequest,
   columnsRequest,
+  envelopesRequest,
   peerDasMetrics,
-}: DownloadAndCacheByRangeProps): Promise<WarnResult<ValidatedResponses, DownloadByRangeError>> {
+}: DownloadAndCacheByRangeProps): Promise<
+  WarnResult<
+    {responses: ValidatedResponses; payloadEnvelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null},
+    DownloadByRangeError
+  >
+> {
   let response: DownloadByRangeResponses;
   try {
     response = await requestByRange({
@@ -208,6 +316,7 @@ export async function downloadByRange({
       blocksRequest,
       blobsRequest,
       columnsRequest,
+      envelopesRequest,
     });
   } catch (err) {
     throw new DownloadByRangeError({
@@ -217,17 +326,16 @@ export async function downloadByRange({
     });
   }
 
-  const validated = await validateResponses({
+  return validateResponses({
     config,
     batchBlocks,
     blocksRequest,
     blobsRequest,
     columnsRequest,
+    envelopesRequest,
     peerDasMetrics,
     ...response,
   });
-
-  return validated;
 }
 
 /**
@@ -239,13 +347,15 @@ export async function requestByRange({
   blocksRequest,
   blobsRequest,
   columnsRequest,
+  envelopesRequest,
 }: DownloadByRangeRequests & {
   network: INetwork;
   peerIdStr: PeerIdStr;
 }): Promise<DownloadByRangeResponses> {
   let blocks: undefined | SignedBeaconBlock[];
   let blobSidecars: undefined | deneb.BlobSidecars;
-  let columnSidecars: undefined | fulu.DataColumnSidecar[];
+  let columnSidecars: undefined | DataColumnSidecar[];
+  let payloadEnvelopes: undefined | gloas.SignedExecutionPayloadEnvelope[];
 
   const requests: Promise<unknown>[] = [];
 
@@ -268,7 +378,15 @@ export async function requestByRange({
   if (columnsRequest) {
     requests.push(
       network.sendDataColumnSidecarsByRange(peerIdStr, columnsRequest).then((columnResponse) => {
-        columnSidecars = columnResponse as fulu.DataColumnSidecar[];
+        columnSidecars = columnResponse;
+      })
+    );
+  }
+
+  if (envelopesRequest) {
+    requests.push(
+      network.sendExecutionPayloadEnvelopesByRange(peerIdStr, envelopesRequest).then((envelopeResponse) => {
+        payloadEnvelopes = envelopeResponse;
       })
     );
   }
@@ -279,6 +397,7 @@ export async function requestByRange({
     blocks,
     blobSidecars,
     columnSidecars,
+    payloadEnvelopes,
   };
 }
 
@@ -291,16 +410,23 @@ export async function validateResponses({
   blocksRequest,
   blobsRequest,
   columnsRequest,
+  envelopesRequest,
   blocks,
   blobSidecars,
   columnSidecars,
+  payloadEnvelopes,
   peerDasMetrics,
 }: DownloadByRangeRequests &
   DownloadByRangeResponses & {
     config: ChainForkConfig;
     batchBlocks?: IBlockInput[];
     peerDasMetrics?: BeaconMetrics["peerDas"] | null;
-  }): Promise<WarnResult<ValidatedResponses, DownloadByRangeError>> {
+  }): Promise<
+  WarnResult<
+    {responses: ValidatedResponses; payloadEnvelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null},
+    DownloadByRangeError
+  >
+> {
   // Blocks are always required for blob/column validation
   // If a blocksRequest is provided, blocks have just been downloaded
   // If no blocksRequest is provided, batchBlocks must have been provided from cache
@@ -326,8 +452,21 @@ export async function validateResponses({
   }
 
   const dataRequest = blobsRequest ?? columnsRequest;
+  if (!dataRequest && !envelopesRequest) {
+    return {result: {responses: validatedResponses, payloadEnvelopes: null}, warnings};
+  }
+
   if (!dataRequest) {
-    return {result: validatedResponses, warnings};
+    // Only envelope validation needed
+    let validatedPayloadEnvelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null = null;
+    if (envelopesRequest) {
+      validatedPayloadEnvelopes = validateEnvelopesByRangeResponse(
+        validatedResponses.validatedBlocks ?? [],
+        batchBlocks,
+        payloadEnvelopes ?? []
+      );
+    }
+    return {result: {responses: validatedResponses, payloadEnvelopes: validatedPayloadEnvelopes}, warnings};
   }
 
   const blocksForDataValidation = getBlocksForDataValidation(
@@ -385,7 +524,17 @@ export async function validateResponses({
     warnings = validatedColumnSidecarsResult.warnings;
   }
 
-  return {result: validatedResponses, warnings};
+  // Validate envelopes if an envelopes request was made
+  let validatedPayloadEnvelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null = null;
+  if (envelopesRequest) {
+    validatedPayloadEnvelopes = validateEnvelopesByRangeResponse(
+      validatedResponses.validatedBlocks ?? [],
+      batchBlocks,
+      payloadEnvelopes ?? []
+    );
+  }
+
+  return {result: {responses: validatedResponses, payloadEnvelopes: validatedPayloadEnvelopes}, warnings};
 }
 
 /**
@@ -615,19 +764,19 @@ export async function validateColumnsByRangeResponse(
   config: ChainForkConfig,
   request: fulu.DataColumnSidecarsByRangeRequest,
   blocks: ValidatedBlock[],
-  columnSidecars: fulu.DataColumnSidecar[],
+  columnSidecars: DataColumnSidecar[],
   peerDasMetrics?: BeaconMetrics["peerDas"] | null
 ): Promise<WarnResult<ValidatedColumnSidecars[], DownloadByRangeError>> {
   const warnings: DownloadByRangeError[] = [];
 
-  // TODO GLOAS: Extend by range column sync to support gloas.DataColumnSidecar and
-  // validate against the block bid commitments instead of the fulu signed header shape
-  const seenColumns = new Map<Slot, Map<number, fulu.DataColumnSidecar>>();
+  const seenColumns = new Map<Slot, Map<number, DataColumnSidecar>>();
   let currentSlot = -1;
   let currentIndex = -1;
   // Check for duplicates and order
   for (const columnSidecar of columnSidecars) {
-    const slot = columnSidecar.signedBlockHeader.message.slot;
+    const slot = isGloasDataColumnSidecar(columnSidecar)
+      ? columnSidecar.slot
+      : columnSidecar.signedBlockHeader.message.slot;
     let seenSlotColumns = seenColumns.get(slot);
     if (!seenSlotColumns) {
       seenSlotColumns = new Map();
@@ -686,20 +835,20 @@ export async function validateColumnsByRangeResponse(
     const slot = block.message.slot;
     const rootHex = toRootHex(blockRoot);
     const forkName = config.getForkName(slot);
-    const columnSidecarsMap: Map<number, fulu.DataColumnSidecar> = seenColumns.get(slot) ?? new Map();
+    const columnSidecarsMap: Map<number, DataColumnSidecar> = seenColumns.get(slot) ?? new Map();
     const columnSidecars = Array.from(columnSidecarsMap.values()).sort((a, b) => a.index - b.index);
 
     let blobCount: number;
     if (!isForkPostFulu(forkName)) {
-      const dataSlot = columnSidecars.at(0)?.signedBlockHeader.message.slot;
       throw new DownloadByRangeError({
         code: DownloadByRangeErrorCode.MISMATCH_BLOCK_FORK,
         slot,
         blockFork: forkName,
-        dataFork: dataSlot ? config.getForkName(dataSlot) : "unknown",
+        dataFork: "unknown",
       });
     }
-    blobCount = getBlobKzgCommitments(forkName, block as SignedBeaconBlock<ForkPostFulu>).length;
+    const kzgCommitments = getBlobKzgCommitments(forkName, block as SignedBeaconBlock<ForkPostFulu>);
+    blobCount = kzgCommitments.length;
 
     if (columnSidecars.length === 0) {
       if (!blobCount) {
@@ -768,15 +917,25 @@ export async function validateColumnsByRangeResponse(
       );
     }
 
+    const validatePromise = isForkPostGloas(forkName)
+      ? validateGloasBlockDataColumnSidecars(
+          slot,
+          blockRoot,
+          kzgCommitments,
+          columnSidecars as gloas.DataColumnSidecar[],
+          peerDasMetrics
+        )
+      : validateFuluBlockDataColumnSidecars(
+          null, // do not pass chain here so we do not validate header signature
+          slot,
+          blockRoot,
+          blobCount,
+          columnSidecars as fulu.DataColumnSidecar[],
+          peerDasMetrics
+        );
+
     validationPromises.push(
-      validateFuluBlockDataColumnSidecars(
-        null, // do not pass chain here so we do not validate header signature
-        slot,
-        blockRoot,
-        blobCount,
-        columnSidecars,
-        peerDasMetrics
-      ).then(() => ({
+      validatePromise.then(() => ({
         blockRoot,
         columnSidecars,
       }))
@@ -882,6 +1041,9 @@ export enum DownloadByRangeErrorCode {
   /** Cached block input type mismatches new data */
   MISMATCH_BLOCK_FORK = "DOWNLOAD_BY_RANGE_ERROR_MISMATCH_BLOCK_FORK",
   MISMATCH_BLOCK_INPUT_TYPE = "DOWNLOAD_BY_RANGE_ERROR_MISMATCH_BLOCK_INPUT_TYPE",
+
+  /** Envelope beaconBlockRoot does not match the block's root */
+  INVALID_ENVELOPE_BEACON_BLOCK_ROOT = "DOWNLOAD_BY_RANGE_ERROR_INVALID_ENVELOPE_BEACON_BLOCK_ROOT",
 }
 
 export type DownloadByRangeErrorType =
@@ -973,6 +1135,61 @@ export type DownloadByRangeErrorType =
       blockRoot: string;
       expected: DAType;
       actual: DAType;
+    }
+  | {
+      code: DownloadByRangeErrorCode.INVALID_ENVELOPE_BEACON_BLOCK_ROOT;
+      slot: Slot;
+      expected: string;
+      actual: string;
     };
 
 export class DownloadByRangeError extends LodestarError<DownloadByRangeErrorType> {}
+
+/**
+ * Validates SignedExecutionPayloadEnvelopes received for a range request.
+ * For each envelope whose slot appears in the downloaded blocks, verifies that
+ * envelope.message.beaconBlockRoot matches the corresponding block's root.
+ * Envelopes for slots not in the batch (orphaned payloads) are silently ignored.
+ */
+export function validateEnvelopesByRangeResponse(
+  validatedBlocks: ValidatedBlock[],
+  batchBlocks: IBlockInput[] | undefined,
+  payloadEnvelopes: gloas.SignedExecutionPayloadEnvelope[]
+): Map<Slot, gloas.SignedExecutionPayloadEnvelope> {
+  // Build a map of slot -> blockRoot for all blocks in the batch
+  const batchBlockRoots = new Map<Slot, Uint8Array>();
+  if (batchBlocks) {
+    for (const blockInput of batchBlocks) {
+      batchBlockRoots.set(blockInput.slot, fromHex(blockInput.blockRootHex));
+    }
+  }
+  for (const {block, blockRoot} of validatedBlocks) {
+    batchBlockRoots.set(block.message.slot, blockRoot);
+  }
+
+  const payloadEnvelopeMap = new Map<Slot, gloas.SignedExecutionPayloadEnvelope>();
+
+  for (const payloadEnvelope of payloadEnvelopes) {
+    const slot = payloadEnvelope.message.payload.slotNumber;
+    const batchBlockRoot = batchBlockRoots.get(slot);
+
+    // Envelopes for slots not in the batch are silently ignored (orphaned payloads)
+    if (batchBlockRoot === undefined) {
+      continue;
+    }
+
+    // Verify beaconBlockRoot matches the block's root
+    if (!byteArrayEquals(payloadEnvelope.message.beaconBlockRoot, batchBlockRoot)) {
+      throw new DownloadByRangeError({
+        code: DownloadByRangeErrorCode.INVALID_ENVELOPE_BEACON_BLOCK_ROOT,
+        slot,
+        expected: toRootHex(batchBlockRoot),
+        actual: toRootHex(payloadEnvelope.message.beaconBlockRoot),
+      });
+    }
+
+    payloadEnvelopeMap.set(slot, payloadEnvelope);
+  }
+
+  return payloadEnvelopeMap;
+}

--- a/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
@@ -12,13 +12,14 @@ import {connect, onPeerConnect} from "../../utils/network.js";
 import {getDevBeaconNode} from "../../utils/node/beacon.js";
 import {getAndInitDevValidators} from "../../utils/node/validator.js";
 
-describe("sync / finalized sync for fulu", () => {
+describe("sync / finalized sync for gloas", () => {
   // chain is finalized at slot 32, plus 4 slots for genesis delay => ~72s it should sync pretty fast
   vi.setConfig({testTimeout: 90_000});
 
   const validatorCount = 8;
   const ELECTRA_FORK_EPOCH = 0;
   const FULU_FORK_EPOCH = 1;
+  const GLOAS_FORK_EPOCH = 2;
   const SLOT_DURATION_MS = 2000;
   const testParams: Partial<ChainConfig> = {
     SLOT_DURATION_MS,
@@ -28,6 +29,7 @@ describe("sync / finalized sync for fulu", () => {
     DENEB_FORK_EPOCH: ELECTRA_FORK_EPOCH,
     ELECTRA_FORK_EPOCH: ELECTRA_FORK_EPOCH,
     FULU_FORK_EPOCH: FULU_FORK_EPOCH,
+    GLOAS_FORK_EPOCH: GLOAS_FORK_EPOCH,
     BLOB_SCHEDULE: [
       {
         EPOCH: 1,
@@ -96,17 +98,24 @@ describe("sync / finalized sync for fulu", () => {
         bn.chain.emitter,
         ChainEvent.forkChoiceFinalized,
         240000,
-        (finalized) => finalized.epoch >= FULU_FORK_EPOCH
+        (finalized) => finalized.epoch >= GLOAS_FORK_EPOCH
       ),
       waitForEvent<routes.events.EventData[routes.events.EventType.head]>(
         bn.chain.emitter,
         routes.events.EventType.head,
         100000,
-        // at block slot 32 imported, finalized checkpoint epoch 2 is processed
+        // at block slot 32 imported, finalized checkpoint epoch 2 is processed.
+        // TODO GLOAS: head's payloadStatus stays EMPTY for every gloas slot 16+ even though every
+        // envelope is imported successfully (FULL variant exists in fork choice). The validator-
+        // side payload-attestation duty (committee selection, signing, gossip publish, API
+        // endpoint, block-production aggregation) is not yet implemented, so the PTC pool stays
+        // empty and `block.body.payloadAttestations` is always empty. Without PTC quorum,
+        // `shouldExtendPayload` returns false and the canonical chain stays on the EMPTY variant.
+        // Revisit once validator-side PTC duty lands.
         ({slot}) => slot === 32
       ),
     ]);
-    loggerNodeA.info("Node A emitted finalized checkpoint event for fulu");
+    loggerNodeA.info("Node A emitted finalized checkpoint event for gloas");
 
     const bn2 = await getDevBeaconNode({
       params: testParams,
@@ -139,7 +148,7 @@ describe("sync / finalized sync for fulu", () => {
 
     try {
       await waitForSynced;
-      loggerNodeB.info("Node B synced to Node A, received fulu head block", {slot: head.message.slot});
+      loggerNodeB.info("Node B synced to Node A, received gloas head block", {slot: head.message.slot});
     } catch (_e) {
       expect.fail("Failed to sync to other node in time");
     }

--- a/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
@@ -105,13 +105,6 @@ describe("sync / finalized sync for gloas", () => {
         routes.events.EventType.head,
         100000,
         // at block slot 32 imported, finalized checkpoint epoch 2 is processed.
-        // TODO GLOAS: head's payloadStatus stays EMPTY for every gloas slot 16+ even though every
-        // envelope is imported successfully (FULL variant exists in fork choice). The validator-
-        // side payload-attestation duty (committee selection, signing, gossip publish, API
-        // endpoint, block-production aggregation) is not yet implemented, so the PTC pool stays
-        // empty and `block.body.payloadAttestations` is always empty. Without PTC quorum,
-        // `shouldExtendPayload` returns false and the canonical chain stays on the EMPTY variant.
-        // Revisit once validator-side PTC duty lands.
         ({slot}) => slot === 32
       ),
     ]);
@@ -151,6 +144,20 @@ describe("sync / finalized sync for gloas", () => {
       loggerNodeB.info("Node B synced to Node A, received gloas head block", {slot: head.message.slot});
     } catch (_e) {
       expect.fail("Failed to sync to other node in time");
+    }
+
+    // Walk Node B's fork-choice from head back through its ancestors. Every gloas block in the
+    // canonical chain below the head MUST have its FULL payload variant in fork-choice
+    const bn2Head = bn2.chain.forkChoice.getHead();
+    const bn2Ancestors = bn2.chain.forkChoice.getAllAncestorBlocks(bn2Head.blockRoot, bn2Head.payloadStatus);
+    const gloasFirstSlot = GLOAS_FORK_EPOCH * SLOTS_PER_EPOCH;
+    for (const block of bn2Ancestors) {
+      if (block.slot >= gloasFirstSlot && block.slot < bn2Head.slot) {
+        expect(bn2.chain.forkChoice.hasPayloadHexUnsafe(block.blockRoot)).toBeWithMessage(
+          true,
+          `Node B missing FULL payload variant for gloas block slot=${block.slot} root=${block.blockRoot}`
+        );
+      }
     }
   });
 });

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -126,7 +126,7 @@ describe.skip("verify+import blocks - range sync perf test", () => {
         });
       });
 
-      await chain.processChainSegment(blocksImport, {
+      await chain.processChainSegment(blocksImport, null, {
         // Only skip importing attestations for finalized sync. For head sync attestation are valuable.
         // Importing attestations also triggers a head update, see https://github.com/ChainSafe/lodestar/issues/3804
         // TODO: Review if this is okay, can we prevent some attacks by importing attestations?

--- a/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -201,8 +201,8 @@ describe("LodestarForkChoice", () => {
       forkChoice.onBlock(block20.message, state20, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
       forkChoice.onBlock(block24.message, state24, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
       forkChoice.onBlock(block28.message, state28, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
-      expect(forkChoice.getAllAncestorBlocks(hashBlock(block16.message), PayloadStatus.FULL)).toHaveLength(3);
-      expect(forkChoice.getAllAncestorBlocks(hashBlock(block24.message), PayloadStatus.FULL)).toHaveLength(5);
+      expect(forkChoice.getAllAncestorBlocks(hashBlock(block16.message), PayloadStatus.FULL)).toHaveLength(4);
+      expect(forkChoice.getAllAncestorBlocks(hashBlock(block24.message), PayloadStatus.FULL)).toHaveLength(6);
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block08.message))).not.toBeNull();
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block12.message))).not.toBeNull();
       expect(forkChoice.hasBlockHex(hashBlock(block08.message))).toBe(true);
@@ -210,10 +210,10 @@ describe("LodestarForkChoice", () => {
       forkChoice.onBlock(block32.message, state32, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
       forkChoice.prune(hashBlock(block16.message));
       expect(forkChoice.getAllAncestorBlocks(hashBlock(block16.message), PayloadStatus.FULL).length).toBeWithMessage(
-        0,
-        "getAllAncestorBlocks should not return finalized block"
+        1,
+        "getAllAncestorBlocks returns the finalized block itself as the last (boundary) node"
       );
-      expect(forkChoice.getAllAncestorBlocks(hashBlock(block24.message), PayloadStatus.FULL)).toHaveLength(2);
+      expect(forkChoice.getAllAncestorBlocks(hashBlock(block24.message), PayloadStatus.FULL)).toHaveLength(3);
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block08.message))).toBe(null);
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block12.message))).toBe(null);
       expect(forkChoice.hasBlockHex(hashBlock(block08.message))).toBe(false);

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -285,16 +285,20 @@ describe("sync / range / batch", async () => {
     // retry download: AwaitingDownload -> Downloading
     // downloadingSuccess: Downloading -> AwaitingProcessing
     batch.startDownloading(peer);
-    batch.downloadingSuccess(peer, [
-      BlockInputPreData.createFromBlock({
-        block: ssz.capella.SignedBeaconBlock.defaultValue(),
-        blockRootHex: "0x1234",
-        source: BlockInputSource.byRoot,
-        seenTimestampSec: Date.now() / 1000,
-        forkName: ForkName.capella,
-        daOutOfRange: false,
-      }),
-    ]);
+    batch.downloadingSuccess(
+      peer,
+      [
+        BlockInputPreData.createFromBlock({
+          block: ssz.capella.SignedBeaconBlock.defaultValue(),
+          blockRootHex: "0x1234",
+          source: BlockInputSource.byRoot,
+          seenTimestampSec: Date.now() / 1000,
+          forkName: ForkName.capella,
+          daOutOfRange: false,
+        }),
+      ],
+      null
+    );
     expect(batch.state.status).toBe(BatchStatus.AwaitingProcessing);
 
     // startProcessing: AwaitingProcessing -> Processing
@@ -334,7 +338,7 @@ describe("sync / range / batch", async () => {
     const batch = new Batch(startEpoch, config, clock, custodyConfig);
 
     expectThrowsLodestarError(
-      () => batch.downloadingSuccess(peer, []),
+      () => batch.downloadingSuccess(peer, [], null),
       new BatchError({
         code: BatchErrorCode.WRONG_STATUS,
         startEpoch,

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -117,7 +117,7 @@ describe("sync / range / chain", () => {
             })
           );
         }
-        return {result: blocks, warnings: null};
+        return {result: {blocks, payloadEnvelopes: null}, warnings: null};
       };
 
       const target: ChainTarget = {slot: computeStartSlotAtEpoch(targetEpoch), root: ZERO_HASH};
@@ -172,7 +172,7 @@ describe("sync / range / chain", () => {
           })
         );
       }
-      return {result: blocks, warnings: null};
+      return {result: {blocks, payloadEnvelopes: null}, warnings: null};
     };
 
     const target: ChainTarget = {slot: computeStartSlotAtEpoch(targetEpoch), root: ZERO_HASH};
@@ -218,9 +218,9 @@ describe("sync / range / chain", () => {
 
 function logSyncChainFns(logger: Logger, fns: SyncChainFns): SyncChainFns {
   return {
-    processChainSegment(blocks, syncType) {
+    processChainSegment(blocks, payloadEnvelopes, syncType) {
       logger.debug("mock processChainSegment", {blocks: blocks.map((b) => b.slot).join(",")});
-      return fns.processChainSegment(blocks, syncType);
+      return fns.processChainSegment(blocks, payloadEnvelopes, syncType);
     },
     downloadByRange(peer, request, syncType) {
       logger.debug("mock downloadBeaconBlocksByRange", request.state.status);

--- a/packages/beacon-node/test/unit/sync/range/utils/batches.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/utils/batches.test.ts
@@ -229,7 +229,7 @@ describe("sync / range / batches", () => {
     batch.startDownloading(peer);
     if (status === BatchStatus.Downloading) return batch;
 
-    batch.downloadingSuccess(peer, []);
+    batch.downloadingSuccess(peer, [], null);
     if (status === BatchStatus.AwaitingProcessing) return batch;
 
     batch.startProcessing();

--- a/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
@@ -186,7 +186,7 @@ describe("sync / range / peerBalancer", () => {
         sampledColumns: [0, 1, 2, 3],
       });
       console.log(blockInput.hasAllData());
-      const x = batch0.downloadingSuccess(peer1.peerId, [blockInput]);
+      const x = batch0.downloadingSuccess(peer1.peerId, [blockInput], null);
       console.log("x", x);
 
       // peer2 and peer3 are the same but peer3 has a lower target slot than the previous download

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1172,13 +1172,12 @@ export class ForkChoice implements IForkChoice {
   }
 
   /**
-   * Returns all blocks backwards starting from a block root.
-   * Return only the non-finalized blocks.
+   * Raw ancestor walk from `blockRoot` back toward the previous finalized block. Includes both
+   * `blockRoot` and the previous-finalized boundary as last element. Mirrors the semantics of
+   * `getAllAncestorAndNonAncestorBlocks.ancestors`
    */
   getAllAncestorBlocks(blockRoot: RootHex, payloadStatus: PayloadStatus): ProtoBlock[] {
-    const blocks = this.protoArray.getAllAncestorNodes(blockRoot, payloadStatus);
-    // the last node is the previous finalized one, it's there to check onBlock finalized checkpoint only.
-    return blocks.slice(0, blocks.length - 1);
+    return this.protoArray.getAllAncestorNodes(blockRoot, payloadStatus);
   }
 
   /**

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -147,8 +147,8 @@ describe("Forkchoice", () => {
     protoArr.onBlock(block, block.slot, null);
     const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
     const summaries = forkchoice.getAllAncestorBlocks(getBlockRoot(genesisSlot + 1), PayloadStatus.FULL);
-    // there are 2 blocks in protoArray but iterateAncestorBlocks should only return non-finalized blocks
-    expect(summaries).toHaveLength(1);
+    // Raw ancestor walk includes both the start and the previous-finalized boundary (genesis).
+    expect(summaries).toHaveLength(2);
     expect(summaries[0]).toEqual({
       ...block,
       bestChild: undefined,
@@ -172,15 +172,14 @@ describe("Forkchoice", () => {
 
     const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
 
-    // `getAllAncestorBlocks` slices off the boundary (previous finalized); the combined walker does
-    // not — callers that want the boundary removed should do it themselves.
+    // Both `getAllAncestorBlocks` and the combined walker's `ancestors` include the previous
+    // finalized boundary as the last element.
     const canonicalBlockRoot = getBlockRoot(genesisSlot + 3);
     const canonicalAncestorBlocks = forkchoice.getAllAncestorBlocks(canonicalBlockRoot, PayloadStatus.FULL);
     const canonicalNonAncestorBlocks = forkchoice.getAllNonAncestorBlocks(canonicalBlockRoot, PayloadStatus.FULL);
     const canonicalCombined = forkchoice.getAllAncestorAndNonAncestorBlocks(canonicalBlockRoot, PayloadStatus.FULL);
 
-    expect(canonicalCombined.ancestors.slice(0, -1)).toEqual(canonicalAncestorBlocks);
-    expect(canonicalCombined.ancestors).toHaveLength(canonicalAncestorBlocks.length + 1);
+    expect(canonicalCombined.ancestors).toEqual(canonicalAncestorBlocks);
     expect(canonicalCombined.nonAncestors).toEqual(canonicalNonAncestorBlocks);
 
     const forkBlockRoot = getBlockRoot(genesisSlot + 10);
@@ -188,8 +187,7 @@ describe("Forkchoice", () => {
     const forkNonAncestorBlocks = forkchoice.getAllNonAncestorBlocks(forkBlockRoot, PayloadStatus.FULL);
     const forkCombined = forkchoice.getAllAncestorAndNonAncestorBlocks(forkBlockRoot, PayloadStatus.FULL);
 
-    expect(forkCombined.ancestors.slice(0, -1)).toEqual(forkAncestorBlocks);
-    expect(forkCombined.ancestors).toHaveLength(forkAncestorBlocks.length + 1);
+    expect(forkCombined.ancestors).toEqual(forkAncestorBlocks);
     expect(forkCombined.nonAncestors).toEqual(forkNonAncestorBlocks);
   });
 


### PR DESCRIPTION
## Motivation

implement gloas range sync

## Description

### Sync pipeline
- `sync/range/batch.ts`: `Batch` state carries `payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null` across every status. Post-gloas batches add an `envelopesRequest` alongside the `columnsRequest` / `blobsRequest`.
- `sync/range/chain.ts`: `processChainSegment` now takes `payloadEnvelopes` and hands it to `processBlocksJob`.
- `sync/utils/downloadByRange.ts`: returns `{blocks, payloadEnvelopes}`; `cacheByRangeResponses` wraps downloaded envelopes into `PayloadEnvelopeInput`s and seeds them into `seenPayloadEnvelopeInputCache` so `importBlock` can find them.

### Import path
- `chain/blocks/importExecutionPayload.ts`: split into two entry points so the range-sync and gossip/API paths can reuse the same envelope verification:
  - `importExecutionPayload(payloadInput, opts)` — assumes DA is already awaited upstream.
  - `processExecutionPayload(payloadInput, signal, opts)` — wrapper used by `PayloadEnvelopeProcessor` that awaits DA via `verifyPayloadsDataAvailability` before calling `importExecutionPayload`.
- `chain/blocks/index.ts`: after each block is imported in a range-sync segment, looks up the matching `PayloadEnvelopeInput` in the map and calls `importExecutionPayload` directly (DA was awaited once for the whole segment in `verifyBlocksInEpoch`).
- `chain/blocks/verifyBlock.ts`: post-gloas DA wait runs on `payloadEnvelopes` via `verifyPayloadsDataAvailability`.
- `chain/blocks/importBlock.ts`: when `opts.fromRangeSync` is set, skips creating the ambient `PayloadEnvelopeInput` since range sync has already seeded the cache.

### Tests
- `test/e2e/sync/finalizedSync.test.ts`: update for gloas and passed. After `waitForSynced`, walks Node B's fork-choice ancestors of the head and asserts `hasPayloadHexUnsafe(root) === true` for every gloas block with `16 ≤ slot < head.slot`, proving range sync delivered a FULL payload variant for every completed gloas slot on the canonical chain.

## AI Assistance Disclosure

Used Claude Code.
