### PR TITLE
feat: update sync notifier for gloas

### DIFF
--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -167,7 +167,14 @@ function getHeadExecutionInfo(
     return [];
   }
 
-  const executionStatusStr = headInfo.executionStatus.toLowerCase();
+  // A PayloadSeparated head is a gloas beacon block imported before its payload envelope
+  // arrives, in that case the exec-block row surfaces the inherited parent anchor (from the
+  // bid), which is already validated. Normalize to "valid" to avoid leaking internal
+  // fork-choice bookkeeping into the log. Once the payload envelope arrives and the FULL
+  // variant becomes head, executionStatus is Valid/Syncing naturally.
+  // TODO GLOAS: revisit once optimistic sync is implemented
+  const executionStatusStr =
+    headInfo.executionStatus === ExecutionStatus.PayloadSeparated ? "valid" : headInfo.executionStatus.toLowerCase();
 
   // Add execution status to notifier only if head is on/post bellatrix
   if (isStatePostBellatrix(headState) && headState.isExecutionStateType) {


### PR DESCRIPTION
This is a minimal change to our sync notifier for gloas. We can think about this more later, there are few options depending on how fancy we want to be, eg. could print out 2 logs per slot, move the log to later in the slot (~10 seconds) to print out current slot payload status, or extend the existing log with payload status of previous slot (eg. add tags like `[full]` and `[empty]`). But what this PR does is much simpler, it just print the `exec-block` of the parent, so in case of EMPTY it might print out the same block number and hash multiple times in a row, which is an indicator for an empty payload but might not be obvious to an operator, but also do they have to know about it? We can talk about how we want this at interop if there is time for it.