### PR TITLE
feat: better self-rate-limit handling

### DIFF
--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -63,6 +63,27 @@ enum FetchResult {
   FailureMaxAttempts = "failure_max_attempts",
 }
 
+class UnknownBlockRateLimitedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnknownBlockRateLimitedError";
+  }
+}
+
+function getRateLimitedUntilMs(e: unknown): number | null {
+  if (!(e instanceof RequestError)) {
+    return null;
+  }
+
+  switch (e.type.code) {
+    case RequestErrorCode.RESP_RATE_LIMITED:
+    case RequestErrorCode.REQUEST_SELF_RATE_LIMITED:
+      return e.type.rateLimitedUntilMs ?? null;
+    default:
+      return null;
+  }
+}
+
 /**
  * BlockInputSync is a class that handles ReqResp to find blocks and data related to a specific blockRoot.  The
  * blockRoot may have been found via object gossip, or the API.  Gossip objects that can trigger a search are block,
@@ -106,6 +127,7 @@ export class BlockInputSync {
   private readonly maxPendingBlocks;
   private subscribedToNetworkEvents = false;
   private peerBalancer: UnknownBlockPeerBalancer;
+  private rateLimitBackoffTimeout: NodeJS.Timeout | undefined;
 
   constructor(
     private readonly config: ChainForkConfig,
@@ -155,6 +177,7 @@ export class BlockInputSync {
 
   unsubscribeFromNetwork(): void {
     this.logger.verbose("BlockInputSync disabled.");
+    this.clearRateLimitBackoffTimer();
     this.chain.emitter.off(ChainEvent.unknownBlockRoot, this.onUnknownBlockRoot);
     this.chain.emitter.off(ChainEvent.unknownEnvelopeBlockRoot, this.onUnknownEnvelopeBlockRoot);
     this.chain.emitter.off(ChainEvent.incompleteBlockInput, this.onIncompleteBlockInput);
@@ -402,6 +425,7 @@ export class BlockInputSync {
   private onPeerDisconnected = (data: NetworkEventData[NetworkEvent.peerDisconnected]): void => {
     const peerId = data.peer;
     this.peerBalancer.onPeerDisconnected(peerId);
+    this.scheduleRateLimitBackoffRetry();
   };
 
   /**
@@ -519,7 +543,7 @@ export class BlockInputSync {
    */
   private triggerUnknownBlockSearch = (): void => {
     // Cheap early stop to prevent calling the network.getConnectedPeers()
-    if (this.pendingBlocks.size === 0 && this.pendingPayloads.size === 0) {
+    if (!this.subscribedToNetworkEvents || (this.pendingBlocks.size === 0 && this.pendingPayloads.size === 0)) {
       return;
     }
 
@@ -607,6 +631,36 @@ export class BlockInputSync {
     }
   };
 
+  private scheduleRateLimitBackoffRetry(): void {
+    this.clearRateLimitBackoffTimer();
+
+    if (!this.subscribedToNetworkEvents || (this.pendingBlocks.size === 0 && this.pendingPayloads.size === 0)) {
+      return;
+    }
+
+    const now = Date.now();
+    const retryAt = this.peerBalancer.getNextRateLimitRetryAt();
+    if (retryAt === null) {
+      return;
+    }
+
+    this.rateLimitBackoffTimeout = setTimeout(
+      () => {
+        this.rateLimitBackoffTimeout = undefined;
+        this.triggerUnknownBlockSearch();
+        this.scheduleRateLimitBackoffRetry();
+      },
+      Math.max(0, retryAt - now)
+    );
+  }
+
+  private clearRateLimitBackoffTimer(): void {
+    if (this.rateLimitBackoffTimeout !== undefined) {
+      clearTimeout(this.rateLimitBackoffTimeout);
+      this.rateLimitBackoffTimeout = undefined;
+    }
+  }
+
   private async downloadBlock(block: BlockInputSyncCacheItem): Promise<void> {
     if (block.status !== PendingBlockInputStatus.pending) {
       return;
@@ -678,6 +732,16 @@ export class BlockInputSync {
         this.onUnknownBlockRoot({rootHex: pending.blockInput.parentRootHex, source: BlockInputSource.byRoot});
       }
     } else {
+      if (res.err instanceof UnknownBlockRateLimitedError) {
+        const pendingBlock = this.pendingBlocks.get(rootHex);
+        if (pendingBlock) {
+          pendingBlock.status = PendingBlockInputStatus.pending;
+        }
+        this.logger.debug("Deferring unknown block download due to peer rate limit", logCtx, res.err);
+        this.scheduleRateLimitBackoffRetry();
+        return;
+      }
+
       this.metrics?.blockInputSync.downloadedBlocksError.inc();
       this.logger.debug("Ignoring unknown block root after many failed downloads", logCtx, res.err);
       this.removeAndDownScoreAllDescendants(block);
@@ -994,12 +1058,19 @@ export class BlockInputSync {
     let envelope = payloadInput?.hasPayloadEnvelope() ? payloadInput.getPayloadEnvelope() : undefined;
 
     let i = 0;
+    let deferredByRateLimit = false;
     while (i++ < this.getMaxDownloadAttempts()) {
       const pendingColumns = payloadInput?.hasAllData()
         ? new Set<number>()
         : new Set(payloadInput?.getMissingSampledColumnMeta().missing ?? []);
       const peerMeta = this.peerBalancer.bestPeerForPendingColumns(pendingColumns, excludedPeers);
       if (peerMeta === null) {
+        if (this.peerBalancer.getNextRateLimitRetryAt(pendingColumns, excludedPeers) !== null) {
+          throw new UnknownBlockRateLimitedError(
+            `Error fetching payload by root slot=${slot} root=${rootHex} after ${i}: peers with needed columns are rate-limited`
+          );
+        }
+
         throw Error(
           `Error fetching payload by root slot=${slot} root=${rootHex} after ${i}: cannot find peer with needed columns=${prettyPrintIndices(Array.from(pendingColumns))}`
         );
@@ -1076,7 +1147,12 @@ export class BlockInputSync {
           e as Error
         );
 
-        if (e instanceof RequestError) {
+        const rateLimitedUntilMs = getRateLimitedUntilMs(e);
+        if (rateLimitedUntilMs !== null) {
+          deferredByRateLimit = true;
+          this.peerBalancer.onRateLimited(peerId, rateLimitedUntilMs);
+          this.scheduleRateLimitBackoffRetry();
+        } else if (e instanceof RequestError) {
           switch (e.type.code) {
             case RequestErrorCode.REQUEST_RATE_LIMITED:
             case RequestErrorCode.REQUEST_TIMEOUT:
@@ -1091,6 +1167,12 @@ export class BlockInputSync {
       } finally {
         this.peerBalancer.onRequestCompleted(peerId);
       }
+    }
+
+    if (deferredByRateLimit && this.peerBalancer.getNextRateLimitRetryAt() !== null) {
+      throw new UnknownBlockRateLimitedError(
+        `Error fetching payload with slot=${slot} root=${rootHex} after ${i - 1} attempts: peers are rate-limited`
+      );
     }
 
     throw Error(`Error fetching payload with slot=${slot} root=${rootHex} after ${i - 1} attempts.`);
@@ -1176,6 +1258,7 @@ export class BlockInputSync {
     }
 
     let i = 0;
+    let deferredByRateLimit = false;
     while (i++ < this.getMaxDownloadAttempts()) {
       const pendingColumns =
         isPendingBlockInput(cacheItem) && isBlockInputColumns(cacheItem.blockInput)
@@ -1183,6 +1266,12 @@ export class BlockInputSync {
           : defaultPendingColumns;
       const peerMeta = this.peerBalancer.bestPeerForPendingColumns(pendingColumns, excludedPeers);
       if (peerMeta === null) {
+        if (this.peerBalancer.getNextRateLimitRetryAt(pendingColumns, excludedPeers) !== null) {
+          throw new UnknownBlockRateLimitedError(
+            `Error fetching UnknownBlockRoot slot=${slot} root=${rootHex} after ${i}: peers with needed columns are rate-limited`
+          );
+        }
+
         // no more peer with needed columns to try, throw error
         const message = `Error fetching UnknownBlockRoot slot=${slot} root=${rootHex} after ${i}: cannot find peer with needed columns=${prettyPrintIndices(Array.from(pendingColumns))}`;
         this.metrics?.blockInputSync.fetchTimeSec.observe(
@@ -1238,16 +1327,23 @@ export class BlockInputSync {
         } else if (e instanceof RequestError) {
           // should look into req_resp metrics in this case
           downloadByRootMetrics?.error.inc({code: "req_resp", client: peerClient});
-          switch (e.type.code) {
-            case RequestErrorCode.REQUEST_RATE_LIMITED:
-            case RequestErrorCode.RESP_RATE_LIMITED:
-            case RequestErrorCode.REQUEST_SELF_RATE_LIMITED:
-            case RequestErrorCode.REQUEST_TIMEOUT:
-              // do not exclude peer for these errors
-              break;
-            default:
-              excludedPeers.add(peerId);
-              break;
+          const rateLimitedUntilMs = getRateLimitedUntilMs(e);
+          if (rateLimitedUntilMs !== null) {
+            deferredByRateLimit = true;
+            this.peerBalancer.onRateLimited(peerId, rateLimitedUntilMs);
+            this.scheduleRateLimitBackoffRetry();
+          } else {
+            switch (e.type.code) {
+              case RequestErrorCode.REQUEST_RATE_LIMITED:
+              case RequestErrorCode.RESP_RATE_LIMITED:
+              case RequestErrorCode.REQUEST_SELF_RATE_LIMITED:
+              case RequestErrorCode.REQUEST_TIMEOUT:
+                // do not exclude peer for these errors
+                break;
+              default:
+                excludedPeers.add(peerId);
+                break;
+            }
           }
         } else {
           // investigate if this happens
@@ -1274,6 +1370,10 @@ export class BlockInputSync {
     } // end while loop over peers
 
     const message = `Error fetching BlockInput with slot=${slot} root=${rootHex} after ${i - 1} attempts.`;
+
+    if (deferredByRateLimit && this.peerBalancer.getNextRateLimitRetryAt() !== null) {
+      throw new UnknownBlockRateLimitedError(`${message} Peers are rate-limited.`);
+    }
 
     if (!isPendingBlockInput(cacheItem)) {
       throw Error(`${message} No block and no data was found.`);
@@ -1406,10 +1506,12 @@ export class BlockInputSync {
 export class UnknownBlockPeerBalancer {
   readonly peersMeta: Map<PeerIdStr, PeerSyncMeta>;
   readonly activeRequests: Map<PeerIdStr, number>;
+  readonly rateLimitedUntilByPeer: Map<PeerIdStr, number>;
 
   constructor() {
     this.peersMeta = new Map();
     this.activeRequests = new Map();
+    this.rateLimitedUntilByPeer = new Map();
   }
 
   /** Trigger on each peer re-status */
@@ -1424,6 +1526,41 @@ export class UnknownBlockPeerBalancer {
   onPeerDisconnected(peerId: PeerIdStr): void {
     this.peersMeta.delete(peerId);
     this.activeRequests.delete(peerId);
+    this.rateLimitedUntilByPeer.delete(peerId);
+  }
+
+  onRateLimited(peerId: PeerIdStr, rateLimitedUntilMs: number): void {
+    this.rateLimitedUntilByPeer.set(peerId, rateLimitedUntilMs);
+  }
+
+  getNextRateLimitRetryAt(pendingColumns?: Set<number>, excludedPeers?: Set<PeerIdStr>): number | null {
+    const now = Date.now();
+    let retryAt: number | null = null;
+
+    for (const [peerId, rateLimitedUntil] of this.rateLimitedUntilByPeer.entries()) {
+      if (rateLimitedUntil <= now) {
+        this.rateLimitedUntilByPeer.delete(peerId);
+        continue;
+      }
+
+      if (excludedPeers?.has(peerId)) {
+        continue;
+      }
+
+      const syncMeta = this.peersMeta.get(peerId);
+      if (syncMeta === undefined) {
+        this.rateLimitedUntilByPeer.delete(peerId);
+        continue;
+      }
+
+      if (pendingColumns !== undefined && !this.peerHasPendingColumns(syncMeta, pendingColumns)) {
+        continue;
+      }
+
+      retryAt = Math.min(retryAt ?? rateLimitedUntil, rateLimitedUntil);
+    }
+
+    return retryAt;
   }
 
   /**
@@ -1472,6 +1609,7 @@ export class UnknownBlockPeerBalancer {
   }
 
   private filterPeers(pendingDataColumns: Set<number>, excludedPeers: Set<PeerIdStr>): PeerIdStr[] {
+    const now = Date.now();
     let maxColumnCount = 0;
     const considerPeers: {peerId: PeerIdStr; columnCount: number}[] = [];
     for (const [peerId, syncMeta] of this.peersMeta.entries()) {
@@ -1480,9 +1618,21 @@ export class UnknownBlockPeerBalancer {
         continue;
       }
 
+      const rateLimitedUntil = this.rateLimitedUntilByPeer.get(peerId);
+      if (rateLimitedUntil !== undefined) {
+        if (now < rateLimitedUntil) {
+          continue;
+        }
+        this.rateLimitedUntilByPeer.delete(peerId);
+      }
+
       const activeRequests = this.activeRequests.get(peerId) ?? 0;
       if (activeRequests >= MAX_CONCURRENT_REQUESTS) {
         // should return peer with no more than MAX_CONCURRENT_REQUESTS active requests
+        continue;
+      }
+
+      if (!this.peerHasPendingColumns(syncMeta, pendingDataColumns)) {
         continue;
       }
 
@@ -1518,5 +1668,13 @@ export class UnknownBlockPeerBalancer {
     }
 
     return eligiblePeers;
+  }
+
+  private peerHasPendingColumns(syncMeta: PeerSyncMeta, pendingDataColumns: Set<number>): boolean {
+    if (pendingDataColumns.size === 0) {
+      return true;
+    }
+
+    return syncMeta.custodyColumns.some((column) => pendingDataColumns.has(column));
   }
 }

--- a/packages/beacon-node/test/e2e/network/reqresp.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqresp.test.ts
@@ -299,17 +299,29 @@ function runTests({useWorker}: {useWorker: boolean}): void {
     );
 
     // First request: responder sends RATE_LIMITED → detected as RESP_RATE_LIMITED
-    await expectRejectedWithLodestarError(
+    await expectRejectedWithRateLimitError(
       netA.sendBeaconBlocksByRange(peerIdB, {startSlot: 0, step: 1, count: 1}),
-      new RequestError({code: RequestErrorCode.RESP_RATE_LIMITED})
+      RequestErrorCode.RESP_RATE_LIMITED
     );
 
     // Second request: SelfRateLimiter has the peer in backoff → blocked before sending
-    await expectRejectedWithLodestarError(
+    await expectRejectedWithRateLimitError(
       netA.sendBeaconBlocksByRange(peerIdB, {startSlot: 0, step: 1, count: 1}),
-      new RequestError({code: RequestErrorCode.REQUEST_SELF_RATE_LIMITED})
+      RequestErrorCode.REQUEST_SELF_RATE_LIMITED
     );
   });
+}
+
+async function expectRejectedWithRateLimitError(promise: Promise<unknown>, code: RequestErrorCode): Promise<void> {
+  try {
+    const value = await promise;
+    throw Error(`Expected promise to reject but returned value: \n\n\t${JSON.stringify(value, null, 2)}`);
+  } catch (e) {
+    expect(e).toBeInstanceOf(RequestError);
+    const type = (e as RequestError).type as {code: RequestErrorCode; rateLimitedUntilMs?: number};
+    expect(type.code).toBe(code);
+    expect(type.rateLimitedUntilMs).toEqual(expect.any(Number));
+  }
 }
 
 function getEmptyEncodedPayloadSignedBeaconBlock(config: ChainForkConfig): ResponseOutgoing {

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -219,7 +219,10 @@ describe("sync / range / chain", () => {
     const downloadByRange: SyncChainFns["downloadByRange"] = async (peerMeta, request, _partialDownload) => {
       if (peerMeta.peerId === peer1) {
         peer1Downloads++;
-        throw new RequestError({code: RequestErrorCode.RESP_RATE_LIMITED});
+        throw new RequestError({
+          code: RequestErrorCode.RESP_RATE_LIMITED,
+          rateLimitedUntilMs: Date.now() + 50,
+        });
       }
 
       // peer2 returns blocks normally

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -6,6 +6,7 @@ import {config as minimalConfig} from "@lodestar/config/default";
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {ForkName} from "@lodestar/params";
+import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
 import {SignedBeaconBlock, gloas, ssz} from "@lodestar/types";
 import {notNullish, sleep, toRootHex} from "@lodestar/utils";
 import {BlockInputNoData} from "../../../src/chain/blocks/blockInput/blockInput.js";
@@ -254,11 +255,18 @@ describe("sync by UnknownBlockSync", {timeout: 20_000}, () => {
     seenBlock?: boolean;
     wrongBlockRoot?: boolean;
     maxPendingBlocks?: number;
+    rateLimitOnce?: boolean;
   }[] = [
     {
       id: "fetch and process multiple unknown blocks",
       event: ChainEvent.unknownBlockRoot,
       finalizedSlot: 0,
+    },
+    {
+      id: "fetch and process multiple unknown blocks after peer rate limit",
+      event: ChainEvent.unknownBlockRoot,
+      finalizedSlot: 0,
+      rateLimitOnce: true,
     },
     {
       id: "fetch and process multiple unknown block parents",
@@ -307,6 +315,7 @@ describe("sync by UnknownBlockSync", {timeout: 20_000}, () => {
     seenBlock = false,
     wrongBlockRoot = false,
     maxPendingBlocks,
+    rateLimitOnce = false,
   } of testCases) {
     it(id, async () => {
       const peer = await getRandPeerIdStr();
@@ -351,6 +360,7 @@ describe("sync by UnknownBlockSync", {timeout: 20_000}, () => {
       const sendBeaconBlocksByRootPromise = new Promise<Parameters<INetwork["sendBeaconBlocksByRoot"]>>((r) => {
         sendBeaconBlocksByRootResolveFn = r;
       });
+      let sendBeaconBlocksByRootCallCount = 0;
 
       const networkEvents = new NetworkEventBus();
       const network: Partial<INetwork> = {
@@ -364,7 +374,15 @@ describe("sync by UnknownBlockSync", {timeout: 20_000}, () => {
         }),
         custodyConfig: {sampledColumns: [], sampleGroups: [[]]} as unknown as CustodyConfig,
         sendBeaconBlocksByRoot: async (_peerId, roots) => {
+          sendBeaconBlocksByRootCallCount++;
           sendBeaconBlocksByRootResolveFn([_peerId, roots]);
+          if (rateLimitOnce && sendBeaconBlocksByRootCallCount === 1) {
+            throw new RequestError({
+              code: RequestErrorCode.RESP_RATE_LIMITED,
+              rateLimitedUntilMs: Date.now() + 100,
+            });
+          }
+
           const correctBlocks = Array.from(roots)
             .map((root) => blocksByRoot.get(toRootHex(root)))
             .filter(notNullish);
@@ -502,6 +520,12 @@ describe("sync by UnknownBlockSync", {timeout: 20_000}, () => {
         await sleep(200);
         // should not send the invalid root block to chain
         expect(processBlockSpy).toHaveBeenCalledOnce();
+      } else if (rateLimitOnce) {
+        await sendBeaconBlocksByRootPromise;
+        expect(processBlockSpy).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(100);
+        await blockCProcessed;
+        expect(sendBeaconBlocksByRootCallCount).toBeGreaterThan(1);
       } else if (reportPeer) {
         // Wait for the network request to happen, then allow async processing to complete
         await sendBeaconBlocksByRootPromise;
@@ -1541,6 +1565,10 @@ describe("UnknownBlockPeerBalancer", async () => {
     }
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   for (const [testCaseIndex, {custodyGroups, excludedPeers, activeRequests, bestPeer}] of testCases.entries()) {
     for (const [i, groups] of custodyGroups.entries()) {
       peers[i].custodyColumns = groups;
@@ -1560,4 +1588,41 @@ describe("UnknownBlockPeerBalancer", async () => {
       }
     });
   } // end for testCases
+
+  it("skips rate-limited peers until their backoff expires", () => {
+    vi.useFakeTimers();
+    const now = 10_000;
+    vi.setSystemTime(now);
+
+    peers[0].custodyColumns = [0];
+    peers[1].custodyColumns = [1];
+    peers[2].custodyColumns = [1];
+    peers[3].custodyColumns = [1];
+
+    peerBalancer.onRateLimited(peer0.peerId, now + 1_000);
+
+    expect(peerBalancer.getNextRateLimitRetryAt(new Set([0]), new Set())).toBe(now + 1_000);
+    expect(peerBalancer.bestPeerForPendingColumns(new Set([0]), new Set())).toBeNull();
+
+    vi.setSystemTime(now + 1_000);
+    const peer = peerBalancer.bestPeerForPendingColumns(new Set([0]), new Set());
+    expect(peer?.peerId).toBe(peer0.peerId);
+    expect(peerBalancer.getNextRateLimitRetryAt(new Set([0]), new Set())).toBeNull();
+  });
+
+  it("reschedules around the earliest tracked rate limit", () => {
+    vi.useFakeTimers();
+    const now = 20_000;
+    vi.setSystemTime(now);
+
+    peerBalancer.onRateLimited(peer0.peerId, now + 1_000);
+    peerBalancer.onRateLimited(peer1.peerId, now + 500);
+    expect(peerBalancer.getNextRateLimitRetryAt()).toBe(now + 500);
+
+    peerBalancer.onPeerDisconnected(peer1.peerId);
+    expect(peerBalancer.getNextRateLimitRetryAt()).toBe(now + 1_000);
+
+    peerBalancer.onRateLimited(peer2.peerId, now + 250);
+    expect(peerBalancer.getNextRateLimitRetryAt()).toBe(now + 250);
+  });
 });

--- a/packages/reqresp/src/ReqResp.ts
+++ b/packages/reqresp/src/ReqResp.ts
@@ -177,10 +177,12 @@ export class ReqResp {
         throw Error(`Request to send to protocol ${protocolID} but it has not been declared`);
       }
 
-      if (!this.selfRateLimiter.allows(peerIdStr, protocolID, requestId)) {
+      const allows = this.selfRateLimiter.allows(peerIdStr, protocolID, requestId);
+      if (allows !== true) {
         // we technically don't send request in this case but would be nice just to track this in the same `outgoingErrorReasons` metric
         this.metrics?.outgoingErrorReasons.inc({reason: RequestErrorCode.REQUEST_SELF_RATE_LIMITED});
-        throw new RequestError({code: RequestErrorCode.REQUEST_SELF_RATE_LIMITED});
+        const rateLimitedUntilMs = typeof allows === "number" ? allows : undefined;
+        throw new RequestError({code: RequestErrorCode.REQUEST_SELF_RATE_LIMITED, rateLimitedUntilMs});
         // don't call this.onOutgoingRequestError() to penalize peer
       }
 
@@ -211,7 +213,7 @@ export class ReqResp {
         }
         if (e.type.code === RequestErrorCode.RESP_RATE_LIMITED) {
           for (const protocolID of protocolIDs) {
-            this.selfRateLimiter.onRateLimited(peerIdStr, protocolID);
+            this.selfRateLimiter.onRateLimited(peerIdStr, protocolID, e.type.rateLimitedUntilMs);
           }
         }
         this.metrics?.outgoingErrorReasons.inc({reason: e.type.code});

--- a/packages/reqresp/src/ReqResp.ts
+++ b/packages/reqresp/src/ReqResp.ts
@@ -210,7 +210,9 @@ export class ReqResp {
           this.metrics?.dialErrors.inc();
         }
         if (e.type.code === RequestErrorCode.RESP_RATE_LIMITED) {
-          this.selfRateLimiter.onRateLimited(peerIdStr);
+          for (const protocolID of protocolIDs) {
+            this.selfRateLimiter.onRateLimited(peerIdStr, protocolID);
+          }
         }
         this.metrics?.outgoingErrorReasons.inc({reason: e.type.code});
 

--- a/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
+++ b/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
@@ -18,7 +18,7 @@ const DISCONNECTED_TIMEOUT_MS = 60 * 1000;
 export const REQUEST_TIMEOUT_MS = 30 * 1000;
 
 /** Default backoff when a peer rate limits us. */
-export const DEFAULT_RATE_LIMIT_BACKOFF_MS = 5_000;
+export const DEFAULT_RATE_LIMIT_BACKOFF_MS = 2_000;
 
 type RequestId = number;
 type RequestIdMs = number;
@@ -68,8 +68,12 @@ export class SelfRateLimiter {
 
   /**
    * called before we send a request to a peer.
+   * Returns one of three outcomes:
+   * - if the peer has rate-limited us and we're still in backoff, returns the timestamp until which we should back off,
+   * - if we've reached the concurrent request limit, returns false,
+   * - otherwise, returns true.
    */
-  allows(peerId: PeerIdStr, protocolId: ProtocolID, requestId: RequestId): boolean {
+  allows(peerId: PeerIdStr, protocolId: ProtocolID, requestId: RequestId): number | boolean {
     const now = Date.now();
 
     const peerRateLimiter = this.rateLimitersPerPeer.getOrDefault(peerId);
@@ -80,7 +84,7 @@ export class SelfRateLimiter {
     const rateLimitedUntil = trackedRequests.rateLimitedUntilMs;
     if (rateLimitedUntil !== undefined) {
       if (now < rateLimitedUntil) {
-        return false;
+        return rateLimitedUntil;
       }
       // Backoff expired, clean up
       trackedRequests.rateLimitedUntilMs = undefined;
@@ -123,11 +127,14 @@ export class SelfRateLimiter {
   /**
    * Called when a peer responds with a rate-limit error, to enforce a backoff period before retrying.
    */
-  onRateLimited(peerId: PeerIdStr, protocolId: ProtocolID): void {
-    const rateLimitedUntil = Date.now() + DEFAULT_RATE_LIMIT_BACKOFF_MS;
+  onRateLimited(
+    peerId: PeerIdStr,
+    protocolId: ProtocolID,
+    rateLimitedUntilMs = Date.now() + DEFAULT_RATE_LIMIT_BACKOFF_MS
+  ): void {
     const peerRateLimiter = this.rateLimitersPerPeer.getOrDefault(peerId);
     const trackedRequests = peerRateLimiter.getOrDefault(protocolId);
-    trackedRequests.rateLimitedUntilMs = rateLimitedUntil;
+    trackedRequests.rateLimitedUntilMs = rateLimitedUntilMs;
     this.logger?.debug("SelfRateLimiter: peer rate limited us, backing off", {peerId, protocolId});
   }
 
@@ -154,6 +161,13 @@ export class SelfRateLimiter {
       if (now - lastSeenTime >= DISCONNECTED_TIMEOUT_MS) {
         this.rateLimitersPerPeer.delete(peerIdStr);
         this.lastSeenRequestsByPeer.delete(peerIdStr);
+      }
+    }
+    for (const peerRateLimiter of this.rateLimitersPerPeer.values()) {
+      for (const trackedRequests of peerRateLimiter.values()) {
+        if (trackedRequests.rateLimitedUntilMs !== undefined && now >= trackedRequests.rateLimitedUntilMs) {
+          trackedRequests.rateLimitedUntilMs = undefined;
+        }
       }
     }
   }

--- a/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
+++ b/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
@@ -23,6 +23,12 @@ export const DEFAULT_RATE_LIMIT_BACKOFF_MS = 5_000;
 type RequestId = number;
 type RequestIdMs = number;
 
+type ProtocolRateLimiter = {
+  activeRequests: Map<RequestId, RequestIdMs>;
+  /** Tracks the timestamp (ms) until which we should not send requests to a peer */
+  rateLimitedUntilMs?: number;
+};
+
 /**
  * Simple rate limiter that allows a maximum of 2 concurrent requests per protocol per peer.
  * Also tracks when a peer has rate-limited us and enforces a backoff period before allowing new requests.
@@ -32,23 +38,21 @@ type RequestIdMs = number;
  * peers. This class acts as the authoritative safety net at the protocol level.
  */
 export class SelfRateLimiter {
-  private readonly rateLimitersPerPeer: MapDef<PeerIdStr, MapDef<ProtocolID, Map<RequestId, RequestIdMs>>>;
+  private readonly rateLimitersPerPeer: MapDef<PeerIdStr, MapDef<ProtocolID, ProtocolRateLimiter>>;
   /**
    * It's not convenient to handle a peer disconnected event so we track the last seen requests by peer.
    * This is the same design to `ReqRespRateLimiter`.
    **/
   private lastSeenRequestsByPeer: Map<string, number>;
-  /** Tracks the timestamp (ms) until which we should not send requests to a peer */
-  private rateLimitedUntilByPeer: Map<PeerIdStr, number>;
   /** Interval to check lastSeenMessagesByPeer */
   private cleanupInterval: NodeJS.Timeout | undefined = undefined;
 
   constructor(private readonly logger?: Logger) {
-    this.rateLimitersPerPeer = new MapDef<PeerIdStr, MapDef<ProtocolID, Map<RequestId, RequestIdMs>>>(
-      () => new MapDef<ProtocolID, Map<RequestId, RequestIdMs>>(() => new Map())
+    this.rateLimitersPerPeer = new MapDef<PeerIdStr, MapDef<ProtocolID, ProtocolRateLimiter>>(
+      () =>
+        new MapDef<ProtocolID, ProtocolRateLimiter>(() => ({activeRequests: new Map(), rateLimitedUntilMs: undefined}))
     );
     this.lastSeenRequestsByPeer = new Map();
-    this.rateLimitedUntilByPeer = new Map();
   }
 
   start(): void {
@@ -68,27 +72,25 @@ export class SelfRateLimiter {
   allows(peerId: PeerIdStr, protocolId: ProtocolID, requestId: RequestId): boolean {
     const now = Date.now();
 
-    // Check if peer has rate-limited us and we're still in backoff
-    const rateLimitedUntil = this.rateLimitedUntilByPeer.get(peerId);
-    if (rateLimitedUntil !== undefined) {
-      if (now < rateLimitedUntil) {
-        // Keep peer alive so checkDisconnectedPeers() doesn't prematurely evict the backoff entry
-        this.lastSeenRequestsByPeer.set(peerId, now);
-        return false;
-      }
-      // Backoff expired, clean up
-      this.rateLimitedUntilByPeer.delete(peerId);
-    }
-
     const peerRateLimiter = this.rateLimitersPerPeer.getOrDefault(peerId);
     const trackedRequests = peerRateLimiter.getOrDefault(protocolId);
     this.lastSeenRequestsByPeer.set(peerId, now);
 
+    // Check if peer has rate-limited us and we're still in backoff
+    const rateLimitedUntil = trackedRequests.rateLimitedUntilMs;
+    if (rateLimitedUntil !== undefined) {
+      if (now < rateLimitedUntil) {
+        return false;
+      }
+      // Backoff expired, clean up
+      trackedRequests.rateLimitedUntilMs = undefined;
+    }
+
     let inProgressRequests = 0;
-    for (const [trackedRequestId, trackedRequestTimeMs] of trackedRequests.entries()) {
+    for (const [trackedRequestId, trackedRequestTimeMs] of trackedRequests.activeRequests.entries()) {
       if (trackedRequestTimeMs + REQUEST_TIMEOUT_MS <= now) {
         // request timed out, remove it
-        trackedRequests.delete(trackedRequestId);
+        trackedRequests.activeRequests.delete(trackedRequestId);
         this.logger?.debug("SelfRateLimiter: request timed out, removing it", {
           requestId: trackedRequestId,
           requestTime: trackedRequestTimeMs,
@@ -104,7 +106,7 @@ export class SelfRateLimiter {
       return false;
     }
 
-    trackedRequests.set(requestId, now);
+    trackedRequests.activeRequests.set(requestId, now);
     return true;
   }
 
@@ -115,16 +117,18 @@ export class SelfRateLimiter {
   requestCompleted(peerId: PeerIdStr, protocolId: ProtocolID, requestId: RequestId): void {
     const peerRateLimiter = this.rateLimitersPerPeer.getOrDefault(peerId);
     const trackedRequests = peerRateLimiter.getOrDefault(protocolId);
-    trackedRequests.delete(requestId);
+    trackedRequests.activeRequests.delete(requestId);
   }
 
   /**
    * Called when a peer responds with a rate-limit error, to enforce a backoff period before retrying.
    */
-  onRateLimited(peerId: PeerIdStr): void {
+  onRateLimited(peerId: PeerIdStr, protocolId: ProtocolID): void {
     const rateLimitedUntil = Date.now() + DEFAULT_RATE_LIMIT_BACKOFF_MS;
-    this.rateLimitedUntilByPeer.set(peerId, rateLimitedUntil);
-    this.logger?.debug("SelfRateLimiter: peer rate limited us, backing off", {peerId});
+    const peerRateLimiter = this.rateLimitersPerPeer.getOrDefault(peerId);
+    const trackedRequests = peerRateLimiter.getOrDefault(protocolId);
+    trackedRequests.rateLimitedUntilMs = rateLimitedUntil;
+    this.logger?.debug("SelfRateLimiter: peer rate limited us, backing off", {peerId, protocolId});
   }
 
   getPeerCount(): number {
@@ -132,7 +136,16 @@ export class SelfRateLimiter {
   }
 
   getRateLimitedPeerCount(): number {
-    return this.rateLimitedUntilByPeer.size;
+    let count = 0;
+    for (const peerRateLimiter of this.rateLimitersPerPeer.values()) {
+      for (const trackedRequests of peerRateLimiter.values()) {
+        if (trackedRequests.rateLimitedUntilMs !== undefined) {
+          count++;
+          break;
+        }
+      }
+    }
+    return count;
   }
 
   private checkDisconnectedPeers(): void {
@@ -141,13 +154,6 @@ export class SelfRateLimiter {
       if (now - lastSeenTime >= DISCONNECTED_TIMEOUT_MS) {
         this.rateLimitersPerPeer.delete(peerIdStr);
         this.lastSeenRequestsByPeer.delete(peerIdStr);
-        this.rateLimitedUntilByPeer.delete(peerIdStr);
-      }
-    }
-    // Also clean up expired backoff entries for peers still connected
-    for (const [peerIdStr, rateLimitedUntil] of this.rateLimitedUntilByPeer.entries()) {
-      if (now >= rateLimitedUntil) {
-        this.rateLimitedUntilByPeer.delete(peerIdStr);
       }
     }
   }

--- a/packages/reqresp/src/request/errors.ts
+++ b/packages/reqresp/src/request/errors.ts
@@ -1,5 +1,6 @@
 import {LodestarError, LodestarErrorObject} from "@lodestar/utils";
 import {RespStatus, RpcResponseStatusError} from "../interface.js";
+import {DEFAULT_RATE_LIMIT_BACKOFF_MS} from "../rate_limiter/selfRateLimiter.js";
 import {ResponseError} from "../response/index.js";
 
 export enum RequestErrorCode {
@@ -35,7 +36,7 @@ export enum RequestErrorCode {
   SSZ_OVER_MAX_SIZE = "SSZ_SNAPPY_ERROR_OVER_SSZ_MAX_SIZE",
 }
 
-type RequestErrorType =
+export type RequestErrorType =
   | {code: RequestErrorCode.INVALID_REQUEST; errorMessage: string}
   | {code: RequestErrorCode.INVALID_RESPONSE_SSZ; errorMessage: string}
   | {code: RequestErrorCode.SERVER_ERROR; errorMessage: string}
@@ -48,8 +49,8 @@ type RequestErrorType =
   | {code: RequestErrorCode.EMPTY_RESPONSE}
   | {code: RequestErrorCode.RESP_TIMEOUT}
   | {code: RequestErrorCode.REQUEST_RATE_LIMITED}
-  | {code: RequestErrorCode.REQUEST_SELF_RATE_LIMITED}
-  | {code: RequestErrorCode.RESP_RATE_LIMITED}
+  | {code: RequestErrorCode.REQUEST_SELF_RATE_LIMITED; rateLimitedUntilMs?: number}
+  | {code: RequestErrorCode.RESP_RATE_LIMITED; rateLimitedUntilMs: number}
   | {code: RequestErrorCode.SSZ_OVER_MAX_SIZE};
 
 export const REQUEST_ERROR_CLASS_NAME = "RequestError";
@@ -83,7 +84,7 @@ export function responseStatusErrorToRequestError(e: ResponseError): RequestErro
   // See https://github.com/ChainSafe/lodestar/issues/8065#issuecomment-3157266196
   const errorMessageLowercase = errorMessage.toLowerCase();
   if (errorMessageLowercase.includes("rate limit")) {
-    return {code: RequestErrorCode.RESP_RATE_LIMITED};
+    return {code: RequestErrorCode.RESP_RATE_LIMITED, rateLimitedUntilMs: Date.now() + DEFAULT_RATE_LIMIT_BACKOFF_MS};
   }
 
   // Grandine's eth2_libp2p fork uses the old Lighthouse GCRA inbound rate limiter which sends
@@ -92,7 +93,7 @@ export function responseStatusErrorToRequestError(e: ResponseError): RequestErro
   // is intentionally not parsed.
   // See https://github.com/ChainSafe/lodestar/issues/8110
   if (errorMessageLowercase.startsWith("wait ")) {
-    return {code: RequestErrorCode.RESP_RATE_LIMITED};
+    return {code: RequestErrorCode.RESP_RATE_LIMITED, rateLimitedUntilMs: Date.now() + DEFAULT_RATE_LIMIT_BACKOFF_MS};
   }
 
   switch (status) {

--- a/packages/reqresp/test/unit/rate_limiter/selfRateLimiter.test.ts
+++ b/packages/reqresp/test/unit/rate_limiter/selfRateLimiter.test.ts
@@ -64,17 +64,17 @@ describe("SelfRateLimiter", () => {
 
       selfRateLimiter.onRateLimited("peer1", "protocol1");
 
-      // All protocols should be blocked for this peer
-      expect(selfRateLimiter.allows("peer1", "protocol1", 2)).toBe(false);
-      expect(selfRateLimiter.allows("peer1", "protocol2", 3)).toBe(false);
+      // The rate-limited protocol should be blocked for this peer
+      expect(selfRateLimiter.allows("peer1", "protocol1", 2)).toBeTypeOf("number");
 
-      // Other peers should not be affected
+      // Other peers and protocols should not be affected
+      expect(selfRateLimiter.allows("peer1", "protocol2", 3)).toBe(true);
       expect(selfRateLimiter.allows("peer2", "protocol1", 4)).toBe(true);
     });
 
     it("should allow requests after backoff expires", () => {
       selfRateLimiter.onRateLimited("peer1", "protocol1");
-      expect(selfRateLimiter.allows("peer1", "protocol1", 1)).toBe(false);
+      expect(selfRateLimiter.allows("peer1", "protocol1", 1)).toBeTypeOf("number");
 
       vi.advanceTimersByTime(DEFAULT_RATE_LIMIT_BACKOFF_MS);
       expect(selfRateLimiter.allows("peer1", "protocol1", 2)).toBe(true);
@@ -97,7 +97,7 @@ describe("SelfRateLimiter", () => {
       selfRateLimiter.onRateLimited("peer1", "protocol1");
 
       vi.advanceTimersByTime(DEFAULT_RATE_LIMIT_BACKOFF_MS / 2);
-      expect(selfRateLimiter.allows("peer1", "protocol1", 1)).toBe(false);
+      expect(selfRateLimiter.allows("peer1", "protocol1", 1)).toBeTypeOf("number");
       expect(selfRateLimiter.getRateLimitedPeerCount()).toBe(1);
     });
 

--- a/packages/reqresp/test/unit/rate_limiter/selfRateLimiter.test.ts
+++ b/packages/reqresp/test/unit/rate_limiter/selfRateLimiter.test.ts
@@ -62,7 +62,7 @@ describe("SelfRateLimiter", () => {
       expect(selfRateLimiter.allows("peer1", "protocol1", 1)).toBe(true);
       selfRateLimiter.requestCompleted("peer1", "protocol1", 1);
 
-      selfRateLimiter.onRateLimited("peer1");
+      selfRateLimiter.onRateLimited("peer1", "protocol1");
 
       // All protocols should be blocked for this peer
       expect(selfRateLimiter.allows("peer1", "protocol1", 2)).toBe(false);
@@ -73,7 +73,7 @@ describe("SelfRateLimiter", () => {
     });
 
     it("should allow requests after backoff expires", () => {
-      selfRateLimiter.onRateLimited("peer1");
+      selfRateLimiter.onRateLimited("peer1", "protocol1");
       expect(selfRateLimiter.allows("peer1", "protocol1", 1)).toBe(false);
 
       vi.advanceTimersByTime(DEFAULT_RATE_LIMIT_BACKOFF_MS);
@@ -83,8 +83,8 @@ describe("SelfRateLimiter", () => {
     it("should track rate limited peer count", () => {
       expect(selfRateLimiter.getRateLimitedPeerCount()).toBe(0);
 
-      selfRateLimiter.onRateLimited("peer1");
-      selfRateLimiter.onRateLimited("peer2");
+      selfRateLimiter.onRateLimited("peer1", "protocol1");
+      selfRateLimiter.onRateLimited("peer2", "protocol1");
       expect(selfRateLimiter.getRateLimitedPeerCount()).toBe(2);
 
       vi.advanceTimersByTime(DEFAULT_RATE_LIMIT_BACKOFF_MS);
@@ -94,7 +94,7 @@ describe("SelfRateLimiter", () => {
     });
 
     it("should keep backoff tracked during blocked attempts", () => {
-      selfRateLimiter.onRateLimited("peer1");
+      selfRateLimiter.onRateLimited("peer1", "protocol1");
 
       vi.advanceTimersByTime(DEFAULT_RATE_LIMIT_BACKOFF_MS / 2);
       expect(selfRateLimiter.allows("peer1", "protocol1", 1)).toBe(false);
@@ -102,7 +102,7 @@ describe("SelfRateLimiter", () => {
     });
 
     it("should clean up expired backoff entries on disconnected peer check", () => {
-      selfRateLimiter.onRateLimited("peer1");
+      selfRateLimiter.onRateLimited("peer1", "protocol1");
       expect(selfRateLimiter.getRateLimitedPeerCount()).toBe(1);
 
       vi.advanceTimersByTime(CHECK_DISCONNECTED_PEERS_INTERVAL_MS + 1);

--- a/packages/reqresp/test/unit/request/errors.test.ts
+++ b/packages/reqresp/test/unit/request/errors.test.ts
@@ -15,6 +15,7 @@ describe("responseStatusErrorToRequestError", () => {
     it(`maps "${errorMessage}" to RESP_RATE_LIMITED`, () => {
       expect(responseStatusErrorToRequestError(new ResponseError(RespStatus.INVALID_REQUEST, errorMessage))).toEqual({
         code: RequestErrorCode.RESP_RATE_LIMITED,
+        rateLimitedUntilMs: expect.any(Number),
       });
     });
   }


### PR DESCRIPTION
**Motivation**

- Builds on #9034 

**Description**

- track rate limits per-peer, per-protocol on the reqresp layer (note that in range and unknown block sync the rate limit is still just per-peer for simplicity)
- include rate-limit timestamp in rate limit errors (use this in range and unknown block sync for backoff time)
- use rate limit in unknown block sync (see this comment: https://github.com/ChainSafe/lodestar/pull/9034#discussion_r2964607092)
- add a timer in range and unknown block sync to trigger another download attempt after backoff time (handles the case where all peers are rate-limited and the sync needs a wake-up)

**AI Assistance Disclosure**

- codex assistance