### PR TITLE
fix: gloas checkpoint sync

### DIFF
--- a/packages/beacon-node/src/api/impl/debug/index.ts
+++ b/packages/beacon-node/src/api/impl/debug/index.ts
@@ -43,7 +43,6 @@ export function getDebugApi({
             validity: (() => {
               switch (node.executionStatus) {
                 case ExecutionStatus.Valid:
-                case ExecutionStatus.PayloadSeparated:
                   return "valid";
                 case ExecutionStatus.Invalid:
                   return "invalid";

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -86,8 +86,8 @@ export async function importBlock(
   fullyVerifiedBlock: FullyVerifiedBlock,
   opts: ImportBlockOpts
 ): Promise<void> {
-  const {blockInput, postState, parentBlockSlot, executionStatus, dataAvailabilityStatus, indexedAttestations} =
-    fullyVerifiedBlock;
+  const {blockInput, postState, parentBlockSlot, dataAvailabilityStatus, indexedAttestations} = fullyVerifiedBlock;
+  let {executionStatus} = fullyVerifiedBlock;
   const block = blockInput.getBlock();
   const source = blockInput.getBlockSource();
   const {slot: blockSlot} = block.message;
@@ -122,12 +122,23 @@ export async function importBlock(
 
   // Should compute checkpoint balances before forkchoice.onBlock
   this.checkpointBalancesCache.processState(blockRootHex, postState);
+  if (fork >= ForkSeq.gloas) {
+    const parentRootHex = toRootHex(block.message.parentRoot);
+    const parentBlock = this.forkChoice.getBlockHexDefaultStatus(parentRootHex);
+    if (parentBlock === null) {
+      throw Error(`Parent block not found in forkChoice, parentRoot=${parentRootHex}`);
+    }
+    if (parentBlock.executionStatus === ExecutionStatus.Invalid) {
+      throw Error(`Parent block has invalid execution status, parentRoot=${parentRootHex}`);
+    }
+    executionStatus = parentBlock.executionStatus;
+  }
   const blockSummary = this.forkChoice.onBlock(
     block.message,
     postState,
     blockDelaySec,
     currentSlot,
-    fork >= ForkSeq.gloas ? ExecutionStatus.PayloadSeparated : executionStatus,
+    executionStatus,
     dataAvailabilityStatus
   );
 

--- a/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
+++ b/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
@@ -61,7 +61,6 @@ function toForkChoiceExecutionStatus(status: ExecutionPayloadStatus): PayloadExe
   switch (status) {
     case ExecutionPayloadStatus.VALID:
       return ExecutionStatus.Valid;
-    // TODO GLOAS: Handle optimistic import for payload
     case ExecutionPayloadStatus.SYNCING:
     case ExecutionPayloadStatus.ACCEPTED:
       return ExecutionStatus.Syncing;
@@ -255,8 +254,7 @@ export async function importExecutionPayload(
       builderIndex: envelope.builderIndex,
       blockHash: blockHashHex,
       blockRoot: blockRootHex,
-      // TODO GLOAS: revisit once we support optimistic import
-      executionOptimistic: false,
+      executionOptimistic: execStatus === ExecutionStatus.Syncing,
     });
   }
 

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -132,7 +132,7 @@ export async function processBlocks(
     // initializeForkChoice as PENDING+EMPTY) and therefore not in verifiedBlocksBySlot — the
     // payload still needs to be imported here to populate the anchor's FULL variant so
     // subsequent slots can find their parent payload.
-    const slots = blocks.map((b) => b.getBlock().message.slot);
+    const slots = Array.from(new Set(blocks.map((b) => b.getBlock().message.slot)));
     for (const slot of slots) {
       const fullyVerifiedBlock = verifiedBlocksBySlot.get(slot);
       if (fullyVerifiedBlock !== undefined) {

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -65,7 +65,7 @@ export async function processBlocks(
   }
 
   try {
-    const {relevantBlocks, parentSlots, parentBlock} = verifyBlocksSanityChecks(this, blocks, opts);
+    const {relevantBlocks, parentSlots, parentBlock} = verifyBlocksSanityChecks(this, blocks, payloadEnvelopes, opts);
 
     // No relevant blocks, skip verifyBlocksInEpoch()
     if (relevantBlocks.length === 0 || parentBlock === null) {
@@ -109,8 +109,10 @@ export async function processBlocks(
     }
 
     const {executionStatuses} = segmentExecStatus;
-    const fullyVerifiedBlocks = relevantBlocks.map(
-      (block, i): FullyVerifiedBlock => ({
+    const verifiedBlocksBySlot = new Map<Slot, FullyVerifiedBlock>();
+    for (let i = 0; i < relevantBlocks.length; i++) {
+      const block = relevantBlocks[i];
+      verifiedBlocksBySlot.set(block.getBlock().message.slot, {
         blockInput: block,
         postState: postStates[i],
         parentBlockSlot: parentSlots[i],
@@ -121,14 +123,23 @@ export async function processBlocks(
         indexedAttestations: indexedAttestationsByBlock[i],
         // TODO: Make this param mandatory and capture in gossip
         seenTimestampSec: opts.seenTimestampSec ?? Math.floor(Date.now() / 1000),
-      })
-    );
+      });
+    }
 
-    for (const fullyVerifiedBlock of fullyVerifiedBlocks) {
-      // TODO: Consider batching importBlock too if it takes significant time
-      await importBlock.call(this, fullyVerifiedBlock, opts);
+    // Iterate slots from the original `blocks` input (which spans the entire batch including
+    // slots filtered out of `relevantBlocks`). The first batch of a checkpoint sync may contain
+    // a payload at the anchor slot whose block is already in fork-choice (added by
+    // initializeForkChoice as PENDING+EMPTY) and therefore not in verifiedBlocksBySlot — the
+    // payload still needs to be imported here to populate the anchor's FULL variant so
+    // subsequent slots can find their parent payload.
+    const slots = blocks.map((b) => b.getBlock().message.slot);
+    for (const slot of slots) {
+      const fullyVerifiedBlock = verifiedBlocksBySlot.get(slot);
+      if (fullyVerifiedBlock !== undefined) {
+        // TODO: Consider batching importBlock too if it takes significant time
+        await importBlock.call(this, fullyVerifiedBlock, opts);
+      }
 
-      const slot = fullyVerifiedBlock.blockInput.getBlock().message.slot;
       const payloadInput = payloadEnvelopes?.get(slot);
       if (payloadInput?.hasPayloadEnvelope()) {
         if (!payloadInput.isComplete()) {

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -94,7 +94,8 @@ export type ImportBlockOpts = {
  *
  * `executionStatus` reflects the outcome of execution payload verification at block-import time:
  * - pre-gloas: Valid | Syncing | PreMerge (from EL notifyNewPayload against the in-block payload)
- * - post-gloas: PayloadSeparated (payload arrives separately as an envelope and is imported later)
+ * - post-gloas: inherited from parent's chain (Valid/Syncing) by importBlock; payload arrives
+ *   separately as an envelope and creates the FULL variant later via onExecutionPayload
  */
 export type FullyVerifiedBlock = {
   blockInput: IBlockInput;

--- a/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
+++ b/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
@@ -41,6 +41,14 @@ export function assertLinearChainSegment(
   // - EMPTY variant (no envelope for slot): execution hash is unchanged
   // null only for pre-merge parents, which cannot precede gloas blocks.
   let currentExecHash: string | null = parentBlock.executionPayloadBlockHash;
+  // Checkpoint sync first batch: parent is the anchor PENDING whose executionPayloadBlockHash
+  // is the inherited parentBlockHash semantic (= grandparent's payload), not its own payload.
+  // If parent's own payload envelope arrives in this batch, advance currentExecHash to that
+  // payload's blockHash so the segment validation sees the true EL chain head.
+  const parentPayloadInput = payloadEnvelopes?.get(parentBlock.slot);
+  if (parentPayloadInput?.hasPayloadEnvelope()) {
+    currentExecHash = parentPayloadInput.getBlockHashHex();
+  }
   // Track the execution hash before the last FULL advancement so we can recover
   // if the next block reveals that envelope was orphaned.
   let prevExecHash: string | null = currentExecHash;

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -125,15 +125,17 @@ export async function verifyBlocksInEpoch(
     }> =
       fork >= ForkSeq.gloas
         ? (async () => {
-            const payloadInputsForDa: PayloadEnvelopeInput[] = [];
-            for (const input of blockInputs) {
-              const pi = payloadEnvelopes?.get(input.slot);
-              if (pi !== undefined) payloadInputsForDa.push(pi);
-            }
+            // Validate DA for ALL payloads in the Map, not just those paired with blockInputs.
+            // A checkpoint-sync batch may include a payload for a slot whose block was filtered
+            // out of relevantBlocks (e.g., the anchor at the finalized slot); that payload still
+            // needs DA validation so it can be imported in processBlocks.
+            const payloadInputsForDa: PayloadEnvelopeInput[] =
+              payloadEnvelopes !== null ? Array.from(payloadEnvelopes.values()) : [];
             const {dataAvailabilityStatuses, availableTime} = await verifyPayloadsDataAvailability(
               payloadInputsForDa,
               abortController.signal
             );
+
             const payloadDAStatuses = new Map<Slot, DataAvailabilityStatus>();
             for (let i = 0; i < payloadInputsForDa.length; i++) {
               payloadDAStatuses.set(payloadInputsForDa[i].slot, dataAvailabilityStatuses[i]);

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -46,8 +46,7 @@ type VerifyBlockExecutionResponse =
   | VerifyExecutionErrorResponse
   | {executionStatus: ExecutionStatus.Valid; lvhResponse: LVHValidResponse; execError: null}
   | {executionStatus: ExecutionStatus.Syncing; lvhResponse?: LVHValidResponse; execError: null}
-  | {executionStatus: ExecutionStatus.PreMerge; lvhResponse: undefined; execError: null}
-  | {executionStatus: ExecutionStatus.PayloadSeparated; lvhResponse: undefined; execError: null};
+  | {executionStatus: ExecutionStatus.PreMerge; lvhResponse: undefined; execError: null};
 
 /**
  * Verifies 1 or more execution payloads from a linear sequence of blocks.
@@ -145,9 +144,10 @@ export async function verifyBlockExecutionPayload(
 ): Promise<VerifyBlockExecutionResponse> {
   const block = blockInput.getBlock();
 
-  // Gloas block doesn't have execution payload. Return right away
+  // Gloas block doesn't have execution payload. Return Syncing as a placeholder; the actual
+  // status for gloas PENDING/EMPTY is derived from parent's chain in importBlock.
   if (isBlockInputNoData(blockInput)) {
-    return {executionStatus: ExecutionStatus.PayloadSeparated, lvhResponse: undefined, execError: null};
+    return {executionStatus: ExecutionStatus.Syncing, lvhResponse: undefined, execError: null};
   }
 
   /** Not null if execution is enabled */
@@ -198,6 +198,7 @@ export async function verifyBlockExecutionPayload(
         executionStatus,
         latestValidExecHash: execResult.latestValidHash,
         invalidateFromParentBlockRoot: blockInput.parentRootHex,
+        invalidateFromParentBlockHash: toRootHex(executionPayloadEnabled.parentHash),
       };
       const execError = new BlockError(block, {
         code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
@@ -281,6 +282,7 @@ function getSegmentErrorResponse(
         executionStatus: ExecutionStatus.Invalid,
         latestValidExecHash: lvhResponse.latestValidExecHash,
         invalidateFromParentBlockRoot: parentBlock.blockRoot,
+        invalidateFromParentBlockHash: parentBlock.executionPayloadBlockHash,
       };
     }
   }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSanityChecks.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSanityChecks.ts
@@ -7,6 +7,7 @@ import {IClock} from "../../util/clock.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
 import {IChainOptions} from "../options.js";
 import {IBlockInput} from "./blockInput/types.js";
+import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {ImportBlockOpts} from "./types.js";
 
 /**
@@ -30,6 +31,7 @@ export function verifyBlocksSanityChecks(
     blacklistedBlocks: Map<RootHex, Slot | null>;
   },
   blocks: IBlockInput[],
+  payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
   opts: ImportBlockOpts
 ): {
   relevantBlocks: IBlockInput[];
@@ -100,13 +102,21 @@ export function verifyBlocksSanityChecks(
         const parentBlockHash = toRootHex(block.message.body.signedExecutionPayloadBid.message.parentBlockHash);
         const parentBlockWithPayload = chain.forkChoice.getBlockHexAndBlockHash(parentRoot, parentBlockHash);
         if (!parentBlockWithPayload) {
-          throw new BlockError(block, {
-            code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
-            parentRoot,
-            parentBlockHash,
-          });
+          // Checkpoint sync: parent's FULL variant may not be in fork-choice yet because the
+          // anchor block is initialized with PENDING+EMPTY only. The parent's payload arrives
+          // in the same batch via payloadEnvelopes and will be imported by processBlocks. If
+          // a matching payload is in the Map, accept the parent as known.
+          const parentPayloadInput = payloadEnvelopes?.get(parentBlockDefaultStatus.slot);
+          if (parentPayloadInput?.getBlockHashHex() !== parentBlockHash) {
+            throw new BlockError(block, {
+              code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
+              parentRoot,
+              parentBlockHash,
+            });
+          }
+        } else {
+          parentBlock = parentBlockWithPayload;
         }
-        parentBlock = parentBlockWithPayload;
       }
       // Parent is known to the fork-choice
       parentBlockSlot = parentBlock.slot;

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -1,7 +1,7 @@
 import {routes} from "@lodestar/api";
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {IBeaconStateView, computeEpochAtSlot} from "@lodestar/state-transition";
-import {BeaconBlock, Epoch, RootHex, Slot, isGloasBeaconBlock, phase0} from "@lodestar/types";
+import {BeaconBlock, Epoch, RootHex, Slot, phase0} from "@lodestar/types";
 import {Logger, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
 import {JobItemQueue} from "../../util/queue/index.js";
@@ -88,12 +88,7 @@ export class QueuedStateRegenerator implements IStateRegenerator {
    */
   getPreStateSync(block: BeaconBlock): IBeaconStateView | null {
     const parentRoot = toRootHex(block.parentRoot);
-    const parentBlock = isGloasBeaconBlock(block)
-      ? this.forkChoice.getBlockHexAndBlockHash(
-          parentRoot,
-          toRootHex(block.body.signedExecutionPayloadBid.message.parentBlockHash)
-        )
-      : this.forkChoice.getBlockHexDefaultStatus(parentRoot);
+    const parentBlock = this.forkChoice.getBlockHexDefaultStatus(parentRoot);
     if (!parentBlock) {
       throw new RegenError({
         code: RegenErrorCode.BLOCK_NOT_IN_FORKCHOICE,

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -9,7 +9,7 @@ import {
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
 } from "@lodestar/state-transition";
-import {BeaconBlock, RootHex, SignedBeaconBlock, Slot, isGloasBeaconBlock} from "@lodestar/types";
+import {BeaconBlock, RootHex, SignedBeaconBlock, Slot} from "@lodestar/types";
 import {Logger, fromHex, toRootHex} from "@lodestar/utils";
 import {IBeaconDb} from "../../db/index.js";
 import {Metrics} from "../../metrics/index.js";
@@ -57,12 +57,7 @@ export class StateRegenerator implements IStateRegeneratorInternal {
     regenCaller: RegenCaller
   ): Promise<IBeaconStateView> {
     const parentRoot = toRootHex(block.parentRoot);
-    const parentBlock = isGloasBeaconBlock(block)
-      ? this.modules.forkChoice.getBlockHexAndBlockHash(
-          parentRoot,
-          toRootHex(block.body.signedExecutionPayloadBid.message.parentBlockHash)
-        )
-      : this.modules.forkChoice.getBlockHexDefaultStatus(parentRoot);
+    const parentBlock = this.modules.forkChoice.getBlockHexDefaultStatus(parentRoot);
     if (!parentBlock) {
       throw new RegenError({
         code: RegenErrorCode.BLOCK_NOT_IN_FORKCHOICE,

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -221,7 +221,7 @@ export class BeaconNode {
 
     let executionEngineOpts = opts.executionEngine;
     if (opts.executionEngine.mode === "mock") {
-      const eth1BlockHash =
+      const lastEth1BlockHash =
         isStatePostBellatrix(anchorState) && anchorState.isExecutionStateType
           ? isStatePostGloas(anchorState)
             ? toRootHex(anchorState.latestBlockHash)
@@ -230,7 +230,7 @@ export class BeaconNode {
       executionEngineOpts = {
         ...opts.executionEngine,
         genesisBlockHash: ZERO_HASH_HEX,
-        eth1BlockHash,
+        eth1BlockHash: opts.executionEngine.eth1BlockHash ?? lastEth1BlockHash,
         genesisTime: anchorState.genesisTime,
         config,
       };

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -221,7 +221,7 @@ export class BeaconNode {
 
     let executionEngineOpts = opts.executionEngine;
     if (opts.executionEngine.mode === "mock") {
-      const lastEth1BlockHash =
+      const latestEth1BlockHash =
         isStatePostBellatrix(anchorState) && anchorState.isExecutionStateType
           ? isStatePostGloas(anchorState)
             ? toRootHex(anchorState.latestBlockHash)
@@ -230,7 +230,7 @@ export class BeaconNode {
       executionEngineOpts = {
         ...opts.executionEngine,
         genesisBlockHash: ZERO_HASH_HEX,
-        eth1BlockHash: opts.executionEngine.eth1BlockHash ?? lastEth1BlockHash,
+        eth1BlockHash: opts.executionEngine.eth1BlockHash ?? latestEth1BlockHash,
         genesisTime: anchorState.genesisTime,
         config,
       };

--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -167,14 +167,7 @@ function getHeadExecutionInfo(
     return [];
   }
 
-  // A PayloadSeparated head is a gloas beacon block imported before its payload envelope
-  // arrives, in that case the exec-block row surfaces the inherited parent anchor (from the
-  // bid), which is already validated. Normalize to "valid" to avoid leaking internal
-  // fork-choice bookkeeping into the log. Once the payload envelope arrives and the FULL
-  // variant becomes head, executionStatus is Valid/Syncing naturally.
-  // TODO GLOAS: revisit once optimistic sync is implemented
-  const executionStatusStr =
-    headInfo.executionStatus === ExecutionStatus.PayloadSeparated ? "valid" : headInfo.executionStatus.toLowerCase();
+  const executionStatusStr = headInfo.executionStatus.toLowerCase();
 
   // Add execution status to notifier only if head is on/post bellatrix
   if (isStatePostBellatrix(headState) && headState.isExecutionStateType) {

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -14,6 +14,7 @@ import {
   deneb,
   fulu,
   gloas,
+  isGloasBeaconBlock,
   isGloasDataColumnSidecar,
   phase0,
 } from "@lodestar/types";
@@ -361,7 +362,7 @@ export async function requestByRange({
   let blocks: undefined | SignedBeaconBlock[];
   let blobSidecars: undefined | deneb.BlobSidecars;
   let columnSidecars: undefined | DataColumnSidecar[];
-  let payloadEnvelopes: undefined | gloas.SignedExecutionPayloadEnvelope[];
+  const payloadEnvelopes: gloas.SignedExecutionPayloadEnvelope[] = [];
 
   const requests: Promise<unknown>[] = [];
 
@@ -369,6 +370,17 @@ export async function requestByRange({
     requests.push(
       network.sendBeaconBlocksByRange(peerIdStr, blocksRequest).then((blockResponse) => {
         blocks = blockResponse;
+        const firstBlock = blockResponse.at(0);
+        if (firstBlock && isGloasBeaconBlock(firstBlock.message)) {
+          return network
+            .sendExecutionPayloadEnvelopesByRoot(peerIdStr, [
+              firstBlock.message.body.signedExecutionPayloadBid.message.parentBlockRoot,
+            ])
+            .then((envelopeResponse) => {
+              payloadEnvelopes?.unshift(...envelopeResponse);
+            });
+        }
+        return undefined;
       })
     );
   }
@@ -392,7 +404,7 @@ export async function requestByRange({
   if (envelopesRequest) {
     requests.push(
       network.sendExecutionPayloadEnvelopesByRange(peerIdStr, envelopesRequest).then((envelopeResponse) => {
-        payloadEnvelopes = envelopeResponse;
+        payloadEnvelopes?.push(...envelopeResponse);
       })
     );
   }
@@ -1179,7 +1191,7 @@ export function validateEnvelopesByRangeResponse(
     const slot = payloadEnvelope.message.payload.slotNumber;
     const batchBlockRoot = batchBlockRoots.get(slot);
 
-    // Envelopes for slots not in the batch are silently ignored (orphaned payloads)
+    // Envelopes for slots not in the batch are silently ignored (orphaned payloads or a parent payload)
     if (batchBlockRoot === undefined) {
       continue;
     }

--- a/packages/beacon-node/test/e2e/sync/checkpointSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/checkpointSync.test.ts
@@ -1,0 +1,221 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {routes} from "@lodestar/api";
+import {ChainConfig} from "@lodestar/config";
+import {ExecutionStatus, PayloadStatus} from "@lodestar/fork-choice";
+import {TimestampFormatCode} from "@lodestar/logger";
+import {LogLevel, TestLoggerOpts, testLogger} from "@lodestar/logger/test-utils";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {BeaconStateView, DataAvailabilityStatus} from "@lodestar/state-transition";
+import {Slot, phase0} from "@lodestar/types";
+import {ChainEvent} from "../../../src/chain/index.js";
+import {waitForEvent} from "../../utils/events/resolver.js";
+import {connect, onPeerConnect} from "../../utils/network.js";
+import {getDevBeaconNode} from "../../utils/node/beacon.js";
+import {getAndInitDevValidators} from "../../utils/node/validator.js";
+
+describe("sync / checkpoint sync optimistic flow for gloas", () => {
+  vi.setConfig({testTimeout: 120_000});
+
+  const validatorCount = 8;
+  const ELECTRA_FORK_EPOCH = 0;
+  const FULU_FORK_EPOCH = 1;
+  const GLOAS_FORK_EPOCH = 2;
+  const SLOT_DURATION_MS = 2000;
+  const testParams: Partial<ChainConfig> = {
+    SLOT_DURATION_MS,
+    ALTAIR_FORK_EPOCH: ELECTRA_FORK_EPOCH,
+    BELLATRIX_FORK_EPOCH: ELECTRA_FORK_EPOCH,
+    CAPELLA_FORK_EPOCH: ELECTRA_FORK_EPOCH,
+    DENEB_FORK_EPOCH: ELECTRA_FORK_EPOCH,
+    ELECTRA_FORK_EPOCH: ELECTRA_FORK_EPOCH,
+    FULU_FORK_EPOCH: FULU_FORK_EPOCH,
+    GLOAS_FORK_EPOCH: GLOAS_FORK_EPOCH,
+    BLOB_SCHEDULE: [
+      {
+        EPOCH: 1,
+        MAX_BLOBS_PER_BLOCK: 3,
+      },
+    ],
+  };
+
+  const afterEachCallbacks: (() => Promise<unknown> | void)[] = [];
+  afterEach(async () => {
+    while (afterEachCallbacks.length > 0) {
+      const callback = afterEachCallbacks.pop();
+      if (callback) await callback();
+    }
+  });
+
+  it("Node B optimistically syncs gloas chain and back-validates ancestors when EL returns VALID", async () => {
+    const genesisSlotsDelay = 4;
+    const genesisTime = Math.floor(Date.now() / 1000) + genesisSlotsDelay * (SLOT_DURATION_MS / 1000);
+
+    const testLoggerOpts: TestLoggerOpts = {
+      level: LogLevel.debug,
+      timestampFormat: {
+        format: TimestampFormatCode.EpochSlot,
+        genesisTime,
+        slotsPerEpoch: SLOTS_PER_EPOCH,
+        secondsPerSlot: SLOT_DURATION_MS / 1000,
+      },
+    };
+
+    const loggerNodeA = testLogger("CheckpointSync-Node-A", testLoggerOpts);
+    const loggerNodeB = testLogger("CheckpointSync-Node-B", testLoggerOpts);
+
+    // Node A: full beacon node syncing past gloas activation
+    const bn = await getDevBeaconNode({
+      params: testParams,
+      options: {
+        sync: {isSingleNode: true},
+        network: {allowPublishToZeroPeers: true, useWorker: false},
+        chain: {blsVerifyAllMainThread: true},
+      },
+      validatorCount,
+      genesisTime,
+      logger: loggerNodeA,
+    });
+    afterEachCallbacks.push(() => bn.close());
+
+    const {validators} = await getAndInitDevValidators({
+      node: bn,
+      logPrefix: "CheckpointSyncVc",
+      validatorsPerClient: validatorCount,
+      validatorClientCount: 1,
+      startIndex: 0,
+      useRestApi: false,
+      testLoggerOpts,
+    });
+    afterEachCallbacks.push(() => Promise.all(validators.map((validator) => validator.close())));
+
+    // Wait for Node A to reach a post-gloas finalized checkpoint
+    await Promise.all([
+      waitForEvent<phase0.Checkpoint>(
+        bn.chain.emitter,
+        ChainEvent.forkChoiceFinalized,
+        240000,
+        (finalized) => finalized.epoch >= GLOAS_FORK_EPOCH
+      ),
+      waitForEvent<routes.events.EventData[routes.events.EventType.head]>(
+        bn.chain.emitter,
+        routes.events.EventType.head,
+        100000,
+        ({slot}) => slot === 32
+      ),
+    ]);
+    loggerNodeA.info("Node A reached post-gloas finalized checkpoint");
+
+    // Get Node A's finalized checkpoint state to use as Node B's anchor. This is what makes
+    // this a true checkpoint sync: the anchor block at the checkpoint is marked Syncing
+    const finalizedCp = bn.chain.forkChoice.getFinalizedCheckpoint();
+    const finalizedStateRes = bn.chain.getStateByCheckpoint(finalizedCp);
+    if (!finalizedStateRes) {
+      throw Error("Node A finalized checkpoint state not available");
+    }
+    const anchorState = (finalizedStateRes.state as BeaconStateView).cachedState;
+    loggerNodeA.info("Got Node A finalized checkpoint state for B anchor", {
+      epoch: finalizedCp.epoch,
+      slot: anchorState.slot,
+    });
+
+    // Node B: starts from Node A's finalized checkpoint state.
+    // use a custom eth1BlockHash so that every newPayload call will return SYNCING
+    const eth1BlockHash = "0x4242424242424242424242424242424242424242";
+    const bn2 = await getDevBeaconNode({
+      params: testParams,
+      options: {
+        api: {rest: {enabled: false}},
+        network: {useWorker: false},
+        chain: {blsVerifyAllMainThread: true},
+        executionEngine: {mode: "mock", eth1BlockHash},
+      },
+      validatorCount,
+      genesisTime,
+      logger: loggerNodeB,
+      anchorState,
+    });
+    afterEachCallbacks.push(() => bn2.close());
+
+    const headSummary = bn.chain.forkChoice.getHead();
+    const waitForSynced = waitForEvent<routes.events.EventData[routes.events.EventType.head]>(
+      bn2.chain.emitter,
+      routes.events.EventType.head,
+      100000,
+      ({slot}) => slot >= headSummary.slot
+    );
+
+    await Promise.all([connect(bn2.network, bn.network), onPeerConnect(bn2.network), onPeerConnect(bn.network)]);
+    loggerNodeA.info("Node B connected to Node A");
+
+    try {
+      await waitForSynced;
+      loggerNodeB.info("Node B synced to Node A's head", {slot: headSummary.slot});
+    } catch (_e) {
+      expect.fail("Node B failed to sync to Node A's head in time");
+    }
+
+    // 4. Confirm optimistic state: every gloas variant on Node B's chain should be Syncing.
+    // - For ancestors below head: check all 3 variants (PENDING, EMPTY, FULL).
+    // - For the head: range sync may have delivered the block but not its envelope yet
+    const bn2Head = bn2.chain.forkChoice.getHead();
+    const gloasFirstSlot = GLOAS_FORK_EPOCH * SLOTS_PER_EPOCH;
+    const bn2Ancestors = bn2.chain.forkChoice.getAllAncestorBlocks(bn2Head.blockRoot, bn2Head.payloadStatus);
+
+    // Build the (blockRoot, slot, variant) tuples once and reuse for both pre- and
+    // post-validation assertions.
+    const variantsToCheck: Array<{blockRoot: string; slot: Slot; variant: PayloadStatus}> = [];
+    for (const ancestor of bn2Ancestors) {
+      if (ancestor.slot < gloasFirstSlot) continue;
+      if (ancestor.blockRoot === bn2Head.blockRoot) continue;
+      for (const variant of [PayloadStatus.PENDING, PayloadStatus.EMPTY, PayloadStatus.FULL]) {
+        variantsToCheck.push({blockRoot: ancestor.blockRoot, slot: ancestor.slot, variant});
+      }
+    }
+    variantsToCheck.push(
+      {blockRoot: bn2Head.blockRoot, slot: bn2Head.slot, variant: PayloadStatus.PENDING},
+      {blockRoot: bn2Head.blockRoot, slot: bn2Head.slot, variant: PayloadStatus.EMPTY}
+    );
+
+    const expectVariantStatus = (
+      blockRoot: string,
+      slot: Slot,
+      variant: PayloadStatus,
+      expected: ExecutionStatus,
+      phase: string
+    ): void => {
+      const node = bn2.chain.forkChoice.getBlockHex(blockRoot, variant);
+      expect(node?.executionStatus).toBeWithMessage(
+        expected,
+        `expected gloas variant ${variant} of slot=${slot} root=${blockRoot} to be ${expected} ${phase}`
+      );
+    };
+
+    for (const {blockRoot, slot, variant} of variantsToCheck) {
+      expectVariantStatus(blockRoot, slot, variant, ExecutionStatus.Syncing, "pre-validation");
+    }
+    loggerNodeB.info("Node B fork-choice: all gloas variants on chain are Syncing (optimistic)");
+
+    // 5. Trigger validation using Node A's known payload for Node B's synced head.
+    // This simulates EL returning VALID for the payload corresponding to the optimistic head.
+    const nodeAHeadFull = bn.chain.forkChoice.getBlockHex(bn2Head.blockRoot, PayloadStatus.FULL);
+    if (nodeAHeadFull === null || nodeAHeadFull.executionPayloadBlockHash === null) {
+      throw Error(`No FULL variant found on Node A for synced head root=${bn2Head.blockRoot}`);
+    }
+    bn2.chain.forkChoice.onExecutionPayload(
+      bn2Head.blockRoot,
+      nodeAHeadFull.executionPayloadBlockHash,
+      nodeAHeadFull.executionPayloadNumber,
+      ExecutionStatus.Valid,
+      DataAvailabilityStatus.Available
+    );
+    loggerNodeB.info("Injected VALID payload for synced head to trigger back-validation");
+
+    // 6. Confirm back-validation: same iteration, plus head's FULL (now created by the
+    // onExecutionPayload call above).
+    variantsToCheck.push({blockRoot: bn2Head.blockRoot, slot: bn2Head.slot, variant: PayloadStatus.FULL});
+    for (const {blockRoot, slot, variant} of variantsToCheck) {
+      expectVariantStatus(blockRoot, slot, variant, ExecutionStatus.Valid, "post-validation");
+    }
+    loggerNodeB.info("All gloas variants on chain back-validated to Valid");
+  });
+});

--- a/packages/beacon-node/test/spec/utils/gossipValidation.ts
+++ b/packages/beacon-node/test/spec/utils/gossipValidation.ts
@@ -311,11 +311,16 @@ function invalidateImportedBlock(chain: BeaconChain, blockRootHex: RootHex, pare
   if (!parentBlock?.executionPayloadBlockHash) {
     throw new Error(`Cannot invalidate ${blockRootHex}: parent ${parentRootHex} has no latest valid execution hash`);
   }
+  const block = chain.forkChoice.getBlockHexDefaultStatus(blockRootHex);
+  if (!block?.executionPayloadBlockHash) {
+    throw new Error(`Cannot invalidate ${blockRootHex}: block has no execution payload hash`);
+  }
 
   chain.forkChoice.validateLatestHash({
     executionStatus: ExecutionStatus.Invalid,
     latestValidExecHash: parentBlock.executionPayloadBlockHash,
     invalidateFromParentBlockRoot: blockRootHex,
+    invalidateFromParentBlockHash: block.executionPayloadBlockHash,
   });
 }
 

--- a/packages/beacon-node/test/unit/chain/blocks/verifyBlocksSanityChecks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyBlocksSanityChecks.test.ts
@@ -39,7 +39,10 @@ describe("chain / blocks / verifyBlocksSanityChecks", () => {
 
   it("PARENT_UNKNOWN", () => {
     forkChoice.getBlockHexDefaultStatus.mockReturnValue(null);
-    expectThrowsLodestarError(() => verifyBlocksSanityChecks(modules, [block], {}), BlockErrorCode.PARENT_UNKNOWN);
+    expectThrowsLodestarError(
+      () => verifyBlocksSanityChecks(modules, [block], null, {}),
+      BlockErrorCode.PARENT_UNKNOWN
+    );
   });
 
   it("PARENT_PAYLOAD_UNKNOWN", () => {
@@ -55,19 +58,19 @@ describe("chain / blocks / verifyBlocksSanityChecks", () => {
     forkChoice.getBlockHexAndBlockHash.mockReturnValue(null);
 
     expectThrowsLodestarError(
-      () => verifyBlocksSanityChecks({...modules, config: gloasConfig}, [gloasBlock as SignedBeaconBlock], {}),
+      () => verifyBlocksSanityChecks({...modules, config: gloasConfig}, [gloasBlock as SignedBeaconBlock], null, {}),
       BlockErrorCode.PARENT_PAYLOAD_UNKNOWN
     );
   });
 
   it("GENESIS_BLOCK", () => {
     block.message.slot = 0;
-    expectThrowsLodestarError(() => verifyBlocksSanityChecks(modules, [block], {}), BlockErrorCode.GENESIS_BLOCK);
+    expectThrowsLodestarError(() => verifyBlocksSanityChecks(modules, [block], null, {}), BlockErrorCode.GENESIS_BLOCK);
   });
 
   it("ALREADY_KNOWN", () => {
     forkChoice.hasBlockHex.mockReturnValue(true);
-    expectThrowsLodestarError(() => verifyBlocksSanityChecks(modules, [block], {}), BlockErrorCode.ALREADY_KNOWN);
+    expectThrowsLodestarError(() => verifyBlocksSanityChecks(modules, [block], null, {}), BlockErrorCode.ALREADY_KNOWN);
   });
 
   it("WOULD_REVERT_FINALIZED_SLOT", () => {
@@ -77,19 +80,22 @@ describe("chain / blocks / verifyBlocksSanityChecks", () => {
       rootHex: "",
     });
     expectThrowsLodestarError(
-      () => verifyBlocksSanityChecks(modules, [block], {}),
+      () => verifyBlocksSanityChecks(modules, [block], null, {}),
       BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT
     );
   });
 
   it("FUTURE_SLOT", () => {
     block.message.slot = currentSlot + 1;
-    expectThrowsLodestarError(() => verifyBlocksSanityChecks(modules, [block], {}), BlockErrorCode.FUTURE_SLOT);
+    expectThrowsLodestarError(() => verifyBlocksSanityChecks(modules, [block], null, {}), BlockErrorCode.FUTURE_SLOT);
   });
 
   it("BLACKLISTED_BLOCK", () => {
     modules.blacklistedBlocks.set(toRootHex(ssz.phase0.BeaconBlock.hashTreeRoot(block.message)), null);
-    expectThrowsLodestarError(() => verifyBlocksSanityChecks(modules, [block], {}), BlockErrorCode.BLACKLISTED_BLOCK);
+    expectThrowsLodestarError(
+      () => verifyBlocksSanityChecks(modules, [block], null, {}),
+      BlockErrorCode.BLACKLISTED_BLOCK
+    );
   });
 
   it("[OK, OK]", () => {
@@ -102,7 +108,9 @@ describe("chain / blocks / verifyBlocksSanityChecks", () => {
     modules.forkChoice = getForkChoice([blocks[0]]);
     clock.setSlot(3);
 
-    const {relevantBlocks, parentSlots} = verifyBlocksSanityChecks(modules, blocksToProcess, {ignoreIfKnown: true});
+    const {relevantBlocks, parentSlots} = verifyBlocksSanityChecks(modules, blocksToProcess, null, {
+      ignoreIfKnown: true,
+    });
 
     expect(relevantBlocks).toEqual([blocks[1], blocks[2]]);
     // Also check parentSlots
@@ -120,7 +128,7 @@ describe("chain / blocks / verifyBlocksSanityChecks", () => {
     modules.forkChoice = getForkChoice([blocks[0], blocks[1]]);
     clock.setSlot(4);
 
-    const {relevantBlocks} = verifyBlocksSanityChecks(modules, blocksToProcess, {
+    const {relevantBlocks} = verifyBlocksSanityChecks(modules, blocksToProcess, null, {
       ignoreIfKnown: true,
     });
 
@@ -140,7 +148,7 @@ describe("chain / blocks / verifyBlocksSanityChecks", () => {
     modules.forkChoice = getForkChoice([blocks[0], blocks[1]], finalizedEpoch);
     clock.setSlot(finalizedSlot + 4);
 
-    const {relevantBlocks} = verifyBlocksSanityChecks(modules, blocksToProcess, {
+    const {relevantBlocks} = verifyBlocksSanityChecks(modules, blocksToProcess, null, {
       ignoreIfFinalized: true,
     });
 
@@ -154,7 +162,8 @@ describe("chain / blocks / verifyBlocksSanityChecks", () => {
 function verifyBlocksSanityChecks(
   modules: Parameters<typeof verifyBlocksImportSanityChecks>[0],
   blocks: SignedBeaconBlock[],
-  opts: Parameters<typeof verifyBlocksImportSanityChecks>[2]
+  payloadEnvelopes: Parameters<typeof verifyBlocksImportSanityChecks>[2],
+  opts: Parameters<typeof verifyBlocksImportSanityChecks>[3]
 ): {relevantBlocks: SignedBeaconBlock[]; parentSlots: Slot[]; parentBlock: ProtoBlock | null} {
   const {relevantBlocks, parentSlots, parentBlock} = verifyBlocksImportSanityChecks(
     modules,
@@ -172,6 +181,7 @@ function verifyBlocksSanityChecks(
         seenTimestampSec: Math.floor(Date.now() / 1000),
       });
     }),
+    payloadEnvelopes,
     opts
   );
   return {

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -798,7 +798,7 @@ export class ForkChoice implements IForkChoice {
               // Fallback to parent block's number (we know it's post-merge from check above)
               return parentBlock.executionPayloadNumber;
             })(),
-            executionStatus: this.getPostGloasExecStatus(executionStatus),
+            executionStatus: this.getPostMergeExecStatus(executionStatus),
             dataAvailabilityStatus,
           }
         : isExecutionBlockBodyType(block.body) &&
@@ -808,7 +808,7 @@ export class ForkChoice implements IForkChoice {
           ? {
               executionPayloadBlockHash: toRootHex(block.body.executionPayload.blockHash),
               executionPayloadNumber: block.body.executionPayload.blockNumber,
-              executionStatus: this.getPreGloasExecStatus(executionStatus),
+              executionStatus: this.getPostMergeExecStatus(executionStatus),
               dataAvailabilityStatus,
             }
           : {
@@ -1467,20 +1467,12 @@ export class ForkChoice implements IForkChoice {
     return dataAvailabilityStatus;
   }
 
-  private getPreGloasExecStatus(
+  private getPostMergeExecStatus(
     executionStatus: BlockExecutionStatus
   ): ExecutionStatus.Valid | ExecutionStatus.Syncing {
-    if (executionStatus === ExecutionStatus.PreMerge || executionStatus === ExecutionStatus.PayloadSeparated)
+    if (executionStatus === ExecutionStatus.PreMerge)
       throw Error(
         `Invalid post-merge execution status: expected: ${ExecutionStatus.Syncing} or ${ExecutionStatus.Valid}, got ${executionStatus}`
-      );
-    return executionStatus;
-  }
-
-  private getPostGloasExecStatus(executionStatus: BlockExecutionStatus): ExecutionStatus.PayloadSeparated {
-    if (executionStatus !== ExecutionStatus.PayloadSeparated)
-      throw Error(
-        `Invalid post-gloas execution status: expected: ${ExecutionStatus.PayloadSeparated}, got ${executionStatus}`
       );
     return executionStatus;
   }

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -24,16 +24,15 @@ export type VoteIndex = number;
  * - Syncing: EL is syncing, payload validity unknown (optimistic sync)
  * - PreMerge: Block is from before The Merge, no execution payload exists
  * - Invalid: Execution payload was invalidated by the EL (post-import status)
- * - PayloadSeparated: Gloas beacon block without embedded execution payload.
- *         The execution payload arrives separately via SignedExecutionPayloadEnvelope.
- *         Gloas blocks WITH execution payload (FULL variant) use Valid/Invalid/Syncing.
+ *
+ * For gloas blocks the PENDING/EMPTY variants inherit `executionStatus` from the parent's chain
+ * (Valid/Syncing/PreMerge); the FULL variant carries the EL response for this block's own payload.
  */
 export enum ExecutionStatus {
   Valid = "Valid",
   Syncing = "Syncing",
   PreMerge = "PreMerge",
   Invalid = "Invalid",
-  PayloadSeparated = "PayloadSeparated",
 }
 
 /**
@@ -61,19 +60,21 @@ export type LVHInvalidResponse = {
   executionStatus: ExecutionStatus.Invalid;
   latestValidExecHash: RootHex | null;
   invalidateFromParentBlockRoot: RootHex;
+  // EL block hash from invalid block's bid (gloas) or payload's parentHash (pre-gloas).
+  // Disambiguates which variant of the parent (FULL vs EMPTY) to invalidate from.
+  invalidateFromParentBlockHash: RootHex;
 };
 export type LVHExecResponse = LVHValidResponse | LVHInvalidResponse;
 
 /**
  * Any execution status that is not definitively invalid.
- * Pre-Gloas: Valid | Syncing | PreMerge
- * Post-Gloas: execution status must be PayloadSeparated (beacon block imported before its payload arrives via SignedExecutionPayloadEnvelope)
+ * Valid | Syncing | PreMerge
  */
 export type BlockExecutionStatus = Exclude<ExecutionStatus, ExecutionStatus.Invalid>;
 
 /**
  * Execution status for a block whose execution payload is present and has been submitted to the EL.
- * Used post-Gloas when transitioning a PayloadSeparated block to FULL via onExecutionPayload().
+ * Used post-Gloas when transitioning a PENDING block to FULL via onExecutionPayload().
  */
 export type PayloadExecutionStatus = ExecutionStatus.Valid | ExecutionStatus.Syncing;
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -252,38 +252,43 @@ export class ProtoArray {
   }
 
   /**
-   * Returns an EMPTY or FULL `ProtoBlock` that has matching block root and block hash
+   * Returns the node index of an EMPTY or FULL variant matching block root and block hash.
+   * Pre-gloas: checks the single variant. Post-gloas: prefers FULL, falls back to EMPTY.
    */
-  getBlockHexAndBlockHash(blockRoot: RootHex, blockHash: RootHex): ProtoBlock | null {
+  getNodeIndexByRootAndBlockHash(blockRoot: RootHex, blockHash: RootHex): number | undefined {
     const variantIndices = this.indices.get(blockRoot);
     if (variantIndices === undefined) {
-      return null;
+      return undefined;
     }
 
     // Pre-Gloas
     if (!Array.isArray(variantIndices)) {
-      const node = this.nodes[variantIndices];
-      return node.executionPayloadBlockHash === blockHash ? node : null;
+      return this.nodes[variantIndices].executionPayloadBlockHash === blockHash ? variantIndices : undefined;
     }
 
-    // Post-Gloas, check empty and full variants
+    // Post-Gloas, prefer FULL then EMPTY
     const fullNodeIndex = variantIndices[PayloadStatus.FULL];
-    if (fullNodeIndex !== undefined) {
-      const fullNode = this.nodes[fullNodeIndex];
-      if (fullNode && fullNode.executionPayloadBlockHash === blockHash) {
-        return fullNode;
-      }
+    if (fullNodeIndex !== undefined && this.nodes[fullNodeIndex].executionPayloadBlockHash === blockHash) {
+      return fullNodeIndex;
     }
 
-    const emptyNode = this.nodes[variantIndices[PayloadStatus.EMPTY]];
-    if (emptyNode && emptyNode.executionPayloadBlockHash === blockHash) {
-      return emptyNode;
+    const emptyNodeIndex = variantIndices[PayloadStatus.EMPTY];
+    if (this.nodes[emptyNodeIndex].executionPayloadBlockHash === blockHash) {
+      return emptyNodeIndex;
     }
 
     // PENDING is the same to EMPTY so not likely we can return it
     // also it's only specific for fork-choice
 
-    return null;
+    return undefined;
+  }
+
+  /**
+   * Returns an EMPTY or FULL `ProtoBlock` that has matching block root and block hash
+   */
+  getBlockHexAndBlockHash(blockRoot: RootHex, blockHash: RootHex): ProtoBlock | null {
+    const idx = this.getNodeIndexByRootAndBlockHash(blockRoot, blockHash);
+    return idx !== undefined ? this.nodes[idx] : null;
   }
 
   /**
@@ -600,7 +605,6 @@ export class ProtoArray {
       weight: 0,
       bestChild: undefined,
       bestDescendant: undefined,
-      // TODO GLOAS: handle optimistic sync
       executionStatus,
       executionPayloadBlockHash,
       executionPayloadNumber,
@@ -612,6 +616,12 @@ export class ProtoArray {
 
     // Add FULL variant to the indices array
     variants[PayloadStatus.FULL] = fullIndex;
+
+    if (executionStatus === ExecutionStatus.Valid) {
+      // Walk up from FULL's parent (its own PENDING). FULL is already Valid; the loop breaks
+      // immediately if we start at FULL. Same pattern as pre-gloas onBlock at line ~533.
+      this.propagateValidExecutionStatusByIndex(pendingIndex);
+    }
 
     // Update bestChild for PENDING node (may now prefer FULL over EMPTY)
     this.maybeUpdateBestChildAndDescendant(pendingIndex, fullIndex, currentSlot, proposerBoostRoot);
@@ -787,11 +797,15 @@ export class ProtoArray {
       // Mark chain ii) as Invalid if LVH is found and non null, else only invalidate invalid_payload
       // if its in fcU.
       //
-      const {invalidateFromParentBlockRoot, latestValidExecHash} = execResponse;
-      // TODO GLOAS: verify if getting the default/canonical node index is correct here
-      const invalidateFromParentIndex = this.getDefaultNodeIndex(invalidateFromParentBlockRoot);
+      const {invalidateFromParentBlockRoot, invalidateFromParentBlockHash, latestValidExecHash} = execResponse;
+      const invalidateFromParentIndex = this.getNodeIndexByRootAndBlockHash(
+        invalidateFromParentBlockRoot,
+        invalidateFromParentBlockHash
+      );
       if (invalidateFromParentIndex === undefined) {
-        throw Error(`Unable to find invalidateFromParentBlockRoot=${invalidateFromParentBlockRoot} in forkChoice`);
+        throw Error(
+          `Unable to find invalidateFromParentBlockRoot=${invalidateFromParentBlockRoot} invalidateFromParentBlockHash=${invalidateFromParentBlockHash} in forkChoice`
+        );
       }
       const latestValidHashIndex =
         latestValidExecHash !== null ? this.getNodeIndexFromLVH(latestValidExecHash, invalidateFromParentIndex) : null;
@@ -826,12 +840,6 @@ export class ProtoArray {
       const node = this.getNodeFromIndex(nodeIndex);
       if (node.executionStatus === ExecutionStatus.PreMerge || node.executionStatus === ExecutionStatus.Valid) {
         break;
-      }
-      // If PayloadSeparated, that means the node is either PENDING or EMPTY, there could be
-      // some ancestor still has syncing status.
-      if (node.executionStatus === ExecutionStatus.PayloadSeparated) {
-        nodeIndex = node.parent;
-        continue;
       }
       this.validateNodeByIndex(nodeIndex);
       nodeIndex = node.parent;
@@ -930,6 +938,13 @@ export class ProtoArray {
     invalidNode.executionStatus = ExecutionStatus.Invalid;
     invalidNode.bestChild = undefined;
     invalidNode.bestDescendant = undefined;
+    // Gloas: PENDING and sibling EMPTY share chain status, flip together
+    if (invalidNode.payloadStatus === PayloadStatus.PENDING) {
+      const variants = this.indices.get(invalidNode.blockRoot);
+      if (Array.isArray(variants)) {
+        this.invalidateNodeByIndex(variants[PayloadStatus.EMPTY]);
+      }
+    }
 
     return invalidNode;
   }
@@ -950,6 +965,13 @@ export class ProtoArray {
 
     if (validNode.executionStatus === ExecutionStatus.Syncing) {
       validNode.executionStatus = ExecutionStatus.Valid;
+    }
+    // Gloas: PENDING and sibling EMPTY share chain status, flip together
+    if (validNode.payloadStatus === PayloadStatus.PENDING) {
+      const variants = this.indices.get(validNode.blockRoot);
+      if (Array.isArray(variants)) {
+        this.validateNodeByIndex(variants[PayloadStatus.EMPTY]);
+      }
     }
     return validNode;
   }

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -168,6 +168,7 @@ describe("executionStatus / normal updates", () => {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "2C",
       invalidateFromParentBlockRoot: "3C",
+      invalidateFromParentBlockHash: "3C",
     },
     3
   );
@@ -231,6 +232,7 @@ describe("executionStatus / normal updates", () => {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "1A",
       invalidateFromParentBlockRoot: "3A",
+      invalidateFromParentBlockHash: "3A",
     },
     3
   );
@@ -278,6 +280,7 @@ describe("executionStatus / invalidate all postmerge chain", () => {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
       invalidateFromParentBlockRoot: "3B",
+      invalidateFromParentBlockHash: "3B",
     },
     3
   );
@@ -358,6 +361,7 @@ describe("executionStatus / poision forkchoice if we invalidate previous valid",
           executionStatus: ExecutionStatus.Invalid,
           latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
           invalidateFromParentBlockRoot: "3A",
+          invalidateFromParentBlockHash: "3A",
         },
         3
       )
@@ -395,6 +399,7 @@ describe("executionStatus / poision forkchoice if we validate previous invalid",
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
       invalidateFromParentBlockRoot: "3B",
+      invalidateFromParentBlockHash: "3B",
     },
     3
   );

--- a/packages/fork-choice/test/unit/protoArray/gloas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/gloas.test.ts
@@ -873,4 +873,197 @@ describe("Gloas Fork Choice", () => {
       expect(protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.FULL)).toBeUndefined();
     });
   });
+
+  describe("Inherited executionStatus on gloas onBlock (F1)", () => {
+    let protoArray: ProtoArray;
+
+    beforeEach(() => {
+      protoArray = new ProtoArray({
+        pruneThreshold: 0,
+        justifiedEpoch: genesisEpoch,
+        justifiedRoot: genesisRoot,
+        finalizedEpoch: genesisEpoch,
+        finalizedRoot: genesisRoot,
+      });
+      // Genesis block is Valid via createTestBlock default
+      protoArray.onBlock(createTestBlock(0, genesisRoot, "0x00"), 0, null);
+    });
+
+    it("PENDING/EMPTY inherit Syncing when caller passes Syncing", () => {
+      const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
+      block.executionStatus = ExecutionStatus.Syncing;
+      protoArray.onBlock(block, gloasForkSlot, null);
+      const pending = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.PENDING);
+      const empty = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.EMPTY);
+      expect(pending?.executionStatus).toBe(ExecutionStatus.Syncing);
+      expect(empty?.executionStatus).toBe(ExecutionStatus.Syncing);
+    });
+
+    it("PENDING/EMPTY inherit Valid when caller passes Valid", () => {
+      const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
+      block.executionStatus = ExecutionStatus.Valid;
+      protoArray.onBlock(block, gloasForkSlot, null);
+      const pending = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.PENDING);
+      const empty = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.EMPTY);
+      expect(pending?.executionStatus).toBe(ExecutionStatus.Valid);
+      expect(empty?.executionStatus).toBe(ExecutionStatus.Valid);
+    });
+  });
+
+  describe("Back-validation in onExecutionPayload (Fix #1)", () => {
+    let protoArray: ProtoArray;
+
+    beforeEach(() => {
+      protoArray = new ProtoArray({
+        pruneThreshold: 0,
+        justifiedEpoch: genesisEpoch,
+        justifiedRoot: genesisRoot,
+        finalizedEpoch: genesisEpoch,
+        finalizedRoot: genesisRoot,
+      });
+      protoArray.onBlock(createTestBlock(0, genesisRoot, "0x00"), 0, null);
+    });
+
+    it("VALID payload back-validates Syncing FULL ancestor on chain", () => {
+      // block1 (gloas, FULL Syncing) → block2 (gloas) extends block1's FULL
+      const block1 = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
+      block1.executionStatus = ExecutionStatus.Syncing;
+      protoArray.onBlock(block1, gloasForkSlot, null);
+      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Syncing);
+
+      const block2 = createTestBlock(gloasForkSlot + 1, "0x03", "0x02", "0x02");
+      block2.executionStatus = ExecutionStatus.Syncing;
+      protoArray.onBlock(block2, gloasForkSlot + 1, null);
+
+      // Pre-condition: block1 FULL is Syncing
+      expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL)?.executionStatus).toBe(
+        ExecutionStatus.Syncing
+      );
+
+      // VALID payload arrives for block2 — should walk up validating block1 FULL + PENDING
+      protoArray.onExecutionPayload("0x03", gloasForkSlot + 1, "0x03", gloasForkSlot + 1, null, ExecutionStatus.Valid);
+
+      expect(getNodeByPayloadStatus(protoArray, "0x03", PayloadStatus.FULL)?.executionStatus).toBe(
+        ExecutionStatus.Valid
+      );
+      expect(getNodeByPayloadStatus(protoArray, "0x03", PayloadStatus.PENDING)?.executionStatus).toBe(
+        ExecutionStatus.Valid
+      );
+      expect(getNodeByPayloadStatus(protoArray, "0x03", PayloadStatus.EMPTY)?.executionStatus).toBe(
+        ExecutionStatus.Valid
+      );
+      expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL)?.executionStatus).toBe(
+        ExecutionStatus.Valid
+      );
+      expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.PENDING)?.executionStatus).toBe(
+        ExecutionStatus.Valid
+      );
+      expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.EMPTY)?.executionStatus).toBe(
+        ExecutionStatus.Valid
+      );
+    });
+
+    it("VALID payload does NOT validate alternative-timeline FULL", () => {
+      // Production semantic: gloas PENDING/EMPTY store parentBlockHash in executionPayloadBlockHash.
+      // FULL stores its own payload hash. Need different hashes to test alt-timeline correctly.
+      const block1 = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
+      block1.executionStatus = ExecutionStatus.Syncing;
+      block1.executionPayloadBlockHash = genesisRoot; // PENDING/EMPTY store parent's payload hash
+      protoArray.onBlock(block1, gloasForkSlot, null);
+
+      // block1 FULL arrives Syncing with its OWN payload hash
+      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02hash", gloasForkSlot, null, ExecutionStatus.Syncing);
+
+      // block2 extends block1's EMPTY (parentBlockHash = genesisRoot, NOT block1's payload hash)
+      const block2 = createTestBlock(gloasForkSlot + 1, "0x03", "0x02", genesisRoot);
+      block2.executionStatus = ExecutionStatus.Syncing;
+      block2.executionPayloadBlockHash = genesisRoot; // PENDING/EMPTY store parent's payload hash
+      protoArray.onBlock(block2, gloasForkSlot + 1, null);
+
+      // VALID for block2 — walk should go through block1's EMPTY, NOT block1's FULL
+      protoArray.onExecutionPayload("0x03", gloasForkSlot + 1, "0x03", gloasForkSlot + 1, null, ExecutionStatus.Valid);
+
+      // block1 FULL must remain Syncing (not on this chain)
+      expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL)?.executionStatus).toBe(
+        ExecutionStatus.Syncing
+      );
+      // block1 EMPTY (on the chain) should now be Valid
+      expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.EMPTY)?.executionStatus).toBe(
+        ExecutionStatus.Valid
+      );
+      expect(getNodeByPayloadStatus(protoArray, "0x03", PayloadStatus.EMPTY)?.executionStatus).toBe(
+        ExecutionStatus.Valid
+      );
+    });
+
+    it("Syncing payload does NOT trigger back-validation", () => {
+      const block1 = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
+      block1.executionStatus = ExecutionStatus.Syncing;
+      protoArray.onBlock(block1, gloasForkSlot, null);
+      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Syncing);
+
+      // FULL is Syncing, ancestors not validated
+      expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL)?.executionStatus).toBe(
+        ExecutionStatus.Syncing
+      );
+      expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.PENDING)?.executionStatus).toBe(
+        ExecutionStatus.Syncing
+      );
+    });
+  });
+
+  describe("Parent variant disambiguation in validateLatestHash (F2)", () => {
+    let protoArray: ProtoArray;
+
+    beforeEach(() => {
+      protoArray = new ProtoArray({
+        pruneThreshold: 0,
+        justifiedEpoch: genesisEpoch,
+        justifiedRoot: genesisRoot,
+        finalizedEpoch: genesisEpoch,
+        finalizedRoot: genesisRoot,
+      });
+      protoArray.onBlock(createTestBlock(0, genesisRoot, "0x00"), 0, null);
+    });
+
+    it("getNodeIndexByRootAndBlockHash returns FULL when hash matches FULL", () => {
+      const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
+      block.executionStatus = ExecutionStatus.Syncing;
+      protoArray.onBlock(block, gloasForkSlot, null);
+      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02hash", gloasForkSlot, null, ExecutionStatus.Syncing);
+
+      // Look up by FULL's payload hash → should return FULL index
+      const fullIdx = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.FULL);
+      const found = protoArray.getNodeIndexByRootAndBlockHash("0x02", "0x02hash");
+      expect(found).toBe(fullIdx);
+    });
+
+    it("getNodeIndexByRootAndBlockHash returns EMPTY when hash matches EMPTY (parent's hash)", () => {
+      // For gloas EMPTY, executionPayloadBlockHash == bid.parentBlockHash (= genesisRoot here)
+      const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
+      block.executionStatus = ExecutionStatus.Syncing;
+      block.executionPayloadBlockHash = genesisRoot; // production semantic for gloas PENDING/EMPTY
+      protoArray.onBlock(block, gloasForkSlot, null);
+
+      // FULL not added yet — only EMPTY available with hash = genesisRoot
+      const emptyIdx = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.EMPTY);
+      const found = protoArray.getNodeIndexByRootAndBlockHash("0x02", genesisRoot);
+      expect(found).toBe(emptyIdx);
+    });
+
+    it("getNodeIndexByRootAndBlockHash returns undefined when no variant matches", () => {
+      const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
+      protoArray.onBlock(block, gloasForkSlot, null);
+      const found = protoArray.getNodeIndexByRootAndBlockHash("0x02", "0xunknown");
+      expect(found).toBeUndefined();
+    });
+
+    it("getNodeIndexByRootAndBlockHash returns pre-gloas FULL when hash matches", () => {
+      const preGloasBlock = createTestBlock(gloasForkSlot - 1, "0x05", genesisRoot);
+      protoArray.onBlock(preGloasBlock, gloasForkSlot - 1, null);
+      const fullIdx = protoArray.getNodeIndexByRootAndStatus("0x05", PayloadStatus.FULL);
+      const found = protoArray.getNodeIndexByRootAndBlockHash("0x05", "0x05");
+      expect(found).toBe(fullIdx);
+    });
+  });
 });

--- a/packages/fork-choice/test/unit/protoArray/gloas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/gloas.test.ts
@@ -929,7 +929,15 @@ describe("Gloas Fork Choice", () => {
       const block1 = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
       block1.executionStatus = ExecutionStatus.Syncing;
       protoArray.onBlock(block1, gloasForkSlot, null);
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Syncing);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Syncing,
+        DataAvailabilityStatus.Available
+      );
 
       const block2 = createTestBlock(gloasForkSlot + 1, "0x03", "0x02", "0x02");
       block2.executionStatus = ExecutionStatus.Syncing;
@@ -941,7 +949,15 @@ describe("Gloas Fork Choice", () => {
       );
 
       // VALID payload arrives for block2 — should walk up validating block1 FULL + PENDING
-      protoArray.onExecutionPayload("0x03", gloasForkSlot + 1, "0x03", gloasForkSlot + 1, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x03",
+        gloasForkSlot + 1,
+        "0x03",
+        gloasForkSlot + 1,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       expect(getNodeByPayloadStatus(protoArray, "0x03", PayloadStatus.FULL)?.executionStatus).toBe(
         ExecutionStatus.Valid
@@ -972,7 +988,15 @@ describe("Gloas Fork Choice", () => {
       protoArray.onBlock(block1, gloasForkSlot, null);
 
       // block1 FULL arrives Syncing with its OWN payload hash
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02hash", gloasForkSlot, null, ExecutionStatus.Syncing);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02hash",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Syncing,
+        DataAvailabilityStatus.Available
+      );
 
       // block2 extends block1's EMPTY (parentBlockHash = genesisRoot, NOT block1's payload hash)
       const block2 = createTestBlock(gloasForkSlot + 1, "0x03", "0x02", genesisRoot);
@@ -981,7 +1005,15 @@ describe("Gloas Fork Choice", () => {
       protoArray.onBlock(block2, gloasForkSlot + 1, null);
 
       // VALID for block2 — walk should go through block1's EMPTY, NOT block1's FULL
-      protoArray.onExecutionPayload("0x03", gloasForkSlot + 1, "0x03", gloasForkSlot + 1, null, ExecutionStatus.Valid);
+      protoArray.onExecutionPayload(
+        "0x03",
+        gloasForkSlot + 1,
+        "0x03",
+        gloasForkSlot + 1,
+        null,
+        ExecutionStatus.Valid,
+        DataAvailabilityStatus.Available
+      );
 
       // block1 FULL must remain Syncing (not on this chain)
       expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL)?.executionStatus).toBe(
@@ -1000,7 +1032,15 @@ describe("Gloas Fork Choice", () => {
       const block1 = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
       block1.executionStatus = ExecutionStatus.Syncing;
       protoArray.onBlock(block1, gloasForkSlot, null);
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, null, ExecutionStatus.Syncing);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Syncing,
+        DataAvailabilityStatus.Available
+      );
 
       // FULL is Syncing, ancestors not validated
       expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL)?.executionStatus).toBe(
@@ -1030,7 +1070,15 @@ describe("Gloas Fork Choice", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
       block.executionStatus = ExecutionStatus.Syncing;
       protoArray.onBlock(block, gloasForkSlot, null);
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02hash", gloasForkSlot, null, ExecutionStatus.Syncing);
+      protoArray.onExecutionPayload(
+        "0x02",
+        gloasForkSlot,
+        "0x02hash",
+        gloasForkSlot,
+        null,
+        ExecutionStatus.Syncing,
+        DataAvailabilityStatus.Available
+      );
 
       // Look up by FULL's payload hash → should return FULL index
       const fullIdx = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.FULL);


### PR DESCRIPTION
**Motivation**

Fix and track gloas checkpoint sync.

**Description**

Foundational changes:

- Remove `ExecutionStatus.PayloadSeparated`. Gloas blocks inherit parent's `executionStatus` via `importBlock`. Consumers work without changes.
- `LVHInvalidResponse` gains `invalidateFromParentBlockHash` to disambiguate parent variant in `validateLatestHash`. New helper `getNodeIndexByRootAndBlockHash`.
- `processBlocks` switches to a slot-keyed import loop. Imports orphan payloads (e.g. anchor's payload during checkpoint sync).
- `verifyBlocksInEpoch` DA-validates every payload in the envelopes Map.
- `verifyBlocksSanityChecks` and `assertLinearChainSegment` accept parent payload from same-batch envelopes.
- `regen.getPreState` looks up parent by default status; gloas variants share `stateRoot`.

Optimistic-sync fixes:

- `onExecutionPayload` back-validates ancestors on VALID, mirroring pre-gloas `onBlock`.
- `validateNodeByIndex` and `invalidateNodeByIndex` flip the sibling EMPTY on PENDING.
- `importExecutionPayload` derives `executionOptimistic` from `execStatus`.

**AI Assistance Disclosure**

Used Claude Code for review, planning, implementation, and test writing.
