### PR TITLE
fix: dedupe persistent-merkle-tree to recover hashtree hasher

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Assert pnpm prints no warnings
         run: scripts/assert_no_pnpm_warnings.sh
 
+      - name: Assert @chainsafe/persistent-merkle-tree is not duplicated
+        run: scripts/assert_persistent_merkle_tree_dedup.sh
+
       - name: Lint Code
         run: pnpm lint
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -74,7 +74,7 @@
     "check-readme": "pnpm exec ts-node ../../scripts/check_readme.ts"
   },
   "dependencies": {
-    "@chainsafe/persistent-merkle-tree": "^1.2.1",
+    "@chainsafe/persistent-merkle-tree": "^1.2.5",
     "@chainsafe/ssz": "^1.4.0",
     "@lodestar/config": "workspace:^",
     "@lodestar/params": "workspace:^",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -114,7 +114,7 @@
     "@chainsafe/enr": "^6.0.1",
     "@chainsafe/libp2p-noise": "^17.0.0",
     "@chainsafe/libp2p-quic": "^2.0.1",
-    "@chainsafe/persistent-merkle-tree": "^1.2.1",
+    "@chainsafe/persistent-merkle-tree": "^1.2.5",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/pubkey-index-map": "^3.0.0",
     "@chainsafe/snappy-wasm": "^0.5.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,7 +62,7 @@
     "@chainsafe/blst": "^2.2.0",
     "@chainsafe/discv5": "^12.0.1",
     "@chainsafe/enr": "^6.0.1",
-    "@chainsafe/persistent-merkle-tree": "^1.2.1",
+    "@chainsafe/persistent-merkle-tree": "^1.2.5",
     "@chainsafe/pubkey-index-map": "^3.0.0",
     "@chainsafe/ssz": "^1.4.0",
     "@chainsafe/threads": "^1.11.3",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@chainsafe/bls": "8.2.0",
     "@chainsafe/blst": "^2.2.0",
-    "@chainsafe/persistent-merkle-tree": "^1.2.1",
+    "@chainsafe/persistent-merkle-tree": "^1.2.5",
     "@chainsafe/ssz": "^1.4.0",
     "@lodestar/api": "workspace:^",
     "@lodestar/config": "workspace:^",

--- a/packages/prover/package.json
+++ b/packages/prover/package.json
@@ -51,7 +51,7 @@
     "generate-fixtures": "node --loader ts-node/esm scripts/generate_fixtures.ts"
   },
   "dependencies": {
-    "@chainsafe/persistent-merkle-tree": "^1.2.1",
+    "@chainsafe/persistent-merkle-tree": "^1.2.5",
     "@ethereumjs/block": "^4.2.2",
     "@ethereumjs/blockchain": "^6.2.2",
     "@ethereumjs/common": "^3.1.2",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@chainsafe/as-sha256": "^1.2.0",
     "@chainsafe/blst": "^2.2.0",
-    "@chainsafe/persistent-merkle-tree": "^1.2.1",
+    "@chainsafe/persistent-merkle-tree": "^1.2.5",
     "@chainsafe/persistent-ts": "^1.0.0",
     "@chainsafe/pubkey-index-map": "^3.0.0",
     "@chainsafe/ssz": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,8 +177,8 @@ importers:
   packages/api:
     dependencies:
       '@chainsafe/persistent-merkle-tree':
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^1.2.5
+        version: 1.2.5
       '@chainsafe/ssz':
         specifier: ^1.4.0
         version: 1.4.0
@@ -235,8 +235,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       '@chainsafe/persistent-merkle-tree':
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^1.2.5
+        version: 1.2.5
       '@chainsafe/prometheus-gc-stats':
         specifier: ^1.0.0
         version: 1.0.2(prom-client@15.1.3)
@@ -446,8 +446,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       '@chainsafe/persistent-merkle-tree':
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^1.2.5
+        version: 1.2.5
       '@chainsafe/pubkey-index-map':
         specifier: ^3.0.0
         version: 3.0.0
@@ -710,8 +710,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@chainsafe/persistent-merkle-tree':
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^1.2.5
+        version: 1.2.5
       '@chainsafe/ssz':
         specifier: ^1.4.0
         version: 1.4.0
@@ -802,8 +802,8 @@ importers:
   packages/prover:
     dependencies:
       '@chainsafe/persistent-merkle-tree':
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^1.2.5
+        version: 1.2.5
       '@ethereumjs/block':
         specifier: ^4.2.2
         version: 4.2.2
@@ -978,8 +978,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@chainsafe/persistent-merkle-tree':
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^1.2.5
+        version: 1.2.5
       '@chainsafe/persistent-ts':
         specifier: ^1.0.0
         version: 1.0.0
@@ -1313,6 +1313,9 @@ packages:
   '@chainsafe/as-sha256@1.2.0':
     resolution: {integrity: sha512-H2BNHQ5C3RS+H0ZvOdovK6GjFAyq5T6LClad8ivwj9Oaiy28uvdsGVS7gNJKuZmg0FGHAI+n7F0Qju6U0QkKDA==}
 
+  '@chainsafe/as-sha256@1.2.4':
+    resolution: {integrity: sha512-3GXDysZOKD6cTYbm48lEdXdUbS7cafjXQZfgHOspTByhoGR/JM3KBXyF3vE6bf63ImjNPyoEZwnQcpYPQ6k3bQ==}
+
   '@chainsafe/benchmark@2.0.2':
     resolution: {integrity: sha512-qL8HpfP3922oPIDC7zarJpVNYddlf5Vv1DDGoOrKT/WRWKyQ0+INgrcs0Z67DbRp3tyZf70du1Oul0A93pAA5g==}
     hasBin: true
@@ -1504,9 +1507,6 @@ packages:
 
   '@chainsafe/persistent-merkle-tree@0.6.1':
     resolution: {integrity: sha512-gcENLemRR13+1MED2NeZBMA7FRS0xQPM7L2vhMqvKkjqtFT4YfjSVADq5U0iLuQLhFUJEMVuA8fbv5v+TN6O9A==}
-
-  '@chainsafe/persistent-merkle-tree@1.2.1':
-    resolution: {integrity: sha512-AOSEVLfaqwb9eTCKuY1ri0DrRxVQ3Rh+we1VBj1GahUGfEdE8OC3Vkbca7Up6RoI9Ip9FLnI31Y7AjKH9ZqAGA==}
 
   '@chainsafe/persistent-merkle-tree@1.2.5':
     resolution: {integrity: sha512-uyv3/nHkD8vNXjdez6q89rhXwGDUp3YX2mBbOwB7/xelgZ9E7hc3HQgOuq1EdfM9Vyh09jiwimXF/hskmymOfQ==}
@@ -7741,6 +7741,8 @@ snapshots:
 
   '@chainsafe/as-sha256@1.2.0': {}
 
+  '@chainsafe/as-sha256@1.2.4': {}
+
   '@chainsafe/benchmark@2.0.2(encoding@0.1.13)':
     dependencies:
       '@actions/cache': 4.0.0(encoding@0.1.13)
@@ -7941,15 +7943,9 @@ snapshots:
       '@chainsafe/as-sha256': 0.4.1
       '@noble/hashes': 1.8.0
 
-  '@chainsafe/persistent-merkle-tree@1.2.1':
-    dependencies:
-      '@chainsafe/as-sha256': 1.2.0
-      '@chainsafe/hashtree': 1.0.2
-      '@noble/hashes': 1.8.0
-
   '@chainsafe/persistent-merkle-tree@1.2.5':
     dependencies:
-      '@chainsafe/as-sha256': 1.2.0
+      '@chainsafe/as-sha256': 1.2.4
       '@chainsafe/hashtree': 1.0.2
       '@noble/hashes': 1.8.0
 

--- a/scripts/assert_persistent_merkle_tree_dedup.sh
+++ b/scripts/assert_persistent_merkle_tree_dedup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Assert @chainsafe/persistent-merkle-tree resolves to a single 1.x instance in pnpm-lock.yaml.
+#
+# persistent-merkle-tree carries a module-scoped `hasher` binding configured by Lodestar at
+# startup via setHasher(hashtree). If a second copy is loaded transitively (e.g. under
+# @chainsafe/ssz when its package.json declares an empty version constraint), Lodestar's
+# setHasher call configures only one copy while ssz internals digest through the other —
+# silently falling back to the slow JS noble hasher and producing a significant GC regression
+# on mainnet (see PR #9211).
+
+set -euo pipefail
+
+LOCKFILE="${1:-pnpm-lock.yaml}"
+PACKAGE="@chainsafe/persistent-merkle-tree"
+MAJOR="1"
+
+matches=$(grep -oE "'${PACKAGE}@${MAJOR}\.[0-9]+\.[0-9]+'" "$LOCKFILE" | sort -u)
+count=$(echo -n "$matches" | grep -c '^' || true)
+
+if [ "$count" -gt 1 ]; then
+  echo "ERROR: found multiple ${MAJOR}.x versions of ${PACKAGE} in ${LOCKFILE}:"
+  echo "$matches" | sed 's/^/  /'
+  echo
+  echo "Multiple instances split the module-scoped hasher singleton — Lodestar's"
+  echo "setHasher(hashtree) call configures only one copy, while @chainsafe/ssz internals"
+  echo "digest via the other (silently falling back to the slow JS noble hasher). Result:"
+  echo "significant GC regression on mainnet."
+  echo
+  echo "Fix: align every workspace package.json pin for ${PACKAGE} with the highest version"
+  echo "present, then run 'pnpm install' to dedupe."
+  exit 1
+fi
+
+echo "OK: single ${MAJOR}.x copy of ${PACKAGE} in ${LOCKFILE}"

--- a/scripts/assert_persistent_merkle_tree_dedup.sh
+++ b/scripts/assert_persistent_merkle_tree_dedup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Assert @chainsafe/persistent-merkle-tree resolves to a single 1.x instance in pnpm-lock.yaml.
+# Assert @chainsafe/persistent-merkle-tree resolves to a single instance in pnpm-lock.yaml.
 #
 # persistent-merkle-tree carries a module-scoped `hasher` binding configured by Lodestar at
 # startup via setHasher(hashtree). If a second copy is loaded transitively (e.g. under
@@ -13,14 +13,37 @@ set -euo pipefail
 
 LOCKFILE="${1:-pnpm-lock.yaml}"
 PACKAGE="@chainsafe/persistent-merkle-tree"
-MAJOR="1"
 
-matches=$(grep -oE "'${PACKAGE}@${MAJOR}\.[0-9]+\.[0-9]+'" "$LOCKFILE" | sort -u)
-count=$(echo -n "$matches" | grep -c '^' || true)
+# Versions known to come from non-runtime legacy paths and excluded from the dedup check.
+# @ethereumjs/util pulls in @chainsafe/ssz@0.11.1 which depends on persistent-merkle-tree@0.6.1.
+# That predates the setHasher API and can't share a singleton with the modern 1.x line.
+EXEMPT_VERSIONS=("0.6.1")
+
+# Extract every resolved version of PACKAGE that appears as a lockfile key.
+# pnpm-lock.yaml keys are of the form '<name>@<version>'[(<peer-dep-suffix>)]':' — version may
+# include pre-release tags (e.g. 1.2.5-alpha.0) and a parenthesized peer-dep suffix.
+# - grep captures everything between '<name>@' and the next ' or :
+# - sed strips any '(...)' peer-dep suffix to normalize on the bare version
+exempt_filter=$(printf '%s\n' "${EXEMPT_VERSIONS[@]}")
+versions=$(
+  grep -oE "'${PACKAGE}@[^':]+" "$LOCKFILE" \
+    | sed "s|'${PACKAGE}@||" \
+    | sed -E 's|\(.+$||' \
+    | grep -vxF "$exempt_filter" \
+    | sort -u
+)
+count=$(echo -n "$versions" | grep -c '^' || true)
+
+if [ "$count" -eq 0 ]; then
+  echo "ERROR: ${PACKAGE} not found in ${LOCKFILE}."
+  echo "The lockfile layout may have changed or the dependency is gone. Update this script"
+  echo "to match, or delete it if ${PACKAGE} is no longer used."
+  exit 1
+fi
 
 if [ "$count" -gt 1 ]; then
-  echo "ERROR: found multiple ${MAJOR}.x versions of ${PACKAGE} in ${LOCKFILE}:"
-  echo "$matches" | sed 's/^/  /'
+  echo "ERROR: found multiple versions of ${PACKAGE} in ${LOCKFILE}:"
+  echo "$versions" | sed 's/^/  /'
   echo
   echo "Multiple instances split the module-scoped hasher singleton — Lodestar's"
   echo "setHasher(hashtree) call configures only one copy, while @chainsafe/ssz internals"
@@ -32,4 +55,4 @@ if [ "$count" -gt 1 ]; then
   exit 1
 fi
 
-echo "OK: single ${MAJOR}.x copy of ${PACKAGE} in ${LOCKFILE}"
+echo "OK: single copy of ${PACKAGE}@${versions} in ${LOCKFILE}"


### PR DESCRIPTION
**Motivation**

After #9211 bumped `@chainsafe/ssz` to `^1.4.0`, the lockfile resolves two copies of `@chainsafe/persistent-merkle-tree`: `1.2.1` (direct pin) and `1.2.5` (transitive under ssz, which declares an empty PMT constraint).
Each PMT module carries its own `hasher` singleton.
`packages/cli/src/applyPreset.ts` only configures PMT 1.2.1 with hashtree; the 1.2.5 copy stays on the JS `noble` default.
Every `hashTreeRoot` going through ssz's internal `merkleize.js` now allocates per digest, causing significantly higher GC on mainnet.
<img width="1348" height="373" alt="Screenshot 2026-05-11 at 13 15 52" src="https://github.com/user-attachments/assets/b8669362-3336-4dc1-b7cd-094aee66e7d8" />

**Description**

- Bump direct `@chainsafe/persistent-merkle-tree` pin from `^1.2.1` to `^1.2.5` across all workspace packages so pnpm dedupes to a single instance.
- Add `scripts/assert_persistent_merkle_tree_dedup.sh` (wired into the `lint` job) to fail CI if the lockfile ever splits 1.x again.

**AI Assistance Disclosure**

Used Claude Code.
