### PR TITLE
fix: remove gloas genesis workarounds

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -49,7 +49,7 @@ import {
   ssz,
 } from "@lodestar/types";
 import {Logger, byteArrayEquals, fromHex, sleep, toHex, toPubkeyHex, toRootHex} from "@lodestar/utils";
-import {ZERO_HASH, ZERO_HASH_HEX} from "../../constants/index.js";
+import {ZERO_HASH_HEX} from "../../constants/index.js";
 import {numToQuantity} from "../../execution/engine/utils.js";
 import {
   IExecutionBuilder,

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -225,12 +225,6 @@ export async function produceBlockBody<T extends BlockType>(
       stateAfterParentPayload = currentState.withParentPayloadApplied(parentExecutionRequests);
     } else {
       parentBlockHash = currentState.latestExecutionPayloadBid.parentBlockHash;
-      // At gloas genesis the committed bid has no prior EL block to reference
-      // (`bid.parentBlockHash` is zero). Fall back to `bid.blockHash` (= eth1 genesis hash) so the
-      // FCU to the EL carries a valid head. Post-genesis bids always reference a non-zero parent.
-      if (byteArrayEquals(parentBlockHash, ZERO_HASH)) {
-        parentBlockHash = currentState.latestExecutionPayloadBid.blockHash;
-      }
       parentExecutionRequests = ssz.electra.ExecutionRequests.defaultValue();
     }
     const prepareRes = await prepareExecutionPayload(

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -268,11 +268,6 @@ export class ForkChoice implements IForkChoice {
       return {shouldOverrideFcu: false, reason: NotReorgedReason.ProposerBoostReorgDisabled};
     }
 
-    // Gloas genesis anchor has no parent in the proto array. No reorg possible.
-    if (headBlock.parentRoot === HEX_ZERO_HASH) {
-      return {shouldOverrideFcu: false, reason: NotReorgedReason.ParentBlockNotAvailable};
-    }
-
     const parentBlock = this.protoArray.getBlock(
       headBlock.parentRoot,
       this.protoArray.getParentPayloadStatus(headBlock)
@@ -391,11 +386,6 @@ export class ForkChoice implements IForkChoice {
         proposerBoostReorg,
       });
       return {proposerHead, isHeadTimely, notReorgedReason: NotReorgedReason.ProposerBoostReorgDisabled};
-    }
-
-    // Gloas genesis anchor has no parent in the proto array. No reorg possible.
-    if (headBlock.parentRoot === HEX_ZERO_HASH) {
-      return {proposerHead, isHeadTimely, notReorgedReason: NotReorgedReason.ParentBlockNotAvailable};
     }
 
     const parentBlock = this.protoArray.getBlock(


### PR DESCRIPTION
These workarounds are no longer needed since the genesis state for gloas was updated. This essentially reverts changes from https://github.com/ChainSafe/lodestar/pull/9273, further gloas genesis related changes will be reverted in the alpha.6 upgrade.