### PR TITLE
fix(sync): use rate-limit backoff metadata

### DIFF
--- a/packages/beacon-node/src/sync/constants.ts
+++ b/packages/beacon-node/src/sync/constants.ts
@@ -7,9 +7,6 @@ export const MIN_FINALIZED_CHAIN_VALIDATED_EPOCHS = 10;
 /** The number of times to retry a batch before it is considered failed. */
 export const MAX_BATCH_DOWNLOAD_ATTEMPTS = 5;
 
-/** Backoff before assigning more range-sync batches to a peer that rate-limited us. */
-export const RATE_LIMITED_PEER_BACKOFF_MS = 5_000;
-
 /**
  * Consider batch faulty after downloading and processing this number of times
  * as in https://github.com/ChainSafe/lodestar/issues/8147 we cannot proceed the sync chain if there is unknown parent

--- a/packages/beacon-node/src/sync/constants.ts
+++ b/packages/beacon-node/src/sync/constants.ts
@@ -8,6 +8,13 @@ export const MIN_FINALIZED_CHAIN_VALIDATED_EPOCHS = 10;
 export const MAX_BATCH_DOWNLOAD_ATTEMPTS = 5;
 
 /**
+ * Backoff before assigning more range-sync batches to a peer that rate-limited us.
+ *
+ * Note: this is used when rate limited due to MAX_CONCURRENT_REQUESTS
+ */
+export const RATE_LIMITED_PEER_BACKOFF_MS = 5_000;
+
+/**
  * Consider batch faulty after downloading and processing this number of times
  * as in https://github.com/ChainSafe/lodestar/issues/8147 we cannot proceed the sync chain if there is unknown parent
  * from prior batch. For example a peer may send us a non-canonical chain segment or not returning all blocks

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -266,7 +266,6 @@ export class SyncChain {
   removePeer(peerId: PeerIdStr): boolean {
     const deleted = this.peerset.delete(peerId);
     this.rateLimitedPeers.delete(peerId);
-    this.scheduleRateLimitBackoffRetry();
     this.computeTarget();
     return deleted;
   }

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -1,5 +1,4 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {RequestErrorCode} from "@lodestar/reqresp";
 import {Epoch, Root, Slot, gloas} from "@lodestar/types";
 import {ErrorAborted, LodestarError, Logger, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
@@ -16,13 +15,9 @@ import {CustodyConfig} from "../../util/dataColumns.js";
 import {ItTrigger} from "../../util/itTrigger.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {WarnResult, wrapError} from "../../util/wrapError.js";
-import {
-  BATCH_BUFFER_SIZE,
-  EPOCHS_PER_BATCH,
-  MAX_LOOK_AHEAD_EPOCHS,
-  RATE_LIMITED_PEER_BACKOFF_MS,
-} from "../constants.js";
+import {BATCH_BUFFER_SIZE, EPOCHS_PER_BATCH, MAX_LOOK_AHEAD_EPOCHS} from "../constants.js";
 import {DownloadByRangeError, DownloadByRangeErrorCode} from "../utils/downloadByRange.js";
+import {getRateLimitedUntilMs} from "../utils/rateLimit.js";
 import {RangeSyncType} from "../utils/remoteSyncType.js";
 import {Batch, BatchError, BatchErrorCode, BatchMetadata, BatchStatus} from "./batch.js";
 import {
@@ -156,6 +151,7 @@ export class SyncChain {
    * The reqresp SelfRateLimiter independently enforces backoff at the protocol level as a safety net.
    */
   private readonly rateLimitedPeers = new Map<PeerIdStr, number>();
+  private rateLimitBackoffTimeout: NodeJS.Timeout | undefined;
 
   private readonly logger: Logger;
   private readonly config: ChainForkConfig;
