### PR TITLE
fix: include latest payload bid in gloas genesis block

### DIFF
--- a/packages/beacon-node/src/chain/initState.ts
+++ b/packages/beacon-node/src/chain/initState.ts
@@ -1,7 +1,8 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ZERO_HASH} from "@lodestar/params";
+import {ForkPostGloas, ForkSeq, ZERO_HASH} from "@lodestar/params";
 import {
   BeaconStateAllForks,
+  BeaconStateGloas,
   IBeaconStateView,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
@@ -52,6 +53,13 @@ export function createGenesisBlock(config: ChainForkConfig, genesisState: Beacon
   const genesisBlock = types.SignedBeaconBlock.defaultValue();
   const stateRoot = genesisState.hashTreeRoot();
   genesisBlock.message.stateRoot = stateRoot;
+
+  if (config.getForkSeq(GENESIS_SLOT) >= ForkSeq.gloas) {
+    const gloasBlock = genesisBlock as SignedBeaconBlock<ForkPostGloas>;
+    const gloasState = genesisState as BeaconStateGloas;
+    gloasBlock.message.body.signedExecutionPayloadBid.message = gloasState.latestExecutionPayloadBid.toValue();
+  }
+
   return genesisBlock;
 }
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -214,6 +214,11 @@ export class ProtoArray {
       return PayloadStatus.FULL;
     }
 
+    // Genesis block has no parent in the proto array
+    if (block.parentRoot === HEX_ZERO_HASH) {
+      return PayloadStatus.FULL;
+    }
+
     const parentBlock = this.getBlockHexAndBlockHash(block.parentRoot, parentBlockHash);
     if (parentBlock == null) {
       throw new ProtoArrayError({


### PR DESCRIPTION
https://github.com/ethpandaops/eth-beacon-genesis/pull/77 changed (correctly) the genesis block, if we don't update our code we get the following error

```
May-05 11:28:59.541[]                 info: Initializing beacon from a valid checkpoint state slot=0, epoch=0, stateRoot=0x1f61a289a92af910c4054649680c27e7530ee2cfafb5a049bfe2e90b4fbfb228, isWithinWeakSubjectivityPeriod=true
 ✖ Error: Genesis block root 0xc6b18cd1592c537a54a4fc9ee3d80457d8dcfb149a1d24a3dbb6035d91b4e77b does not match genesis state latest block root 0x5fd9bcb81d982bfa6e786f6877ce7052055c44d3893a3273ac7065589ec8ce71
    at persistAnchorState (file:///usr/app/packages/beacon-node/src/chain/initState.ts:35:13)
    at checkAndPersistAnchorState (file:///usr/app/packages/beacon-node/src/chain/initState.ts:123:11)
    at initBeaconState (file:///usr/app/packages/cli/src/cmds/beacon/initBeaconState.ts:324:11)
    at Object.beaconHandler [as handler] (file:///usr/app/packages/cli/src/cmds/beacon/handler.ts:79:9)
```

there is also a secondary error
```
May-06 19:09:23.004[chain]           error: Failed to run prepareForNextSlot nextEpoch=1, isEpochTransition=false, prepareSlot=2, code=PROTO_ARRAY_ERROR_UNKNOWN_PARENT_BLOCK, parentRoot=0x0000000000000000000000000000000000000000000000000000000000000000, parentHash=0x06eef0d8abaf3ff8032b81b1ada02b10a5987cca8ac1732d268a2cdd8145bc2f
Error: PROTO_ARRAY_ERROR_UNKNOWN_PARENT_BLOCK
    at ProtoArray.getParentPayloadStatus (file:///usr/app/packages/fork-choice/src/protoArray/protoArray.ts:219:13)
    at ForkChoice.shouldOverrideForkChoiceUpdate (file:///usr/app/packages/fork-choice/src/forkChoice/forkChoice.ts:273:23)
    at ForkChoice.predictProposerHead (file:///usr/app/packages/fork-choice/src/forkChoice/forkChoice.ts:344:25)
    at ForkChoice.updateAndGetHead (file:///usr/app/packages/fork-choice/src/forkChoice/forkChoice.ts:230:28)
    at BeaconChain.predictProposerHead (file:///usr/app/packages/beacon-node/src/chain/chain.ts:1163:30)
    at Clock.prepareForNextSlot (file:///usr/app/packages/beacon-node/src/chain/prepareNextSlot.ts:133:43)
```

which is fixed in this PR as well but should be unrelated, I am not sure how genesis was working but I had the same error when testing FOCIL, might just be that we were operating on an old genesis state before


Related https://github.com/ethereum/consensus-specs/pull/5173, https://github.com/ethpandaops/eth-beacon-genesis/issues/76