### PR TITLE
fix: reject `ShufflingCache` promise on regen failure

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1270,27 +1270,33 @@ export class BeaconChain implements IBeaconChain {
     // this is to prevent multiple calls to get shuffling for the same epoch and dependent root
     // any subsequent calls of the same epoch and dependent root will wait for this promise to resolve
     this.shufflingCache.insertPromise(attEpoch, shufflingDependentRoot);
-    const blockEpoch = computeEpochAtSlot(attHeadBlock.slot);
+    try {
+      const blockEpoch = computeEpochAtSlot(attHeadBlock.slot);
 
-    let state: IBeaconStateView;
-    if (blockEpoch < attEpoch - 1) {
-      // thanks to one epoch look ahead, we don't need to dial up to attEpoch
-      const targetSlot = computeStartSlotAtEpoch(attEpoch - 1);
-      this.metrics?.gossipAttestation.useHeadBlockStateDialedToTargetEpoch.inc({caller: regenCaller});
-      state = await this.regen.getBlockSlotState(attHeadBlock, targetSlot, {dontTransferCache: true}, regenCaller);
-    } else if (blockEpoch > attEpoch) {
-      // should not happen, handled inside attestation verification code
-      throw Error(`Block epoch ${blockEpoch} is after attestation epoch ${attEpoch}`);
-    } else {
-      // should use either current or next shuffling of head state
-      // it's not likely to hit this since these shufflings are cached already
-      // so handle just in case
-      this.metrics?.gossipAttestation.useHeadBlockState.inc({caller: regenCaller});
-      state = await this.regen.getState(attHeadBlock.stateRoot, regenCaller);
+      let state: IBeaconStateView;
+      if (blockEpoch < attEpoch - 1) {
+        // thanks to one epoch look ahead, we don't need to dial up to attEpoch
+        const targetSlot = computeStartSlotAtEpoch(attEpoch - 1);
+        this.metrics?.gossipAttestation.useHeadBlockStateDialedToTargetEpoch.inc({caller: regenCaller});
+        state = await this.regen.getBlockSlotState(attHeadBlock, targetSlot, {dontTransferCache: true}, regenCaller);
+      } else if (blockEpoch > attEpoch) {
+        // should not happen, handled inside attestation verification code
+        throw Error(`Block epoch ${blockEpoch} is after attestation epoch ${attEpoch}`);
+      } else {
+        // should use either current or next shuffling of head state
+        // it's not likely to hit this since these shufflings are cached already
+        // so handle just in case
+        this.metrics?.gossipAttestation.useHeadBlockState.inc({caller: regenCaller});
+        state = await this.regen.getState(attHeadBlock.stateRoot, regenCaller);
+      }
+      // resolve the promise to unblock other calls of the same epoch and dependent root
+      this.shufflingCache.processState(state);
+      return state.getShufflingAtEpoch(attEpoch);
+    } catch (err) {
+      // ensure the cached promise does not hang concurrent awaiters on regen failure
+      this.shufflingCache.rejectPromise(attEpoch, shufflingDependentRoot, err);
+      throw err;
     }
-    // resolve the promise to unblock other calls of the same epoch and dependent root
-    this.shufflingCache.processState(state);
-    return state.getShufflingAtEpoch(attEpoch);
   }
 
   /**

--- a/packages/beacon-node/src/chain/shufflingCache.ts
+++ b/packages/beacon-node/src/chain/shufflingCache.ts
@@ -39,6 +39,7 @@ type PromiseCacheItem = {
   timeInsertedMs: number;
   promise: Promise<EpochShuffling>;
   resolveFn: (shuffling: EpochShuffling) => void;
+  rejectFn: (reason?: unknown) => void;
 };
 
 type CacheItem = ShufflingCacheItem | PromiseCacheItem;
@@ -98,10 +99,15 @@ export class ShufflingCache {
       );
     }
     let resolveFn: ((shuffling: EpochShuffling) => void) | null = null;
-    const promise = new Promise<EpochShuffling>((resolve) => {
+    let rejectFn: ((reason?: unknown) => void) | null = null;
+    const promise = new Promise<EpochShuffling>((resolve, reject) => {
       resolveFn = resolve;
+      rejectFn = reject;
     });
-    if (resolveFn === null) {
+    // Attach a no-op handler so a rejection without other awaiters is not treated as an
+    // unhandledRejection. Concurrent awaiters still observe the rejection through their own subscription.
+    promise.catch(() => {});
+    if (resolveFn === null || rejectFn === null) {
       throw new Error("Promise Constructor was not executed immediately");
     }
 
@@ -110,9 +116,23 @@ export class ShufflingCache {
       timeInsertedMs: Date.now(),
       promise,
       resolveFn,
+      rejectFn,
     };
     this.itemsByDecisionRootByEpoch.getOrDefault(epoch).set(decisionRoot, cacheItem);
     this.metrics?.shufflingCache.insertPromiseCount.inc();
+  }
+
+  /**
+   * Reject and remove a pending promise so concurrent awaiters fail fast and future requests
+   * for the same key can retry the computation. No-op if the entry is missing or already a shuffling.
+   */
+  rejectPromise(epoch: Epoch, decisionRoot: RootHex, reason: unknown): void {
+    const innerMap = this.itemsByDecisionRootByEpoch.getOrDefault(epoch);
+    const cacheItem = innerMap.get(decisionRoot);
+    if (cacheItem && isPromiseCacheItem(cacheItem)) {
+      cacheItem.rejectFn(reason);
+      innerMap.delete(decisionRoot);
+    }
   }
 
   /**

--- a/packages/beacon-node/test/unit/chain/shufflingCache.test.ts
+++ b/packages/beacon-node/test/unit/chain/shufflingCache.test.ts
@@ -52,4 +52,15 @@ describe("ShufflingCache", () => {
     // inserting other promise should throw error
     expect(() => shufflingCache.insertPromise(currentEpoch, "0x02")).toThrow();
   });
+
+  it("should reject and remove pending promise via rejectPromise", async () => {
+    const previousEpoch = state.epochCtx.epoch - 1;
+    const previousDecisionRoot = state.epochCtx.previousDecisionRoot;
+    shufflingCache.insertPromise(previousEpoch, previousDecisionRoot);
+    const shufflingRequest = shufflingCache.get(previousEpoch, previousDecisionRoot);
+    shufflingCache.rejectPromise(previousEpoch, previousDecisionRoot, new Error("regen failed"));
+    await expect(shufflingRequest).rejects.toThrow("regen failed");
+    // entry was removed so future requests for the same key can retry
+    expect(await shufflingCache.get(previousEpoch, previousDecisionRoot)).toBeNull();
+  });
 });


### PR DESCRIPTION
Before: a failed `regen` inside `regenStateForAttestationVerification` left the inserted shuffling promise pending in `ShufflingCache`, so concurrent awaiters on the same `(epoch, decisionRoot)` hung forever and future requests reused the dead entry.
After: on regen failure, `ShufflingCache.rejectPromise(epoch, root, err)` rejects the pending promise and drops the entry, so awaiters fail fast and the next call retries cleanly.