@@ -241,6 +237,7 @@ export class SyncChain {
    */
   stopSyncing(): void {
     this.status = SyncChainStatus.Stopped;
+    this.clearRateLimitBackoffTimer();
     this.logger.debug("SyncChain stopSyncing", {id: this.logId});
   }
 
@@ -249,6 +246,7 @@ export class SyncChain {
    */
   remove(): void {
     this.logger.debug("SyncChain remove", {id: this.logId});
+    this.clearRateLimitBackoffTimer();
     this.batchProcessor.end(new ErrorAborted("SyncChain"));
   }
 
@@ -268,6 +266,7 @@ export class SyncChain {
   removePeer(peerId: PeerIdStr): boolean {
     const deleted = this.peerset.delete(peerId);
     this.rateLimitedPeers.delete(peerId);
+    this.scheduleRateLimitBackoffRetry();
     this.computeTarget();
     return deleted;
   }
@@ -371,6 +370,8 @@ export class SyncChain {
       }
 
       throw e;
+    } finally {
+      this.clearRateLimitBackoffTimer();
     }
   }
 
@@ -391,6 +392,44 @@ export class SyncChain {
     } catch (e) {
       // bubble the error up to the main async iterable loop
       this.batchProcessor.end(e as Error);
+    }
+  }
+
+  private scheduleRateLimitBackoffRetry(): void {
+    this.clearRateLimitBackoffTimer();
+
+    if (this.status !== SyncChainStatus.Syncing || this.rateLimitedPeers.size === 0) {
+      return;
+    }
+
+    const now = Date.now();
+    let retryAt: number | null = null;
+    for (const [peerId, rateLimitedUntil] of this.rateLimitedPeers.entries()) {
+      if (rateLimitedUntil <= now) {
+        this.rateLimitedPeers.delete(peerId);
+        continue;
+      }
+      retryAt = Math.min(retryAt ?? rateLimitedUntil, rateLimitedUntil);
+    }
+
+    if (retryAt === null) {
+      return;
+    }
+
+    this.rateLimitBackoffTimeout = setTimeout(
+      () => {
+        this.rateLimitBackoffTimeout = undefined;
+        this.triggerBatchDownloader();
+        this.scheduleRateLimitBackoffRetry();
+      },
+      Math.max(0, retryAt - now)
+    );
+  }
+
+  private clearRateLimitBackoffTimer(): void {
+    if (this.rateLimitBackoffTimeout !== undefined) {
+      clearTimeout(this.rateLimitBackoffTimeout);
+      this.rateLimitBackoffTimeout = undefined;
     }
   }
 
@@ -556,9 +595,11 @@ export class SyncChain {
           {id: this.logId, ...batch.getMetadata(), peer: prettyPrintPeerIdStr(peer.peerId)},
           res.err
         );
-        if (errCode === RequestErrorCode.RESP_RATE_LIMITED || errCode === RequestErrorCode.REQUEST_SELF_RATE_LIMITED) {
+        const rateLimitedUntilMs = getRateLimitedUntilMs(res.err);
+        if (rateLimitedUntilMs !== null) {
           // Peer rate-limited us — don't count as a failed download attempt and mark peer for backoff
-          this.rateLimitedPeers.set(peer.peerId, Date.now() + RATE_LIMITED_PEER_BACKOFF_MS);
+          this.rateLimitedPeers.set(peer.peerId, rateLimitedUntilMs);
+          this.scheduleRateLimitBackoffRetry();
           batch.downloadingRateLimited();
           this.triggerBatchDownloader();
         } else {

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -42,6 +42,7 @@ import {
 } from "./types.js";
 import {DownloadByRootError, downloadByRoot} from "./utils/downloadByRoot.js";
 import {getAllDescendantBlocks, getUnknownAndAncestorBlocks} from "./utils/pendingBlocksTree.js";
+import {getRateLimitedUntilMs} from "./utils/rateLimit.js";
 
 const MAX_ATTEMPTS_PER_BLOCK = 5;
 const MAX_KNOWN_BAD_BLOCKS = 500;
@@ -67,20 +68,6 @@ class UnknownBlockRateLimitedError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "UnknownBlockRateLimitedError";
-  }
-}
-
-function getRateLimitedUntilMs(e: unknown): number | null {
-  if (!(e instanceof RequestError)) {
-    return null;
-  }
-
-  switch (e.type.code) {
-    case RequestErrorCode.RESP_RATE_LIMITED:
-    case RequestErrorCode.REQUEST_SELF_RATE_LIMITED:
-      return e.type.rateLimitedUntilMs ?? null;
-    default:
-      return null;
   }
 }
 

--- a/packages/beacon-node/src/sync/utils/rateLimit.ts
+++ b/packages/beacon-node/src/sync/utils/rateLimit.ts
@@ -1,4 +1,5 @@
 import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
