### PR TITLE
feat: count equivocator weight in gloas is_head_weak

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1196,6 +1196,8 @@ export class BeaconChain implements IBeaconChain {
         mode: UpdateHeadOpt.GetProposerHead,
         secFromSlot,
         slot,
+        getEquivocatingCommitteeWeightIncrements: (headBlock) =>
+          this.computeEquivocatingCommitteeWeightIncrements(headBlock),
       });
 
       if (isHeadTimely && notReorgedReason !== undefined) {
@@ -1208,6 +1210,44 @@ export class BeaconChain implements IBeaconChain {
     } finally {
       timer?.();
     }
+  }
+
+  /**
+   * Sum effective-balance increments of validators that are both members of any committee at
+   * `headBlock.slot` and tracked as equivocators by fork choice. Returns 0 pre-Gloas, when there
+   * are no equivocators, or when head state is not synchronously available.
+   * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#modified-is_head_weak
+   */
+  private computeEquivocatingCommitteeWeightIncrements(headBlock: ProtoBlock): number {
+    const headEpoch = computeEpochAtSlot(headBlock.slot);
+    if (!isForkPostGloas(this.config.getForkName(headBlock.slot))) {
+      return 0;
+    }
+    const equivocatingIndices = this.forkChoice.getEquivocatingIndices();
+    if (equivocatingIndices.size === 0) {
+      return 0;
+    }
+    const headState = this.regen.getStateSync(headBlock.stateRoot);
+    if (headState === null) {
+      return 0;
+    }
+    let shuffling: EpochShuffling;
+    try {
+      shuffling = headState.getShufflingAtEpoch(headEpoch);
+    } catch {
+      return 0;
+    }
+    const slotCommittees = shuffling.committees[headBlock.slot % SLOTS_PER_EPOCH];
+    const ebi = headState.effectiveBalanceIncrements;
+    let weight = 0;
+    for (const committee of slotCommittees) {
+      for (const validatorIndex of committee) {
+        if (equivocatingIndices.has(validatorIndex)) {
+          weight += ebi[validatorIndex] ?? 0;
+        }
+      }
+    }
+    return weight;
   }
 
   /**

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -66,9 +66,22 @@ export enum UpdateHeadOpt {
   GetPredictedProposerHead = "getPredictedProposerHead", // With predictProposerHead
 }
 
+/**
+ * Sum of effective-balance increments for validators that are members of any committee at
+ * `head.slot` and in `store.equivocating_indices`. Used by Gloas `is_head_weak`
+ * (https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#modified-is_head_weak).
+ * Computed by the chain layer since fork-choice has no committee access.
+ */
+export type GetEquivocatingCommitteeWeightIncrementsFn = (head: ProtoBlock) => number;
+
 export type UpdateAndGetHeadOpt =
   | {mode: UpdateHeadOpt.GetCanonicalHead}
-  | {mode: UpdateHeadOpt.GetProposerHead; secFromSlot: number; slot: Slot}
+  | {
+      mode: UpdateHeadOpt.GetProposerHead;
+      secFromSlot: number;
+      slot: Slot;
+      getEquivocatingCommitteeWeightIncrements?: GetEquivocatingCommitteeWeightIncrementsFn;
+    }
   | {mode: UpdateHeadOpt.GetPredictedProposerHead; secFromSlot: number; slot: Slot};
 
 // the initial vote epoch for all validators
@@ -229,11 +242,13 @@ export class ForkChoice implements IForkChoice {
       case UpdateHeadOpt.GetPredictedProposerHead:
         return {head: this.predictProposerHead(canonicalHeadBlock, opt.secFromSlot, opt.slot)};
       case UpdateHeadOpt.GetProposerHead: {
+        const equivocatingCommitteeWeightIncrements =
+          opt.getEquivocatingCommitteeWeightIncrements?.(canonicalHeadBlock) ?? 0;
         const {
           proposerHead: head,
           isHeadTimely,
           notReorgedReason,
-        } = this.getProposerHead(canonicalHeadBlock, opt.secFromSlot, opt.slot);
+        } = this.getProposerHead(canonicalHeadBlock, opt.secFromSlot, opt.slot, equivocatingCommitteeWeightIncrements);
         return {head, isHeadTimely, notReorgedReason};
       }
       case UpdateHeadOpt.GetCanonicalHead:
