### PR TITLE
fix: allow known PayloadEnvelopeInput

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -5,6 +5,7 @@ import {
   BUILDER_INDEX_SELF_BUILD,
   ForkPostBellatrix,
   ForkPostFulu,
+  ForkPostGloas,
   ForkPreGloas,
   NUMBER_OF_COLUMNS,
   SLOTS_PER_HISTORICAL_ROOT,
@@ -109,6 +110,18 @@ export function getBeaconBlockApi({
       seenTimestampSec,
       blockRootHex: blockRoot,
     });
+
+    if (isForkPostGloas(fork)) {
+      chain.seenPayloadEnvelopeInputCache.add({
+        blockRootHex: blockRoot,
+        block: signedBlock as SignedBeaconBlock<ForkPostGloas>,
+        forkName: fork,
+        sampledColumns: chain.custodyConfig.sampledColumns,
+        custodyColumns: chain.custodyConfig.custodyColumns,
+        timeCreatedSec: seenTimestampSec,
+      });
+    }
+
     let blobSidecars: deneb.BlobSidecars, dataColumnSidecars: fulu.DataColumnSidecar[];
 
     if (isDenebBlockContents(signedBlockContents)) {

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -9,14 +9,7 @@ import {
   NotReorgedReason,
   getSafeExecutionBlockHash,
 } from "@lodestar/fork-choice";
-import {
-  ForkPostAltair,
-  ForkPostElectra,
-  ForkPostGloas,
-  ForkSeq,
-  MAX_SEED_LOOKAHEAD,
-  SLOTS_PER_EPOCH,
-} from "@lodestar/params";
+import {ForkPostAltair, ForkPostElectra, ForkSeq, MAX_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
   IBeaconStateView,
   RootCache,
@@ -27,17 +20,7 @@ import {
   isStatePostAltair,
   isStatePostBellatrix,
 } from "@lodestar/state-transition";
-import {
-  Attestation,
-  BeaconBlock,
-  SignedBeaconBlock,
-  altair,
-  capella,
-  electra,
-  isGloasBeaconBlock,
-  phase0,
-  ssz,
-} from "@lodestar/types";
+import {Attestation, BeaconBlock, altair, capella, electra, isGloasBeaconBlock, phase0, ssz} from "@lodestar/types";
 import {isErrorAborted, toRootHex} from "@lodestar/utils";
 import {ZERO_HASH_HEX} from "../../constants/index.js";
 import {callInNextEventLoop} from "../../util/eventLoop.js";
@@ -135,18 +118,13 @@ export async function importBlock(
   // Some block event handlers require state being in state cache so need to do this before emitting EventType.block
   this.regen.processState(blockRootHex, postState);
 
-  // For range sync, PayloadEnvelope is created before reaching this
-  // we also don't need to trigger getBlobs() in that case
+  // For range sync we skip triggerGetBlobs because column fetching is handled in the range path.
   if (fork >= ForkSeq.gloas && !opts.fromRangeSync) {
-    const payloadInput = this.seenPayloadEnvelopeInputCache.add({
-      blockRootHex,
-      block: block as SignedBeaconBlock<ForkPostGloas>,
-      forkName: blockInput.forkName,
-      sampledColumns: this.custodyConfig.sampledColumns,
-      custodyColumns: this.custodyConfig.custodyColumns,
-      timeCreatedSec: fullyVerifiedBlock.seenTimestampSec,
-    });
-    this.logger.debug("Created PayloadEnvelopeInput for block", {
+    const payloadInput = this.seenPayloadEnvelopeInputCache.get(blockRootHex);
+    if (!payloadInput) {
+      throw Error(`PayloadEnvelopeInput not seeded for block ${blockRootHex} before importBlock`);
+    }
+    this.logger.debug("PayloadEnvelopeInput ready for block", {
       slot: blockSlot,
       root: blockRootHex,
       source: source.source,

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -121,15 +121,11 @@ export async function importBlock(
   // For range sync we skip triggerGetBlobs because column fetching is handled in the range path.
   if (fork >= ForkSeq.gloas && !opts.fromRangeSync) {
     const payloadInput = this.seenPayloadEnvelopeInputCache.get(blockRootHex);
+    // PayloadEnvelopeInput is supposed to have right after we have block
+    // there are 4 sources of them: gossip, by root, by range and api
     if (!payloadInput) {
       throw Error(`PayloadEnvelopeInput not seeded for block ${blockRootHex} before importBlock`);
     }
-    this.logger.debug("PayloadEnvelopeInput ready for block", {
-      slot: blockSlot,
-      root: blockRootHex,
-      source: source.source,
-      ...(opts.seenTimestampSec !== undefined ? {recvToImport: Date.now() / 1000 - opts.seenTimestampSec} : {}),
-    });
 
     // Immediately attempt fetch of data columns from execution engine as the bid contains kzg commitments
     // which is all the information we need so there is no reason to delay until execution payload arrives

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
@@ -156,6 +156,7 @@ export class PayloadEnvelopeInput {
       throw new Error("Payload envelope beacon_block_root mismatch");
     }
 
+    // TODO GLOAS: track source by metrics, maybe inside the seen cache
     const source: SourceMeta = {
       source: props.source,
       seenTimestampSec: props.seenTimestampSec,

--- a/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
@@ -78,8 +78,9 @@ export class SeenPayloadEnvelopeInput {
   };
 
   add(props: Omit<CreateFromBlockProps, "daOutOfRange">): PayloadEnvelopeInput {
-    if (this.payloadInputs.has(props.blockRootHex)) {
-      throw new Error(`PayloadEnvelopeInput already exists for block ${props.blockRootHex}`);
+    const existing = this.payloadInputs.get(props.blockRootHex);
+    if (existing !== undefined) {
+      return existing;
     }
     const daOutOfRange = isDaOutOfRange(this.config, props.forkName, props.block.message.slot, this.clock.currentEpoch);
     const input = PayloadEnvelopeInput.createFromBlock({...props, daOutOfRange});

--- a/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
@@ -80,12 +80,21 @@ export class SeenPayloadEnvelopeInput {
   add(props: Omit<CreateFromBlockProps, "daOutOfRange">): PayloadEnvelopeInput {
     const existing = this.payloadInputs.get(props.blockRootHex);
     if (existing !== undefined) {
+      this.logger?.verbose("SeenPayloadEnvelopeInput.add reused existing entry", {
+        slot: existing.slot,
+        root: props.blockRootHex,
+      });
       return existing;
     }
     const daOutOfRange = isDaOutOfRange(this.config, props.forkName, props.block.message.slot, this.clock.currentEpoch);
     const input = PayloadEnvelopeInput.createFromBlock({...props, daOutOfRange});
     this.payloadInputs.set(props.blockRootHex, input);
     this.metrics?.seenCache.payloadEnvelopeInput.created.inc();
+    this.logger?.verbose("SeenPayloadEnvelopeInput.add created new entry", {
+      slot: input.slot,
+      root: props.blockRootHex,
+      daOutOfRange,
+    });
     return input;
   }
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -185,6 +185,18 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
     });
     try {
       await validateGossipBlock(config, chain, signedBlock, fork);
+
+      if (isForkPostGloas(fork)) {
+        chain.seenPayloadEnvelopeInputCache.add({
+          blockRootHex,
+          block: signedBlock as SignedBeaconBlock<ForkPostGloas>,
+          forkName: fork,
+          sampledColumns: chain.custodyConfig.sampledColumns,
+          custodyColumns: chain.custodyConfig.custodyColumns,
+          timeCreatedSec: seenTimestampSec,
+        });
+      }
+
       const blockInputMeta = blockInput.getLogMeta();
 
       const recvToValidation = Date.now() / 1000 - seenTimestampSec;

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -185,9 +185,24 @@ export function cacheByRangeResponses({
     }
   }
 
-  // Build payloadEnvelopes map for gloas: start from existing (partial download) state.
-  // The entries are wrappers around (block + envelope + sampled columns) and also seeded into
-  // seenPayloadEnvelopeInputCache so importBlock can find them without creating a duplicate.
+  // Seed seenPayloadEnvelopeInputCache for every gloas block in the batch, regardless of whether
+  // the peer returned its envelope. Without this, a block returned without its envelope would be
+  // imported with no cache entry, and later payload-by-root sync would throw
+  // "Missing PayloadEnvelopeInput for known block" (see issue #9306).
+  for (const blockInput of updatedBatchBlocks.values()) {
+    if (!blockInput.hasBlock() || !isForkPostGloas(blockInput.forkName)) continue;
+    seenPayloadEnvelopeInputCache.add({
+      blockRootHex: blockInput.blockRootHex,
+      block: blockInput.getBlock() as SignedBeaconBlock<ForkPostGloas>,
+      forkName: blockInput.forkName,
+      sampledColumns: custodyConfig.sampledColumns,
+      custodyColumns: custodyConfig.custodyColumns,
+      timeCreatedSec: seenTimestampSec,
+    });
+  }
+
+  // Attach envelopes to entries whose envelope was returned by the peer. The returned
+  // payloadEnvelopes map only contains entries with envelopes ready for importExecutionPayload.
   let payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null = null;
   if (downloadedPayloadEnvelopes !== null) {
     payloadEnvelopes = new Map(existingPayloadEnvelopes ?? []);
@@ -198,20 +213,11 @@ export function cacheByRangeResponses({
         // No block to pair this envelope with; drop silently
         continue;
       }
-      const {blockRootHex} = blockInput;
 
-      // Reuse any existing PayloadEnvelopeInput (e.g. gossip arrived first) to avoid
-      // duplicate cache entries. If missing, create a fresh one from the block's bid.
-      let payloadInput = seenPayloadEnvelopeInputCache.get(blockRootHex);
+      const payloadInput = seenPayloadEnvelopeInputCache.get(blockInput.blockRootHex);
       if (payloadInput === undefined) {
-        payloadInput = seenPayloadEnvelopeInputCache.add({
-          blockRootHex,
-          block: blockInput.getBlock() as SignedBeaconBlock<ForkPostGloas>,
-          forkName: blockInput.forkName,
-          sampledColumns: custodyConfig.sampledColumns,
-          custodyColumns: custodyConfig.custodyColumns,
-          timeCreatedSec: seenTimestampSec,
-        });
+        // Unreachable given the loop above seeded an entry for every gloas block in the batch.
+        continue;
       }
 
       if (!payloadInput.hasPayloadEnvelope()) {

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -3,6 +3,7 @@ import {ChainForkConfig} from "@lodestar/config";
 import {
   ForkPostDeneb,
   ForkPostFulu,
+  ForkPostGloas,
   ForkPreFulu,
   isForkPostDeneb,
   isForkPostFulu,
@@ -111,6 +112,17 @@ export async function downloadByRoot({
       blockRootHex: rootHex,
       seenTimestampSec: Date.now() / 1000,
       source: BlockInputSource.byRoot,
+    });
+  }
+
+  if (isForkPostGloas(blockInput.forkName)) {
+    chain.seenPayloadEnvelopeInputCache.add({
+      blockRootHex: rootHex,
+      block: blockInput.getBlock() as SignedBeaconBlock<ForkPostGloas>,
+      forkName: blockInput.forkName,
+      sampledColumns: chain.custodyConfig.sampledColumns,
+      custodyColumns: chain.custodyConfig.custodyColumns,
+      timeCreatedSec: Date.now() / 1000,
     });
   }
 

--- a/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
@@ -123,10 +123,10 @@ describe("sync / unknown block sync thru gloas", () => {
         testLoggerOpts,
       });
 
-      afterEachCallbacks.push(() => Promise.all(validators.map((v) => v.close().catch(() => {}))));
-
-      // stop bn after validators
       afterEachCallbacks.push(() => bn.close().catch(() => {}));
+      // Cleanup callbacks run LIFO: close validators before Node A so a late
+      // proposal tick cannot call into a closing beacon node.
+      afterEachCallbacks.push(() => Promise.all(validators.map((v) => v.close().catch(() => {}))));
 
       const payloadEvent = await waitForTargetPayloadOnNodeA;
       loggerNodeA.info("Node A selected gloas payload target", {slot: payloadEvent.slot, root: payloadEvent.blockRoot});
@@ -178,6 +178,18 @@ describe("sync / unknown block sync thru gloas", () => {
         forkName: bn.chain.config.getForkName(headSlot),
         daOutOfRange: false,
       });
+      if (event === ChainEvent.blockUnknownParent || event === ChainEvent.incompleteBlockInput) {
+        // This test injects a BlockInput directly into Node B, bypassing the gossip handler
+        // that normally seeds PayloadEnvelopeInput for Gloas blocks before unknown sync sees it.
+        bn2.chain.seenPayloadEnvelopeInputCache.add({
+          blockRootHex: headRootHex,
+          block: head,
+          forkName: headInput.forkName,
+          sampledColumns: bn2.chain.custodyConfig.sampledColumns,
+          custodyColumns: bn2.chain.custodyConfig.custodyColumns,
+          timeCreatedSec: headInput.getTimeComplete(),
+        });
+      }
       const waitForPayloadImported = expectsPayloadImport
         ? waitForEvent<routes.events.EventData[routes.events.EventType.executionPayload]>(
             bn2.chain.emitter,

--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -261,6 +261,17 @@ const forkChoiceTest =
                     seenTimestampSec: 0,
                     daOutOfRange: false,
                   });
+                  // importBlock requires a PayloadEnvelopeInput to exist for gloas blocks; in
+                  // production this is seeded by gossip / by-root / by-range / API producers.
+                  // Spec tests bypass those, so seed it here to mirror the gossip-handler path.
+                  chain.seenPayloadEnvelopeInputCache.add({
+                    blockRootHex,
+                    block: signedBlock as SignedBeaconBlock<ForkPostGloas>,
+                    forkName: fork,
+                    sampledColumns: chain.custodyConfig.sampledColumns,
+                    custodyColumns: chain.custodyConfig.custodyColumns,
+                    timeCreatedSec: Date.now() / 1000,
+                  });
                 } else if (forkSeq >= ForkSeq.fulu) {
                   if (columns === undefined) {
                     columns = [];

--- a/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
@@ -59,4 +59,22 @@ describe("SeenPayloadEnvelopeInput", () => {
 
     expect(cache.get(rootHex)).toBeDefined();
   });
+
+  it("add returns the existing entry on duplicate root", () => {
+    const {block, rootHex} = generateBlock({forkName: ForkName.gloas, slot: 1});
+    const props = {
+      blockRootHex: rootHex,
+      block,
+      forkName: ForkName.gloas,
+      sampledColumns: [],
+      custodyColumns: [],
+      timeCreatedSec: Date.now() / 1000,
+    };
+
+    const first = cache.add(props);
+    const second = cache.add(props);
+
+    expect(second).toBe(first);
+    expect(cache.size()).toBe(1);
+  });
 });

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -405,6 +405,7 @@ describe("sync by UnknownBlockSync", {timeout: 20_000}, () => {
         clock: new ClockStopped(0),
         forkChoice: forkChoice as IForkChoice,
         genesisTime: 0,
+        custodyConfig: {sampledColumns: [], custodyColumns: []} as unknown as CustodyConfig,
         processBlock: async (blockInput, opts) => {
           const block = blockInput.getBlock();
           const parentRootHex = toRootHex(block.message.parentRoot);
@@ -455,6 +456,7 @@ describe("sync by UnknownBlockSync", {timeout: 20_000}, () => {
           prune: () => {},
         } as unknown as SeenBlockInput,
         seenPayloadEnvelopeInputCache: {
+          add: vi.fn(),
           get: vi.fn().mockReturnValue(undefined),
           prune: vi.fn(),
         } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
@@ -638,12 +640,14 @@ describe("UnknownBlockSync", () => {
         emitter,
         clock: new ClockStopped(0),
         config: gloasConfig,
+        custodyConfig,
         genesisTime: 0,
         metrics: null,
         serializedCache: {delete: vi.fn()} as unknown as IBeaconChain["serializedCache"],
         getBlockByRoot: vi.fn().mockResolvedValue(null),
         processExecutionPayload: vi.fn().mockResolvedValue(undefined),
         seenPayloadEnvelopeInputCache: {
+          add: vi.fn(),
           get: vi.fn().mockReturnValue(undefined),
           prune: vi.fn(),
         } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
@@ -713,6 +717,7 @@ describe("UnknownBlockSync", () => {
         chainOverrides: {
           processExecutionPayload,
           seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
             get: vi.fn().mockImplementation((root: string) => (root === blockRootHex ? payloadInput : undefined)),
             prune: vi.fn(),
           } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
@@ -782,6 +787,7 @@ describe("UnknownBlockSync", () => {
         chainOverrides: {
           processExecutionPayload,
           seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
             get: vi.fn().mockImplementation((root: string) => (root === blockRootHex ? payloadInput : undefined)),
             prune: vi.fn(),
           } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
@@ -846,6 +852,7 @@ describe("UnknownBlockSync", () => {
           processBlock,
           processExecutionPayload,
           seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
             get: vi.fn().mockImplementation((root: string) => (root === blockRootHex ? cachedPayloadInput : undefined)),
             prune: vi.fn(),
           } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
@@ -940,6 +947,7 @@ describe("UnknownBlockSync", () => {
           processBlock,
           processExecutionPayload,
           seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
             get: vi.fn().mockImplementation((root: string) => (root === blockRootHex ? payloadInput : undefined)),
             prune: vi.fn(),
           } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
@@ -1026,6 +1034,7 @@ describe("UnknownBlockSync", () => {
         chainOverrides: {
           processExecutionPayload,
           seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
             get: vi.fn().mockImplementation((root: string) => (root === blockRootHex ? payloadInput : undefined)),
             prune: vi.fn(),
           } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
@@ -1079,6 +1088,7 @@ describe("UnknownBlockSync", () => {
         chainOverrides: {
           processExecutionPayload,
           seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
             get: vi.fn().mockImplementation((root: string) => (root === blockRootHex ? payloadInput : undefined)),
             prune: vi.fn(),
           } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
@@ -1115,6 +1125,7 @@ describe("UnknownBlockSync", () => {
         chainOverrides: {
           processExecutionPayload,
           seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
             get: vi.fn().mockReturnValue(payloadInput),
             prune: vi.fn(),
           } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
@@ -1178,6 +1189,7 @@ describe("UnknownBlockSync", () => {
           processExecutionPayload,
           processBlock,
           seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
             get: vi.fn().mockImplementation((root: string) => (root === parentRootHex ? payloadInput : undefined)),
             prune: vi.fn(),
           } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
@@ -1266,6 +1278,7 @@ describe("UnknownBlockSync", () => {
         chainOverrides: {
           processBlock,
           seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
             get: vi
               .fn()
               .mockImplementation((root: string) => (root === parentRootHex ? parentPayloadInput : undefined)),
@@ -1336,6 +1349,7 @@ describe("UnknownBlockSync", () => {
           processExecutionPayload,
           processBlock,
           seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
             get: vi.fn().mockImplementation((root: string) => (root === parentRootHex ? payloadInput : undefined)),
             prune: seenPayloadPrune,
           } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
@@ -1420,6 +1434,7 @@ describe("UnknownBlockSync", () => {
       emitter: new ChainEventEmitter(),
       config: gloasConfig,
       clock: new ClockStopped(0),
+      custodyConfig: {sampledColumns: [], custodyColumns: []} as unknown as CustodyConfig,
       genesisTime: 0,
       metrics: null,
       processBlock,
@@ -1434,6 +1449,7 @@ describe("UnknownBlockSync", () => {
         hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
       } as unknown as IForkChoice,
       seenPayloadEnvelopeInputCache: {
+        add: vi.fn(),
         get: vi.fn(),
         prune: vi.fn(),
       } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],


### PR DESCRIPTION
**Motivation**

- we restrict adding PayloadEnvelopeInput once for nothing
- specifically in #9306 where range sync cannot add PayloadEnvelopeInput, but Unknown Block Sync see the block in forkchoice and expect we do have that PayloadEnvelopeInput

**Description**

Follow the same flow like with BlockInput, add it when:
- download by root
- download by range
- gossip handler

Closes #9306

**AI Assistance Disclosure**

Created with Claude
