### PR TITLE
fix(docs): allow core-js postinstall scripts under pnpm v11

### DIFF
--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 minimumReleaseAge: 2880
 
 nodeLinker: isolated
+
+allowBuilds:
+  core-js: true
+  core-js-pure: true


### PR DESCRIPTION
## Summary

After the pnpm v11 upgrade (#9299), the **Deploy docs** workflow fails at the `cd docs && pnpm install` step with:

```
ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: core-js-pure@3.36.0, core-js@3.36.0
```

pnpm v11 defaults [`strict-dep-builds=true`](https://pnpm.io/9.x/settings#strictdepbuilds), so any transitive dependency with a postinstall script that isn't explicitly allowed (or denied) in `allowBuilds` fails the install with exit 1.

The root `pnpm-workspace.yaml` already declares `core-js: true` in its `allowBuilds` map, but `docs/` is a separate pnpm project (it has its own `pnpm-lock.yaml` and its own `pnpm-workspace.yaml`) and didn't inherit that decision. Docusaurus pulls in both `core-js` and `core-js-pure` transitively, so the docs install needs the same allow entries.

This PR adds the matching entries to `docs/pnpm-workspace.yaml`:

```yaml
allowBuilds:
  core-js: true
  core-js-pure: true
```

## Verification

Reproduced locally on a fresh worktree at the upstream `unstable` HEAD with Node 24 + pnpm 11.0.0:

- **Before:** `cd docs && pnpm install` exits 1 with the `ERR_PNPM_IGNORED_BUILDS` error (matches CI run [25682774486](https://github.com/ChainSafe/lodestar/actions/runs/25682774486)).
- **After:** `cd docs && pnpm install` resolves 1189 packages and exits 0 with no error.

## Test plan

- [ ] CI `Deploy docs` workflow succeeds against this branch.

## AI Assistance Disclosure

- [x] AI-assisted: investigation of the failing `Deploy docs` run, reproduction of the install error under pnpm 11.0.0, identification of the `allowBuilds` mechanism mirroring the root `pnpm-workspace.yaml`, and authoring of the one-file patch. All changes were reviewed before commit.

🤖 Generated with AI assistance