### PR TITLE
fix(cli): log final close confirmation at info level

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -145,7 +145,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       async () => {
         try {
           await node.close();
-          logger.debug("Beacon node closed");
+          logger.info("Beacon node closed");
           // Explicitly exit until active handles issue is resolved
           // See https://github.com/ChainSafe/lodestar/issues/5642
           process.exit(0);

--- a/packages/cli/src/cmds/bootnode/handler.ts
+++ b/packages/cli/src/cmds/bootnode/handler.ts
@@ -142,7 +142,7 @@ export async function bootnodeHandler(args: BootnodeArgs & GlobalArgs): Promise<
 
           await metricsServer?.close();
           await discv5.stop();
-          logger.debug("Bootnode closed");
+          logger.info("Bootnode closed");
         } catch (e) {
           logger.error("Error closing bootnode", {}, e as Error);
           // Must explicitly exit process due to potential active handles


### PR DESCRIPTION
## Motivation

At default `--logLevel info`, beacon-node shutdown looks like a hang. The console shows:

```
info: Stopping gracefully, use Ctrl+C again to force process exit
<nothing>
```

…and then the process just exits. The actual shutdown is healthy and completes in ~2-3 seconds, but with no user-visible signal you can't tell whether the node hung mid-close or finished cleanly.

The `"Beacon node closed"` line that confirms a clean shutdown was logged at `debug` level, so it's invisible at the default log level. Same pattern for `bootnode`.

## Description

- `packages/cli/src/cmds/beacon/handler.ts`: bump `"Beacon node closed"` from `logger.debug` to `logger.info`.
- `packages/cli/src/cmds/bootnode/handler.ts`: bump `"Bootnode closed"` from `logger.debug` to `logger.info`.

## Verification

Ran a beacon node with `--logLevel info`, sent SIGTERM after sync. Console output now ends with:

```
info: Stopping gracefully, use Ctrl+C again to force process exit
info: Beacon node closed
```

Process exits ~2s after SIGTERM. Clean signal that shutdown completed.

🤖 Generated with AI assistance