### PR TITLE
fix(network): guard against undefined custodyGroups in shouldDialPeer

### DIFF
--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -527,7 +527,7 @@ export class PeerDiscovery {
 
   private shouldDialPeer(peer: CachedENR): boolean {
     const forkSeq = this.config.getForkSeq(this.clock.currentSlot);
-    if (forkSeq >= ForkSeq.fulu && peer.custodyGroups !== null) {
+    if (forkSeq >= ForkSeq.fulu && peer.custodyGroups != null) {
       // pre-fulu `this.custodyGroupQueries` is empty
       // starting from fulu, we need to make sure we have stable subnet sampling peers first
       // given SAMPLES_PER_SLOT = 8 and 100 peers, we have 800 custody columns from peers


### PR DESCRIPTION
**Motivation**

Fixes #9320. The error `Error onDiscovered - Cannot read properties of undefined (reading 'includes')` was reported on glamsterdam-devnet-2.

**Description**

In `shouldDialPeer` (`packages/beacon-node/src/network/peers/discover.ts`), the fulu-only branch is gated by `peer.custodyGroups !== null`. The strict `!==` lets `undefined` through, so `peer.custodyGroups.includes(group)` on the next iteration throws. Switching to loose `!= null` skips the branch on both `null` and `undefined`, matching the existing optional-chained pattern used at line 261 (`cachedENR.custodyGroups?.includes(group)`).

Closes #9320

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

This PR was written with assistance from Claude Code. I reviewed the change, ran `pnpm --filter @lodestar/beacon-node... build` and `vitest run test/unit/network/peers/discover.test.ts` locally before pushing.