### PR TITLE
chore: index proposer preferences by slot first

### DIFF
--- a/packages/beacon-node/src/chain/seenCache/seenProposerPreferences.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenProposerPreferences.ts
@@ -5,16 +5,16 @@ import {MapDef} from "@lodestar/utils";
  * Tracks signed proposer preferences we've already seen per (dependent_root, proposal_slot, validator_index).
  */
 export class SeenProposerPreferences {
-  private readonly validatorBySlotByDependentRoot = new MapDef<RootHex, Map<Slot, ValidatorIndex>>(
-    () => new Map<Slot, ValidatorIndex>()
+  private readonly validatorByDependentRootBySlot = new MapDef<Slot, Map<RootHex, ValidatorIndex>>(
+    () => new Map<RootHex, ValidatorIndex>()
   );
 
   isKnown(dependentRoot: RootHex, proposalSlot: Slot, validatorIndex: ValidatorIndex): boolean {
-    return this.validatorBySlotByDependentRoot.get(dependentRoot)?.get(proposalSlot) === validatorIndex;
+    return this.validatorByDependentRootBySlot.get(proposalSlot)?.get(dependentRoot) === validatorIndex;
   }
 
   add(dependentRoot: RootHex, proposalSlot: Slot, validatorIndex: ValidatorIndex): void {
-    this.validatorBySlotByDependentRoot.getOrDefault(dependentRoot).set(proposalSlot, validatorIndex);
+    this.validatorByDependentRootBySlot.getOrDefault(proposalSlot).set(dependentRoot, validatorIndex);
   }
 
   /**
@@ -23,14 +23,9 @@ export class SeenProposerPreferences {
    * on each slot tick.
    */
   prune(currentSlot: Slot): void {
-    for (const [dependentRoot, slotMap] of this.validatorBySlotByDependentRoot.entries()) {
-      for (const slot of slotMap.keys()) {
-        if (slot < currentSlot) {
-          slotMap.delete(slot);
-        }
-      }
-      if (slotMap.size === 0) {
-        this.validatorBySlotByDependentRoot.delete(dependentRoot);
+    for (const [slot] of this.validatorByDependentRootBySlot.entries()) {
+      if (slot < currentSlot) {
+        this.validatorByDependentRootBySlot.delete(slot);
       }
     }
   }

--- a/packages/beacon-node/src/chain/seenCache/seenProposerPreferences.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenProposerPreferences.ts
@@ -23,7 +23,7 @@ export class SeenProposerPreferences {
    * on each slot tick.
    */
   prune(currentSlot: Slot): void {
-    for (const [slot] of this.validatorByDependentRootBySlot.entries()) {
+    for (const slot of this.validatorByDependentRootBySlot.keys()) {
       if (slot < currentSlot) {
         this.validatorByDependentRootBySlot.delete(slot);
       }


### PR DESCRIPTION
**Motivation**

As suggested by @twoeths in #9303, the current map nesting in `SeenProposerPreferences` (`Map<dependentRoot, Map<slot, validatorIndex>>`) makes pruning inefficient — it requires iterating through every dependent root and checking each slot individually.

**Description**

Swaps the map nesting to `Map<slot, Map<dependentRoot, validatorIndex>>` so that pruning can delete entire slot entries directly from the outer map. No changes to the public API; `isKnown`, `add`, and `prune` all retain their existing signatures and behavior.

Closes #9309

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Used Claude to discuss the approach and review the implementation.
