### PR TITLE
ci: drop redundant pnpm bootstrap on arm64 publish

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -31,8 +31,6 @@ jobs:
       - name: Install arm64 specifics
         if: matrix.arch == 'arm64'
         run: |-
-          # Install missing pnpm
-          curl -fsSL https://get.pnpm.io/install.sh | sh -
           # Install missing build-essential
           sudo apt-get update
           sudo apt-get install -y build-essential python3


### PR DESCRIPTION
## Summary

- The arm64 build leg of the publish workflow runs `curl -fsSL https://get.pnpm.io/install.sh | sh -` to bootstrap pnpm. That installer always pulls the **latest** pnpm; **11.0.8** dropped today and `pnpm setup` now hard-errors when `PNPM_HOME` is not in `PATH`, breaking the `v1.43.0-rc.0` publish: [run 25559324365 / job 75029848553](https://github.com/ChainSafe/lodestar/actions/runs/25559324365/job/75029848553).
- v1.42.0-rc.0 worked because the installer pulled pnpm 10.33.0 ([previous run](https://github.com/ChainSafe/lodestar/actions/runs/23947458219)).
- The very next step (`./.github/actions/setup-and-build`) already runs `pnpm/action-setup@v4`, which honors the `packageManager` field in `package.json` (currently pinned to `pnpm@10.24.0`) and installs pnpm correctly — making the curl bootstrap redundant.

## Test plan

- [ ] Re-tag / re-trigger the publish workflow (or run `Build binaries` via `workflow_dispatch`) and confirm the arm64 leg completes through the pnpm setup, install, and caxa packaging steps.
- [ ] Verify the produced arm64 tarball still passes the `Sanity check binary` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)