### PR TITLE
docs: clarify --serveHistoricalState and --chain.pruneHistory help text

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -100,7 +100,7 @@ export const options: CliCommandOptions<ChainArgs> = {
     description:
       "Spawn a worker thread to regenerate finalized beacon states on demand and serve them via the debug REST API (e.g. `/eth/v2/debug/beacon/states/{state_id}`). \
 Does not backfill historical data — only states the node already has (since genesis sync or `--checkpointState`) can be regenerated. \
-Regeneration cost depends on `--chain.archiveStateEpochFrequency` (default 1024) and may affect validator performance.",
+Regeneration cost depends on `--chain.archiveStateEpochFrequency` and may affect validator performance.",
     type: "boolean",
     default: defaultOptions.chain.serveHistoricalState,
     group: "chain",
@@ -318,7 +318,7 @@ Will double processing times. Use only for debugging purposes.",
 
   "chain.pruneHistory": {
     description:
-      "Continually prune finalized blocks older than `MIN_EPOCHS_FOR_BLOCK_REQUESTS` (33024 epochs / ~5 months on mainnet) and all archived states before the finalized epoch. \
+      "Continually prune finalized blocks older than `MIN_EPOCHS_FOR_BLOCK_REQUESTS` (e.g., 33024 epochs / ~5 months on mainnet) and all archived states before the finalized epoch. \
 Use this to minimize disk usage when the node does not need to serve historical data. \
 Initial pruning may be slow on first startup with an existing large database.",
     type: "boolean",

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -98,7 +98,7 @@ export const options: CliCommandOptions<ChainArgs> = {
 
   serveHistoricalState: {
     description:
-      "Regenerate finalized beacon states on demand and serve them via the debug REST API (e.g. `/eth/v2/debug/beacon/states/{state_id}`). \
+      "Regenerate finalized beacon states on demand and serve them via the REST API (e.g. `/eth/v2/debug/beacon/states/{state_id}`). \
 Does not backfill historical data, only states the node already has (since genesis sync or `--checkpointState`) can be regenerated. \
 Regeneration cost depends on `--chain.archiveStateEpochFrequency` and may affect validator performance.",
     type: "boolean",

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -98,8 +98,8 @@ export const options: CliCommandOptions<ChainArgs> = {
 
   serveHistoricalState: {
     description:
-      "Spawn a worker thread to regenerate finalized beacon states on demand and serve them via the debug REST API (e.g. `/eth/v2/debug/beacon/states/{state_id}`). \
-Does not backfill historical data — only states the node already has (since genesis sync or `--checkpointState`) can be regenerated. \
+      "Regenerate finalized beacon states on demand and serve them via the debug REST API (e.g. `/eth/v2/debug/beacon/states/{state_id}`). \
+Does not backfill historical data, only states the node already has (since genesis sync or `--checkpointState`) can be regenerated. \
 Regeneration cost depends on `--chain.archiveStateEpochFrequency` and may affect validator performance.",
     type: "boolean",
     default: defaultOptions.chain.serveHistoricalState,
@@ -318,7 +318,7 @@ Will double processing times. Use only for debugging purposes.",
 
   "chain.pruneHistory": {
     description:
-      "Continually prune finalized blocks older than `MIN_EPOCHS_FOR_BLOCK_REQUESTS` (e.g., 33024 epochs / ~5 months on mainnet) and all archived states before the finalized epoch. \
+      "Continually prune finalized blocks older than `MIN_EPOCHS_FOR_BLOCK_REQUESTS` (33024 epochs / ~5 months on mainnet) and all archived states before the finalized epoch. \
 Use this to minimize disk usage when the node does not need to serve historical data. \
 Initial pruning may be slow on first startup with an existing large database.",
     type: "boolean",

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -319,7 +319,7 @@ Will double processing times. Use only for debugging purposes.",
   "chain.pruneHistory": {
     description:
       "Continually prune finalized blocks older than `MIN_EPOCHS_FOR_BLOCK_REQUESTS` (33024 epochs / ~5 months on mainnet) and all archived states before the finalized epoch. \
-Use this to minimize disk usage when the node does not need to serve historical data. \
+This is useful to minimize disk usage when the node does not need to serve historical data. \
 Initial pruning may be slow on first startup with an existing large database.",
     type: "boolean",
     default: defaultOptions.chain.pruneHistory,

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -98,7 +98,9 @@ export const options: CliCommandOptions<ChainArgs> = {
 
   serveHistoricalState: {
     description:
-      "Enable regenerating finalized state to serve historical data. Fetching this data is expensive and may affect validator performance.",
+      "Spawn a worker thread to regenerate finalized beacon states on demand and serve them via the debug REST API (e.g. `/eth/v2/debug/beacon/states/{state_id}`). \
+Does not backfill historical data — only states the node already has (since genesis sync or `--checkpointState`) can be regenerated. \
+Regeneration cost depends on `--chain.archiveStateEpochFrequency` (default 1024) and may affect validator performance.",
     type: "boolean",
     default: defaultOptions.chain.serveHistoricalState,
     group: "chain",
@@ -315,7 +317,10 @@ Will double processing times. Use only for debugging purposes.",
   },
 
   "chain.pruneHistory": {
-    description: "Prune historical blocks and state",
+    description:
+      "Continually prune finalized blocks older than `MIN_EPOCHS_FOR_BLOCK_REQUESTS` (33024 epochs / ~5 months on mainnet) and all archived states before the finalized epoch. \
+Use this to minimize disk usage when the node does not need to serve historical data. \
+Initial pruning may be slow on first startup with an existing large database.",
     type: "boolean",
     default: defaultOptions.chain.pruneHistory,
     group: "chain",


### PR DESCRIPTION
## Motivation

The current `--help` text for `--serveHistoricalState` and `--chain.pruneHistory` is too terse, which leads to confusion about what these flags actually do. This came up in [a question from yorickdowne on Discord](https://discord.com/channels/593655374469660673/1499337830533431427) about backfill semantics. Nico explained both flags in chat and asked for the help docs to be improved so users don't have to dig into the docs site.

## Description

Updates both descriptions in `packages/cli/src/options/beaconNodeOptions/chain.ts`:

- **`--serveHistoricalState`**: clarifies that it only spawns a worker thread to regenerate states the node already has on demand (i.e. since genesis sync or `--checkpointState`); it does not backfill historical data. Also notes the regeneration cost tradeoff with `--chain.archiveStateEpochFrequency`.
- **`--chain.pruneHistory`**: states the actual retention boundary (`MIN_EPOCHS_FOR_BLOCK_REQUESTS` = 33024 epochs / ~5 months on mainnet) and clarifies that archived states before the finalized epoch are also pruned.

No behavior changes — `--help` text only.

## Steps to test or reproduce

```bash
pnpm build && ./packages/cli/bin/lodestar beacon --help | grep -A 4 -E "serveHistoricalState|pruneHistory"
```

Closes #N/A