### PR TITLE
chore(deps): bump actions group (excluding setup-node and pnpm/action-setup)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Restore performance downloaded states
       - name: Restore performance state cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: packages/state-transition/test-cache
           key: perf-states-${{ hashFiles('packages/state-transition/test/perf/params.ts') }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -43,13 +43,13 @@ jobs:
           npx caxa -m "Unpacking Lodestar binary, please wait..." -e "dashboards/**" -e "docs/**" -D -p "pnpm clean:nm && pnpm install --frozen-lockfile --prod" --input . --output "lodestar" -- "{{caxa}}/node_modules/.bin/node" "--max-old-space-size=8192" "{{caxa}}/packages/cli/bin/lodestar.js"
           tar -czf "dist/lodestar-${{ inputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz" "lodestar"
       - name: Upload binaries
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binaries-${{ matrix.os }}
           path: dist/
           if-no-files-found: error
       - name: Sanity check binary
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             exec.exec('./lodestar dev');

--- a/.github/workflows/build-debug-node.yml
+++ b/.github/workflows/build-debug-node.yml
@@ -44,7 +44,7 @@ jobs:
         working-directory: "nodejs"
 
       - name: Upload build to artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nodejs-debug-build-${{ github.event.inputs.version }}
           path: nodejs-debug-build-${{ github.event.inputs.version }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -64,7 +64,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -77,4 +77,4 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
 
       - name: Restore dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/nightly-spec-tests.yml
+++ b/.github/workflows/nightly-spec-tests.yml
@@ -100,7 +100,7 @@ jobs:
           steps.spec_minimal.outcome == 'failure' ||
           steps.spec_mainnet.outcome == 'failure' ||
           steps.spec_validator.outcome == 'failure'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: spec-test-logs
           path: |

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -36,7 +36,7 @@ jobs:
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
       - name: Restore dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/publish-nextfork.yml
+++ b/.github/workflows/publish-nextfork.yml
@@ -37,7 +37,7 @@ jobs:
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
       - name: Restore dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # master
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # master
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -57,7 +57,7 @@ jobs:
           GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
       - name: Upload debug log test files for "packages/cli"
         if: ${{ always() }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sim-test-multifork-logs
           path: packages/cli/test-logs
@@ -86,7 +86,7 @@ jobs:
           GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
       - name: Upload debug log test files for "packages/cli"
         if: ${{ always() }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sim-test-endpoints-logs
           path: packages/cli/test-logs
@@ -115,7 +115,7 @@ jobs:
           GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
       - name: Upload debug log test files for "packages/cli"
         if: ${{ always() }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sim-test-eth-backup-provider-logs
           path: packages/cli/test-logs
@@ -144,7 +144,7 @@ jobs:
           GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
       - name: Upload debug log test files for "packages/cli"
         if: ${{ always() }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sim-test-mixed-clients-logs
           path: packages/cli/test-logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
 
       # Cache validator slashing protection data tests
       - name: Restore spec tests cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: packages/validator/spec-tests
           key: spec-test-data-${{ hashFiles('packages/validator/test/spec/params.ts') }}
@@ -156,7 +156,7 @@ jobs:
 
       - name: Upload debug log test for test env
         if: ${{ always() }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: debug-e2e-test-logs-node-${{matrix.node}}
           path: test-logs/e2e-test-env
@@ -199,7 +199,7 @@ jobs:
 
       # Download spec tests with cache
       - name: Restore spec tests cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: packages/beacon-node/spec-tests
           key: spec-test-data-${{ hashFiles('spec-tests-version.json') }}


### PR DESCRIPTION
## Summary

Supersedes #9325. Re-applies the safe subset of dependabot's grouped actions bump and holds back `actions/setup-node` v6.3.0 → v6.4.0 plus the `pnpm/action-setup` v4 SHA bump until the underlying CI regression is understood and fixed.

The original dependabot PR failed `Check native module portability` with `spawn node-gyp ENOENT` during the `classic-level` postinstall (run log: https://github.com/ChainSafe/lodestar/actions/runs/25655927503/job/75304253313):

```
.../node_modules/classic-level install$ node-gyp-build
.../node_modules/classic-level install: Error: spawn node-gyp ENOENT
.../node_modules/classic-level install:   syscall: 'spawn node-gyp',
.../node_modules/classic-level install:   spawnargs: [ 'rebuild' ]
```

The same `actions/setup-node` v6.4.0 + `pnpm/action-setup` SHA bump is present in 5 other workflows that also run `pnpm install` with native deps (`docs.yml`, `docs-backfill.yml`, `docs-version.yml`, `publish-dev.yml`, `publish-nextfork.yml`), so those bumps are reverted here as well to avoid the same regression hitting docs/publish on post-merge pushes. Only `native-portability.yml` runs on PR triggers, so those failures would not have been caught at PR time.

## Bumps taken

| Action | From | To |
| --- | --- | --- |
| actions/cache | 5.0.4 | 5.0.5 |
| actions/upload-artifact | 7.0.0 | 7.0.1 |
| actions/github-script | 8.0.0 | 9.0.0 |
| github/codeql-action | 4.35.1 | 4.35.4 |
| softprops/action-gh-release | 2.6.1 | 3.0.0 |

## Bumps held back (for follow-up)

| Action | From | To | Reason |
| --- | --- | --- | --- |
| actions/setup-node | 6.3.0 | 6.4.0 | `spawn node-gyp ENOENT` regression for native-deps install (`classic-level`) |
| pnpm/action-setup | (v4 SHA) | (v4 SHA) | Bundled with setup-node bump in the same workflows; held back as a unit |

Root cause for the held-back pair is still TBD — setup-node v6.4.0 only ships an `@actions/*` dependency upgrade per its release notes, so it is plausible the failure stems from the npm-bundled `node-gyp` no longer being on PATH for spawn from postinstall scripts. Need to either (a) explicitly install `node-gyp` globally before `pnpm install` in workflows with native deps, or (b) understand the v6.4.0 behavior change before taking the bump.

## AI Assistance Disclosure

- [x] AI-assisted: investigation, scope split, and PR text drafted with Claude Code assistance. All changes were reviewed before commit.
