### PR TITLE
fix: inject latest payload bid into Gloas genesis block body

### DIFF
--- a/packages/beacon-node/src/chain/initState.ts
+++ b/packages/beacon-node/src/chain/initState.ts
@@ -1,7 +1,8 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ZERO_HASH} from "@lodestar/params";
+import {ForkPostGloas, ForkSeq, ZERO_HASH} from "@lodestar/params";
 import {
   BeaconStateAllForks,
+  BeaconStateGloas,
   IBeaconStateView,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
@@ -52,6 +53,18 @@ export function createGenesisBlock(config: ChainForkConfig, genesisState: Beacon
   const genesisBlock = types.SignedBeaconBlock.defaultValue();
   const stateRoot = genesisState.hashTreeRoot();
   genesisBlock.message.stateRoot = stateRoot;
+
+  // Gloas: per spec helper `create_signed_genesis_block`, the genesis block body's
+  // `signedExecutionPayloadBid.message` must equal `state.latestExecutionPayloadBid`,
+  // otherwise the body root in the block does not match `state.latestBlockHeader.bodyRoot`.
+  // See https://github.com/ethereum/consensus-specs/pull/5173 and
+  // https://github.com/ethpandaops/eth-beacon-genesis/issues/76.
+  if (config.getForkSeq(GENESIS_SLOT) >= ForkSeq.gloas) {
+    const gloasBlock = genesisBlock as SignedBeaconBlock<ForkPostGloas>;
+    const gloasState = genesisState as BeaconStateGloas;
+    gloasBlock.message.body.signedExecutionPayloadBid.message = gloasState.latestExecutionPayloadBid.toValue();
+  }
+
   return genesisBlock;
 }
 

--- a/packages/beacon-node/test/unit/chain/initState.test.ts
+++ b/packages/beacon-node/test/unit/chain/initState.test.ts
@@ -1,0 +1,63 @@
+import {describe, expect, it} from "vitest";
+import {createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {ForkPostGloas} from "@lodestar/params";
+import {SignedBeaconBlock, ssz} from "@lodestar/types";
+import {createGenesisBlock} from "../../../src/chain/initState.js";
+
+describe("createGenesisBlock", () => {
+  it("Should set state root and leave default body for pre-Gloas genesis", () => {
+    const phase0Config = createChainForkConfig(defaultChainConfig);
+    const phase0State = ssz.phase0.BeaconState.defaultViewDU();
+    const expectedStateRoot = phase0State.hashTreeRoot();
+
+    const block = createGenesisBlock(phase0Config, phase0State);
+
+    expect(block.message.stateRoot).toEqual(expectedStateRoot);
+    expect(ssz.phase0.BeaconBlockBody.equals(block.message.body, ssz.phase0.BeaconBlockBody.defaultValue())).toBe(true);
+  });
+
+  it("Should inject state.latestExecutionPayloadBid into body for Gloas genesis", () => {
+    const gloasConfig = createChainForkConfig({
+      ...defaultChainConfig,
+      ALTAIR_FORK_EPOCH: 0,
+      BELLATRIX_FORK_EPOCH: 0,
+      CAPELLA_FORK_EPOCH: 0,
+      DENEB_FORK_EPOCH: 0,
+      ELECTRA_FORK_EPOCH: 0,
+      FULU_FORK_EPOCH: 0,
+      GLOAS_FORK_EPOCH: 0,
+    });
+
+    // Mirror the spec helper `create_genesis_state`: populate latestExecutionPayloadBid
+    // with execution_requests_root = hash_tree_root(ExecutionRequests()) and derive
+    // latestBlockHeader.bodyRoot from a body whose bid message matches.
+    // See https://github.com/ethereum/consensus-specs/pull/5173 and
+    // https://github.com/ethpandaops/eth-beacon-genesis/issues/76.
+    const bid = ssz.gloas.ExecutionPayloadBid.defaultValue();
+    bid.executionRequestsRoot = ssz.electra.ExecutionRequests.hashTreeRoot(
+      ssz.electra.ExecutionRequests.defaultValue()
+    );
+
+    const expectedBody = ssz.gloas.BeaconBlockBody.defaultValue();
+    expectedBody.signedExecutionPayloadBid.message = bid;
+
+    const state = ssz.gloas.BeaconState.defaultViewDU();
+    state.latestExecutionPayloadBid = ssz.gloas.ExecutionPayloadBid.toViewDU(bid);
+    state.latestBlockHeader = ssz.phase0.BeaconBlockHeader.toViewDU({
+      slot: 0,
+      proposerIndex: 0,
+      parentRoot: new Uint8Array(32),
+      stateRoot: new Uint8Array(32),
+      bodyRoot: ssz.gloas.BeaconBlockBody.hashTreeRoot(expectedBody),
+    });
+    state.commit();
+
+    const block = createGenesisBlock(gloasConfig, state) as SignedBeaconBlock<ForkPostGloas>;
+
+    expect(block.message.stateRoot).toEqual(state.hashTreeRoot());
+    expect(ssz.gloas.ExecutionPayloadBid.equals(block.message.body.signedExecutionPayloadBid.message, bid)).toBe(true);
+    // Consistency check used by persistAnchorState: the body root of the constructed
+    // genesis block must match latestBlockHeader.bodyRoot from the anchor state.
+    expect(ssz.gloas.BeaconBlockBody.hashTreeRoot(block.message.body)).toEqual(state.latestBlockHeader.bodyRoot);
+  });
+});


### PR DESCRIPTION
**Motivation**

[consensus-specs#5173](https://github.com/ethereum/consensus-specs/pull/5173) adds the `create_signed_genesis_block` helper, codifying that a Gloas genesis `BeaconBlockBody` must have its `signedExecutionPayloadBid.message` populated with the genesis state's `latestExecutionPayloadBid`. The genesis state side has always been spec-conformant (state's `latestBlockHeader.bodyRoot` is computed from a body containing the bid), but `createGenesisBlock` here built the block body from `SignedBeaconBlock.defaultValue()` and only stamped `stateRoot`. For Gloas the body root therefore did not match `state.latestBlockHeader.bodyRoot`, and the consistency check in `persistAnchorState` would reject any spec-conformant Gloas anchor state — including those produced by Lighthouse and (once fixed) `eth-beacon-genesis`.

This is the client-side half of [ethpandaops/eth-beacon-genesis#76](https://github.com/ethpandaops/eth-beacon-genesis/issues/76). Sproul's plan is to fix the generator to match the spec; once that lands, every CL needs to construct the matching genesis block.

**Description**

For Gloas+, set `body.signedExecutionPayloadBid.message = state.latestExecutionPayloadBid` on the block returned by `createGenesisBlock`. Pre-Gloas behavior is unchanged.

Added a unit test covering both branches:
- pre-Gloas: body remains the default empty body, only `stateRoot` is stamped.
- Gloas: the constructed body's bid message matches the state's `latestExecutionPayloadBid`, and the resulting body root equals `state.latestBlockHeader.bodyRoot` (the consistency check used by `persistAnchorState`).

**Follow-ups not in this PR**

`initializeBeaconStateFromEth1` is also missing Gloas state init (`latestExecutionPayloadBid`, `builders`, `executionPayloadAvailability`, `payloadExpectedWithdrawals`, `builderPendingPayments`/`Withdrawals`, `ptcWindow`, plus body-root derivation matching the spec helper). That's the spec-test / deposit-driven interop builder path and is a larger change; happy to follow up in a separate PR if we want it.