### PR TITLE
fix: drop voluntary exits invalidated by parent execution requests

### DIFF
--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -166,16 +166,18 @@ export class PrepareNextSlotScheduler {
         }
 
         let parentBlockHash: Bytes32;
-        // Apply parent payload once here as it's reused by EL prep and SSE emit below
         let stateAfterParentPayload: IBeaconStateViewBellatrix = updatedPrepareState;
         if (isStatePostGloas(updatedPrepareState)) {
           if (this.chain.forkChoice.shouldExtendPayload(updatedHead.blockRoot)) {
             parentBlockHash = updatedPrepareState.latestExecutionPayloadBid.blockHash;
-            const parentExecutionRequests = await this.chain.getParentExecutionRequests(
-              updatedHead.slot,
-              updatedHead.blockRoot
-            );
-            stateAfterParentPayload = updatedPrepareState.withParentPayloadApplied(parentExecutionRequests);
+            // Apply parent payload once here as it's reused by EL prep and SSE emit below
+            if (feeRecipient !== undefined || this.chain.opts.emitPayloadAttributes === true) {
+              const parentExecutionRequests = await this.chain.getParentExecutionRequests(
+                updatedHead.slot,
+                updatedHead.blockRoot
+              );
+              stateAfterParentPayload = updatedPrepareState.withParentPayloadApplied(parentExecutionRequests);
+            }
           } else {
             parentBlockHash = updatedPrepareState.latestExecutionPayloadBid.parentBlockHash;
           }

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -166,11 +166,12 @@ export class PrepareNextSlotScheduler {
         }
 
         let parentBlockHash: Bytes32;
+        // Apply parent payload once here as it's reused by EL prep and SSE emit below
         let stateAfterParentPayload: IBeaconStateViewBellatrix = updatedPrepareState;
         if (isStatePostGloas(updatedPrepareState)) {
           if (this.chain.forkChoice.shouldExtendPayload(updatedHead.blockRoot)) {
             parentBlockHash = updatedPrepareState.latestExecutionPayloadBid.blockHash;
-            // Apply parent payload once here as it's reused by EL prep and SSE emit below
+            // Skip applying parent payload unless we're proposing the next slot or have to emit payload_attributes events
             if (feeRecipient !== undefined || this.chain.opts.emitPayloadAttributes === true) {
               const parentExecutionRequests = await this.chain.getParentExecutionRequests(
                 updatedHead.slot,

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -4,13 +4,14 @@ import {getSafeExecutionBlockHash} from "@lodestar/fork-choice";
 import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH, isForkPostBellatrix} from "@lodestar/params";
 import {
   IBeaconStateView,
+  IBeaconStateViewBellatrix,
   StateHashTreeRootSource,
   computeEpochAtSlot,
   computeTimeAtSlot,
   isStatePostBellatrix,
   isStatePostGloas,
 } from "@lodestar/state-transition";
-import {Bytes32, Slot, electra} from "@lodestar/types";
+import {Bytes32, Slot} from "@lodestar/types";
 import {Logger, fromHex, isErrorAborted, sleep} from "@lodestar/utils";
 import {GENESIS_SLOT, ZERO_HASH_HEX} from "../constants/constants.js";
 import {BuilderStatus} from "../execution/builder/http.js";
@@ -165,18 +166,22 @@ export class PrepareNextSlotScheduler {
         }
 
         let parentBlockHash: Bytes32;
-        let isExtendingPayload = false;
+        // Apply parent payload once here as it's reused by EL prep and SSE emit below
+        let stateAfterParentPayload: IBeaconStateViewBellatrix = updatedPrepareState;
         if (isStatePostGloas(updatedPrepareState)) {
-          isExtendingPayload = this.chain.forkChoice.shouldExtendPayload(updatedHead.blockRoot);
-          parentBlockHash = isExtendingPayload
-            ? updatedPrepareState.latestExecutionPayloadBid.blockHash
-            : updatedPrepareState.latestExecutionPayloadBid.parentBlockHash;
+          if (this.chain.forkChoice.shouldExtendPayload(updatedHead.blockRoot)) {
+            parentBlockHash = updatedPrepareState.latestExecutionPayloadBid.blockHash;
+            const parentExecutionRequests = await this.chain.getParentExecutionRequests(
+              updatedHead.slot,
+              updatedHead.blockRoot
+            );
+            stateAfterParentPayload = updatedPrepareState.withParentPayloadApplied(parentExecutionRequests);
+          } else {
+            parentBlockHash = updatedPrepareState.latestExecutionPayloadBid.parentBlockHash;
+          }
         } else {
           parentBlockHash = updatedPrepareState.latestExecutionPayloadHeader.blockHash;
         }
-
-        // Reused by the SSE emit below to avoid a second DB lookup on cache miss
-        let parentExecutionRequests: electra.ExecutionRequests | undefined;
 
         if (feeRecipient) {
           const preparationTime =
@@ -186,13 +191,6 @@ export class PrepareNextSlotScheduler {
           const safeBlockHash = getSafeExecutionBlockHash(this.chain.forkChoice);
           const finalizedBlockHash =
             this.chain.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
-
-          if (isExtendingPayload) {
-            parentExecutionRequests = await this.chain.getParentExecutionRequests(
-              updatedHead.slot,
-              updatedHead.blockRoot
-            );
-          }
 
           // awaiting here instead of throwing an async call because there is no other task
           // left for scheduler and this gives nice semantics to catch and log errors in the
@@ -205,9 +203,8 @@ export class PrepareNextSlotScheduler {
             parentBlockHash,
             safeBlockHash,
             finalizedBlockHash,
-            updatedPrepareState,
-            feeRecipient,
-            parentExecutionRequests
+            stateAfterParentPayload,
+            feeRecipient
           );
           this.logger.verbose("PrepareNextSlotScheduler prepared new payload", {
             prepareSlot,
@@ -234,20 +231,12 @@ export class PrepareNextSlotScheduler {
           (feeRecipient || this.chain.opts.emitPayloadAttributes === true) &&
           this.chain.emitter.listenerCount(routes.events.EventType.payloadAttributes)
         ) {
-          // if we didn't fetch above (not proposing), SSE still needs it here
-          if (!parentExecutionRequests && isExtendingPayload) {
-            parentExecutionRequests = await this.chain.getParentExecutionRequests(
-              updatedHead.slot,
-              updatedHead.blockRoot
-            );
-          }
           const data = getPayloadAttributesForSSE(fork as ForkPostBellatrix, this.chain, {
-            prepareState: updatedPrepareState,
+            prepareState: stateAfterParentPayload,
             prepareSlot,
             parentBlockRoot: fromHex(updatedHead.blockRoot),
             parentBlockHash,
             feeRecipient: feeRecipient ?? "0x0000000000000000000000000000000000000000",
-            parentExecutionRequests,
           });
           this.chain.emitter.emit(routes.events.EventType.payloadAttributes, {data, version: fork});
         }

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -632,9 +632,6 @@ export async function produceBlockBody<T extends BlockType>(
 
 /**
  * Produce ExecutionPayload for post-merge.
- *
- * Post-gloas, when extending a full parent, callers must apply
- * parent execution payload first (see `withParentPayloadApplied`).
  */
 export async function prepareExecutionPayload(
   chain: {
@@ -647,6 +644,10 @@ export async function prepareExecutionPayload(
   parentBlockHash: Bytes32,
   safeBlockHash: RootHex,
   finalizedBlockHash: RootHex,
+  /**
+   * Post-gloas, when extending a full parent, callers must apply
+   * parent execution payload first (see `withParentPayloadApplied`).
+   */
   state: IBeaconStateViewBellatrix,
   suggestedFeeRecipient: string
 ): Promise<{prepType: PayloadPreparationType; payloadId: PayloadId}> {

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -214,19 +214,25 @@ export async function produceBlockBody<T extends BlockType>(
     });
 
     // Get execution payload from EL
+    let parentBlockHash: Bytes32;
+    let parentExecutionRequests: electra.ExecutionRequests;
+    // Apply parent payload once here as it's reused by EL prep and voluntary exit filtering below
+    let stateAfterParentPayload: IBeaconStateViewBellatrix = currentState;
     const isExtendingPayload = this.forkChoice.shouldExtendPayload(toRootHex(parentBlockRoot));
-    let parentBlockHash = isExtendingPayload
-      ? currentState.latestExecutionPayloadBid.blockHash
-      : currentState.latestExecutionPayloadBid.parentBlockHash;
-    // At gloas genesis the committed bid has no prior EL block to reference
-    // (`bid.parentBlockHash` is zero). Fall back to `bid.blockHash` (= eth1 genesis hash) so the
-    // FCU to the EL carries a valid head. Post-genesis bids always reference a non-zero parent.
-    if (isStatePostGloas(currentState) && byteArrayEquals(parentBlockHash, ZERO_HASH)) {
+    if (isExtendingPayload) {
       parentBlockHash = currentState.latestExecutionPayloadBid.blockHash;
+      parentExecutionRequests = await this.getParentExecutionRequests(parentBlock.slot, parentBlock.blockRoot);
+      stateAfterParentPayload = currentState.withParentPayloadApplied(parentExecutionRequests);
+    } else {
+      parentBlockHash = currentState.latestExecutionPayloadBid.parentBlockHash;
+      // At gloas genesis the committed bid has no prior EL block to reference
+      // (`bid.parentBlockHash` is zero). Fall back to `bid.blockHash` (= eth1 genesis hash) so the
+      // FCU to the EL carries a valid head. Post-genesis bids always reference a non-zero parent.
+      if (byteArrayEquals(parentBlockHash, ZERO_HASH)) {
+        parentBlockHash = currentState.latestExecutionPayloadBid.blockHash;
+      }
+      parentExecutionRequests = ssz.electra.ExecutionRequests.defaultValue();
     }
-    const parentExecutionRequests = isExtendingPayload
-      ? await this.getParentExecutionRequests(parentBlock.slot, parentBlock.blockRoot)
-      : ssz.electra.ExecutionRequests.defaultValue();
     const prepareRes = await prepareExecutionPayload(
       this,
       this.logger,
@@ -235,9 +241,8 @@ export async function produceBlockBody<T extends BlockType>(
       parentBlockHash,
       safeBlockHash,
       finalizedBlockHash ?? ZERO_HASH_HEX,
-      currentState,
-      feeRecipient,
-      parentExecutionRequests
+      stateAfterParentPayload,
+      feeRecipient
     );
 
     const {prepType, payloadId} = prepareRes;
@@ -296,6 +301,14 @@ export async function produceBlockBody<T extends BlockType>(
       blockSlot - 1
     );
     gloasBody.parentExecutionRequests = parentExecutionRequests;
+    // Drop voluntary exits that parent_execution_requests have invalidated (e.g. a withdrawal
+    // request initiating an exit on the same validator). Op pool selected against the unapplied
+    // state, so re-validate against the post-apply state to avoid producing an invalid block.
+    if (isExtendingPayload && commonBlockBody.voluntaryExits.length > 0) {
+      gloasBody.voluntaryExits = commonBlockBody.voluntaryExits.filter((signedVoluntaryExit) =>
+        stateAfterParentPayload.isValidVoluntaryExit(signedVoluntaryExit, false)
+      );
+    }
     blockBody = gloasBody as AssembledBodyType<T>;
 
     // Store execution payload data required to construct execution payload envelope later
@@ -619,6 +632,9 @@ export async function produceBlockBody<T extends BlockType>(
 
 /**
  * Produce ExecutionPayload for post-merge.
+ *
+ * Post-gloas, when extending a full parent, callers must apply
+ * parent execution payload first (see `withParentPayloadApplied`).
  */
 export async function prepareExecutionPayload(
   chain: {
@@ -632,8 +648,7 @@ export async function prepareExecutionPayload(
   safeBlockHash: RootHex,
   finalizedBlockHash: RootHex,
   state: IBeaconStateViewBellatrix,
-  suggestedFeeRecipient: string,
-  parentExecutionRequests?: electra.ExecutionRequests
+  suggestedFeeRecipient: string
 ): Promise<{prepType: PayloadPreparationType; payloadId: PayloadId}> {
   const timestamp = computeTimeAtSlot(chain.config, state.slot, state.genesisTime);
   const prevRandao = state.getRandaoMix(state.epoch);
@@ -670,7 +685,6 @@ export async function prepareExecutionPayload(
       parentBlockRoot,
       parentBlockHash,
       feeRecipient: suggestedFeeRecipient,
-      parentExecutionRequests,
     });
 
     payloadId = await chain.executionEngine.notifyForkchoiceUpdate(
@@ -729,14 +743,16 @@ export function getPayloadAttributesForSSE(
     parentBlockRoot,
     parentBlockHash,
     feeRecipient,
-    parentExecutionRequests,
   }: {
+    /**
+     * Post-gloas, when extending a full parent, callers must apply
+     * parent execution payload first (see `withParentPayloadApplied`).
+     */
     prepareState: IBeaconStateViewBellatrix;
     prepareSlot: Slot;
     parentBlockRoot: Root;
     parentBlockHash: Bytes32;
     feeRecipient: string;
-    parentExecutionRequests?: electra.ExecutionRequests;
   }
 ): SSEPayloadAttributes {
   const payloadAttributes = preparePayloadAttributes(fork, chain, {
@@ -745,7 +761,6 @@ export function getPayloadAttributesForSSE(
     parentBlockRoot,
     parentBlockHash,
     feeRecipient,
-    parentExecutionRequests,
   });
 
   let parentBlockNumber: number;
@@ -784,14 +799,16 @@ function preparePayloadAttributes(
     parentBlockRoot,
     parentBlockHash,
     feeRecipient,
-    parentExecutionRequests,
   }: {
+    /**
+     * Post-gloas, when extending a full parent, callers must apply
+     * parent execution payload first (see `withParentPayloadApplied`).
+     */
     prepareState: IBeaconStateViewBellatrix;
     prepareSlot: Slot;
     parentBlockRoot: Root;
     parentBlockHash: Bytes32;
     feeRecipient: string;
-    parentExecutionRequests?: electra.ExecutionRequests;
   }
 ): SSEPayloadAttributes["payloadAttributes"] {
   const timestamp = computeTimeAtSlot(chain.config, prepareSlot, prepareState.genesisTime);
@@ -810,11 +827,13 @@ function preparePayloadAttributes(
     if (isStatePostGloas(prepareState)) {
       const isExtendingPayload = byteArrayEquals(parentBlockHash, prepareState.latestExecutionPayloadBid.blockHash);
       if (isExtendingPayload) {
-        if (parentExecutionRequests === undefined) {
-          throw new Error("parentExecutionRequests required when extending full parent");
+        // applyParentExecutionPayload sets latestBlockHash = parentBid.blockHash, so a mismatch
+        // here means the caller did not apply parent payload to prepareState
+        if (!byteArrayEquals(prepareState.latestBlockHash, prepareState.latestExecutionPayloadBid.blockHash)) {
+          throw new Error("Expected state with parent execution payload applied for withdrawals");
         }
         (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
-          prepareState.getExpectedWithdrawalsForFullParent(parentExecutionRequests);
+          prepareState.getExpectedWithdrawals().expectedWithdrawals;
       } else {
         // When the parent block is empty, state.payloadExpectedWithdrawals holds a batch
         // already deducted from CL balances but never credited on the EL (the envelope

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -804,7 +804,7 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
    * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.5/specs/gloas/validator.md#executionpayload
    */
   withParentPayloadApplied(executionRequests: electra.ExecutionRequests): IBeaconStateViewGloas {
-    if (!isStatePostGloas(this)) {
+    if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
       throw new Error("withParentPayloadApplied is not available before Gloas");
     }
     const stateCopy = this.cachedState.clone(true) as CachedBeaconStateGloas;

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -68,7 +68,7 @@ import {canBuilderCoverBid} from "../util/gloas.js";
 import {loadState} from "../util/loadState/loadState.js";
 import {getRandaoMix} from "../util/seed.js";
 import {getLatestWeakSubjectivityCheckpointEpoch} from "../util/weakSubjectivity.js";
-import {IBeaconStateView, IBeaconStateViewLatestFork} from "./interface.js";
+import {IBeaconStateView, IBeaconStateViewGloas, IBeaconStateViewLatestFork, isStatePostGloas} from "./interface.js";
 
 export class BeaconStateView implements IBeaconStateViewLatestFork {
   private readonly config: BeaconConfig;
@@ -803,16 +803,19 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
   /**
    * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.5/specs/gloas/validator.md#executionpayload
    */
-  getExpectedWithdrawalsForFullParent(executionRequests: electra.ExecutionRequests): capella.Withdrawal[] {
-    const fork = this.config.getForkSeq(this.cachedState.slot);
-    if (fork < ForkSeq.gloas) {
-      throw new Error("getExpectedWithdrawalsForFullParent is not available before Gloas");
+  withParentPayloadApplied(executionRequests: electra.ExecutionRequests): IBeaconStateViewGloas {
+    if (!isStatePostGloas(this)) {
+      throw new Error("withParentPayloadApplied is not available before Gloas");
     }
-    // Make a copy of the state to avoid mutability issues
     const stateCopy = this.cachedState.clone(true) as CachedBeaconStateGloas;
-    // Apply parent payload before computing withdrawals
+
     applyParentExecutionPayload(stateCopy, executionRequests);
 
-    return getExpectedWithdrawals(fork, stateCopy).expectedWithdrawals;
+    const stateView = new BeaconStateView(stateCopy);
+    if (!isStatePostGloas(stateView)) {
+      throw new Error("Expected gloas state after clone");
+    }
+
+    return stateView;
   }
 }

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -255,11 +255,12 @@ export interface IBeaconStateViewGloas extends IBeaconStateViewFulu {
   getEpochPTCs(epoch: Epoch): Uint32Array[];
   getIndexInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number;
   /**
-   * Compute expected withdrawals as if the parent was FULL.
-   * Clones the state, applies parent payload effects, then computes withdrawals.
-   * Used by prepare_execution_payload when building on FULL parent.
+   * Clone the state and apply parent execution payload effects, returning the new view.
+   * Used during block production and prepareNextSlot so that withdrawals and
+   * operation selection (e.g. voluntary exits) see the same post-apply state that the block
+   * processor will see at import.
    */
-  getExpectedWithdrawalsForFullParent(executionRequests: electra.ExecutionRequests): capella.Withdrawal[];
+  withParentPayloadApplied(executionRequests: electra.ExecutionRequests): IBeaconStateViewGloas;
 }
 
 /**

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -255,7 +255,7 @@ export interface IBeaconStateViewGloas extends IBeaconStateViewFulu {
   getEpochPTCs(epoch: Epoch): Uint32Array[];
   getIndexInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number;
   /**
-   * Clone the state and apply parent execution payload effects, returning the new view.
+   * Clone the state and apply parent execution payload effects.
    * Used during block production and prepareNextSlot so that withdrawals and
    * operation selection (e.g. voluntary exits) see the same post-apply state that the block
    * processor will see at import.


### PR DESCRIPTION
see https://github.com/ethereum/consensus-specs/pull/5176

> *Note*: Because execution request processing is deferred, a request in
`parent_execution_requests` can invalidate a voluntary exit in the same block.
For example, a withdrawal request for a validator will cause a voluntary exit
for the same validator to fail, invalidating the entire block. When selecting
voluntary exits to include, proposers must take heed of this interaction.