### PR TITLE
chore: fail nightly spec tests workflow if any tests failed

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -32,7 +32,7 @@ runs:
       run: echo "key=build-cache-${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
     - name: Restore build
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: cache-build-restore
       with:
         path: |
@@ -58,7 +58,7 @@ runs:
       run: pnpm check-bundle
 
     - name: Cache build artifacts
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           lib/

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c # v4
+    - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
 
     - name: Setup Node
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -32,7 +32,7 @@ runs:
       run: echo "key=build-cache-${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
     - name: Restore build
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: cache-build-restore
       with:
         path: |
@@ -58,7 +58,7 @@ runs:
       run: pnpm check-bundle
 
     - name: Cache build artifacts
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           lib/

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+    - uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c # v4
 
     - name: Setup Node
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/nightly-spec-tests.yml
+++ b/.github/workflows/nightly-spec-tests.yml
@@ -36,6 +36,12 @@ jobs:
     # Don't run scheduled copies of this workflow on forks.
     if: ${{ github.event_name != 'schedule' || github.repository == 'ChainSafe/lodestar' }}
     runs-on: warp-ubuntu-2204-x64-4x
+    # Force bash with -eo pipefail so vitest failures propagate through `tee`.
+    # Warp runners' implicit default shell is `bash -e` (no pipefail), which
+    # would swallow the exit code and hide genuine test failures.
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Noticed in https://github.com/ChainSafe/lodestar/actions/runs/24883830643 that even if tests fail the workflow itself passes. ~~Also updated node actions to get rid of some deprecation warnings.~~