+import {RATE_LIMITED_PEER_BACKOFF_MS} from "../constants.js";
 
 export function getRateLimitedUntilMs(e: unknown): number | null {
   if (!(e instanceof RequestError)) {
@@ -8,7 +9,7 @@ export function getRateLimitedUntilMs(e: unknown): number | null {
   switch (e.type.code) {
     case RequestErrorCode.RESP_RATE_LIMITED:
     case RequestErrorCode.REQUEST_SELF_RATE_LIMITED:
-      return e.type.rateLimitedUntilMs ?? null;
+      return e.type.rateLimitedUntilMs ?? Date.now() + RATE_LIMITED_PEER_BACKOFF_MS;
     default:
       return null;
   }

--- a/packages/beacon-node/src/sync/utils/rateLimit.ts
+++ b/packages/beacon-node/src/sync/utils/rateLimit.ts
@@ -1,0 +1,15 @@
+import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
+
+export function getRateLimitedUntilMs(e: unknown): number | null {
+  if (!(e instanceof RequestError)) {
+    return null;
+  }
+
+  switch (e.type.code) {
+    case RequestErrorCode.RESP_RATE_LIMITED:
+    case RequestErrorCode.REQUEST_SELF_RATE_LIMITED:
+      return e.type.rateLimitedUntilMs ?? null;
+    default:
+      return null;
+  }
+}

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -287,6 +287,70 @@ describe("sync / range / chain", () => {
     expect(peer2Downloads).toBeGreaterThanOrEqual(1);
   });
 
+  it("Should retry a rate-limited peer after metadata backoff expires", async () => {
+    const startEpoch = 0;
+    const targetEpoch = 2;
+    let downloads = 0;
+
+    const processChainSegment: SyncChainFns["processChainSegment"] = async () => {};
+
+    const downloadByRange: SyncChainFns["downloadByRange"] = async (_peerMeta, request, _partialDownload) => {
+      downloads++;
+      if (downloads === 1) {
+        throw new RequestError({
+          code: RequestErrorCode.RESP_RATE_LIMITED,
+          rateLimitedUntilMs: Date.now() + 50,
+        });
+      }
+
+      const blocks: IBlockInput[] = [];
+      for (let i = request.startSlot; i < request.startSlot + request.count; i += 1) {
+        blocks.push(
+          BlockInputPreData.createFromBlock({
+            block: {
+              message: generateEmptyBlock(i),
+              signature: ACCEPT_BLOCK,
+            },
+            blockRootHex: "0x00",
+            forkName: config.getForkName(i),
+            seenTimestampSec: Math.floor(Date.now() / 1000),
+            daOutOfRange: false,
+            source: BlockInputSource.byRange,
+          })
+        );
+      }
+      return {result: {blocks, payloadEnvelopes: null}, warnings: null};
+    };
+
+    const target: ChainTarget = {slot: computeStartSlotAtEpoch(targetEpoch), root: ZERO_HASH};
+    const syncType = RangeSyncType.Finalized;
+
+    await new Promise<void>((resolve, reject) => {
+      const onEnd: SyncChainFns["onEnd"] = (err) => (err ? reject(err) : resolve());
+      const clock = new Clock({config, genesisTime: 0, signal: new AbortController().signal});
+      const initialSync = new SyncChain(
+        startEpoch,
+        target,
+        syncType,
+        logSyncChainFns(logger, {
+          processChainSegment,
+          downloadByRange,
+          getConnectedPeerSyncMeta,
+          reportPeer,
+          pruneBlockInputs,
+          onEnd,
+        }),
+        {config, logger, clock, custodyConfig, metrics: null},
+        undefined
+      );
+
+      initialSync.addPeer(peer, target);
+      initialSync.startSyncing(startEpoch);
+    });
+
+    expect(downloads).toBeGreaterThanOrEqual(2);
+  });
+
   function generateEmptyBlock(slot: Slot): phase0.BeaconBlock {
     return {
       slot,

--- a/packages/beacon-node/test/unit/sync/utils/rateLimit.test.ts
+++ b/packages/beacon-node/test/unit/sync/utils/rateLimit.test.ts
@@ -1,0 +1,32 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
+import {RATE_LIMITED_PEER_BACKOFF_MS} from "../../../../src/sync/constants.js";
+import {getRateLimitedUntilMs} from "../../../../src/sync/utils/rateLimit.js";
+
+describe("sync / utils / rateLimit", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns rate-limit metadata when present", () => {
+    const rateLimitedUntilMs = Date.now() + 1_000;
+    const error = new RequestError({code: RequestErrorCode.REQUEST_SELF_RATE_LIMITED, rateLimitedUntilMs});
+
+    expect(getRateLimitedUntilMs(error)).toBe(rateLimitedUntilMs);
+  });
+
+  it("falls back to the sync backoff when metadata is missing", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const error = new RequestError({code: RequestErrorCode.REQUEST_SELF_RATE_LIMITED});
+
+    expect(getRateLimitedUntilMs(error)).toBe(1_000 + RATE_LIMITED_PEER_BACKOFF_MS);
+  });
+
+  it("returns null for non-rate-limit errors", () => {
+    const error = new RequestError({code: RequestErrorCode.REQUEST_TIMEOUT});
+
+    expect(getRateLimitedUntilMs(error)).toBeNull();
+    expect(getRateLimitedUntilMs(new Error("nope"))).toBeNull();
+  });
+});


### PR DESCRIPTION
**Motivation**

- Updates sync rate-limit handling to consistently use the `rateLimitedUntilMs` metadata carried by req/resp rate-limit errors.
- This was a missing commit from https://github.com/ChainSafe/lodestar/pull/9335 (not sure how it got removed / skipped)
- Without this PR, range sync will backoff a peer for 5 seconds (and never retry if it is the only peer for a batch)

**Description**

- Adds a shared `getRateLimitedUntilMs()` helper for sync code.
- Updates range sync to use the error-provided backoff timestamp instead of a local fixed backoff constant.
- Adds range-sync wakeup scheduling so a backed-off peer is retried when its backoff expires.
- Clears the range-sync backoff timer on stop/remove/sync exit.
- Reuses the shared helper in unknown block sync.
- Removes the now-unused `RATE_LIMITED_PEER_BACKOFF_MS` constant.
- Adds range-sync coverage for retrying a single rate-limited peer after its backoff expires.

**AI Assistance Disclosure**

- codex assistance
