### PR TITLE
fix: prune PayloadEnvelopeInput on the same branch

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -335,15 +335,6 @@ export class BeaconChain implements IBeaconChain {
       metrics,
       logger,
     });
-    this.seenPayloadEnvelopeInputCache = new SeenPayloadEnvelopeInput({
-      config,
-      clock,
-      chainEvents: emitter,
-      signal,
-      serializedCache: this.serializedCache,
-      metrics,
-      logger,
-    });
 
     this._earliestAvailableSlot = anchorState.slot;
 
@@ -423,6 +414,18 @@ export class BeaconChain implements IBeaconChain {
     this.payloadEnvelopeProcessor = new PayloadEnvelopeProcessor(this, metrics, signal);
 
     this.forkChoice = forkChoice;
+
+    this.seenPayloadEnvelopeInputCache = new SeenPayloadEnvelopeInput({
+      config,
+      clock,
+      forkChoice,
+      chainEvents: emitter,
+      signal,
+      serializedCache: this.serializedCache,
+      metrics,
+      logger,
+    });
+
     this.clock = clock;
     this.regen = regen;
     this.bls = bls;

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -222,7 +222,7 @@ export class PrepareNextSlotScheduler {
           // and head.parent (proposer-boost-reorg fallback). Anything older is evicted.
           const updatedHeadParent = this.chain.forkChoice.getBlockHexDefaultStatus(updatedHead.parentRoot);
           if (updatedHeadParent) {
-            this.chain.seenPayloadEnvelopeInputCache.pruneBelow(updatedHeadParent.slot);
+            this.chain.seenPayloadEnvelopeInputCache.pruneBelowParent(updatedHeadParent);
           }
         }
 

--- a/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
@@ -141,12 +141,12 @@ export class SeenPayloadEnvelopeInput {
         const input = this.payloadInputs.get(block.blockRoot);
         if (input) {
           this.evictPayloadInput(input);
+          this.logger?.verbose("SeenPayloadEnvelopeInput.pruneBelowParent deleted", {
+            slot: block.slot,
+            root: block.blockRoot,
+          });
         }
       }
-      this.logger?.debug("SeenPayloadEnvelopeInput.pruneBelowParent deleted", {
-        slot: block.slot,
-        root: block.blockRoot,
-      });
     }
   }
 

