### PR TITLE
feat: add PTC data availability and quorum tracking

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -276,7 +276,8 @@ export function getBeaconPoolApi({
             chain.forkChoice.notifyPtcMessages(
               toRootHex(payloadAttestationMessage.data.beaconBlockRoot),
               [validatorCommitteeIndex],
-              payloadAttestationMessage.data.payloadPresent
+              payloadAttestationMessage.data.payloadPresent,
+              payloadAttestationMessage.data.blobDataAvailable
             );
 
             await network.publishPayloadAttestationMessage(payloadAttestationMessage);

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -292,7 +292,8 @@ export async function importBlock(
           this.forkChoice.notifyPtcMessages(
             toRootHex(payloadAttestation.data.beaconBlockRoot),
             ptcIndices,
-            payloadAttestation.data.payloadPresent
+            payloadAttestation.data.payloadPresent,
+            payloadAttestation.data.blobDataAvailable
           );
         }
       } catch (e) {

--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -38,6 +38,14 @@ export enum ChainEvent {
    */
   forkChoiceFinalized = "forkChoice:finalized",
   /**
+   * This event signals that the PTC quorum for payload timeliness has been reached.
+   */
+  forkChoicePTCQuorumPayloadTimely = "forkChoice:PTCQuorumPayloadTimely",
+  /**
+   * This event signals that the PTC quorum for data availability has been reached.
+   */
+  forkChoicePTCQuorumDataAvailable = "forkChoice:PTCQuorumDataAvailable",
+  /**
    * This event signals that dependent services (e.g. custody sampling) should update to account for the new target group count.
    */
   updateTargetCustodyGroupCount = "updateTargetCustodyGroupCount",
@@ -112,6 +120,9 @@ export type IChainEvents = ApiEvents & {
 
   [ChainEvent.forkChoiceJustified]: (checkpoint: CheckpointWithHex) => void;
   [ChainEvent.forkChoiceFinalized]: (checkpoint: CheckpointWithHex) => void;
+
+  [ChainEvent.forkChoicePTCQuorumPayloadTimely]: (blockRoot: RootHex, payloadTimely: boolean) => void;
+  [ChainEvent.forkChoicePTCQuorumDataAvailable]: (blockRoot: RootHex, dataAvailable: boolean) => void;
 
   [ChainEvent.updateTargetCustodyGroupCount]: (targetGroupCount: number) => void;
 

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -115,6 +115,10 @@ export function initializeForkChoiceFromFinalizedState(
       {
         onJustified: (cp) => emitter.emit(ChainEvent.forkChoiceJustified, cp),
         onFinalized: (cp) => emitter.emit(ChainEvent.forkChoiceFinalized, cp),
+        onPTCQuorumPayloadTimely: (blockRoot, payloadTimely) =>
+          emitter.emit(ChainEvent.forkChoicePTCQuorumPayloadTimely, blockRoot, payloadTimely),
+        onPTCQuorumDataAvailable: (blockRoot, dataAvailable) =>
+          emitter.emit(ChainEvent.forkChoicePTCQuorumDataAvailable, blockRoot, dataAvailable),
       }
     ),
 
@@ -204,6 +208,10 @@ export function initializeForkChoiceFromUnfinalizedState(
     {
       onJustified: (cp) => emitter.emit(ChainEvent.forkChoiceJustified, cp),
       onFinalized: (cp) => emitter.emit(ChainEvent.forkChoiceFinalized, cp),
+      onPTCQuorumPayloadTimely: (blockRoot, payloadTimely) =>
+        emitter.emit(ChainEvent.forkChoicePTCQuorumPayloadTimely, blockRoot, payloadTimely),
+      onPTCQuorumDataAvailable: (blockRoot, dataAvailable) =>
+        emitter.emit(ChainEvent.forkChoicePTCQuorumDataAvailable, blockRoot, dataAvailable),
     }
   );
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1147,7 +1147,8 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       chain.forkChoice.notifyPtcMessages(
         toRootHex(payloadAttestationMessage.data.beaconBlockRoot),
         [validationResult.validatorCommitteeIndex],
-        payloadAttestationMessage.data.payloadPresent
+        payloadAttestationMessage.data.payloadPresent,
+        payloadAttestationMessage.data.blobDataAvailable
       );
     },
     [GossipType.execution_payload_bid]: async ({

--- a/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
@@ -159,9 +159,12 @@ describe("sync / finalized sync for gloas", () => {
           `Node B missing FULL payload variant for gloas block slot=${block.slot} root=${block.blockRoot}`
         );
         if (block.slot > gloasFirstSlot) {
-          const ptcVotes = bn2.chain.forkChoice.getPTCVotes(block.blockRoot) ?? [];
+          const ptcVotes = bn2.chain.forkChoice.getPTCVotes(block.blockRoot);
+          if (ptcVotes === null) {
+            expect.fail("Block not found or not a Gloas block");
+          }
 
-          expect(ptcVotes.some(Boolean)).toBeWithMessage(
+          expect(ptcVotes.payloadTimelyYea + ptcVotes.payloadTimelyNay > 0).toBeWithMessage(
             true,
             `Node A missing PTC votes for gloas block slot=${block.slot} root=${block.blockRoot}`
           );

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -137,6 +137,8 @@ describe.skip(`getAttestationsForBlock vc=${vc}`, () => {
         },
         justifiedBalancesGetter: () => originalState.epochCtx.effectiveBalanceIncrements,
         equivocatingIndices: new Set(),
+        setPtcQuorumPayloadTimely: () => {},
+        setPtcQuorumDataAvailable: () => {},
       };
       forkchoice = new ForkChoice(originalState.config, fcStore, protoArray, originalState.validators.length, null);
     },

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -950,12 +950,13 @@ export class ForkChoice implements IForkChoice {
     if (votes === null) {
       return;
     }
+    const {payloadTimelyYea, payloadTimelyNay, dataAvailableYea, dataAvailableNay} = votes;
+
     const newVotes = this.protoArray.notifyPtcMessages(blockRoot, ptcIndices, payloadPresent, dataAvailable);
     if (newVotes === null) {
       return;
     }
 
-    const {payloadTimelyYea, payloadTimelyNay, dataAvailableYea, dataAvailableNay} = votes;
     const {
       payloadTimelyYea: newPayloadTimelyYea,
       payloadTimelyNay: newPayloadTimelyNay,

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -944,8 +944,15 @@ export class ForkChoice implements IForkChoice {
    * Updates the PTC votes for multiple validators attesting to a block
    * Spec: gloas/fork-choice.md#new-on_payload_attestation_message
    */
-  notifyPtcMessages(blockRoot: RootHex, ptcIndices: number[], payloadPresent: boolean): void {
-    this.protoArray.notifyPtcMessages(blockRoot, ptcIndices, payloadPresent);
+  notifyPtcMessages(blockRoot: RootHex, ptcIndices: number[], payloadPresent: boolean, dataAvailable: boolean): void {
+    const newQuorums = this.protoArray.notifyPtcMessages(blockRoot, ptcIndices, payloadPresent, dataAvailable);
+
+    if (newQuorums.payloadTimely !== null) {
+      this.fcStore.setPtcQuorumPayloadTimely(blockRoot, newQuorums.payloadTimely);
+    }
+    if (newQuorums.dataAvailable !== null) {
+      this.fcStore.setPtcQuorumDataAvailable(blockRoot, newQuorums.dataAvailable);
+    }
   }
 
   /**

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -35,6 +35,7 @@ import {
   HEX_ZERO_HASH,
   LVHExecResponse,
   NULL_VOTE_INDEX,
+  PTCVotes,
   PayloadExecutionStatus,
   PayloadStatus,
   ProtoBlock,
@@ -42,7 +43,7 @@ import {
   VoteIndex,
   isGloasBlock,
 } from "../protoArray/interface.js";
-import {ProtoArray} from "../protoArray/protoArray.js";
+import {DATA_AVAILABILITY_TIMELY_THRESHOLD, PAYLOAD_TIMELY_THRESHOLD, ProtoArray} from "../protoArray/protoArray.js";
 import {ForkChoiceError, ForkChoiceErrorCode, InvalidAttestationCode, InvalidBlockCode} from "./errors.js";
 import {
   AncestorResult,
@@ -945,13 +946,43 @@ export class ForkChoice implements IForkChoice {
    * Spec: gloas/fork-choice.md#new-on_payload_attestation_message
    */
   notifyPtcMessages(blockRoot: RootHex, ptcIndices: number[], payloadPresent: boolean, dataAvailable: boolean): void {
-    const newQuorums = this.protoArray.notifyPtcMessages(blockRoot, ptcIndices, payloadPresent, dataAvailable);
-
-    if (newQuorums.payloadTimely !== null) {
-      this.fcStore.setPtcQuorumPayloadTimely(blockRoot, newQuorums.payloadTimely);
+    const votes = this.protoArray.getPTCVotes(blockRoot);
+    if (votes === null) {
+      return;
     }
-    if (newQuorums.dataAvailable !== null) {
-      this.fcStore.setPtcQuorumDataAvailable(blockRoot, newQuorums.dataAvailable);
+    const newVotes = this.protoArray.notifyPtcMessages(blockRoot, ptcIndices, payloadPresent, dataAvailable);
+    if (newVotes === null) {
+      return;
+    }
+
+    const {payloadTimelyYea, payloadTimelyNay, dataAvailableYea, dataAvailableNay} = votes;
+    const {
+      payloadTimelyYea: newPayloadTimelyYea,
+      payloadTimelyNay: newPayloadTimelyNay,
+      dataAvailableYea: newDataAvailableYea,
+      dataAvailableNay: newDataAvailableNay,
+    } = newVotes;
+
+    if (payloadTimelyYea <= PAYLOAD_TIMELY_THRESHOLD && newPayloadTimelyYea > PAYLOAD_TIMELY_THRESHOLD) {
+      this.fcStore.setPtcQuorumPayloadTimely(blockRoot, true);
+    }
+
+    if (payloadTimelyNay <= PAYLOAD_TIMELY_THRESHOLD && newPayloadTimelyNay > PAYLOAD_TIMELY_THRESHOLD) {
+      this.fcStore.setPtcQuorumPayloadTimely(blockRoot, false);
+    }
+
+    if (
+      dataAvailableYea <= DATA_AVAILABILITY_TIMELY_THRESHOLD &&
+      newDataAvailableYea > DATA_AVAILABILITY_TIMELY_THRESHOLD
+    ) {
+      this.fcStore.setPtcQuorumDataAvailable(blockRoot, true);
+    }
+
+    if (
+      dataAvailableNay <= DATA_AVAILABILITY_TIMELY_THRESHOLD &&
+      newDataAvailableNay > DATA_AVAILABILITY_TIMELY_THRESHOLD
+    ) {
+      this.fcStore.setPtcQuorumDataAvailable(blockRoot, false);
     }
   }
 
@@ -1060,10 +1091,8 @@ export class ForkChoice implements IForkChoice {
     return this.protoArray.hasPayload(blockRoot);
   }
 
-  getPTCVotes(blockRootHex: RootHex): (boolean | null)[] | null {
-    const votes = this.protoArray.getPTCVotes(blockRootHex);
-    if (votes === null) return null;
-    return votes.toBoolArray().map((v) => v ?? null);
+  getPTCVotes(blockRootHex: RootHex): PTCVotes | null {
+    return this.protoArray.getPTCVotes(blockRootHex);
   }
 
   /**

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -185,8 +185,9 @@ export interface IForkChoice {
    * @param blockRoot - The beacon block root being attested
    * @param ptcIndices - Array of PTC committee indices that voted
    * @param payloadPresent - Whether validators attest the payload is present
+   * @param dataAvailable - Whether validators attest the data is available
    */
-  notifyPtcMessages(blockRoot: RootHex, ptcIndices: number[], payloadPresent: boolean): void;
+  notifyPtcMessages(blockRoot: RootHex, ptcIndices: number[], payloadPresent: boolean, dataAvailable: boolean): void;
   /**
    * Notify fork choice that an execution payload has arrived (Gloas fork)
    * Creates the FULL variant of a Gloas block when the payload becomes available

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -3,6 +3,7 @@ import {AttesterSlashing, BeaconBlock, Epoch, IndexedAttestation, Root, RootHex,
 import {
   BlockExecutionStatus,
   LVHExecResponse,
+  PTCVotes,
   PayloadExecutionStatus,
   PayloadStatus,
   ProtoBlock,
@@ -233,7 +234,7 @@ export interface IForkChoice {
   hasPayloadUnsafe(blockRoot: Root): boolean;
   hasPayloadHexUnsafe(blockRoot: RootHex): boolean;
   getSlotsPresent(windowStart: number): number;
-  getPTCVotes(blockRootHex: RootHex): (boolean | null)[] | null;
+  getPTCVotes(blockRootHex: RootHex): PTCVotes | null;
   /**
    * Returns a `ProtoBlock` if the block is known **and** a descendant of the finalized root.
    */

--- a/packages/fork-choice/src/forkChoice/store.ts
+++ b/packages/fork-choice/src/forkChoice/store.ts
@@ -44,6 +44,8 @@ export interface IForkChoiceStore {
   unrealizedFinalizedCheckpoint: CheckpointWithHex;
   justifiedBalancesGetter: JustifiedBalancesGetter;
   equivocatingIndices: Set<ValidatorIndex>;
+  setPtcQuorumPayloadTimely(blockRoot: RootHex, payloadTimely: boolean): void;
+  setPtcQuorumDataAvailable(blockRoot: RootHex, dataAvailable: boolean): void;
 }
 
 /**
@@ -67,6 +69,8 @@ export class ForkChoiceStore implements IForkChoiceStore {
     private readonly events?: {
       onJustified: (cp: CheckpointWithHex) => void;
       onFinalized: (cp: CheckpointWithHex) => void;
+      onPTCQuorumPayloadTimely: (blockRoot: RootHex, payloadTimely: boolean) => void;
+      onPTCQuorumDataAvailable: (blockRoot: RootHex, dataAvailable: boolean) => void;
     }
   ) {
     this.justifiedBalancesGetter = justifiedBalancesGetter;
@@ -97,6 +101,14 @@ export class ForkChoiceStore implements IForkChoiceStore {
     const cp = toCheckpointWithHex(checkpoint);
     this._finalizedCheckpoint = cp;
     this.events?.onFinalized(cp);
+  }
+
+  setPtcQuorumPayloadTimely(blockRoot: RootHex, payloadTimely: boolean) {
+    this.events?.onPTCQuorumPayloadTimely(blockRoot, payloadTimely);
+  }
+
+  setPtcQuorumDataAvailable(blockRoot: RootHex, dataAvailable: boolean) {
+    this.events?.onPTCQuorumDataAvailable(blockRoot, dataAvailable);
   }
 }
 

--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -29,6 +29,7 @@ export type {
   BlockExtraMeta,
   LVHInvalidResponse,
   LVHValidResponse,
+  PTCVotes,
   PayloadExecutionStatus,
   ProtoBlock,
   ProtoNode,

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -1,3 +1,4 @@
+import {BitArray} from "@chainsafe/ssz";
 import {DataAvailabilityStatus} from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot, UintNum64} from "@lodestar/types";
 
@@ -154,4 +155,20 @@ export type ProtoNode = ProtoBlock & {
   weight: number;
   bestChild?: number;
   bestDescendant?: number;
+};
+
+/**
+ * type to track PTC votes
+ *
+ * true means quorum of yea,
+ * false means quorum of nay,
+ * null means not enough votes
+ */
+export type PTCQuorum = boolean | null;
+export type PTCVotes = {
+  votes: BitArray;
+  payloadTimelyYea: number;
+  payloadTimelyNay: number;
+  dataAvailableYea: number;
+  dataAvailableNay: number;
 };

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -69,12 +69,12 @@ export class ProtoArray {
   private previousProposerBoost: ProposerBoost | null = null;
 
   /**
-   * PTC (Payload Timeliness Committee) votes per block as yea/nay bitvectors.
-   * Maps block root to BitArrays of PTC_SIZE bits (512 mainnet, 2 minimal)
+   * PTC (Payload Timeliness Committee) votes per block as one observed-vote bitvector plus yea/nay counters.
+   * Maps block root to PTC vote tracking for PTC_SIZE members (512 mainnet, 2 minimal)
    * Spec: gloas/fork-choice.md#modified-store (line 148)
    *
-   * Bit i is set in the matching 0/1 bitvector for an observed PTC message.
-   * Equivocation is not resolved here; once a quorum is cached, later contradictory messages do not replace it.
+   * Bit i is set once an observed PTC message from member i has been counted.
+   * Equivocation is not resolved here; later contradictory messages from the same member are ignored.
    * Used by is_payload_timely() and is_payload_data_available()
    */
   private ptcVotes = new Map<RootHex, PTCVotes>();
@@ -640,8 +640,7 @@ export class ProtoArray {
    * @param payloadTimely - Whether the validators attest the payload is timely
    * @param dataAvailable - Whether the validators attest the data is available
    *
-   * @returns An object containing _new_ quorum of payloadTimely and dataAvailable
-   * This will only return a boolean if the quorum has changed.
+   * @returns The updated vote counts, or null when the block is unknown or pre-Gloas.
    */
   notifyPtcMessages(
     blockRoot: RootHex,
@@ -655,7 +654,7 @@ export class ProtoArray {
       return null;
     }
 
-    const payloadTimelyKey = payloadTimely ? "payloadTimelyYea" : "payloadTimelyYea";
+    const payloadTimelyKey = payloadTimely ? "payloadTimelyYea" : "payloadTimelyNay";
     const dataAvailableKey = dataAvailable ? "dataAvailableYea" : "dataAvailableNay";
 
     for (const ptcIndex of ptcIndices) {

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -2,13 +2,14 @@ import {BitArray} from "@chainsafe/ssz";
 import {GENESIS_EPOCH, PTC_SIZE} from "@lodestar/params";
 import {DataAvailabilityStatus, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot} from "@lodestar/types";
-import {bitCount, toRootHex} from "@lodestar/utils";
+import {toRootHex} from "@lodestar/utils";
 import {ForkChoiceError, ForkChoiceErrorCode} from "../forkChoice/errors.js";
 import {LVHExecError, LVHExecErrorCode, ProtoArrayError, ProtoArrayErrorCode} from "./errors.js";
 import {
   ExecutionStatus,
   HEX_ZERO_HASH,
   LVHExecResponse,
+  PTCVotes,
   PayloadExecutionStatus,
   PayloadStatus,
   ProtoBlock,
@@ -20,22 +21,13 @@ import {
  * Threshold for payload timeliness (>50% of PTC must vote)
  * Spec: gloas/fork-choice.md (PAYLOAD_TIMELY_THRESHOLD = PTC_SIZE // 2)
  */
-const PAYLOAD_TIMELY_THRESHOLD = Math.floor(PTC_SIZE / 2);
+export const PAYLOAD_TIMELY_THRESHOLD = Math.floor(PTC_SIZE / 2);
 
 /**
  * Threshold for data availability (>50% of PTC must vote)
  * Spec: gloas/fork-choice.md (DATA_AVAILABILITY_TIMELY_THRESHOLD = PTC_SIZE // 2)
  */
-const DATA_AVAILABILITY_TIMELY_THRESHOLD = Math.floor(PTC_SIZE / 2);
-
-/**
- * type to track PTC votes
- *
- * true means quorum of yea,
- * false means quorum of nay,
- * null means not enough votes
- */
-type Quorum = boolean | null;
+export const DATA_AVAILABILITY_TIMELY_THRESHOLD = Math.floor(PTC_SIZE / 2);
 
 export const DEFAULT_PRUNE_THRESHOLD = 0;
 type ProposerBoost = {root: RootHex; score: number};
@@ -77,28 +69,15 @@ export class ProtoArray {
   private previousProposerBoost: ProposerBoost | null = null;
 
   /**
-   * PTC (Payload Timeliness Committee) votes per block as bitvectors
-   * Maps block root to BitArray of PTC_SIZE bits (512 mainnet, 2 minimal)
+   * PTC (Payload Timeliness Committee) votes per block as yea/nay bitvectors.
+   * Maps block root to BitArrays of PTC_SIZE bits (512 mainnet, 2 minimal)
    * Spec: gloas/fork-choice.md#modified-store (line 148)
    *
-   * Bit i is set if PTC member i voted payload_present=true
+   * Bit i is set in the matching 0/1 bitvector for an observed PTC message.
+   * Equivocation is not resolved here; once a quorum is cached, later contradictory messages do not replace it.
    * Used by is_payload_timely() and is_payload_data_available()
    */
-  private ptcVotes = new Map<
-    RootHex,
-    {
-      payloadTimely: {
-        0: BitArray;
-        1: BitArray;
-        quorum: Quorum;
-      };
-      dataAvailable: {
-        0: BitArray;
-        1: BitArray;
-        quorum: Quorum;
-      };
-    }
-  >();
+  private ptcVotes = new Map<RootHex, PTCVotes>();
 
   constructor({
     pruneThreshold,
@@ -536,16 +515,11 @@ export class ProtoArray {
       // Initialize PTC votes for this block (all false initially)
       // Spec: gloas/fork-choice.md#modified-on_block (line 645)
       this.ptcVotes.set(block.blockRoot, {
-        payloadTimely: {
-          0: BitArray.fromBitLen(PTC_SIZE),
-          1: BitArray.fromBitLen(PTC_SIZE),
-          quorum: null,
-        },
-        dataAvailable: {
-          0: BitArray.fromBitLen(PTC_SIZE),
-          1: BitArray.fromBitLen(PTC_SIZE),
-          quorum: null,
-        },
+        votes: BitArray.fromBitLen(PTC_SIZE),
+        payloadTimelyYea: 0,
+        payloadTimelyNay: 0,
+        dataAvailableYea: 0,
+        dataAvailableNay: 0,
       });
     } else {
       // Pre-Gloas: Only create FULL node (payload embedded in block)
@@ -663,7 +637,7 @@ export class ProtoArray {
    *
    * @param blockRoot - The beacon block root being attested
    * @param ptcIndices - Array of PTC committee indices that voted (0..PTC_SIZE-1)
-   * @param payloadPresent - Whether the validators attest the payload is present
+   * @param payloadTimely - Whether the validators attest the payload is timely
    * @param dataAvailable - Whether the validators attest the data is available
    *
    * @returns An object containing _new_ quorum of payloadTimely and dataAvailable
@@ -672,51 +646,36 @@ export class ProtoArray {
   notifyPtcMessages(
     blockRoot: RootHex,
     ptcIndices: number[],
-    payloadPresent: boolean,
+    payloadTimely: boolean,
     dataAvailable: boolean
-  ): {payloadTimely: Quorum; dataAvailable: Quorum} {
+  ): PTCVotes | null {
     const votes = this.ptcVotes.get(blockRoot);
-    const newQuorums: {
-      payloadTimely: Quorum;
-      dataAvailable: Quorum;
-    } = {
-      payloadTimely: null,
-      dataAvailable: null,
-    };
     if (votes === undefined) {
       // Block not found or not a Gloas block, ignore
-      return newQuorums;
+      return null;
     }
-    const payloadPresentKey = payloadPresent ? 1 : 0;
-    const dataAvailableKey = dataAvailable ? 1 : 0;
+
+    const payloadTimelyKey = payloadTimely ? "payloadTimelyYea" : "payloadTimelyYea";
+    const dataAvailableKey = dataAvailable ? "dataAvailableYea" : "dataAvailableNay";
 
     for (const ptcIndex of ptcIndices) {
       if (ptcIndex < 0 || ptcIndex >= PTC_SIZE) {
         throw new Error(`Invalid PTC index: ${ptcIndex}, must be 0..${PTC_SIZE - 1}`);
       }
 
-      votes.payloadTimely[payloadPresentKey].set(ptcIndex, true);
-      votes.dataAvailable[dataAvailableKey].set(ptcIndex, true);
+      if (votes.votes.get(ptcIndex)) {
+        continue;
+      }
+      votes.votes.set(ptcIndex, true);
+
+      votes[payloadTimelyKey]++;
+      votes[dataAvailableKey]++;
     }
 
-    if (
-      votes.payloadTimely.quorum === null &&
-      bitCount(votes.payloadTimely[payloadPresentKey].uint8Array) > PAYLOAD_TIMELY_THRESHOLD
-    ) {
-      votes.payloadTimely.quorum = newQuorums.payloadTimely = payloadPresent;
-    }
-
-    if (
-      votes.dataAvailable.quorum === null &&
-      bitCount(votes.dataAvailable[dataAvailableKey].uint8Array) > DATA_AVAILABILITY_TIMELY_THRESHOLD
-    ) {
-      votes.dataAvailable.quorum = newQuorums.dataAvailable = dataAvailable;
-    }
-
-    return newQuorums;
+    return votes;
   }
 
-  getPTCVotes(blockRootHex: RootHex): BitArray | null {
+  getPTCVotes(blockRootHex: RootHex): PTCVotes | null {
     const votes = this.ptcVotes.get(blockRootHex);
     if (votes === undefined) {
       // Block not found or not a Gloas block
@@ -750,7 +709,7 @@ export class ProtoArray {
     }
 
     // Count votes for payload_present=true
-    return votes.payloadTimely.quorum === true;
+    return votes.payloadTimelyYea > PAYLOAD_TIMELY_THRESHOLD;
   }
 
   /**
@@ -777,7 +736,7 @@ export class ProtoArray {
     }
 
     // Count votes for data_available=true
-    return votes.dataAvailable.quorum === true;
+    return votes.dataAvailableYea > DATA_AVAILABILITY_TIMELY_THRESHOLD;
   }
 
   /**
@@ -795,7 +754,7 @@ export class ProtoArray {
    * Spec: gloas/fork-choice.md#new-should_extend_payload
    *
    * Returns true if payload is verified (FULL variant exists) AND:
-   * 1. Payload is timely, OR
+   * 1. Payload is timely and blob data is available according to PTC, OR
    * 2. No proposer boost root (empty/zero hash), OR
    * 3. Proposer boost root's parent is not this block, OR
    * 4. Proposer boost root extends FULL parent
@@ -808,8 +767,8 @@ export class ProtoArray {
       return false;
     }
 
-    // Condition 1: Payload is timely
-    if (this.isPayloadTimely(blockRoot)) {
+    // Condition 1: Payload is timely and data is available
+    if (this.isPayloadTimely(blockRoot) && this.isDataAvailable(blockRoot)) {
       return true;
     }
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -22,6 +22,21 @@ import {
  */
 const PAYLOAD_TIMELY_THRESHOLD = Math.floor(PTC_SIZE / 2);
 
+/**
+ * Threshold for data availability (>50% of PTC must vote)
+ * Spec: gloas/fork-choice.md (DATA_AVAILABILITY_TIMELY_THRESHOLD = PTC_SIZE // 2)
+ */
+const DATA_AVAILABILITY_TIMELY_THRESHOLD = Math.floor(PTC_SIZE / 2);
+
+/**
+ * type to track PTC votes
+ *
+ * true means quorum of yea,
+ * false means quorum of nay,
+ * null means not enough votes
+ */
+type Quorum = boolean | null;
+
 export const DEFAULT_PRUNE_THRESHOLD = 0;
 type ProposerBoost = {root: RootHex; score: number};
 
@@ -67,9 +82,23 @@ export class ProtoArray {
    * Spec: gloas/fork-choice.md#modified-store (line 148)
    *
    * Bit i is set if PTC member i voted payload_present=true
-   * Used by is_payload_timely() to determine if payload is timely
+   * Used by is_payload_timely() and is_payload_data_available()
    */
-  private ptcVotes = new Map<RootHex, BitArray>();
+  private ptcVotes = new Map<
+    RootHex,
+    {
+      payloadTimely: {
+        0: BitArray;
+        1: BitArray;
+        quorum: Quorum;
+      };
+      dataAvailable: {
+        0: BitArray;
+        1: BitArray;
+        quorum: Quorum;
+      };
+    }
+  >();
 
   constructor({
     pruneThreshold,
@@ -506,7 +535,18 @@ export class ProtoArray {
 
       // Initialize PTC votes for this block (all false initially)
       // Spec: gloas/fork-choice.md#modified-on_block (line 645)
-      this.ptcVotes.set(block.blockRoot, BitArray.fromBitLen(PTC_SIZE));
+      this.ptcVotes.set(block.blockRoot, {
+        payloadTimely: {
+          0: BitArray.fromBitLen(PTC_SIZE),
+          1: BitArray.fromBitLen(PTC_SIZE),
+          quorum: null,
+        },
+        dataAvailable: {
+          0: BitArray.fromBitLen(PTC_SIZE),
+          1: BitArray.fromBitLen(PTC_SIZE),
+          quorum: null,
+        },
+      });
     } else {
       // Pre-Gloas: Only create FULL node (payload embedded in block)
       const node: ProtoNode = {
@@ -622,21 +662,56 @@ export class ProtoArray {
    * @param blockRoot - The beacon block root being attested
    * @param ptcIndices - Array of PTC committee indices that voted (0..PTC_SIZE-1)
    * @param payloadPresent - Whether the validators attest the payload is present
+   * @param dataAvailable - Whether the validators attest the data is available
+   *
+   * @returns An object containing _new_ quorum of payloadTimely and dataAvailable
+   * This will only return a boolean if the quorum has changed.
    */
-  notifyPtcMessages(blockRoot: RootHex, ptcIndices: number[], payloadPresent: boolean): void {
+  notifyPtcMessages(
+    blockRoot: RootHex,
+    ptcIndices: number[],
+    payloadPresent: boolean,
+    dataAvailable: boolean
+  ): {payloadTimely: Quorum; dataAvailable: Quorum} {
     const votes = this.ptcVotes.get(blockRoot);
+    const newQuorums: {
+      payloadTimely: Quorum;
+      dataAvailable: Quorum;
+    } = {
+      payloadTimely: null,
+      dataAvailable: null,
+    };
     if (votes === undefined) {
       // Block not found or not a Gloas block, ignore
-      return;
+      return newQuorums;
     }
+    const payloadPresentKey = payloadPresent ? 1 : 0;
+    const dataAvailableKey = dataAvailable ? 1 : 0;
 
     for (const ptcIndex of ptcIndices) {
       if (ptcIndex < 0 || ptcIndex >= PTC_SIZE) {
         throw new Error(`Invalid PTC index: ${ptcIndex}, must be 0..${PTC_SIZE - 1}`);
       }
 
-      votes.set(ptcIndex, payloadPresent);
+      votes.payloadTimely[payloadPresentKey].set(ptcIndex, true);
+      votes.dataAvailable[dataAvailableKey].set(ptcIndex, true);
     }
+
+    if (
+      votes.payloadTimely.quorum === null &&
+      bitCount(votes.payloadTimely[payloadPresentKey].uint8Array) > PAYLOAD_TIMELY_THRESHOLD
+    ) {
+      votes.payloadTimely.quorum = newQuorums.payloadTimely = payloadPresent;
+    }
+
+    if (
+      votes.dataAvailable.quorum === null &&
+      bitCount(votes.dataAvailable[dataAvailableKey].uint8Array) > DATA_AVAILABILITY_TIMELY_THRESHOLD
+    ) {
+      votes.dataAvailable.quorum = newQuorums.dataAvailable = dataAvailable;
+    }
+
+    return newQuorums;
   }
 
   /**
@@ -663,8 +738,34 @@ export class ProtoArray {
     }
 
     // Count votes for payload_present=true
-    const yesVotes = bitCount(votes.uint8Array);
-    return yesVotes > PAYLOAD_TIMELY_THRESHOLD;
+    return votes.payloadTimely.quorum === true;
+  }
+
+  /**
+   * Check if execution payload for a block has data available
+   * Spec: gloas/fork-choice.md#new-is_payload_data_available
+   *
+   * Returns true if:
+   * 1. Block has PTC votes tracked
+   * 2. Payload is locally available (FULL variant exists in proto array)
+   * 3. More than DATA_AVAILABILITY_TIMELY_THRESHOLD (>50% of PTC) members voted data_available=true
+   *
+   * @param blockRoot - The beacon block root to check
+   */
+  isDataAvailable(blockRoot: RootHex): boolean {
+    const votes = this.ptcVotes.get(blockRoot);
+    if (votes === undefined) {
+      // Block not found or not a Gloas block
+      return false;
+    }
+
+    // If payload is not locally available, the data is not available
+    if (!this.hasPayload(blockRoot)) {
+      return false;
+    }
+
+    // Count votes for data_available=true
+    return votes.dataAvailable.quorum === true;
   }
 
   /**

--- a/packages/fork-choice/test/perf/forkChoice/util.ts
+++ b/packages/fork-choice/test/perf/forkChoice/util.ts
@@ -78,6 +78,8 @@ export function initializeForkChoice(opts: Opts): ForkChoice {
     },
     justifiedBalancesGetter: () => balances,
     equivocatingIndices: new Set(Array.from({length: opts.initialEquivocatedCount}, (_, i) => i)),
+    setPtcQuorumPayloadTimely: () => {},
+    setPtcQuorumDataAvailable: () => {},
   };
 
   const forkchoice = new ForkChoice(config, fcStore, protoArr, opts.initialValidatorCount, null);

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -83,6 +83,8 @@ describe("Forkchoice", () => {
     },
     justifiedBalancesGetter: () => new Uint16Array([32]),
     equivocatingIndices: new Set(),
+    setPtcQuorumPayloadTimely: () => {},
+    setPtcQuorumDataAvailable: () => {},
   };
 
   const getParentBlockRoot = (slot: number, skippedSlots: number[] = []): RootHex => {

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -140,6 +140,8 @@ describe("Forkchoice / GetProposerHead", () => {
     },
     justifiedBalancesGetter: () => new Uint16Array(Array(32).fill(150)),
     equivocatingIndices: new Set(),
+    setPtcQuorumPayloadTimely: () => {},
+    setPtcQuorumDataAvailable: () => {},
   };
 
   // head block's weight < 30 is considered weak. parent block's total weight > 240 is considered strong

--- a/packages/fork-choice/test/unit/forkChoice/shouldOverrideForkChoiceUpdate.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/shouldOverrideForkChoiceUpdate.test.ts
@@ -140,6 +140,8 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
     },
     justifiedBalancesGetter: () => new Uint16Array(Array(32).fill(150)),
     equivocatingIndices: new Set(),
+    setPtcQuorumPayloadTimely: () => {},
+    setPtcQuorumDataAvailable: () => {},
   };
 
   const testCases: {

--- a/packages/fork-choice/test/unit/protoArray/gloas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/gloas.test.ts
@@ -2,7 +2,7 @@ import {beforeEach, describe, expect, it} from "vitest";
 import {PTC_SIZE} from "@lodestar/params";
 import {DataAvailabilityStatus, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {RootHex} from "@lodestar/types";
-import {ExecutionStatus, PayloadStatus, ProtoArray, ProtoBlock, ProtoNode} from "../../../src/index.js";
+import {ExecutionStatus, type PTCVotes, PayloadStatus, ProtoArray, ProtoBlock, ProtoNode} from "../../../src/index.js";
 
 describe("Gloas Fork Choice", () => {
   const genesisEpoch = 0;
@@ -62,6 +62,34 @@ describe("Gloas Fork Choice", () => {
 
   function getNonQuorumIndices(): number[] {
     return Array.from({length: Math.floor(PTC_SIZE / 2)}, (_, i) => i);
+  }
+
+  function expectPtcVotes(
+    votes: PTCVotes | null,
+    expected: {
+      payloadTimelyYea: number;
+      payloadTimelyNay: number;
+      dataAvailableYea: number;
+      dataAvailableNay: number;
+      votedCount: number;
+    }
+  ): void {
+    if (votes === null) {
+      throw new Error("Expected PTC votes");
+    }
+
+    expect(votes.payloadTimelyYea).toBe(expected.payloadTimelyYea);
+    expect(votes.payloadTimelyNay).toBe(expected.payloadTimelyNay);
+    expect(votes.dataAvailableYea).toBe(expected.dataAvailableYea);
+    expect(votes.dataAvailableNay).toBe(expected.dataAvailableNay);
+
+    let votedCount = 0;
+    for (let i = 0; i < PTC_SIZE; i++) {
+      if (votes.votes.get(i)) {
+        votedCount++;
+      }
+    }
+    expect(votedCount).toBe(expected.votedCount);
   }
 
   describe("ProtoArray indices lookup", () => {
@@ -405,10 +433,16 @@ describe("Gloas Fork Choice", () => {
 
       // Vote yes from validators below the quorum threshold
       const indices = Array.from({length: Math.min(3, Math.floor(PTC_SIZE / 2))}, (_, i) => i);
-      const quorums = protoArray.notifyPtcMessages("0x02", indices, true, true);
+      const votes = protoArray.notifyPtcMessages("0x02", indices, true, true);
 
       // Still not timely (need >50% of PTC_SIZE)
-      expect(quorums).toEqual({payloadTimely: null, dataAvailable: null});
+      expectPtcVotes(votes, {
+        payloadTimelyYea: indices.length,
+        payloadTimelyNay: 0,
+        dataAvailableYea: indices.length,
+        dataAvailableNay: 0,
+        votedCount: indices.length,
+      });
       expect(protoArray.isPayloadTimely("0x02")).toBe(false);
     });
 
@@ -456,10 +490,16 @@ describe("Gloas Fork Choice", () => {
 
       // Vote yes from majority of PTC (>50%)
       const indices = getQuorumIndices();
-      const quorums = protoArray.notifyPtcMessages("0x02", indices, true, true);
+      const votes = protoArray.notifyPtcMessages("0x02", indices, true, true);
 
       // Should now be timely
-      expect(quorums).toEqual({payloadTimely: true, dataAvailable: true});
+      expectPtcVotes(votes, {
+        payloadTimelyYea: indices.length,
+        payloadTimelyNay: 0,
+        dataAvailableYea: indices.length,
+        dataAvailableNay: 0,
+        votedCount: indices.length,
+      });
       expect(protoArray.isPayloadTimely("0x02")).toBe(true);
       expect(protoArray.isDataAvailable("0x02")).toBe(true);
     });
@@ -481,9 +521,15 @@ describe("Gloas Fork Choice", () => {
       protoArray.onBlock(proposerBoostBlock, gloasForkSlot + 1, "0x03Root");
 
       const indices = getQuorumIndices();
-      const quorums = protoArray.notifyPtcMessages("0x02Root", indices, true, false);
+      const votes = protoArray.notifyPtcMessages("0x02Root", indices, true, false);
 
-      expect(quorums).toEqual({payloadTimely: true, dataAvailable: false});
+      expectPtcVotes(votes, {
+        payloadTimelyYea: indices.length,
+        payloadTimelyNay: 0,
+        dataAvailableYea: 0,
+        dataAvailableNay: indices.length,
+        votedCount: indices.length,
+      });
       expect(protoArray.isPayloadTimely("0x02Root")).toBe(true);
       expect(protoArray.isDataAvailable("0x02Root")).toBe(false);
       expect(protoArray.shouldExtendPayload("0x02Root", "0x03Root")).toBe(false);
@@ -505,9 +551,16 @@ describe("Gloas Fork Choice", () => {
       const proposerBoostBlock = createTestBlock(gloasForkSlot + 1, "0x03Root", "0x02Root", "0x02Root");
       protoArray.onBlock(proposerBoostBlock, gloasForkSlot + 1, "0x03Root");
 
-      const quorums = protoArray.notifyPtcMessages("0x02Root", getQuorumIndices(), true, true);
+      const indices = getQuorumIndices();
+      const votes = protoArray.notifyPtcMessages("0x02Root", indices, true, true);
 
-      expect(quorums).toEqual({payloadTimely: true, dataAvailable: true});
+      expectPtcVotes(votes, {
+        payloadTimelyYea: indices.length,
+        payloadTimelyNay: 0,
+        dataAvailableYea: indices.length,
+        dataAvailableNay: 0,
+        votedCount: indices.length,
+      });
       expect(protoArray.isPayloadTimely("0x02Root")).toBe(true);
       expect(protoArray.isDataAvailable("0x02Root")).toBe(true);
       expect(protoArray.shouldExtendPayload("0x02Root", "0x03Root")).toBe(true);
@@ -529,10 +582,17 @@ describe("Gloas Fork Choice", () => {
       );
 
       // Vote yes from exactly 50% (not >50%)
-      const quorums = protoArray.notifyPtcMessages("0x02", getNonQuorumIndices(), true, true);
+      const indices = getNonQuorumIndices();
+      const votes = protoArray.notifyPtcMessages("0x02", indices, true, true);
 
       // Should not be timely (need >50%, not >=50%)
-      expect(quorums).toEqual({payloadTimely: null, dataAvailable: null});
+      expectPtcVotes(votes, {
+        payloadTimelyYea: indices.length,
+        payloadTimelyNay: 0,
+        dataAvailableYea: indices.length,
+        dataAvailableNay: 0,
+        votedCount: indices.length,
+      });
       expect(protoArray.isPayloadTimely("0x02")).toBe(false);
       expect(protoArray.isDataAvailable("0x02")).toBe(false);
     });
@@ -552,10 +612,46 @@ describe("Gloas Fork Choice", () => {
         DataAvailabilityStatus.Available
       );
 
-      const quorums = protoArray.notifyPtcMessages("0x02", getQuorumIndices(), false, true);
+      const indices = getQuorumIndices();
+      const votes = protoArray.notifyPtcMessages("0x02", indices, false, true);
 
-      expect(quorums).toEqual({payloadTimely: false, dataAvailable: true});
+      expectPtcVotes(votes, {
+        payloadTimelyYea: 0,
+        payloadTimelyNay: indices.length,
+        dataAvailableYea: indices.length,
+        dataAvailableNay: 0,
+        votedCount: indices.length,
+      });
       expect(protoArray.isPayloadTimely("0x02")).toBe(false);
+      expect(protoArray.isDataAvailable("0x02")).toBe(true);
+    });
+
+    it("does not treat later opposite PTC messages as vote changes", () => {
+      const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
+      protoArray.onBlock(block, gloasForkSlot, null);
+
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
+
+      const indices = getQuorumIndices();
+      protoArray.notifyPtcMessages("0x02", indices, true, true);
+      const votes = protoArray.notifyPtcMessages("0x02", indices, false, false);
+
+      expectPtcVotes(votes, {
+        payloadTimelyYea: indices.length,
+        payloadTimelyNay: 0,
+        dataAvailableYea: indices.length,
+        dataAvailableNay: 0,
+        votedCount: indices.length,
+      });
+      expect(protoArray.isPayloadTimely("0x02")).toBe(true);
       expect(protoArray.isDataAvailable("0x02")).toBe(true);
     });
 

--- a/packages/fork-choice/test/unit/protoArray/gloas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/gloas.test.ts
@@ -23,7 +23,7 @@ describe("Gloas Fork Choice", () => {
   ): ProtoNode | undefined {
     const index = protoArray.getNodeIndexByRootAndStatus(blockRoot, payloadStatus);
     if (index === undefined) return undefined;
-    return (protoArray as any).nodes[index];
+    return protoArray.nodes[index];
   }
 
   function createTestBlock(
@@ -56,10 +56,18 @@ describe("Gloas Fork Choice", () => {
     };
   }
 
+  function getQuorumIndices(): number[] {
+    return Array.from({length: Math.floor(PTC_SIZE / 2) + 1}, (_, i) => i);
+  }
+
+  function getNonQuorumIndices(): number[] {
+    return Array.from({length: Math.floor(PTC_SIZE / 2)}, (_, i) => i);
+  }
+
   describe("ProtoArray indices lookup", () => {
     it("indices map stores variants correctly for pre-Gloas blocks", () => {
       const protoArray = ProtoArray.initialize(createTestBlock(0, genesisRoot, "0x00"), 0);
-      const variants = (protoArray as any).indices.get(genesisRoot);
+      const variants = protoArray.indices.get(genesisRoot);
       expect(variants).toBeDefined();
       // Pre-Gloas: variants is the FULL index
       expect(variants).toBe(0);
@@ -80,8 +88,11 @@ describe("Gloas Fork Choice", () => {
       const gloasBlock = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
       protoArray.onBlock(gloasBlock, gloasForkSlot, null);
 
-      const variants = (protoArray as any).indices.get("0x02");
+      const variants = protoArray.indices.get("0x02");
       expect(variants).toBeDefined();
+      if (!Array.isArray(variants)) {
+        throw new Error("Expected Gloas variants");
+      }
       // Gloas: variants[PENDING] and variants[EMPTY] should be defined
       expect(variants[PayloadStatus.PENDING]).toBeDefined();
       expect(variants[PayloadStatus.EMPTY]).toBeDefined();
@@ -392,10 +403,12 @@ describe("Gloas Fork Choice", () => {
       // Initially not timely (no votes)
       expect(protoArray.isPayloadTimely("0x02")).toBe(false);
 
-      // Vote yes from validators at indices 0, 1, 2
-      protoArray.notifyPtcMessages("0x02", [0, 1, 2], true);
+      // Vote yes from validators below the quorum threshold
+      const indices = Array.from({length: Math.min(3, Math.floor(PTC_SIZE / 2))}, (_, i) => i);
+      const quorums = protoArray.notifyPtcMessages("0x02", indices, true, true);
 
       // Still not timely (need >50% of PTC_SIZE)
+      expect(quorums).toEqual({payloadTimely: null, dataAvailable: null});
       expect(protoArray.isPayloadTimely("0x02")).toBe(false);
     });
 
@@ -403,15 +416,15 @@ describe("Gloas Fork Choice", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
       protoArray.onBlock(block, gloasForkSlot, null);
 
-      expect(() => protoArray.notifyPtcMessages("0x02", [-1], true)).toThrow(/Invalid PTC index/);
-      expect(() => protoArray.notifyPtcMessages("0x02", [PTC_SIZE], true)).toThrow(/Invalid PTC index/);
-      expect(() => protoArray.notifyPtcMessages("0x02", [PTC_SIZE + 1], true)).toThrow(/Invalid PTC index/);
-      expect(() => protoArray.notifyPtcMessages("0x02", [0, 1, PTC_SIZE], true)).toThrow(/Invalid PTC index/);
+      expect(() => protoArray.notifyPtcMessages("0x02", [-1], true, true)).toThrow(/Invalid PTC index/);
+      expect(() => protoArray.notifyPtcMessages("0x02", [PTC_SIZE], true, true)).toThrow(/Invalid PTC index/);
+      expect(() => protoArray.notifyPtcMessages("0x02", [PTC_SIZE + 1], true, true)).toThrow(/Invalid PTC index/);
+      expect(() => protoArray.notifyPtcMessages("0x02", [0, 1, PTC_SIZE], true, true)).toThrow(/Invalid PTC index/);
     });
 
     it("notifyPtcMessages() handles unknown block gracefully", () => {
       // Should not throw for unknown block
-      expect(() => protoArray.notifyPtcMessages("0x99", [0], true)).not.toThrow();
+      expect(() => protoArray.notifyPtcMessages("0x99", [0], true, true)).not.toThrow();
     });
 
     it("isPayloadTimely() returns false when payload not locally available", () => {
@@ -419,9 +432,8 @@ describe("Gloas Fork Choice", () => {
       protoArray.onBlock(block, gloasForkSlot, null);
 
       // Vote yes from majority of PTC
-      const threshold = Math.floor(PTC_SIZE / 2) + 1;
-      const indices = Array.from({length: threshold}, (_, i) => i);
-      protoArray.notifyPtcMessages("0x02", indices, true);
+      const indices = getQuorumIndices();
+      protoArray.notifyPtcMessages("0x02", indices, true, true);
 
       // Without execution payload (no FULL variant), should return false
       expect(protoArray.isPayloadTimely("0x02")).toBe(false);
@@ -443,12 +455,62 @@ describe("Gloas Fork Choice", () => {
       );
 
       // Vote yes from majority of PTC (>50%)
-      const threshold = Math.floor(PTC_SIZE / 2) + 1;
-      const indices = Array.from({length: threshold}, (_, i) => i);
-      protoArray.notifyPtcMessages("0x02", indices, true);
+      const indices = getQuorumIndices();
+      const quorums = protoArray.notifyPtcMessages("0x02", indices, true, true);
 
       // Should now be timely
+      expect(quorums).toEqual({payloadTimely: true, dataAvailable: true});
       expect(protoArray.isPayloadTimely("0x02")).toBe(true);
+      expect(protoArray.isDataAvailable("0x02")).toBe(true);
+    });
+
+    it("shouldExtendPayload() requires data availability quorum for timely payloads", () => {
+      const block = createTestBlock(gloasForkSlot, "0x02Root", genesisRoot, genesisRoot);
+      protoArray.onBlock(block, gloasForkSlot, null);
+      protoArray.onExecutionPayload(
+        "0x02Root",
+        gloasForkSlot,
+        "0x02FullHash",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
+
+      const proposerBoostBlock = createTestBlock(gloasForkSlot + 1, "0x03Root", "0x02Root", "0x02Root");
+      protoArray.onBlock(proposerBoostBlock, gloasForkSlot + 1, "0x03Root");
+
+      const indices = getQuorumIndices();
+      const quorums = protoArray.notifyPtcMessages("0x02Root", indices, true, false);
+
+      expect(quorums).toEqual({payloadTimely: true, dataAvailable: false});
+      expect(protoArray.isPayloadTimely("0x02Root")).toBe(true);
+      expect(protoArray.isDataAvailable("0x02Root")).toBe(false);
+      expect(protoArray.shouldExtendPayload("0x02Root", "0x03Root")).toBe(false);
+    });
+
+    it("shouldExtendPayload() extends when payload timely and data availability quorums are reached", () => {
+      const block = createTestBlock(gloasForkSlot, "0x02Root", genesisRoot, genesisRoot);
+      protoArray.onBlock(block, gloasForkSlot, null);
+      protoArray.onExecutionPayload(
+        "0x02Root",
+        gloasForkSlot,
+        "0x02FullHash",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
+
+      const proposerBoostBlock = createTestBlock(gloasForkSlot + 1, "0x03Root", "0x02Root", "0x02Root");
+      protoArray.onBlock(proposerBoostBlock, gloasForkSlot + 1, "0x03Root");
+
+      const quorums = protoArray.notifyPtcMessages("0x02Root", getQuorumIndices(), true, true);
+
+      expect(quorums).toEqual({payloadTimely: true, dataAvailable: true});
+      expect(protoArray.isPayloadTimely("0x02Root")).toBe(true);
+      expect(protoArray.isDataAvailable("0x02Root")).toBe(true);
+      expect(protoArray.shouldExtendPayload("0x02Root", "0x03Root")).toBe(true);
     });
 
     it("isPayloadTimely() returns false when threshold not met", () => {
@@ -467,15 +529,15 @@ describe("Gloas Fork Choice", () => {
       );
 
       // Vote yes from exactly 50% (not >50%)
-      const threshold = Math.floor(PTC_SIZE / 2);
-      const indices = Array.from({length: threshold}, (_, i) => i);
-      protoArray.notifyPtcMessages("0x02", indices, true);
+      const quorums = protoArray.notifyPtcMessages("0x02", getNonQuorumIndices(), true, true);
 
       // Should not be timely (need >50%, not >=50%)
+      expect(quorums).toEqual({payloadTimely: null, dataAvailable: null});
       expect(protoArray.isPayloadTimely("0x02")).toBe(false);
+      expect(protoArray.isDataAvailable("0x02")).toBe(false);
     });
 
-    it("isPayloadTimely() counts only 'true' votes", () => {
+    it("tracks payload timeliness and data availability quorums independently", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
       protoArray.onBlock(block, gloasForkSlot, null);
 
@@ -490,23 +552,11 @@ describe("Gloas Fork Choice", () => {
         DataAvailabilityStatus.Available
       );
 
-      // Vote mixed yes/no
-      const threshold = Math.floor(PTC_SIZE / 2) + 1;
-      // Vote yes from indices 0..threshold-1
-      const yesIndices = Array.from({length: threshold}, (_, i) => i);
-      protoArray.notifyPtcMessages("0x02", yesIndices, true);
-      // Vote no from indices threshold..PTC_SIZE-1
-      const noIndices = Array.from({length: PTC_SIZE - threshold}, (_, i) => i + threshold);
-      protoArray.notifyPtcMessages("0x02", noIndices, false);
+      const quorums = protoArray.notifyPtcMessages("0x02", getQuorumIndices(), false, true);
 
-      // Should be timely (threshold met)
-      expect(protoArray.isPayloadTimely("0x02")).toBe(true);
-
-      // Change some yes votes to no
-      protoArray.notifyPtcMessages("0x02", [0, 1], false);
-
-      // Should no longer be timely
+      expect(quorums).toEqual({payloadTimely: false, dataAvailable: true});
       expect(protoArray.isPayloadTimely("0x02")).toBe(false);
+      expect(protoArray.isDataAvailable("0x02")).toBe(true);
     });
 
     it("isPayloadTimely() returns false for unknown block", () => {
@@ -521,7 +571,7 @@ describe("Gloas Fork Choice", () => {
       expect(protoArray.isPayloadTimely("0x02")).toBe(false);
 
       // notifyPtcMessages should be no-op
-      expect(() => protoArray.notifyPtcMessages("0x02", [0], true)).not.toThrow();
+      expect(() => protoArray.notifyPtcMessages("0x02", [0], true, true)).not.toThrow();
     });
   });
 
@@ -816,7 +866,7 @@ describe("Gloas Fork Choice", () => {
       // Set PTC votes for block1
       const threshold = Math.floor(PTC_SIZE / 2) + 1;
       const indices = Array.from({length: threshold}, (_, i) => i);
-      protoArray.notifyPtcMessages("0x02", indices, true);
+      protoArray.notifyPtcMessages("0x02", indices, true, true);
 
       // Verify PTC votes are set
       expect(protoArray.isPayloadTimely("0x02")).toBe(true);


### PR DESCRIPTION
**Motivation**

- potentially want to understand when PTC untimely and data unavailable votes get cast.

**Description**

- add data availability PTC tracking
- track nay votes separately from yea votes
- cache quorum reached status
- emit event when quorum is reached, yea or nay