### PR TITLE
chore: remove epoch_boundary sanity handler

### DIFF
--- a/packages/beacon-node/test/spec/presets/sanity.test.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.test.ts
@@ -23,7 +23,6 @@ const sanity: TestRunnerFn<any, BeaconStateAllForks> = (fork, testName, testSuit
     case "slots":
       return sanitySlots(fork, testName, testSuite);
     case "blocks":
-    case "epoch_boundary":
       return sanityBlocks(fork, testName, testSuite);
     default:
       throw Error(`Unknown sanity test ${testName}`);


### PR DESCRIPTION
this shouldn't be needed, will be fixed once https://github.com/ethereum/consensus-specs/pull/5158 is merged