--- a/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
@@ -1,7 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {CheckpointWithHex} from "@lodestar/fork-choice";
+import {CheckpointWithHex, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
-import {RootHex, Slot} from "@lodestar/types";
+import {RootHex} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {IClock} from "../../util/clock.js";
@@ -16,6 +16,7 @@ export {PayloadEnvelopeInput} from "../blocks/payloadEnvelopeInput/index.js";
 export type SeenPayloadEnvelopeInputModules = {
   config: ChainForkConfig;
   clock: IClock;
+  forkChoice: IForkChoice;
   chainEvents: ChainEventEmitter;
   signal: AbortSignal;
   serializedCache: SerializedCache;
@@ -39,6 +40,7 @@ export type SeenPayloadEnvelopeInputModules = {
 export class SeenPayloadEnvelopeInput {
   private readonly config: ChainForkConfig;
   private readonly clock: IClock;
+  private readonly forkChoice: IForkChoice;
   private readonly chainEvents: ChainEventEmitter;
   private readonly signal: AbortSignal;
   private readonly serializedCache: SerializedCache;
@@ -46,9 +48,19 @@ export class SeenPayloadEnvelopeInput {
   private readonly logger?: Logger;
   private payloadInputs = new Map<RootHex, PayloadEnvelopeInput>();
 
-  constructor({config, clock, chainEvents, signal, serializedCache, metrics, logger}: SeenPayloadEnvelopeInputModules) {
+  constructor({
+    config,
+    clock,
+    forkChoice,
+    chainEvents,
+    signal,
+    serializedCache,
+    metrics,
+    logger,
+  }: SeenPayloadEnvelopeInputModules) {
     this.config = config;
     this.clock = clock;
+    this.forkChoice = forkChoice;
     this.chainEvents = chainEvents;
     this.signal = signal;
     this.serializedCache = serializedCache;
@@ -67,14 +79,27 @@ export class SeenPayloadEnvelopeInput {
       });
     }
 
-    this.chainEvents.on(ChainEvent.forkChoiceFinalized, this.onFinalized);
+    this.chainEvents.on(ChainEvent.forkChoiceFinalized, this.pruneFinalized);
     this.signal.addEventListener("abort", () => {
-      this.chainEvents.off(ChainEvent.forkChoiceFinalized, this.onFinalized);
+      this.chainEvents.off(ChainEvent.forkChoiceFinalized, this.pruneFinalized);
     });
   }
 
-  private onFinalized = (checkpoint: CheckpointWithHex): void => {
-    this.pruneBelow(computeStartSlotAtEpoch(checkpoint.epoch));
+  private pruneFinalized = (checkpoint: CheckpointWithHex): void => {
+    const finalizedSlot = computeStartSlotAtEpoch(checkpoint.epoch);
+    let deletedCount = 0;
+    for (const [, input] of this.payloadInputs) {
+      if (input.slot < finalizedSlot) {
+        this.evictPayloadInput(input);
+        deletedCount++;
+      }
+    }
+
+    this.logger?.debug("SeenPayloadEnvelopeInput.pruneFinalized deleted entries", {
+      finalizedSlot,
+      finalizedRoot: checkpoint.rootHex,
+      deletedCount,
+    });
   };
 
   add(props: Omit<CreateFromBlockProps, "daOutOfRange">): PayloadEnvelopeInput {
@@ -110,15 +135,19 @@ export class SeenPayloadEnvelopeInput {
     return this.payloadInputs.size;
   }
 
-  pruneBelow(slot: Slot): void {
-    let deletedCount = 0;
-    for (const [, input] of this.payloadInputs) {
-      if (input.slot < slot) {
-        this.evictPayloadInput(input);
-        deletedCount++;
+  pruneBelowParent(parentBlock: ProtoBlock): void {
+    for (const block of this.forkChoice.getAllAncestorBlocks(parentBlock.blockRoot, parentBlock.payloadStatus)) {
+      if (block.slot < parentBlock.slot) {
+        const input = this.payloadInputs.get(block.blockRoot);
+        if (input) {
+          this.evictPayloadInput(input);
+        }
       }
+      this.logger?.debug("SeenPayloadEnvelopeInput.pruneBelowParent deleted", {
+        slot: block.slot,
+        root: block.blockRoot,
+      });
     }
-    this.logger?.debug("SeenPayloadEnvelopeInput.pruneBelow deleted entries", {slot, deletedCount});
   }
 
   private evictPayloadInput(payloadInput: PayloadEnvelopeInput): void {

--- a/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
@@ -1,6 +1,9 @@
-import {beforeEach, describe, expect, it} from "vitest";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {ExecutionStatus, IForkChoice, PayloadStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {ForkName} from "@lodestar/params";
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
+import {RootHex} from "@lodestar/types";
 import {ChainEventEmitter} from "../../../../src/chain/emitter.js";
 import {SeenPayloadEnvelopeInput} from "../../../../src/chain/seenCache/seenPayloadEnvelopeInput.js";
 import {SerializedCache} from "../../../../src/util/serializedCache.js";
@@ -11,16 +14,21 @@ describe("SeenPayloadEnvelopeInput", () => {
   let cache: SeenPayloadEnvelopeInput;
   let abortController: AbortController;
   let chainEvents: ChainEventEmitter;
+  let forkChoice: IForkChoice;
   let serializedCache: SerializedCache;
 
   beforeEach(() => {
     chainEvents = new ChainEventEmitter();
     abortController = new AbortController();
+    forkChoice = {
+      getAllAncestorBlocks: vi.fn(),
+    } as unknown as IForkChoice;
     serializedCache = new SerializedCache();
 
     cache = new SeenPayloadEnvelopeInput({
       config,
       clock: getMockedClock(),
+      forkChoice,
       chainEvents,
       signal: abortController.signal,
       serializedCache,
@@ -42,20 +50,48 @@ describe("SeenPayloadEnvelopeInput", () => {
     return rootHex;
   }
 
-  it("pruneBelow removes payload inputs below the cutoff slot", () => {
+  function protoBlock(blockRoot: RootHex, slot: number): ProtoBlock {
+    return {
+      slot,
+      blockRoot,
+      parentRoot: blockRoot,
+      stateRoot: blockRoot,
+      targetRoot: blockRoot,
+      justifiedEpoch: 0,
+      justifiedRoot: blockRoot,
+      finalizedEpoch: 0,
+      finalizedRoot: blockRoot,
+      unrealizedJustifiedEpoch: 0,
+      unrealizedJustifiedRoot: blockRoot,
+      unrealizedFinalizedEpoch: 0,
+      unrealizedFinalizedRoot: blockRoot,
+      timeliness: false,
+      executionPayloadBlockHash: null,
+      executionStatus: ExecutionStatus.PreMerge,
+      dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+      payloadStatus: PayloadStatus.FULL,
+      parentBlockHash: null,
+    };
+  }
+
+  it("pruneBelowParent removes ancestor payload inputs below the parent slot", () => {
     const oldRootHex = addPayloadInput(1);
     const newRootHex = addPayloadInput(2);
+    const parentBlock = protoBlock(newRootHex, 2);
 
-    cache.pruneBelow(2);
+    vi.mocked(forkChoice.getAllAncestorBlocks).mockReturnValue([parentBlock, protoBlock(oldRootHex, 1)]);
+    cache.pruneBelowParent(parentBlock);
 
     expect(cache.get(oldRootHex)).toBeUndefined();
     expect(cache.get(newRootHex)).toBeDefined();
   });
 
-  it("pruneBelow keeps payload inputs at or above the cutoff slot", () => {
+  it("pruneBelowParent keeps payload inputs at the parent slot", () => {
     const rootHex = addPayloadInput(1);
+    const parentBlock = protoBlock(rootHex, 1);
 
-    cache.pruneBelow(1);
+    vi.mocked(forkChoice.getAllAncestorBlocks).mockReturnValue([parentBlock]);
+    cache.pruneBelowParent(parentBlock);
 
     expect(cache.get(rootHex)).toBeDefined();
   });


### PR DESCRIPTION
**Motivation**

- got `PayloadEnvelopeInput not seeded for block 0xab52e1c6751d0701c940d6d854c0c6d69814bccdbc0d773585cb08b3a4cdbd3e`

**Description**

- we should only delete payload envelope input of processed block. To do that, only delete the one in the same branch of a block

Closes #9316

**AI Assistance Disclosure**

Created with the help of Codex