### PR TITLE
fix: queue envelope if it comes before block

### DIFF
--- a/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
@@ -10,6 +10,10 @@ import {ExecutionPayloadEnvelopeError, ExecutionPayloadEnvelopeErrorCode, Gossip
 import {IBeaconChain} from "../index.js";
 import {RegenCaller} from "../regen/index.js";
 
+export type ValidateExecutionPayloadEnvelopeOpts = {
+  ignoreIfKnown?: boolean;
+};
+
 export async function validateApiExecutionPayloadEnvelope(
   chain: IBeaconChain,
   executionPayloadEnvelope: gloas.SignedExecutionPayloadEnvelope
@@ -19,14 +23,16 @@ export async function validateApiExecutionPayloadEnvelope(
 
 export async function validateGossipExecutionPayloadEnvelope(
   chain: IBeaconChain,
-  executionPayloadEnvelope: gloas.SignedExecutionPayloadEnvelope
+  executionPayloadEnvelope: gloas.SignedExecutionPayloadEnvelope,
+  opts: ValidateExecutionPayloadEnvelopeOpts = {}
 ): Promise<void> {
-  return validateExecutionPayloadEnvelope(chain, executionPayloadEnvelope);
+  return validateExecutionPayloadEnvelope(chain, executionPayloadEnvelope, opts);
 }
 
 async function validateExecutionPayloadEnvelope(
   chain: IBeaconChain,
-  executionPayloadEnvelope: gloas.SignedExecutionPayloadEnvelope
+  executionPayloadEnvelope: gloas.SignedExecutionPayloadEnvelope,
+  opts: ValidateExecutionPayloadEnvelopeOpts = {}
 ): Promise<void> {
   const envelope = executionPayloadEnvelope.message;
   const {payload} = envelope;
@@ -50,6 +56,9 @@ async function validateExecutionPayloadEnvelope(
   const envelopeBlock = chain.forkChoice.getBlockHex(blockRootHex, PayloadStatus.FULL);
   const payloadInput = chain.seenPayloadEnvelopeInputCache.get(blockRootHex);
   if (envelopeBlock || payloadInput?.hasPayloadEnvelope()) {
+    if (opts.ignoreIfKnown) {
+      return;
+    }
     throw new ExecutionPayloadEnvelopeError(GossipAction.IGNORE, {
       code: ExecutionPayloadEnvelopeErrorCode.ENVELOPE_ALREADY_KNOWN,
       blockRoot: blockRootHex,

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -894,7 +894,7 @@ export function createLodestarMetrics(
         name: "lodestar_gossip_execution_payload_envelope_wait_for_block_seconds",
         help: "Time spent in execution_payload gossip handler waiting for an unknown beacon block, labelled by outcome",
         labelNames: ["result"],
-        buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 4, 6, 12],
+        buckets: [0.05, 0.1, 0.5, 1, 2, 4],
       }),
     },
     // recovery in the case of specific blob rows required

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -890,6 +890,12 @@ export function createLodestarMetrics(
         labelNames: ["source"],
         buckets: [0.5, 1, 2, 4, 6, 12],
       }),
+      waitForBlock: register.histogram<{result: "resolved" | "timeout"}>({
+        name: "lodestar_gossip_execution_payload_envelope_wait_for_block_seconds",
+        help: "Time spent in execution_payload gossip handler waiting for an unknown beacon block, labelled by outcome",
+        labelNames: ["result"],
+        buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 4, 6, 12],
+      }),
     },
     // recovery in the case of specific blob rows required
     recoverBlobSidecars: {

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1062,21 +1062,56 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       const {serializedData} = gossipData;
       const signedEnvelope = sszDeserialize(topic, serializedData);
       const envelope = signedEnvelope.message;
+      const slot = envelope.payload.slotNumber;
+      const blockRootHex = toRootHex(envelope.beaconBlockRoot);
 
-      // unlike BlockInput, we send the envelope into UnknownBlockInput sync
-      // inside the sync it'll reconcile into PayloadEnvelopeInput and share the same cache with gossip
+      // If the beacon block has not yet been imported, hand the envelope to BlockInputSync
+      // (so it can reconcile via reconcilePayloadEnvelope as soon as the block lands) and
+      // wait for the block to import. This lets us validate, Accept, and forward to gossipsub
+      // instead of failing fast with BLOCK_ROOT_UNKNOWN -> Ignore.
+      let waited = false;
+      if (!chain.forkChoice.hasBlockHexUnsafe(blockRootHex)) {
+        chain.emitter.emit(ChainEvent.envelopeUnknownBlock, {
+          envelope: signedEnvelope,
+          peer: peerIdStr,
+          source: BlockInputSource.gossip,
+        });
+        waited = true;
+        logger.verbose("Waiting for unknown block before validating execution payload envelope", {
+          slot,
+          root: blockRootHex,
+        });
+        const waitStartSec = Date.now() / 1000;
+        const found = await chain.waitForBlock(slot, blockRootHex);
+        const waitElapsedSec = Date.now() / 1000 - waitStartSec;
+        metrics?.gossipExecutionPayloadEnvelope.waitForBlock.observe(
+          {result: found ? "resolved" : "timeout"},
+          waitElapsedSec
+        );
+        if (!found) {
+          logger.verbose("Timed out waiting for unknown block", {slot, root: blockRootHex, waitElapsedSec});
+          throw new ExecutionPayloadEnvelopeError(GossipAction.IGNORE, {
+            code: ExecutionPayloadEnvelopeErrorCode.BLOCK_ROOT_UNKNOWN,
+            blockRoot: blockRootHex,
+          });
+        }
+        logger.verbose("Block imported, resuming execution payload envelope validation", {
+          slot,
+          root: blockRootHex,
+          waitElapsedSec,
+        });
+      }
+
       try {
-        await validateGossipExecutionPayloadEnvelope(chain, signedEnvelope);
+        await validateGossipExecutionPayloadEnvelope(chain, signedEnvelope, {ignoreIfKnown: waited});
       } catch (e) {
         if (e instanceof ExecutionPayloadEnvelopeError) {
-          const {beaconBlockRoot} = signedEnvelope.message;
-          const slot = signedEnvelope.message.payload.slotNumber;
-          logger.debug("Gossip envelope has error", {slot, root: toRootHex(beaconBlockRoot), code: e.type.code});
+          logger.debug("Gossip envelope has error", {slot, root: blockRootHex, code: e.type.code});
           if (e.type.code === ExecutionPayloadEnvelopeErrorCode.BLOCK_ROOT_UNKNOWN) {
-            chain.emitter.emit(ChainEvent.envelopeUnknownBlock, {
-              envelope: signedEnvelope,
-              peer: peerIdStr,
-              source: BlockInputSource.gossip,
+            // Should be unreachable: handler awaits chain.waitForBlock above before validating.
+            logger.debug("Unexpected BLOCK_ROOT_UNKNOWN in execution_payload handler", {
+              slot,
+              root: blockRootHex,
             });
           }
 
@@ -1092,12 +1127,10 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         throw e;
       }
 
-      const slot = envelope.payload.slotNumber;
       const delaySec = seenTimestampSec - computeTimeAtSlot(config, slot, chain.genesisTime);
       metrics?.gossipExecutionPayloadEnvelope.elapsedTimeTillReceived.observe({source: OpSource.gossip}, delaySec);
       chain.validatorMonitor?.registerExecutionPayloadEnvelope(OpSource.gossip, delaySec, signedEnvelope);
 
-      const blockRootHex = toRootHex(envelope.beaconBlockRoot);
       const payloadInput = chain.seenPayloadEnvelopeInputCache.get(blockRootHex);
 
       if (!payloadInput) {
@@ -1106,6 +1139,13 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
           code: ExecutionPayloadEnvelopeErrorCode.PAYLOAD_ENVELOPE_INPUT_MISSING,
           blockRoot: blockRootHex,
         });
+      }
+
+      if (payloadInput.hasPayloadEnvelope()) {
+        // BlockInputSync.reconcilePayloadEnvelope already added the same envelope while we
+        // waited. Nothing left to do — return so gossipValidatorFn maps to Accept and gossipsub
+        // forwards.
+        return;
       }
 
       chain.serializedCache.set(signedEnvelope, serializedData);

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -870,7 +870,7 @@ export class BlockInputSync {
 
     if (!payloadInput.hasPayloadEnvelope()) {
       const validationResult = await wrapError(
-        validateGossipExecutionPayloadEnvelope(this.chain, pendingPayload.envelope)
+        validateGossipExecutionPayloadEnvelope(this.chain, pendingPayload.envelope, {ignoreIfKnown: true})
       );
       if (validationResult.err) {
         this.logger.debug(
@@ -1079,7 +1079,7 @@ export class BlockInputSync {
         }
 
         if (!payloadInput.hasPayloadEnvelope()) {
-          await validateGossipExecutionPayloadEnvelope(this.chain, envelope);
+          await validateGossipExecutionPayloadEnvelope(this.chain, envelope, {ignoreIfKnown: true});
         }
 
         let pendingPayload = this.toPendingPayloadInput(payloadInput, cacheItem, envelope);


### PR DESCRIPTION
**Motivation**

- we did not forward envelope to the network if it comes before the block

**Description**

- wait for block in gossip handler
- still emit `ChainEvent.envelopeUnknownBlock` event to unknown block sync

- pros:
  - keep network processor and unknown block sync unchanged
  - can have metrics + logs for us to debug

- cons:
  - throw error after 12s, but this does not affect UnknownBlock sync

**AI Assistance Disclosure**
Created with Claude