### PR TITLE
fix: correct DA status for payload

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -128,7 +128,6 @@ export async function importBlock(
     blockDelaySec,
     currentSlot,
     fork >= ForkSeq.gloas ? ExecutionStatus.PayloadSeparated : executionStatus,
-    // TODO GLOAS: this is not useful post-gloas, may need to remove it?
     dataAvailabilityStatus
   );
 

--- a/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
+++ b/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ExecutionStatus, PayloadExecutionStatus, getSafeExecutionBlockHash} from "@lodestar/fork-choice";
-import {isStatePostGloas} from "@lodestar/state-transition";
+import {DataAvailabilityStatus, isStatePostGloas} from "@lodestar/state-transition";
 import {fromHex, isErrorAborted} from "@lodestar/utils";
 import {ZERO_HASH_HEX} from "../../constants/index.js";
 import {ExecutionPayloadStatus} from "../../execution/index.js";
@@ -93,6 +93,7 @@ function toForkChoiceExecutionStatus(status: ExecutionPayloadStatus): PayloadExe
 export async function importExecutionPayload(
   this: BeaconChain,
   payloadInput: PayloadEnvelopeInput,
+  dataAvailabilityStatus: DataAvailabilityStatus,
   opts: ImportPayloadOpts = {}
 ): Promise<void> {
   const signedEnvelope = payloadInput.getPayloadEnvelope();
@@ -221,7 +222,13 @@ export async function importExecutionPayload(
 
   // 6. Update fork choice, transitions the block's PENDING variant to FULL
   const execStatus = toForkChoiceExecutionStatus(execResult.status);
-  this.forkChoice.onExecutionPayload(blockRootHex, blockHashHex, envelope.payload.blockNumber, execStatus);
+  this.forkChoice.onExecutionPayload(
+    blockRootHex,
+    blockHashHex,
+    envelope.payload.blockNumber,
+    execStatus,
+    dataAvailabilityStatus
+  );
 
   // 7. Queue notifyForkchoiceUpdate to engine api
   const head = this.forkChoice.getHead();
@@ -275,6 +282,6 @@ export async function processExecutionPayload(
   signal: AbortSignal,
   opts: ImportPayloadOpts = {}
 ): Promise<void> {
-  await verifyPayloadsDataAvailability([payloadInput], signal);
-  await importExecutionPayload.call(this, payloadInput, opts);
+  const {dataAvailabilityStatuses} = await verifyPayloadsDataAvailability([payloadInput], signal);
+  await importExecutionPayload.call(this, payloadInput, dataAvailabilityStatuses[0], opts);
 }

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -90,8 +90,14 @@ export async function processBlocks(
 
     // Fully verify a block to be imported immediately after. Does not produce any side-effects besides adding intermediate
     // states in the state cache through regen.
-    const {postStates, dataAvailabilityStatuses, proposerBalanceDeltas, segmentExecStatus, indexedAttestationsByBlock} =
-      await verifyBlocksInEpoch.call(this, parentBlock, relevantBlocks, payloadEnvelopes, opts);
+    const {
+      postStates,
+      blockDAStatuses,
+      payloadDAStatuses,
+      proposerBalanceDeltas,
+      segmentExecStatus,
+      indexedAttestationsByBlock,
+    } = await verifyBlocksInEpoch.call(this, parentBlock, relevantBlocks, payloadEnvelopes, opts);
 
     // If segmentExecStatus has lvhForkchoice then, the entire segment should be invalid
     // and we need to further propagate
@@ -110,7 +116,7 @@ export async function processBlocks(
         parentBlockSlot: parentSlots[i],
         executionStatus: executionStatuses[i],
         // start supporting optimistic syncing/processing
-        dataAvailabilityStatus: dataAvailabilityStatuses[i],
+        dataAvailabilityStatus: blockDAStatuses[i],
         proposerBalanceDelta: proposerBalanceDeltas[i],
         indexedAttestations: indexedAttestationsByBlock[i],
         // TODO: Make this param mandatory and capture in gossip
@@ -130,9 +136,11 @@ export async function processBlocks(
           throw new Error(`Payload envelope for slot ${slot} not complete after DA verification`);
         }
         // we already awaited DA in verifyBlocksInEpoch for this segment
-        // TODO GLOAS: may need FullyVerifiedPayload here with DatAvailabilityStatus added from here
-        // the current flow use that data from the forkchoice pending node which is not correct
-        await importExecutionPayload.call(this, payloadInput, {validSignature: false});
+        const payloadDA = payloadDAStatuses.get(slot);
+        if (payloadDA === undefined) {
+          throw new Error(`Missing payload DA status for slot ${slot}`);
+        }
+        await importExecutionPayload.call(this, payloadInput, payloadDA, {validSignature: false});
       }
 
       await nextEventLoop();

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
@@ -64,6 +64,7 @@ export class PayloadEnvelopeInput {
   readonly proposerIndex: ValidatorIndex;
   readonly bid: gloas.ExecutionPayloadBid;
   readonly versionedHashes: VersionedHashes;
+  readonly daOutOfRange: boolean;
 
   private columnsCache = new Map<ColumnIndex, ColumnWithSource>();
 
@@ -87,6 +88,7 @@ export class PayloadEnvelopeInput {
     sampledColumns: ColumnIndex[];
     custodyColumns: ColumnIndex[];
     timeCreatedSec: number;
+    daOutOfRange: boolean;
   }) {
     this.blockRootHex = props.blockRootHex;
     this.slot = props.slot;
@@ -97,13 +99,14 @@ export class PayloadEnvelopeInput {
     this.sampledColumns = props.sampledColumns;
     this.custodyColumns = props.custodyColumns;
     this.timeCreatedSec = props.timeCreatedSec;
+    this.daOutOfRange = props.daOutOfRange;
     this.payloadEnvelopeDataPromise = createPromise();
     this.allDataPromise = createPromise();
     this.columnsDataPromise = createPromise();
 
     const noBlobs = props.bid.blobKzgCommitments.length === 0;
     const noSampledColumns = props.sampledColumns.length === 0;
-    const hasAllData = noBlobs || noSampledColumns;
+    const hasAllData = props.daOutOfRange || noBlobs || noSampledColumns;
 
     if (hasAllData) {
       this.state = {hasPayload: false, hasAllData: true, hasComputedAllData: true};
@@ -125,6 +128,7 @@ export class PayloadEnvelopeInput {
       sampledColumns: props.sampledColumns,
       custodyColumns: props.custodyColumns,
       timeCreatedSec: props.timeCreatedSec,
+      daOutOfRange: props.daOutOfRange,
     });
   }
 

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/types.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/types.ts
@@ -27,6 +27,7 @@ export type CreateFromBlockProps = {
   sampledColumns: ColumnIndex[];
   custodyColumns: ColumnIndex[];
   timeCreatedSec: number;
+  daOutOfRange: boolean;
 };
 
 export type AddPayloadEnvelopeProps = SourceMeta & {

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -41,7 +41,8 @@ export async function verifyBlocksInEpoch(
   postStates: IBeaconStateView[];
   proposerBalanceDeltas: number[];
   segmentExecStatus: SegmentExecStatus;
-  dataAvailabilityStatuses: DataAvailabilityStatus[];
+  blockDAStatuses: DataAvailabilityStatus[];
+  payloadDAStatuses: Map<Slot, DataAvailabilityStatus>;
   indexedAttestationsByBlock: IndexedAttestation[][];
 }> {
   const blocks = blockInputs.map((blockInput) => blockInput.getBlock());
@@ -116,8 +117,12 @@ export async function verifyBlocksInEpoch(
 
     // Pick the data-availability source by fork:
     // - Pre-Gloas: blob/Fulu-column data lives in IBlockInput → verifyBlocksDataAvailability.
-    // - Post-Gloas: verifyPayloadsDataAvailability
-    const daAvailabilityPromise =
+    // - Post-Gloas: verifyPayloadsDataAvailability (payload-level DA, keyed by slot).
+    const daAvailabilityPromise: Promise<{
+      blockDAStatuses: DataAvailabilityStatus[];
+      payloadDAStatuses: Map<Slot, DataAvailabilityStatus>;
+      availableTime: number;
+    }> =
       fork >= ForkSeq.gloas
         ? (async () => {
             const payloadInputsForDa: PayloadEnvelopeInput[] = [];
@@ -125,19 +130,37 @@ export async function verifyBlocksInEpoch(
               const pi = payloadEnvelopes?.get(input.slot);
               if (pi !== undefined) payloadInputsForDa.push(pi);
             }
-            await verifyPayloadsDataAvailability(payloadInputsForDa, abortController.signal);
+            const {dataAvailabilityStatuses, availableTime} = await verifyPayloadsDataAvailability(
+              payloadInputsForDa,
+              abortController.signal
+            );
+            const payloadDAStatuses = new Map<Slot, DataAvailabilityStatus>();
+            for (let i = 0; i < payloadInputsForDa.length; i++) {
+              payloadDAStatuses.set(payloadInputsForDa[i].slot, dataAvailabilityStatuses[i]);
+            }
             return {
               // post-gloas, DataAvailabilityStatus is NotRequired for forkChoice.onBlock() ProtoBlock
-              dataAvailabilityStatuses: blockInputs.map(() => DataAvailabilityStatus.NotRequired),
-              availableTime: Date.now(),
+              blockDAStatuses: blockInputs.map(() => DataAvailabilityStatus.NotRequired),
+              payloadDAStatuses,
+              availableTime,
             };
           })()
-        : verifyBlocksDataAvailability(blockInputs, abortController.signal);
+        : (async () => {
+            const {dataAvailabilityStatuses, availableTime} = await verifyBlocksDataAvailability(
+              blockInputs,
+              abortController.signal
+            );
+            return {
+              blockDAStatuses: dataAvailabilityStatuses,
+              payloadDAStatuses: new Map<Slot, DataAvailabilityStatus>(),
+              availableTime,
+            };
+          })();
 
     // batch all I/O operations to reduce overhead
     const [
       segmentExecStatus,
-      {dataAvailabilityStatuses, availableTime},
+      {blockDAStatuses, payloadDAStatuses, availableTime},
       {postStates, proposerBalanceDeltas, verifyStateTime},
       {verifySignaturesTime},
     ] = await Promise.all([
@@ -258,7 +281,14 @@ export async function verifyBlocksInEpoch(
       );
     }
 
-    return {postStates, dataAvailabilityStatuses, proposerBalanceDeltas, segmentExecStatus, indexedAttestationsByBlock};
+    return {
+      postStates,
+      blockDAStatuses,
+      payloadDAStatuses,
+      proposerBalanceDeltas,
+      segmentExecStatus,
+      indexedAttestationsByBlock,
+    };
   } finally {
     abortController.abort();
   }

--- a/packages/beacon-node/src/chain/blocks/verifyPayloadsDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyPayloadsDataAvailability.ts
@@ -28,11 +28,14 @@ export async function verifyPayloadsDataAvailability(
   await Promise.all(promises);
 
   const availableTime = Math.max(0, Math.max(...payloadInputs.map((payloadInput) => payloadInput.getTimeComplete())));
-  const dataAvailabilityStatuses: DataAvailabilityStatus[] = payloadInputs.map((payloadInput) =>
-    payloadInput.getBlobKzgCommitments().length === 0
+  const dataAvailabilityStatuses: DataAvailabilityStatus[] = payloadInputs.map((payloadInput) => {
+    if (payloadInput.daOutOfRange) {
+      return DataAvailabilityStatus.OutOfRange;
+    }
+    return payloadInput.getBlobKzgCommitments().length === 0
       ? DataAvailabilityStatus.NotRequired
-      : DataAvailabilityStatus.Available
-  );
+      : DataAvailabilityStatus.Available;
+  });
 
   return {dataAvailabilityStatuses, availableTime};
 }

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -336,6 +336,8 @@ export class BeaconChain implements IBeaconChain {
       logger,
     });
     this.seenPayloadEnvelopeInputCache = new SeenPayloadEnvelopeInput({
+      config,
+      clock,
       chainEvents: emitter,
       signal,
       serializedCache: this.serializedCache,

--- a/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
@@ -1,9 +1,12 @@
+import {ChainForkConfig} from "@lodestar/config";
 import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {RootHex, Slot} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
+import {IClock} from "../../util/clock.js";
 import {SerializedCache} from "../../util/serializedCache.js";
+import {isDaOutOfRange} from "../blocks/blockInput/index.js";
 import {CreateFromBlockProps, PayloadEnvelopeInput} from "../blocks/payloadEnvelopeInput/index.js";
 import {ChainEvent, ChainEventEmitter} from "../emitter.js";
 
@@ -11,6 +14,8 @@ export type {PayloadEnvelopeInputState} from "../blocks/payloadEnvelopeInput/ind
 export {PayloadEnvelopeInput} from "../blocks/payloadEnvelopeInput/index.js";
 
 export type SeenPayloadEnvelopeInputModules = {
+  config: ChainForkConfig;
+  clock: IClock;
   chainEvents: ChainEventEmitter;
   signal: AbortSignal;
   serializedCache: SerializedCache;
@@ -32,6 +37,8 @@ export type SeenPayloadEnvelopeInputModules = {
  * ticks; subsequent ticks settle it back.
  */
 export class SeenPayloadEnvelopeInput {
+  private readonly config: ChainForkConfig;
+  private readonly clock: IClock;
   private readonly chainEvents: ChainEventEmitter;
   private readonly signal: AbortSignal;
   private readonly serializedCache: SerializedCache;
@@ -39,7 +46,9 @@ export class SeenPayloadEnvelopeInput {
   private readonly logger?: Logger;
   private payloadInputs = new Map<RootHex, PayloadEnvelopeInput>();
 
-  constructor({chainEvents, signal, serializedCache, metrics, logger}: SeenPayloadEnvelopeInputModules) {
+  constructor({config, clock, chainEvents, signal, serializedCache, metrics, logger}: SeenPayloadEnvelopeInputModules) {
+    this.config = config;
+    this.clock = clock;
     this.chainEvents = chainEvents;
     this.signal = signal;
     this.serializedCache = serializedCache;
@@ -68,11 +77,12 @@ export class SeenPayloadEnvelopeInput {
     this.pruneBelow(computeStartSlotAtEpoch(checkpoint.epoch));
   };
 
-  add(props: CreateFromBlockProps): PayloadEnvelopeInput {
+  add(props: Omit<CreateFromBlockProps, "daOutOfRange">): PayloadEnvelopeInput {
     if (this.payloadInputs.has(props.blockRootHex)) {
       throw new Error(`PayloadEnvelopeInput already exists for block ${props.blockRootHex}`);
     }
-    const input = PayloadEnvelopeInput.createFromBlock(props);
+    const daOutOfRange = isDaOutOfRange(this.config, props.forkName, props.block.message.slot, this.clock.currentEpoch);
+    const input = PayloadEnvelopeInput.createFromBlock({...props, daOutOfRange});
     this.payloadInputs.set(props.blockRootHex, input);
     this.metrics?.seenCache.payloadEnvelopeInput.created.inc();
     return input;

--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -20,6 +20,7 @@ import {InputType} from "@lodestar/spec-test-util";
 import {
   BeaconStateAllForks,
   BeaconStateView,
+  DataAvailabilityStatus,
   IBeaconStateViewGloas,
   createCachedBeaconState,
   createPubkeyCache,
@@ -421,7 +422,8 @@ const forkChoiceTest =
                   beaconBlockRoot,
                   blockHash,
                   blockNumber,
-                  ExecutionStatus.Valid
+                  ExecutionStatus.Valid,
+                  DataAvailabilityStatus.Available
                 );
                 if (!isValid) throw Error("Expect error since this is a negative test");
               } catch (e) {

--- a/packages/beacon-node/test/unit/chain/blocks/verifyPayloadsDataAvailability.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyPayloadsDataAvailability.test.ts
@@ -10,7 +10,15 @@ import {
   verifyPayloadsDataAvailability,
 } from "../../../../src/chain/blocks/verifyPayloadsDataAvailability.js";
 
-function buildPayloadEnvelopeInput({blobCount, sampledColumns}: {blobCount: number; sampledColumns: ColumnIndex[]}): {
+function buildPayloadEnvelopeInput({
+  blobCount,
+  sampledColumns,
+  daOutOfRange = false,
+}: {
+  blobCount: number;
+  sampledColumns: ColumnIndex[];
+  daOutOfRange?: boolean;
+}): {
   payloadInput: PayloadEnvelopeInput;
   signedEnvelope: gloas.SignedExecutionPayloadEnvelope;
 } {
@@ -29,6 +37,7 @@ function buildPayloadEnvelopeInput({blobCount, sampledColumns}: {blobCount: numb
     sampledColumns,
     custodyColumns: sampledColumns,
     timeCreatedSec: Date.now() / 1000,
+    daOutOfRange,
   });
 
   const signedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
@@ -147,6 +156,18 @@ describe("verifyPayloadsDataAvailability", () => {
     controller.abort();
     await expect(waitPromise).rejects.toThrow();
   });
+
+  it("emits OutOfRange when daOutOfRange=true and skips waiting for columns", async () => {
+    const sampled = [0, 1];
+    const {payloadInput} = buildPayloadEnvelopeInput({blobCount: 1, sampledColumns: sampled, daOutOfRange: true});
+
+    // Even with blobs declared and no columns delivered, hasAllData should be true at construction
+    expect(payloadInput.hasAllData()).toBe(true);
+
+    const controller = new AbortController();
+    const {dataAvailabilityStatuses} = await verifyPayloadsDataAvailability([payloadInput], controller.signal);
+    expect(dataAvailabilityStatuses).toEqual([DataAvailabilityStatus.OutOfRange]);
+  });
 });
 
 describe("PayloadEnvelopeInput.waitForEnvelopeAndAllData", () => {
@@ -172,6 +193,7 @@ describe("PayloadEnvelopeInput.waitForEnvelopeAndAllData", () => {
       sampledColumns,
       custodyColumns: sampledColumns,
       timeCreatedSec: Date.now() / 1000,
+      daOutOfRange: false,
     });
 
     const signedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();

--- a/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
@@ -4,7 +4,8 @@ import {ForkName} from "@lodestar/params";
 import {ChainEventEmitter} from "../../../../src/chain/emitter.js";
 import {SeenPayloadEnvelopeInput} from "../../../../src/chain/seenCache/seenPayloadEnvelopeInput.js";
 import {SerializedCache} from "../../../../src/util/serializedCache.js";
-import {generateBlock} from "../../../utils/blocksAndData.js";
+import {getMockedClock} from "../../../mocks/clock.js";
+import {config, generateBlock} from "../../../utils/blocksAndData.js";
 
 describe("SeenPayloadEnvelopeInput", () => {
   let cache: SeenPayloadEnvelopeInput;
@@ -18,6 +19,8 @@ describe("SeenPayloadEnvelopeInput", () => {
     serializedCache = new SerializedCache();
 
     cache = new SeenPayloadEnvelopeInput({
+      config,
+      clock: getMockedClock(),
       chainEvents,
       signal: abortController.signal,
       serializedCache,

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -79,6 +79,7 @@ function buildPayloadFixture({
     sampledColumns,
     custodyColumns: sampledColumns,
     timeCreatedSec: Date.now() / 1000,
+    daOutOfRange: false,
   });
 
   const envelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
@@ -1410,6 +1411,7 @@ describe("UnknownBlockSync", () => {
         sampledColumns: [],
         custodyColumns: [],
         timeCreatedSec: Date.now() / 1000,
+        daOutOfRange: false,
       });
 
       const childBlock = ssz.gloas.SignedBeaconBlock.defaultValue();

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -957,7 +957,8 @@ export class ForkChoice implements IForkChoice {
     blockRoot: RootHex,
     executionPayloadBlockHash: RootHex,
     executionPayloadNumber: number,
-    executionStatus: PayloadExecutionStatus
+    executionStatus: PayloadExecutionStatus,
+    dataAvailabilityStatus: DataAvailabilityStatus
   ): void {
     this.protoArray.onExecutionPayload(
       blockRoot,
@@ -965,7 +966,8 @@ export class ForkChoice implements IForkChoice {
       executionPayloadBlockHash,
       executionPayloadNumber,
       this.proposerBoostRoot,
-      executionStatus
+      executionStatus,
+      dataAvailabilityStatus
     );
   }
 

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -203,7 +203,8 @@ export interface IForkChoice {
     blockRoot: RootHex,
     executionPayloadBlockHash: RootHex,
     executionPayloadNumber: number,
-    executionStatus: PayloadExecutionStatus
+    executionStatus: PayloadExecutionStatus,
+    dataAvailabilityStatus: DataAvailabilityStatus
   ): void;
   /**
    * Call `onTick` for all slots between `fcStore.getCurrentSlot()` and the provided `currentSlot`.

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -1,6 +1,6 @@
 import {BitArray} from "@chainsafe/ssz";
 import {GENESIS_EPOCH, PTC_SIZE} from "@lodestar/params";
-import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {DataAvailabilityStatus, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot} from "@lodestar/types";
 import {bitCount, toRootHex} from "@lodestar/utils";
 import {ForkChoiceError, ForkChoiceErrorCode} from "../forkChoice/errors.js";
@@ -549,7 +549,8 @@ export class ProtoArray {
     executionPayloadBlockHash: RootHex,
     executionPayloadNumber: number,
     proposerBoostRoot: RootHex | null,
-    executionStatus: PayloadExecutionStatus
+    executionStatus: PayloadExecutionStatus,
+    dataAvailabilityStatus: DataAvailabilityStatus
   ): void {
     // First check if block exists
     const variants = this.indices.get(blockRoot);
@@ -591,7 +592,7 @@ export class ProtoArray {
       });
     }
 
-    // Create FULL variant as a child of PENDING (sibling to EMPTY)
+    // Create FULL variant as a child of PENDING (sibling to EMPTY).
     const fullNode: ProtoNode = {
       ...pendingNode,
       parent: pendingIndex, // Points to own PENDING (same as EMPTY)
@@ -603,6 +604,7 @@ export class ProtoArray {
       executionStatus,
       executionPayloadBlockHash,
       executionPayloadNumber,
+      dataAvailabilityStatus,
     };
 
     const fullIndex = this.nodes.length;

--- a/packages/fork-choice/test/unit/protoArray/gloas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/gloas.test.ts
@@ -272,7 +272,15 @@ describe("Gloas Fork Choice", () => {
       expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL)).toBeUndefined();
 
       // Call onExecutionPayload
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       // FULL should now exist
       const fullNode = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL);
@@ -284,7 +292,15 @@ describe("Gloas Fork Choice", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
       protoArray.onBlock(block, gloasForkSlot, null);
 
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       const fullNode = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL);
       const pendingIndex = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.PENDING);
@@ -296,8 +312,24 @@ describe("Gloas Fork Choice", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
       protoArray.onBlock(block, gloasForkSlot, null);
 
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Valid);
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       // Should still only have one FULL node
       const fullNode = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL);
@@ -313,13 +345,29 @@ describe("Gloas Fork Choice", () => {
 
       // Calling onExecutionPayload should throw for pre-Gloas blocks
       expect(() =>
-        protoArray.onExecutionPayload("0x02", gloasForkSlot - 1, "0x02", gloasForkSlot - 1, null, ExecutionStatus.Valid)
+        protoArray.onExecutionPayload(
+          "0x02",
+          gloasForkSlot - 1,
+          "0x02",
+          gloasForkSlot - 1,
+          null,
+          ExecutionStatus.Valid,
+          DataAvailabilityStatus.Available
+        )
       ).toThrow();
     });
 
     it("throws for unknown block", () => {
       expect(() =>
-        protoArray.onExecutionPayload("0x99", gloasForkSlot, "0x99", gloasForkSlot, null, ExecutionStatus.Valid)
+        protoArray.onExecutionPayload(
+          "0x99",
+          gloasForkSlot,
+          "0x99",
+          gloasForkSlot,
+          null,
+          ExecutionStatus.Valid,
+          DataAvailabilityStatus.Available
+        )
       ).toThrow();
     });
   });
@@ -384,7 +432,15 @@ describe("Gloas Fork Choice", () => {
       protoArray.onBlock(block, gloasForkSlot, null);
 
       // Make execution payload available by creating FULL variant
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       // Vote yes from majority of PTC (>50%)
       const threshold = Math.floor(PTC_SIZE / 2) + 1;
@@ -400,7 +456,15 @@ describe("Gloas Fork Choice", () => {
       protoArray.onBlock(block, gloasForkSlot, null);
 
       // Make execution payload available by creating FULL variant
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       // Vote yes from exactly 50% (not >50%)
       const threshold = Math.floor(PTC_SIZE / 2);
@@ -416,7 +480,15 @@ describe("Gloas Fork Choice", () => {
       protoArray.onBlock(block, gloasForkSlot, null);
 
       // Make execution payload available by creating FULL variant
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       // Vote mixed yes/no
       const threshold = Math.floor(PTC_SIZE / 2) + 1;
@@ -469,7 +541,15 @@ describe("Gloas Fork Choice", () => {
     it("intra-block: EMPTY/FULL variants have PENDING as parent", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
       protoArray.onBlock(block, gloasForkSlot, null);
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       const pendingIndex = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.PENDING);
       const emptyNode = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.EMPTY);
@@ -483,7 +563,15 @@ describe("Gloas Fork Choice", () => {
       // Block A
       const blockA = createTestBlock(gloasForkSlot, "0x02Root", genesisRoot, genesisRoot);
       protoArray.onBlock(blockA, gloasForkSlot, null);
-      protoArray.onExecutionPayload("0x02Root", gloasForkSlot, "0x02Hash", gloasForkSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02Root",
+        gloasForkSlot,
+        "0x02Hash",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       // Block B extends A's FULL (parentBlockHash matches)
       const blockB = createTestBlock(gloasForkSlot + 1, "0x03Root", "0x02Root", "0x02Hash");
@@ -512,7 +600,15 @@ describe("Gloas Fork Choice", () => {
       const blockSlot = gloasForkSlot + 10;
       const block = createTestBlock(blockSlot, "0x02", genesisRoot, genesisRoot);
       protoArray.onBlock(block, blockSlot, null);
-      protoArray.onExecutionPayload("0x02", blockSlot, "0x02", blockSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02",
+        blockSlot,
+        "0x02",
+        blockSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       const emptyIndex = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.EMPTY);
       if (emptyIndex === undefined) throw new Error("Expected emptyIndex to exist");
@@ -589,7 +685,15 @@ describe("Gloas Fork Choice", () => {
       const blockSlot = gloasForkSlot + 10;
       const block = createTestBlock(blockSlot, "0x02", genesisRoot, genesisRoot);
       protoArray.onBlock(block, blockSlot, null);
-      protoArray.onExecutionPayload("0x02", blockSlot, "0x02", blockSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02",
+        blockSlot,
+        "0x02",
+        blockSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       const emptyIndex = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.EMPTY);
       if (emptyIndex === undefined) throw new Error("Expected emptyIndex to exist");
@@ -646,7 +750,15 @@ describe("Gloas Fork Choice", () => {
       protoArray.onBlock(block3, gloasForkSlot + 2, null);
 
       // Create all three variants for block1: PENDING, EMPTY, FULL
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       // Get block1's variants indices before pruning
       const block1PendingBefore = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.PENDING);
@@ -691,7 +803,15 @@ describe("Gloas Fork Choice", () => {
       protoArray.onBlock(block2, gloasForkSlot + 1, null);
 
       // Create FULL variant for block1
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       // Set PTC votes for block1
       const threshold = Math.floor(PTC_SIZE / 2) + 1;
@@ -718,7 +838,15 @@ describe("Gloas Fork Choice", () => {
       protoArray.onBlock(block2, gloasForkSlot + 1, null);
 
       // Create all three variants for block1
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       // Verify all three variants exist via the public API
       const pendingIdx = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.PENDING);


### PR DESCRIPTION
**Motivation**

- the current DA status of FULL ProtoBlock inherits PENDING variant which is not correct. This PR fixes it

**Description**

Thread payload DA through the import pipeline to the FULL ProtoBlock variant, mimicking the pre-Gloas `BlockInput` flow.

- Add `daOutOfRange` to `PayloadEnvelopeInput`; `SeenPayloadEnvelopeInput.add()` computes it via `isDaOutOfRange`.
- Add `dataAvailabilityStatus` param to `forkChoice.onExecutionPayload` so the FULL variant stops inheriting from PENDING.
- `verifyPayloadsDataAvailability` returns DA status, `importExecutionPayload` consumes it.
- `verifyBlocksInEpoch` returns `payloadDAStatuses: Map<Slot, DataAvailabilityStatus>` for `processBlocks` to look up per slot.

**AI Assistance Disclosure**

Used Claude Code.