### PR TITLE
fix: queue payload envelopes in network processor

### DIFF
--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -4,7 +4,6 @@ import {routes} from "@lodestar/api";
 import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {IBeaconStateView} from "@lodestar/state-transition";
 import {DataColumnSidecar, RootHex, deneb, phase0} from "@lodestar/types";
-import {SignedExecutionPayloadEnvelope} from "@lodestar/types/gloas";
 import {PeerIdStr} from "../util/peerId.js";
 import {BlockInputSource, IBlockInput} from "./blocks/blockInput/types.js";
 import {PayloadEnvelopeInput} from "./blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
@@ -61,10 +60,6 @@ export enum ChainEvent {
    */
   blockUnknownParent = "blockUnknownParent",
   /**
-   * Trigger BlockInputSync to find a SignedBeaconBlock given a SignedExecutionPayloadEnvelop received
-   */
-  envelopeUnknownBlock = "envelopeUnknownBlock",
-  /**
    * Trigger BlockInputSync to find a SignedBeaconBlock with specified block root.
    */
   unknownBlockRoot = "unknownBlockRoot",
@@ -92,11 +87,6 @@ type ApiEvents = {[K in routes.events.EventType]: (data: routes.events.EventData
 
 export type ChainEventData = {
   [ChainEvent.blockUnknownParent]: {blockInput: IBlockInput; peer: PeerIdStr; source: BlockInputSource};
-  [ChainEvent.envelopeUnknownBlock]: {
-    envelope: SignedExecutionPayloadEnvelope;
-    peer?: PeerIdStr;
-    source: BlockInputSource;
-  };
   [ChainEvent.unknownBlockRoot]: {rootHex: RootHex; peer?: PeerIdStr; source: BlockInputSource};
   [ChainEvent.incompleteBlockInput]: {blockInput: IBlockInput; peer: PeerIdStr; source: BlockInputSource};
   [ChainEvent.incompletePayloadEnvelope]: {
@@ -124,7 +114,6 @@ export type IChainEvents = ApiEvents & {
   // Sync events that are chain->chain. Initiated from network requests but do not cross the network
   // barrier so are considered ChainEvent(s).
   [ChainEvent.blockUnknownParent]: (data: ChainEventData[ChainEvent.blockUnknownParent]) => void;
-  [ChainEvent.envelopeUnknownBlock]: (data: ChainEventData[ChainEvent.envelopeUnknownBlock]) => void;
   [ChainEvent.unknownBlockRoot]: (data: ChainEventData[ChainEvent.unknownBlockRoot]) => void;
   [ChainEvent.incompleteBlockInput]: (data: ChainEventData[ChainEvent.incompleteBlockInput]) => void;
   [ChainEvent.incompletePayloadEnvelope]: (data: ChainEventData[ChainEvent.incompletePayloadEnvelope]) => void;

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1072,13 +1072,6 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
           const {beaconBlockRoot} = signedEnvelope.message;
           const slot = signedEnvelope.message.payload.slotNumber;
           logger.debug("Gossip envelope has error", {slot, root: toRootHex(beaconBlockRoot), code: e.type.code});
-          if (e.type.code === ExecutionPayloadEnvelopeErrorCode.BLOCK_ROOT_UNKNOWN) {
-            chain.emitter.emit(ChainEvent.envelopeUnknownBlock, {
-              envelope: signedEnvelope,
-              peer: peerIdStr,
-              source: BlockInputSource.gossip,
-            });
-          }
 
           if (e.action === GossipAction.REJECT) {
             chain.persistInvalidSszValue(

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -76,6 +76,7 @@ type WorkOpts = {
  */
 const executeGossipWorkOrderObj: Record<GossipType, WorkOpts> = {
   [GossipType.beacon_block]: {bypassQueue: true},
+  [GossipType.execution_payload]: {bypassQueue: true},
   [GossipType.blob_sidecar]: {bypassQueue: true},
   [GossipType.data_column_sidecar]: {bypassQueue: true},
   [GossipType.beacon_aggregate_and_proof]: {},
@@ -88,7 +89,6 @@ const executeGossipWorkOrderObj: Record<GossipType, WorkOpts> = {
   [GossipType.sync_committee]: {},
   [GossipType.light_client_finality_update]: {},
   [GossipType.light_client_optimistic_update]: {},
-  [GossipType.execution_payload]: {bypassQueue: true},
   [GossipType.payload_attestation_message]: {},
   [GossipType.execution_payload_bid]: {},
   [GossipType.proposer_preferences]: {},

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -444,8 +444,7 @@ export class NetworkProcessor {
         }
         case GossipType.execution_payload: {
           // extractBlockSlotRootFn does not return a root for this topic.
-          // Extract beacon_block_root directly and proactively trigger block sync if missing.
-          // Do NOT await the block — the handler runs immediately; BlockInputSync handles recovery.
+          // Extract beacon_block_root directly
           const blockRoot = getBeaconBlockRootFromExecutionPayloadEnvelopeSerialized(message.msg.data);
           if (blockRoot && !this.chain.forkChoice.hasBlockHexUnsafe(blockRoot)) {
             this.searchUnknownBlock(
@@ -453,9 +452,10 @@ export class NetworkProcessor {
               BlockInputSource.network_processor,
               message.propagationSource.toString()
             );
+            // We always want to await the block
+            // This allows us to properly forward the payload envelope
+            preprocessResult = {action: PreprocessAction.AwaitBlock, root: blockRoot};
           }
-          // do not await the block, we want UnknownBlockSync to handle it.
-          preprocessResult = {action: PreprocessAction.PushToQueue};
           break;
         }
         case GossipType.execution_payload_bid: {

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -145,7 +145,6 @@ export class BlockInputSync {
       this.chain.emitter.on(ChainEvent.incompleteBlockInput, this.onIncompleteBlockInput);
       this.chain.emitter.on(ChainEvent.incompletePayloadEnvelope, this.onIncompletePayloadEnvelope);
       this.chain.emitter.on(ChainEvent.blockUnknownParent, this.onUnknownParent);
-      this.chain.emitter.on(ChainEvent.envelopeUnknownBlock, this.onEnvelopeUnknownBlock);
       this.chain.emitter.on(routes.events.EventType.block, this.onBlockImported);
       this.chain.emitter.on(routes.events.EventType.executionPayload, this.onPayloadImported);
       this.network.events.on(NetworkEvent.peerConnected, this.onPeerConnected);
@@ -161,7 +160,6 @@ export class BlockInputSync {
     this.chain.emitter.off(ChainEvent.incompleteBlockInput, this.onIncompleteBlockInput);
     this.chain.emitter.off(ChainEvent.incompletePayloadEnvelope, this.onIncompletePayloadEnvelope);
     this.chain.emitter.off(ChainEvent.blockUnknownParent, this.onUnknownParent);
-    this.chain.emitter.off(ChainEvent.envelopeUnknownBlock, this.onEnvelopeUnknownBlock);
     this.chain.emitter.off(routes.events.EventType.block, this.onBlockImported);
     this.chain.emitter.off(routes.events.EventType.executionPayload, this.onPayloadImported);
     this.network.events.off(NetworkEvent.peerConnected, this.onPeerConnected);
@@ -260,19 +258,6 @@ export class BlockInputSync {
       this.metrics?.blockInputSync.source.inc({source: data.source});
     } catch (e) {
       this.logger.debug("Error handling unknownParent event", {}, e as Error);
-    }
-  };
-
-  private onEnvelopeUnknownBlock = (data: ChainEventData[ChainEvent.envelopeUnknownBlock]): void => {
-    try {
-      const blockRootHex = toRootHex(data.envelope.message.beaconBlockRoot);
-      this.addByRootHex(blockRootHex, data.peer);
-      this.addByPayloadEnvelope(data.envelope, data.peer);
-      this.triggerUnknownBlockSearch();
-      this.metrics?.blockInputSync.requests.inc({type: PendingBlockType.UNKNOWN_DATA});
-      this.metrics?.blockInputSync.source.inc({source: data.source});
-    } catch (e) {
-      this.logger.debug("Error handling envelopeUnknownBlock event", {}, e as Error);
     }
   };
 
@@ -379,41 +364,6 @@ export class BlockInputSync {
       this.logger.verbose(`Pruned ${prunedItemCount} items from BlockInputSync.pendingPayloads`);
     }
     return added;
-  };
-
-  private addByPayloadEnvelope = (envelope: gloas.SignedExecutionPayloadEnvelope, peerIdStr?: PeerIdStr): void => {
-    const rootHex = toRootHex(envelope.message.beaconBlockRoot);
-    const existingPendingPayload = this.pendingPayloads.get(rootHex);
-    let pendingPayload = this.pendingPayloads.get(rootHex);
-    if (!pendingPayload || !isPendingPayloadEnvelope(pendingPayload)) {
-      pendingPayload = {
-        status: PendingPayloadInputStatus.waitingForBlock,
-        envelope,
-        peerIdStrings: new Set(existingPendingPayload?.peerIdStrings ?? []),
-        timeAddedSec: existingPendingPayload?.timeAddedSec ?? Date.now() / 1000,
-      };
-      this.pendingPayloads.set(rootHex, pendingPayload);
-
-      this.logger.verbose("Added payload envelope to BlockInputSync.pendingPayloads", {
-        slot: envelope.message.payload.slotNumber,
-        root: rootHex,
-      });
-    } else {
-      this.logger.debug("Overwriting pending payload envelope for root already waiting for block", {
-        slot: envelope.message.payload.slotNumber,
-        root: rootHex,
-      });
-      pendingPayload.envelope = envelope;
-    }
-
-    if (peerIdStr) {
-      pendingPayload.peerIdStrings.add(peerIdStr);
-    }
-
-    const prunedItemCount = pruneSetToMax(this.pendingPayloads, this.maxPendingBlocks);
-    if (prunedItemCount > 0) {
-      this.logger.verbose(`Pruned ${prunedItemCount} items from BlockInputSync.pendingPayloads`);
-    }
   };
 
   private addByPayloadInput = (

--- a/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
@@ -70,11 +70,6 @@ describe("sync / unknown block sync thru gloas", () => {
       expectsPayloadImport: true,
     },
     {
-      id: "should do an envelopeUnknownBlock sync from another BN",
-      event: ChainEvent.envelopeUnknownBlock,
-      expectsPayloadImport: true,
-    },
-    {
       id: "should do an incompletePayloadEnvelope sync from another BN",
       event: ChainEvent.incompletePayloadEnvelope,
       expectsPayloadImport: true,
@@ -232,20 +227,6 @@ describe("sync / unknown block sync thru gloas", () => {
             source: BlockInputSource.gossip,
           });
           break;
-        case ChainEvent.envelopeUnknownBlock: {
-          // Node A produced the head; its cache has the full signed envelope (populated via
-          // publishExecutionPayloadEnvelope -> payloadInput.addPayloadEnvelope).
-          const payloadInputOnA = bn.chain.seenPayloadEnvelopeInputCache.get(headRootHex);
-          if (!payloadInputOnA?.hasPayloadEnvelope()) {
-            throw Error(`Expected node A to have signed envelope for ${headRootHex}`);
-          }
-          bn2.chain.emitter.emit(ChainEvent.envelopeUnknownBlock, {
-            envelope: payloadInputOnA.getPayloadEnvelope(),
-            peer: sourcePeerId,
-            source: BlockInputSource.gossip,
-          });
-          break;
-        }
         case ChainEvent.incompletePayloadEnvelope: {
           // get the chain started with an unknownBlockRoot
           bn2.chain.emitter.emit(ChainEvent.unknownBlockRoot, {

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -585,7 +585,6 @@ describe("UnknownBlockSync", () => {
           expect(events.listenerCount(ChainEvent.unknownBlockRoot)).toBe(1);
           expect(events.listenerCount(ChainEvent.blockUnknownParent)).toBe(1);
           expect(events.listenerCount(ChainEvent.unknownEnvelopeBlockRoot)).toBe(1);
-          expect(events.listenerCount(ChainEvent.envelopeUnknownBlock)).toBe(1);
           expect(events.listenerCount(ChainEvent.incompletePayloadEnvelope)).toBe(1);
           expect(events.listenerCount(routes.events.EventType.block)).toBe(1);
           expect(events.listenerCount(routes.events.EventType.executionPayload)).toBe(1);
@@ -594,7 +593,6 @@ describe("UnknownBlockSync", () => {
           expect(events.listenerCount(ChainEvent.unknownBlockRoot)).toBe(0);
           expect(events.listenerCount(ChainEvent.blockUnknownParent)).toBe(0);
           expect(events.listenerCount(ChainEvent.unknownEnvelopeBlockRoot)).toBe(0);
-          expect(events.listenerCount(ChainEvent.envelopeUnknownBlock)).toBe(0);
           expect(events.listenerCount(ChainEvent.incompletePayloadEnvelope)).toBe(0);
           expect(events.listenerCount(routes.events.EventType.block)).toBe(0);
           expect(events.listenerCount(routes.events.EventType.executionPayload)).toBe(0);
@@ -1002,173 +1000,6 @@ describe("UnknownBlockSync", () => {
       expect(processExecutionPayload).toHaveBeenCalledTimes(2);
       expect(processExecutionPayload).toHaveBeenNthCalledWith(1, payloadInput);
       expect(processExecutionPayload).toHaveBeenNthCalledWith(2, payloadInput);
-    });
-
-    it("waits for block after envelopeUnknownBlock and processes payload on block import", async () => {
-      const peer = await getRandPeerIdStr();
-      const {blockRootHex, payloadInput, envelope} = buildPayloadFixture({
-        blobCount: 0,
-        sampledColumns: [],
-        slot: 1,
-      });
-
-      let cachedPayloadInput: PayloadEnvelopeInput | undefined;
-      let blockKnown = false;
-      const processExecutionPayload = vi.fn().mockResolvedValue(undefined);
-      const {emitter} = setupPayloadSyncTest({
-        chainOverrides: {
-          processExecutionPayload,
-          seenPayloadEnvelopeInputCache: {
-            get: vi.fn().mockImplementation((root: string) => (root === blockRootHex ? cachedPayloadInput : undefined)),
-            prune: vi.fn(),
-          } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
-          forkChoice: {
-            hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
-            hasBlockHex: vi.fn().mockImplementation((root: string) => root === blockRootHex && blockKnown),
-            getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
-          } as unknown as IForkChoice,
-        },
-      });
-
-      emitter.emit(ChainEvent.envelopeUnknownBlock, {
-        envelope,
-        peer,
-        source: BlockInputSource.gossip,
-      });
-
-      await sleep(20);
-      expect(processExecutionPayload).not.toHaveBeenCalled();
-
-      cachedPayloadInput = payloadInput;
-      blockKnown = true;
-      emitter.emit(routes.events.EventType.block, {slot: 1, block: blockRootHex, executionOptimistic: false});
-
-      await sleep(50);
-
-      expect(validateGossipExecutionPayloadEnvelope).toHaveBeenCalledOnce();
-      expect(processExecutionPayload).toHaveBeenCalledTimes(1);
-      expect(processExecutionPayload).toHaveBeenCalledWith(payloadInput);
-      expect(payloadInput.hasPayloadEnvelope()).toBe(true);
-    });
-
-    it("reuses a queued envelope when incomplete payload input arrives for the same root", async () => {
-      const peer = await getRandPeerIdStr();
-      const {payloadInput, envelope} = buildPayloadFixture({
-        blobCount: 0,
-        sampledColumns: [],
-        slot: 1,
-      });
-
-      const sendExecutionPayloadEnvelopesByRoot = vi.fn();
-      const processExecutionPayload = vi.fn().mockResolvedValue(undefined);
-      const {emitter} = setupPayloadSyncTest({
-        chainOverrides: {
-          processExecutionPayload,
-          seenPayloadEnvelopeInputCache: {
-            get: vi.fn().mockReturnValue(undefined),
-            prune: vi.fn(),
-          } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
-          forkChoice: {
-            hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
-            hasBlockHex: vi.fn().mockImplementation((root: string) => root === payloadInput.blockRootHex),
-            getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
-          } as unknown as IForkChoice,
-        },
-        networkOverrides: {sendExecutionPayloadEnvelopesByRoot},
-      });
-
-      emitter.emit(ChainEvent.envelopeUnknownBlock, {
-        envelope,
-        peer,
-        source: BlockInputSource.gossip,
-      });
-
-      await sleep(20);
-
-      expect(processExecutionPayload).not.toHaveBeenCalled();
-
-      emitter.emit(ChainEvent.incompletePayloadEnvelope, {
-        payloadInput,
-        peer,
-        source: BlockInputSource.gossip,
-      });
-
-      await sleep(20);
-
-      expect(sendExecutionPayloadEnvelopesByRoot).not.toHaveBeenCalled();
-      expect(processExecutionPayload).toHaveBeenCalledTimes(1);
-      expect(processExecutionPayload).toHaveBeenCalledWith(payloadInput);
-      expect(payloadInput.hasPayloadEnvelope()).toBe(true);
-      expect(payloadInput.getPayloadEnvelope()).toBe(envelope);
-    });
-
-    it("refetches by root if a queued envelope fails validation after block import", async () => {
-      const peer = await getRandPeerIdStr();
-      const {blockRoot, blockRootHex, payloadInput, envelope} = buildPayloadFixture({
-        blobCount: 0,
-        sampledColumns: [],
-        slot: 1,
-      });
-
-      const invalidEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
-      invalidEnvelope.message.beaconBlockRoot = blockRoot;
-      invalidEnvelope.message.payload.slotNumber = 1;
-
-      vi.mocked(validateGossipExecutionPayloadEnvelope).mockImplementationOnce(async (_chain, signedEnvelope) => {
-        if (signedEnvelope === invalidEnvelope) {
-          throw new Error("invalid queued envelope");
-        }
-      });
-
-      let connected = false;
-      let cachedPayloadInput: PayloadEnvelopeInput | undefined;
-      let blockKnown = false;
-      const processExecutionPayload = vi.fn().mockResolvedValue(undefined);
-      const sendExecutionPayloadEnvelopesByRoot = vi.fn().mockResolvedValueOnce([envelope]);
-      const {emitter} = setupPayloadSyncTest({
-        chainOverrides: {
-          processExecutionPayload,
-          seenPayloadEnvelopeInputCache: {
-            get: vi.fn().mockImplementation((root: string) => (root === blockRootHex ? cachedPayloadInput : undefined)),
-            prune: vi.fn(),
-          } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
-          forkChoice: {
-            hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
-            hasBlockHex: vi.fn().mockImplementation((root: string) => root === blockRootHex && blockKnown),
-            getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
-          } as unknown as IForkChoice,
-        },
-        networkOverrides: {
-          getConnectedPeers: () => (connected ? [peer] : []),
-          sendExecutionPayloadEnvelopesByRoot,
-        },
-        peers: [{peerId: peer}],
-      });
-
-      emitter.emit(ChainEvent.envelopeUnknownBlock, {
-        envelope: invalidEnvelope,
-        peer,
-        source: BlockInputSource.gossip,
-      });
-
-      await sleep(20);
-
-      expect(sendExecutionPayloadEnvelopesByRoot).not.toHaveBeenCalled();
-      expect(processExecutionPayload).not.toHaveBeenCalled();
-
-      connected = true;
-      cachedPayloadInput = payloadInput;
-      blockKnown = true;
-      emitter.emit(routes.events.EventType.block, {slot: 1, block: blockRootHex, executionOptimistic: false});
-
-      await sleep(50);
-
-      expect(sendExecutionPayloadEnvelopesByRoot).toHaveBeenCalledTimes(1);
-      expect(sendExecutionPayloadEnvelopesByRoot).toHaveBeenNthCalledWith(1, peer, [blockRoot]);
-      expect(validateGossipExecutionPayloadEnvelope).toHaveBeenCalledTimes(2);
-      expect(processExecutionPayload).toHaveBeenCalledTimes(1);
-      expect(processExecutionPayload).toHaveBeenCalledWith(payloadInput);
-      expect(payloadInput.hasPayloadEnvelope()).toBe(true);
     });
 
     it("retries payload processing on a later scheduler pass after an execution engine error", async () => {


### PR DESCRIPTION
**Motivation**

- without this, queued payloads get IGNOREd during gossip

**Description**

- queue payloads inside the network processor rather than unknown block sync
- move payload envelope network processor queue priority (2nd behind beacon blocks)