### PR TITLE
fix: range sync mismarks partial batches as fully downloaded

### DIFF
--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -895,14 +895,11 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
     return this.getAllColumnsWithSource().map(({columnSidecar}) => columnSidecar);
   }
 
+  /**
+   * This function strictly checks all missing column from sampledColumns
+   * hasAllData is not considered
+   */
   getMissingSampledColumnMeta(): MissingColumnMeta {
-    if (this.state.hasAllData) {
-      return {
-        missing: [],
-        versionedHashes: this.state.versionedHashes,
-      };
-    }
-
     const missing: number[] = [];
     for (const index of this.sampledColumns) {
       if (!this.columnsCache.has(index)) {

--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -896,10 +896,16 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
   }
 
   /**
-   * This function strictly checks all missing column from sampledColumns
-   * hasAllData is not considered
+   * Strictly checks missing sampled columns. Does NOT short-circuit on `state.hasAllData`.
    */
   getMissingSampledColumnMeta(): MissingColumnMeta {
+    if (this.state.hasComputedAllData) {
+      return {
+        missing: [],
+        versionedHashes: this.state.versionedHashes,
+      };
+    }
+
     const missing: number[] = [];
     for (const index of this.sampledColumns) {
       if (!this.columnsCache.has(index)) {

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
@@ -312,10 +312,13 @@ export class PayloadEnvelopeInput {
   }
 
   /**
-   * This function strictly checks all missing column from sampledColumns
-   * hasAllData is not considered
+   * Strictly checks missing sampled columns. Does NOT short-circuit on `state.hasAllData`.
    */
   getMissingSampledColumnMeta(): MissingColumnMeta {
+    if (this.state.hasComputedAllData) {
+      return {missing: [], versionedHashes: this.versionedHashes};
+    }
+
     const missing: ColumnIndex[] = [];
     for (const index of this.sampledColumns) {
       if (!this.columnsCache.has(index)) {

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
@@ -311,11 +311,11 @@ export class PayloadEnvelopeInput {
     return this.state.hasAllData;
   }
 
+  /**
+   * This function strictly checks all missing column from sampledColumns
+   * hasAllData is not considered
+   */
   getMissingSampledColumnMeta(): MissingColumnMeta {
-    if (this.state.hasAllData) {
-      return {missing: [], versionedHashes: this.versionedHashes};
-    }
-
     const missing: ColumnIndex[] = [];
     for (const index of this.sampledColumns) {
       if (!this.columnsCache.has(index)) {

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -267,11 +267,15 @@ export class Batch {
       // range of 40 - 63, startSlot will be inclusive but subtraction will exclusive so need to + 1
       const count = endSlot - dataStartSlot + 1;
       if (isForkPostFulu(this.forkName) && withinValidRequestWindow) {
-        requests.columnsRequest = {
-          count,
-          startSlot: dataStartSlot,
-          columns: Array.from(neededColumns),
-        };
+        // Skip the column re-request when we have no specific column indices outstanding.
+        // Peer rejects an empty `columns` list
+        if (neededColumns.size > 0) {
+          requests.columnsRequest = {
+            count,
+            startSlot: dataStartSlot,
+            columns: Array.from(neededColumns),
+          };
+        }
       } else if (isForkPostDeneb(this.forkName) && withinValidRequestWindow) {
         requests.blobsRequest = {
           count,

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -202,6 +202,7 @@ export class Batch {
     const envelopesBySlot = this.state.payloadEnvelopes ?? new Map<Slot, PayloadEnvelopeInput>();
 
     // ensure blocks are in slot-wise order
+    const isPostGloas = isForkPostGloas(this.forkName);
     for (const blockInput of blocks) {
       const blockSlot = blockInput.slot;
       // check if block/data is present (hasBlock/hasAllData). If present then check if startSlot is the same as
@@ -217,21 +218,36 @@ export class Batch {
       if (blockInput.hasBlock() && blockStartSlot === blockSlot) {
         blockStartSlot = blockSlot + 1;
       }
-      if (
-        blockInput.hasBlock() &&
-        envelopeStartSlot === blockSlot &&
-        envelopesBySlot.get(blockSlot)?.hasPayloadEnvelope()
-      ) {
-        envelopeStartSlot = blockSlot + 1;
-      }
-      if (!blockInput.hasAllData()) {
-        if (isBlockInputColumns(blockInput)) {
-          for (const index of blockInput.getMissingSampledColumnMeta().missing) {
+
+      // Range sync uses hasComputedAllData (all sampled columns physically present), not hasAllData
+      // which flips at the reconstruction threshold. Sync never triggers reconstruction, so accepting
+      // a half-downloaded block here makes writeBlockInputToDb later block on waitForComputedAllData.
+      if (isPostGloas) {
+        // Post-Gloas: column data lives on PayloadEnvelopeInput, not on BlockInputNoData.
+        const payloadInput = envelopesBySlot.get(blockSlot);
+        if (blockInput.hasBlock() && envelopeStartSlot === blockSlot && payloadInput?.hasPayloadEnvelope()) {
+          envelopeStartSlot = blockSlot + 1;
+        }
+        if (payloadInput && !payloadInput.hasComputedAllData()) {
+          for (const index of payloadInput.getMissingSampledColumnMeta().missing) {
             neededColumns.add(index);
           }
+        } else if (payloadInput?.hasComputedAllData() && dataStartSlot === blockSlot) {
+          // Only advance dataStartSlot when we know columns for this slot are complete. If
+          // payloadInput is missing entirely we cannot tell, so stop here so the next round
+          // re-requests columns (and envelopes) starting at this slot.
+          dataStartSlot = blockSlot + 1;
         }
-      } else if (dataStartSlot === blockSlot) {
-        dataStartSlot = blockSlot + 1;
+      } else {
+        if (isBlockInputColumns(blockInput) ? !blockInput.hasComputedAllData() : !blockInput.hasAllData()) {
+          if (isBlockInputColumns(blockInput)) {
+            for (const index of blockInput.getMissingSampledColumnMeta().missing) {
+              neededColumns.add(index);
+            }
+          }
+        } else if (dataStartSlot === blockSlot) {
+          dataStartSlot = blockSlot + 1;
+        }
       }
     }
 
@@ -379,7 +395,11 @@ export class Batch {
     const slots = new Set<number>();
     for (const block of blocks) {
       slots.add(block.slot);
-      if (!block.hasBlockAndAllData()) {
+      const dataComplete = isBlockInputColumns(block)
+        ? // by_range needs to download all columns
+          block.hasBlock() && block.hasComputedAllData()
+        : block.hasBlockAndAllData();
+      if (!dataComplete) {
         allComplete = false;
       }
     }
@@ -395,11 +415,22 @@ export class Batch {
     }
     const newPayloadEnvelopes = payloadEnvelopes ?? this.state.payloadEnvelopes;
 
+    if (allComplete && isForkPostGloas(this.forkName)) {
+      for (const block of blocks) {
+        const payloadInput = newPayloadEnvelopes?.get(block.slot);
+        // by_range needs to download all columns
+        if (!payloadInput?.hasPayloadEnvelope() || !payloadInput.hasComputedAllData()) {
+          allComplete = false;
+          break;
+        }
+      }
+    }
+
     if (allComplete) {
       this.state = {status: BatchStatus.AwaitingProcessing, blocks, payloadEnvelopes: newPayloadEnvelopes};
     } else {
-      this.requests = this.getRequests(blocks);
       this.state = {status: BatchStatus.AwaitingDownload, blocks, payloadEnvelopes: newPayloadEnvelopes};
+      this.requests = this.getRequests(blocks);
     }
 
     return this.state as DownloadSuccessState;

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -202,12 +202,10 @@ export function cacheByRangeResponses({
     });
   }
 
-  // Attach envelopes to entries whose envelope was returned by the peer. The returned
-  // payloadEnvelopes map only contains entries with envelopes ready for importExecutionPayload.
-  let payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null = null;
+  let payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null =
+    existingPayloadEnvelopes !== null ? new Map(existingPayloadEnvelopes) : null;
   if (downloadedPayloadEnvelopes !== null) {
-    payloadEnvelopes = new Map(existingPayloadEnvelopes ?? []);
-
+    payloadEnvelopes ??= new Map();
     for (const [slot, envelope] of downloadedPayloadEnvelopes) {
       const blockInput = updatedBatchBlocks.get(slot);
       if (!blockInput?.hasBlock() || !isForkPostGloas(blockInput.forkName)) {

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -1,9 +1,16 @@
 import {generateKeyPair} from "@libp2p/crypto/keys";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {ForkName} from "@lodestar/params";
-import {ssz} from "@lodestar/types";
-import {BlockInputPreData} from "../../../../src/chain/blocks/blockInput/blockInput.js";
+import {SignedBeaconBlock, ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {
+  BlockInputColumns,
+  BlockInputNoData,
+  BlockInputPreData,
+} from "../../../../src/chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource} from "../../../../src/chain/blocks/blockInput/types.js";
+import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
+import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
 import {computeNodeIdFromPrivateKey} from "../../../../src/network/subnets/index.js";
 import {Batch, BatchError, BatchErrorCode, BatchStatus} from "../../../../src/sync/range/batch.js";
 import {CustodyConfig} from "../../../../src/util/dataColumns.js";
@@ -261,6 +268,196 @@ describe("sync / range / batch", async () => {
 
   describe("downloadingSuccess", () => {
     it("should handle blocks that are not in slot-wise order", () => {});
+
+    describe("post-Gloas", () => {
+      const startEpoch = config.GLOAS_FORK_EPOCH + 1;
+      const seenTimestampSec = Date.now() / 1000;
+
+      function buildGloasBlockWithEnvelope({
+        slot,
+        blobCount = 0,
+        sampledColumns = [],
+        addEnvelope = true,
+        addAllColumns = true,
+      }: {
+        slot: number;
+        blobCount?: number;
+        sampledColumns?: number[];
+        addEnvelope?: boolean;
+        addAllColumns?: boolean;
+      }): {blockInput: BlockInputNoData; payloadInput: PayloadEnvelopeInput} {
+        const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+        block.message.slot = slot;
+        block.message.body.signedExecutionPayloadBid.message.blobKzgCommitments = Array.from({length: blobCount}, () =>
+          Buffer.alloc(48, 0x11)
+        );
+        const blockRoot = ssz.gloas.BeaconBlock.hashTreeRoot(block.message);
+        const blockRootHex = toRootHex(blockRoot);
+        const blockInput = BlockInputNoData.createFromBlock({
+          block: block as SignedBeaconBlock<typeof ForkName.gloas>,
+          blockRootHex,
+          forkName: ForkName.gloas,
+          daOutOfRange: false,
+          seenTimestampSec,
+          source: BlockInputSource.byRange,
+          peerIdStr: peer,
+        });
+        const payloadInput = PayloadEnvelopeInput.createFromBlock({
+          blockRootHex,
+          block: block as SignedBeaconBlock<typeof ForkName.gloas>,
+          forkName: ForkName.gloas,
+          sampledColumns,
+          custodyColumns: sampledColumns,
+          timeCreatedSec: seenTimestampSec,
+          daOutOfRange: false,
+        });
+        if (addEnvelope) {
+          const envelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+          envelope.message.beaconBlockRoot = blockRoot;
+          envelope.message.payload.slotNumber = slot;
+          payloadInput.addPayloadEnvelope({
+            envelope,
+            source: PayloadEnvelopeInputSource.byRange,
+            seenTimestampSec,
+            peerIdStr: peer,
+          });
+        }
+        if (addAllColumns && sampledColumns.length > 0) {
+          for (const index of sampledColumns) {
+            const columnSidecar = ssz.gloas.DataColumnSidecar.defaultValue();
+            columnSidecar.beaconBlockRoot = blockRoot;
+            columnSidecar.slot = slot;
+            columnSidecar.index = index;
+            payloadInput.addColumn({
+              columnSidecar,
+              source: PayloadEnvelopeInputSource.byRange,
+              seenTimestampSec,
+              peerIdStr: peer,
+            });
+          }
+        }
+        return {blockInput, payloadInput};
+      }
+
+      it("transitions to AwaitingProcessing when every block has a complete payload envelope", () => {
+        const batch = new Batch(startEpoch, config, clock, custodyConfig);
+        batch.startDownloading(peer);
+
+        const {blockInput: bi1, payloadInput: pi1} = buildGloasBlockWithEnvelope({slot: batch.startSlot});
+        const {blockInput: bi2, payloadInput: pi2} = buildGloasBlockWithEnvelope({slot: batch.startSlot + 1});
+        const payloadEnvelopes = new Map([
+          [bi1.slot, pi1],
+          [bi2.slot, pi2],
+        ]);
+
+        batch.downloadingSuccess(peer, [bi1, bi2], payloadEnvelopes);
+
+        expect(batch.state.status).toBe(BatchStatus.AwaitingProcessing);
+      });
+
+      it("stays AwaitingDownload when a block has no payload envelope", () => {
+        const batch = new Batch(startEpoch, config, clock, custodyConfig);
+        batch.startDownloading(peer);
+
+        const {blockInput: bi1, payloadInput: pi1} = buildGloasBlockWithEnvelope({slot: batch.startSlot});
+        // Block downloaded but envelope is missing for this slot
+        const {blockInput: bi2} = buildGloasBlockWithEnvelope({slot: batch.startSlot + 1, addEnvelope: false});
+        const payloadEnvelopes = new Map([[bi1.slot, pi1]]);
+
+        batch.downloadingSuccess(peer, [bi1, bi2], payloadEnvelopes);
+
+        expect(batch.state.status).toBe(BatchStatus.AwaitingDownload);
+        expect(batch.requests.envelopesRequest).toBeDefined();
+      });
+
+      it("stays AwaitingDownload when a payload envelope is missing sampled columns", () => {
+        const batch = new Batch(startEpoch, config, clock, custodyConfig);
+        batch.startDownloading(peer);
+
+        const sampledColumns = [0, 1];
+        const {blockInput: bi1, payloadInput: pi1} = buildGloasBlockWithEnvelope({
+          slot: batch.startSlot,
+          blobCount: 1,
+          sampledColumns,
+          addAllColumns: true,
+        });
+        // Envelope received but its sampled columns were not
+        const {blockInput: bi2, payloadInput: pi2} = buildGloasBlockWithEnvelope({
+          slot: batch.startSlot + 1,
+          blobCount: 1,
+          sampledColumns,
+          addAllColumns: false,
+        });
+        const payloadEnvelopes = new Map([
+          [bi1.slot, pi1],
+          [bi2.slot, pi2],
+        ]);
+
+        batch.downloadingSuccess(peer, [bi1, bi2], payloadEnvelopes);
+
+        expect(batch.state.status).toBe(BatchStatus.AwaitingDownload);
+        expect(batch.requests.columnsRequest).toBeDefined();
+        // Re-request must start at the slot whose payload is missing columns,
+        // and only include the missing column indices.
+        expect(batch.requests.columnsRequest?.startSlot).toBe(bi2.slot);
+        expect(batch.requests.columnsRequest?.columns).toEqual(sampledColumns);
+      });
+    });
+
+    describe("Fulu (pre-Gloas)", () => {
+      const startEpoch = config.FULU_FORK_EPOCH + 1;
+      const seenTimestampSec = Date.now() / 1000;
+
+      it("stays AwaitingDownload when reconstruction threshold reached but sampled columns missing", () => {
+        const batch = new Batch(startEpoch, config, clock, custodyConfig);
+        batch.startDownloading(peer);
+
+        // Pick sampled indices outside the range we'll fill so they stay physically missing
+        const sampledColumns = [100, 101, 102, 103];
+        const block = ssz.fulu.SignedBeaconBlock.defaultValue();
+        block.message.slot = batch.startSlot;
+        block.message.body.blobKzgCommitments = [Buffer.alloc(48, 0x11)];
+        const blockRoot = ssz.fulu.BeaconBlock.hashTreeRoot(block.message);
+        const blockRootHex = toRootHex(blockRoot);
+
+        const blockInput = BlockInputColumns.createFromBlock({
+          block: block as SignedBeaconBlock<typeof ForkName.fulu>,
+          blockRootHex,
+          forkName: ForkName.fulu,
+          daOutOfRange: false,
+          seenTimestampSec,
+          source: BlockInputSource.byRange,
+          peerIdStr: peer,
+          sampledColumns,
+          custodyColumns: sampledColumns,
+        });
+
+        // Add NUMBER_OF_COLUMNS/2 columns at non-sampled indices (0..63) to hit the
+        // reconstruction threshold without any sampled column being physically present.
+        for (let i = 0; i < 64; i++) {
+          const columnSidecar = ssz.fulu.DataColumnSidecar.defaultValue();
+          columnSidecar.index = i;
+          blockInput.addColumn({
+            columnSidecar,
+            blockRootHex,
+            source: BlockInputSource.byRange,
+            seenTimestampSec,
+            peerIdStr: peer,
+          });
+        }
+
+        // Reconstruction-threshold semantics: hasAllData true, hasComputedAllData false.
+        expect(blockInput.hasAllData()).toBe(true);
+        expect(blockInput.hasComputedAllData()).toBe(false);
+
+        batch.downloadingSuccess(peer, [blockInput], null);
+
+        expect(batch.state.status).toBe(BatchStatus.AwaitingDownload);
+        expect(batch.requests.columnsRequest).toBeDefined();
+        expect(batch.requests.columnsRequest?.startSlot).toBe(batch.startSlot);
+        expect(batch.requests.columnsRequest?.columns.slice().sort((a, b) => a - b)).toEqual(sampledColumns);
+      });
+    });
   });
 
   it("Complete state flow", () => {


### PR DESCRIPTION
**Motivation**

Fix this error seen on glamsterdam-devnet-1:

```
Apr-30 08:44:15.721[sync]          verbose: Batch process error id=Head-4, startEpoch=14, startSlot=448, count=32, status=Processing, blocksReq=startSlot=448,count=32, columnsReq=startSlot=448,count=32,cols=[0-127], envelopesReq=startSlot=448,count=32, downloadAttempts=0, processingAttempts=0, blockCount=29, blockSlots=[448-458, 460-470, 472-478], envelopeSlots=[448-458, 460-470, 472-473, 476-478], peers=16...2xphLu, code=BLOCK_ERROR_BEACON_CHAIN_ERROR, error=Timeout
Error: Timeout
    at timeoutPromise (file:///usr/src/lodestar/packages/utils/src/timeout.ts:19:11)
    at runNextTicks (node:internal/process/task_queues:65:5)
    at listOnTimeout (node:internal/timers:567:9)
    at processTimers (node:internal/timers:541:7)
    at withTimeout (file:///usr/src/lodestar/packages/utils/src/timeout.ts:23:12)
    at async Promise.all (index 0)
    at verifyPayloadsDataAvailability (file:///usr/src/lodestar/packages/beacon-node/src/chain/blocks/verifyPayloadsDataAvailability.ts:28:3)
    at file:///usr/src/lodestar/packages/beacon-node/src/chain/blocks/verifyBlock.ts:134:63
    at async Promise.all (index 1)
    at BeaconChain.verifyBlocksInEpoch (file:///usr/src/lodestar/packages/beacon-node/src/chain/blocks/verifyBlock.ts:168:9)
```

```
grep -e "code=BLOCK_ERROR_BEACON_CHAIN_ERROR, error=Timeout" -rn beacon-2026-04-30.log | wc -l
17
```

The batch advanced to `Processing` with some sampled columns still missing. `verifyPayloadsDataAvailability` then timed out waiting for column data that was never delivered.

This same class of bug also affects Fulu range sync — This PR fixes both forks.

**Description**

Two related defects in `Batch.downloadingSuccess` / `Batch.getRequests`:

Changes:

- `Batch.downloadingSuccess`: per-block check uses `hasComputedAllData()` for `BlockInputColumns` (Fulu); post-Gloas pass requires each block to have a corresponding `PayloadEnvelopeInput` with `hasPayloadEnvelope() && hasComputedAllData()`. Returns to `AwaitingDownload` otherwise so `getRequests` can build the next request.
- `Batch.getRequests`: post-Gloas branch derives envelope and column completeness from the `PayloadEnvelopeInput` map. Pre-Gloas Fulu branch tightened to `hasComputedAllData()`.
- `getMissingSampledColumnMeta()` on both `BlockInputColumns` and `PayloadEnvelopeInput`: removed the `state.hasAllData` short-circuit. The function now always reports actual missing sampled columns. Existing callers either already guard with `hasAllData()` first (no behavior change) or specifically need the strict semantic (`recoverDataColumnSidecars` publishing path, `unknownBlock`/`downloadByRoot` retry, range sync).

**AI Assistance Disclosure**

Used Claude Code (Opus 4.7) to investigate the production log, trace the root cause through `Batch` / `BlockInputColumns` / `PayloadEnvelopeInput`, and draft the patch and tests.
