### PR TITLE
fix: builder payment quorum integer overflow at mainnet-scale stake

### DIFF
--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -51,7 +51,8 @@ export function processAttestationsAltair(
   let newSeenAttesters = 0;
   let newSeenAttestersEffectiveBalance = 0;
 
-  const builderWeightMap: Map<number, number> = new Map();
+  // bigint accumulator: per-slot gwei weight can exceed Number.MAX_SAFE_INTEGER at mainnet-scale stake
+  const builderWeightMap: Map<number, bigint> = new Map();
 
   for (const attestation of attestations) {
     const data = attestation.data;
@@ -150,7 +151,7 @@ export function processAttestationsAltair(
       const existingWeight =
         builderWeightMap.get(builderPendingPaymentIndex) ??
         (state as CachedBeaconStateGloas).builderPendingPayments.get(builderPendingPaymentIndex).weight;
-      const updatedWeight = existingWeight + paymentWeightToAdd * EFFECTIVE_BALANCE_INCREMENT;
+      const updatedWeight = existingWeight + BigInt(paymentWeightToAdd) * BigInt(EFFECTIVE_BALANCE_INCREMENT);
       builderWeightMap.set(builderPendingPaymentIndex, updatedWeight);
     }
   }

--- a/packages/state-transition/src/block/processExecutionPayloadBid.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadBid.ts
@@ -73,7 +73,7 @@ export function processExecutionPayloadBid(state: CachedBeaconStateGloas, block:
 
   if (amount > 0) {
     const pendingPaymentView = ssz.gloas.BuilderPendingPayment.toViewDU({
-      weight: 0,
+      weight: 0n,
       withdrawal: ssz.gloas.BuilderPendingWithdrawal.toViewDU({
         feeRecipient: bid.feeRecipient,
         amount,

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -25,12 +25,14 @@ export function isBuilderWithdrawalCredential(withdrawalCredentials: Uint8Array)
   return withdrawalCredentials[0] === BUILDER_WITHDRAWAL_PREFIX;
 }
 
-export function getBuilderPaymentQuorumThreshold(state: CachedBeaconStateGloas): number {
-  const quorum =
-    Math.floor((state.epochCtx.totalActiveBalanceIncrements * EFFECTIVE_BALANCE_INCREMENT) / SLOTS_PER_EPOCH) *
-    BUILDER_PAYMENT_THRESHOLD_NUMERATOR;
-
-  return Math.floor(quorum / BUILDER_PAYMENT_THRESHOLD_DENOMINATOR);
+export function getBuilderPaymentQuorumThreshold(state: CachedBeaconStateGloas): bigint {
+  // bigint to avoid f64 precision loss: totalActiveBalanceIncrements * EFFECTIVE_BALANCE_INCREMENT
+  // exceeds Number.MAX_SAFE_INTEGER once total active stake passes ~9M ETH.
+  const totalGwei = BigInt(state.epochCtx.totalActiveBalanceIncrements) * BigInt(EFFECTIVE_BALANCE_INCREMENT);
+  return (
+    ((totalGwei / BigInt(SLOTS_PER_EPOCH)) * BigInt(BUILDER_PAYMENT_THRESHOLD_NUMERATOR)) /
+    BigInt(BUILDER_PAYMENT_THRESHOLD_DENOMINATOR)
+  );
 }
 
 function hasBuilderIndexFlag(index: number): boolean {

--- a/packages/state-transition/test/unit/util/gloas.test.ts
+++ b/packages/state-transition/test/unit/util/gloas.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from "vitest";
+import {
+  BUILDER_PAYMENT_THRESHOLD_DENOMINATOR,
+  BUILDER_PAYMENT_THRESHOLD_NUMERATOR,
+  EFFECTIVE_BALANCE_INCREMENT,
+  SLOTS_PER_EPOCH,
+} from "@lodestar/params";
+import {CachedBeaconStateGloas} from "../../../src/types.js";
+import {getBuilderPaymentQuorumThreshold} from "../../../src/util/gloas.js";
+
+describe("getBuilderPaymentQuorumThreshold", () => {
+  function refQuorum(totalActiveBalanceIncrements: number): bigint {
+    const totalGwei = BigInt(totalActiveBalanceIncrements) * BigInt(EFFECTIVE_BALANCE_INCREMENT);
+    return (
+      ((totalGwei / BigInt(SLOTS_PER_EPOCH)) * BigInt(BUILDER_PAYMENT_THRESHOLD_NUMERATOR)) /
+      BigInt(BUILDER_PAYMENT_THRESHOLD_DENOMINATOR)
+    );
+  }
+
+  function makeStateStub(totalActiveBalanceIncrements: number): CachedBeaconStateGloas {
+    return {epochCtx: {totalActiveBalanceIncrements}} as unknown as CachedBeaconStateGloas;
+  }
+
+  // Stake levels chosen to bracket the f64 precision boundary: 9_007_199 ETH increments
+  // multiplied by EFFECTIVE_BALANCE_INCREMENT (1e9) equals 2^53 - 1.
+  it.each([
+    {label: "tiny devnet (~50k ETH)", totalActiveBalanceIncrements: 50_000},
+    {label: "below f64 boundary (~9M ETH)", totalActiveBalanceIncrements: 9_000_000},
+    {label: "mainnet today (~35M ETH)", totalActiveBalanceIncrements: 35_000_000},
+    {label: "MaxEB worst case (~64M ETH)", totalActiveBalanceIncrements: 64_000_000},
+  ])("matches bigint reference at $label", ({totalActiveBalanceIncrements}) => {
+    const got = getBuilderPaymentQuorumThreshold(makeStateStub(totalActiveBalanceIncrements));
+    expect(got).toEqual(refQuorum(totalActiveBalanceIncrements));
+  });
+});

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -71,7 +71,8 @@ export const BuilderPendingWithdrawal = new ContainerType(
 
 export const BuilderPendingPayment = new ContainerType(
   {
-    weight: UintNum64,
+    // bigint to avoid f64 precision loss when accumulating gwei weight at mainnet-scale stake
+    weight: UintBn64,
     withdrawal: BuilderPendingWithdrawal,
   },
   {typeName: "BuilderPendingPayment", jsonCase: "eth2"}


### PR DESCRIPTION
## Summary

`getBuilderPaymentQuorumThreshold` (in `packages/state-transition/src/util/gloas.ts`) computes `totalActiveBalanceIncrements * EFFECTIVE_BALANCE_INCREMENT` as a JS `number`. The intermediate gwei product crosses `Number.MAX_SAFE_INTEGER` (`2^53 - 1 ≈ 9.007 × 10^15`) once total active stake passes ~9 M ETH, silently losing precision. Other CL clients (Prysm, Lighthouse, Teku, Nimbus, Grandine) compute the spec-exact uint64 result, so a Gloas-enabled mainnet would see Lodestar diverge on the post-state root at the first epoch transition that promotes any builder payment near the quorum boundary, forking Lodestar nodes off the network.

The same overflow class also affects the per-slot `BuilderPendingPayment.weight` accumulator in `processAttestationsAltair.ts`: cumulative attesting weight against a single slot can exceed 2^53 gwei at mainnet stake.

### Why now

Bug is **dormant on `glamsterdam-devnet-3`** (~50 k ETH stake — two orders of magnitude below the 2^53 boundary, so f64 and uint64 agree to the bit) and on every other current network because Gloas isn't activated anywhere yet. It would activate **on day one of Gloas mainnet** with no attacker required — the network's stake itself is the trigger. Landing the fix before any Gloas activation costs nothing; landing it after costs a fork.

### Arithmetic

| Scenario | totalActiveBalanceIncrements (ETH) | × 1e9 (gwei) | > 2^53? |
|---|---|---|---|
| `glamsterdam-devnet-3` (~50 k ETH) | 5 × 10^4 | 5 × 10^13 | No (180× under) |
| Mainnet today (~35 M ETH) | 3.5 × 10^7 | 3.5 × 10^16 | **Yes** (3.88× over) |
| MaxEB worst case (~64 M ETH) | 6.4 × 10^7 | 6.4 × 10^16 | **Yes** (7.1× over) |

## Changes

| File | Change |
|---|---|
| `packages/types/src/gloas/sszTypes.ts` | `BuilderPendingPayment.weight`: `UintNum64` → `UintBn64`. On-wire encoding identical (uint64 LE); local TS type becomes `bigint`, matching the spec's domain. |
| `packages/state-transition/src/util/gloas.ts` | `getBuilderPaymentQuorumThreshold` rewritten to use bigint intermediates; return type `number` → `bigint`. |
| `packages/state-transition/src/block/processAttestationsAltair.ts` | Per-slot builder weight accumulator: `Map<number, number>` → `Map<number, bigint>`; arithmetic in bigint. |
| `packages/state-transition/src/block/processExecutionPayloadBid.ts` | Initial `weight: 0` literal → `0n`. |
| `packages/state-transition/test/unit/util/gloas.test.ts` (new) | Precision regression test: parameterised across 50 k / 9 M / 35 M / 64 M ETH stake, asserts equivalence with a bigint reference. Brackets the f64 boundary. |

The comparison `payment.weight >= quorum` in `processBuilderPendingPayments.ts:14` needed no code change — both sides are now `bigint`, comparison flows through.

## Scope

Fully **Gloas-only**:

- `BuilderPendingPayment` is a Gloas-only SSZ container; not embedded pre-Gloas.
- `processBuilderPendingPayments` is registered only in the Gloas branch (`epoch/index.ts:166-168`).
- The accumulator block in `processAttestationsAltair.ts:146` is gated behind `if (fork >= ForkSeq.gloas)`.
- `getBuilderPaymentQuorumThreshold` and `processExecutionPayloadBid` are Gloas-only.
- Wire compatibility: `UintBn64` and `UintNum64` produce bit-identical SSZ bytes — state roots / block roots / gossip serialisation unchanged.
- Behavioural compatibility: at sub-2^53 stake the bigint result equals the prior f64 result to the bit, so existing devnet-3 nodes with and without this fix will produce identical state roots.

## Test plan

- [x] `pnpm --filter @lodestar/types build` — clean
- [x] `pnpm --filter @lodestar/state-transition exec vitest run --project unit` — **244/244 passed**, includes new `gloas.test.ts`
- [x] `pnpm lint` on `@lodestar/types` and `@lodestar/state-transition` — clean
- [ ] Spec tests (`pnpm download-spec-tests && pnpm test:spec`) — not run locally; CI will cover
- [ ] Devnet smoke run on `glamsterdam-devnet-3` once merged — expected behaviour unchanged at this stake
- [ ] `pnpm check-types` repo-wide — not run; note that `packages/state-transition/src/util/validator.ts` has 4 pre-existing build errors on `glamsterdam-devnet-3` (and `unstable`) introduced by `87cbe69c66` (EIP-8061 churn), unrelated to this PR

## AI disclosure

Fix drafted with assistance from Claude (Opus 4.7, 1 M context). Bug originally surfaced from an audit-style code-read of the Gloas state-transition path; arithmetic, fix design, and PR text reviewed and authored interactively with parithosh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)