@@ -372,7 +387,8 @@ export class ForkChoice implements IForkChoice {
   getProposerHead(
     headBlock: ProtoBlock,
     secFromSlot: number,
-    slot: Slot
+    slot: Slot,
+    equivocatingCommitteeWeightIncrements = 0
   ): {proposerHead: ProtoBlock; isHeadTimely: boolean; notReorgedReason?: NotReorgedReason} {
     const isHeadTimely = headBlock.timeliness;
     let proposerHead = headBlock;
@@ -424,13 +440,15 @@ export class ForkChoice implements IForkChoice {
 
     // No reorg if headBlock is "not weak" ie. headBlock's weight exceeds (REORG_HEAD_WEIGHT_THRESHOLD = 20)% of total attester weight
     // https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/phase0/fork-choice.md#is_head_weak
+    // Gloas additionally counts weight from equivocating validators in head-slot committees.
+    // https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#modified-is_head_weak
     const reorgThreshold = getCommitteeFraction(this.fcStore.justified.totalBalance, {
       slotsPerEpoch: SLOTS_PER_EPOCH,
       committeePercent: this.config.REORG_HEAD_WEIGHT_THRESHOLD,
     });
     const headNode = this.protoArray.getNode(headBlock.blockRoot, headBlock.payloadStatus);
     // If headNode is unavailable, give up reorg
-    if (headNode === undefined || headNode.weight >= reorgThreshold) {
+    if (headNode === undefined || headNode.weight + equivocatingCommitteeWeightIncrements >= reorgThreshold) {
       return {proposerHead, isHeadTimely, notReorgedReason: NotReorgedReason.HeadBlockNotWeak};
     }
 
@@ -569,6 +587,10 @@ export class ForkChoice implements IForkChoice {
 
   getJustifiedCheckpoint(): CheckpointWithHex {
     return this.fcStore.justified.checkpoint;
+  }
+
+  getEquivocatingIndices(): ReadonlySet<ValidatorIndex> {
+    return this.fcStore.equivocatingIndices;
   }
 
   /**

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -1,5 +1,14 @@
 import {DataAvailabilityStatus, EffectiveBalanceIncrements, IBeaconStateView} from "@lodestar/state-transition";
-import {AttesterSlashing, BeaconBlock, Epoch, IndexedAttestation, Root, RootHex, Slot} from "@lodestar/types";
+import {
+  AttesterSlashing,
+  BeaconBlock,
+  Epoch,
+  IndexedAttestation,
+  Root,
+  RootHex,
+  Slot,
+  ValidatorIndex,
+} from "@lodestar/types";
 import {
   BlockExecutionStatus,
   LVHExecResponse,
@@ -123,6 +132,7 @@ export interface IForkChoice {
   getAllNodes(): ProtoNode[];
   getFinalizedCheckpoint(): CheckpointWithHex;
   getJustifiedCheckpoint(): CheckpointWithHex;
+  getEquivocatingIndices(): ReadonlySet<ValidatorIndex>;
   /**
    * Add `block` to the fork choice DAG.
    *

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -151,6 +151,8 @@ describe("Forkchoice / GetProposerHead", () => {
     currentSlot?: Slot;
     secFromSlot?: number;
     expectedNotReorgedReason?: NotReorgedReason;
+    // Gloas-only: extra weight added to the head from equivocating committee members at head's slot
+    equivocatingCommitteeWeightIncrements?: number;
   }[] = [
     {
       id: "Case that meets all conditions to be re-orged",
@@ -232,6 +234,36 @@ describe("Forkchoice / GetProposerHead", () => {
       secFromSlot: config.getProposerReorgCutoffMs(ForkName.phase0) / 1000 + 1,
       expectedNotReorgedReason: NotReorgedReason.NotProposingOnTime,
     },
+    // Gloas: modified `is_head_weak` adds weight from equivocating committee members at head slot.
+    // Head with weight 29 (< threshold 30) is weak by phase0 rule, but with 2 increments of equivocator
+    // weight added (29 + 2 = 31 >= 30), head becomes "not weak" — no reorg.
+    // https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#modified-is_head_weak
+    {
+      id: "Gloas: no reorg when equivocator weight pushes head above threshold",
+      parentBlock: {...baseParentHeadBlock},
+      headBlock: {...baseHeadBlock},
+      expectReorg: false,
+      equivocatingCommitteeWeightIncrements: 2,
+      expectedNotReorgedReason: NotReorgedReason.HeadBlockNotWeak,
+    },
+    // Gloas monotonicity: equivocator weight that doesn't reach the threshold doesn't change the
+    // outcome — head still weak, reorg still proceeds (29 + 0 = 29 < 30).
+    {
+      id: "Gloas: zero equivocator weight matches phase0 reorg behavior",
+      parentBlock: {...baseParentHeadBlock},
+      headBlock: {...baseHeadBlock},
+      expectReorg: true,
+      equivocatingCommitteeWeightIncrements: 0,
+    },
+    // Gloas: equivocator weight that closes exactly to the threshold makes head not weak.
+    {
+      id: "Gloas: equivocator weight tying threshold makes head not weak",
+      parentBlock: {...baseParentHeadBlock},
+      headBlock: {...baseHeadBlock},
+      expectReorg: false,
+      equivocatingCommitteeWeightIncrements: 1, // 29 + 1 = 30, the threshold
+      expectedNotReorgedReason: NotReorgedReason.HeadBlockNotWeak,
+    },
   ];
 
   beforeEach(() => {
@@ -246,6 +278,7 @@ describe("Forkchoice / GetProposerHead", () => {
     currentSlot: proposalSlot,
     secFromSlot,
     expectedNotReorgedReason,
+    equivocatingCommitteeWeightIncrements,
   } of testCases) {
     it(`${id}`, async () => {
       protoArr.onBlock(parentBlock, parentBlock.slot, null);
@@ -271,7 +304,8 @@ describe("Forkchoice / GetProposerHead", () => {
       const {proposerHead, isHeadTimely, notReorgedReason} = forkChoice.getProposerHead(
         headBlock,
         currentSecFromSlot,
-        currentSlot
+        currentSlot,
+        equivocatingCommitteeWeightIncrements
       );
 
       expect(isHeadTimely).toBe(headBlock.timeliness);


### PR DESCRIPTION
**Motivation**

Gloas updates `is_head_weak` to also count weight from validators that are in head-slot committees AND in `store.equivocating_indices` ([spec](https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fork-choice.md#modified-is_head_weak)). Without it, head weight can decrease as equivocations land, breaking monotonicity.
                                                                                                                                                  
**Description**

`getProposerHead` takes an optional `equivocatingCommitteeWeightIncrements` (default 0) added to `headNode.weight` before the threshold check. The chain layer computes it via a callback on `updateAndGetHead` since fork-choice has no committee access. New `IForkChoice.getEquivocatingIndices()` getter. Fork-gated to Gloas.

Scope kept to `getProposerHead`; `shouldOverrideForkChoiceUpdate` and `should_apply_proposer_boost` don't call `is_head_weak` either, but that's a pre-existing gap separate from this issue left for follow-up.

Tests cover the threshold boundary cases.

Closes #9232

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Used Claude Code to draft the implementation. Reviewed every line and made the design calls myself.