### PR TITLE
feat: assert chain segment in range sync

### DIFF
--- a/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
+++ b/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
@@ -17,8 +17,6 @@ export type ChainSegmentResult = {warnings: OrphanedPayloadEnvelope[] | null};
  * Assert this chain segment of blocks is linear with slot numbers and hashes,
  * and that the provided envelopes are consistent with their respective blocks.
  *
- * Must be called after verifyBlocksSanityChecks so that parentBlock (from forkchoice)
- * is available to seed the execution hash chain.
  *
  * For each block:
  * - Verifies parent root + slot linearity
@@ -31,7 +29,7 @@ export function assertLinearChainSegment(
   config: ChainForkConfig,
   blocks: IBlockInput[],
   payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
-  parentBlock: ProtoBlock
+  parentBlock: ProtoBlock | null
 ): ChainSegmentResult {
   const warnings: OrphanedPayloadEnvelope[] = [];
 
@@ -39,15 +37,16 @@ export function assertLinearChainSegment(
   // Starts from the known forkchoice parent's execution hash.
   // - FULL variant (envelope present for slot): advances to envelope.payload.blockHash
   // - EMPTY variant (no envelope for slot): execution hash is unchanged
-  // null only for pre-merge parents, which cannot precede gloas blocks.
-  let currentExecHash: string | null = parentBlock.executionPayloadBlockHash;
+  let currentExecHash: string | null = parentBlock?.executionPayloadBlockHash ?? null;
   // Checkpoint sync first batch: parent is the anchor PENDING whose executionPayloadBlockHash
   // is the inherited parentBlockHash semantic (= grandparent's payload), not its own payload.
   // If parent's own payload envelope arrives in this batch, advance currentExecHash to that
   // payload's blockHash so the segment validation sees the true EL chain head.
-  const parentPayloadInput = payloadEnvelopes?.get(parentBlock.slot);
-  if (parentPayloadInput?.hasPayloadEnvelope()) {
-    currentExecHash = parentPayloadInput.getBlockHashHex();
+  if (parentBlock !== null) {
+    const parentPayloadInput = payloadEnvelopes?.get(parentBlock.slot);
+    if (parentPayloadInput?.hasPayloadEnvelope()) {
+      currentExecHash = parentPayloadInput.getBlockHashHex();
+    }
   }
   // Track the execution hash before the last FULL advancement so we can recover
   // if the next block reveals that envelope was orphaned.
@@ -76,27 +75,31 @@ export function assertLinearChainSegment(
       }
     }
 
-    if (isGloasBeaconBlock(block.message) && currentExecHash !== null) {
-      // Verify the bid's parentBlockHash matches the tracked execution hash.
-      // This ensures the block was built on the correct FULL or EMPTY variant of its parent.
-      const bidParentHash = toRootHex(block.message.body.signedExecutionPayloadBid.message.parentBlockHash);
-      if (bidParentHash !== currentExecHash) {
-        // Maybe the previous slot's FULL envelope was orphaned — try falling back.
-        // If even prevExecHash doesn't match, the segment is non-linear.
-        if (bidParentHash !== prevExecHash) {
-          throw new BlockError(block, {
-            code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
-            parentRoot: toRootHex(block.message.parentRoot),
-            parentBlockHash: bidParentHash,
-          });
-        }
-        if (lastFullSlot !== null && payloadEnvelopes !== null) {
-          const orphanedInput = payloadEnvelopes.get(lastFullSlot);
-          if (orphanedInput != null) {
-            warnings.push({slot: lastFullSlot, payloadEnvelopeInput: orphanedInput});
+    if (isGloasBeaconBlock(block.message)) {
+      // Bid check fires only when we have a seeded execution hash. With parentBlock=null the
+      // chain is seeded mid-segment by the first FULL envelope.
+      if (currentExecHash !== null) {
+        // Verify the bid's parentBlockHash matches the tracked execution hash.
+        // This ensures the block was built on the correct FULL or EMPTY variant of its parent.
+        const bidParentHash = toRootHex(block.message.body.signedExecutionPayloadBid.message.parentBlockHash);
+        if (bidParentHash !== currentExecHash) {
+          // Maybe the previous slot's FULL envelope was orphaned — try falling back.
+          // If even prevExecHash doesn't match, the segment is non-linear.
+          if (bidParentHash !== prevExecHash) {
+            throw new BlockError(block, {
+              code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
+              parentRoot: toRootHex(block.message.parentRoot),
+              parentBlockHash: bidParentHash,
+            });
           }
+          if (lastFullSlot !== null && payloadEnvelopes !== null) {
+            const orphanedInput = payloadEnvelopes.get(lastFullSlot);
+            if (orphanedInput != null) {
+              warnings.push({slot: lastFullSlot, payloadEnvelopeInput: orphanedInput});
+            }
+          }
+          currentExecHash = prevExecHash;
         }
-        currentExecHash = prevExecHash;
       }
 
       const payloadInput = payloadEnvelopes?.get(slot) ?? null;

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -543,6 +543,8 @@ export class SyncChain {
           case DownloadByRangeErrorCode.OUT_OF_ORDER_BLOCKS:
           case DownloadByRangeErrorCode.OUT_OF_RANGE_BLOCKS:
           case DownloadByRangeErrorCode.PARENT_ROOT_MISMATCH:
+          case DownloadByRangeErrorCode.INVALID_ENVELOPE_BEACON_BLOCK_ROOT:
+          case DownloadByRangeErrorCode.INVALID_CHAIN_SEGMENT:
           case BlobSidecarErrorCode.INCLUSION_PROOF_INVALID:
           case BlobSidecarErrorCode.INVALID_KZG_PROOF_BATCH:
           case DataColumnSidecarErrorCode.INCORRECT_KZG_COMMITMENTS_COUNT:

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -3,14 +3,21 @@ import {StrictEventEmitter} from "strict-event-emitter-types";
 import {BeaconConfig} from "@lodestar/config";
 import {IBeaconStateViewGloas, computeStartSlotAtEpoch, isStatePostGloas} from "@lodestar/state-transition";
 import {Epoch, Status, fulu} from "@lodestar/types";
-import {Logger, toRootHex} from "@lodestar/utils";
+import {Logger, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {IBlockInput} from "../../chain/blocks/blockInput/types.js";
 import {AttestationImportOpt, ImportBlockOpts} from "../../chain/blocks/index.js";
+import {assertLinearChainSegment} from "../../chain/blocks/utils/chainSegment.js";
+import {BlockError} from "../../chain/errors/index.js";
 import {IBeaconChain} from "../../chain/index.js";
 import {Metrics} from "../../metrics/index.js";
 import {INetwork} from "../../network/index.js";
 import {PeerIdStr} from "../../util/peerId.js";
-import {cacheByRangeResponses, downloadByRange} from "../utils/downloadByRange.js";
+import {
+  DownloadByRangeError,
+  DownloadByRangeErrorCode,
+  cacheByRangeResponses,
+  downloadByRange,
+} from "../utils/downloadByRange.js";
 import {RangeSyncType, getRangeSyncTarget, rangeSyncTypes} from "../utils/remoteSyncType.js";
 import {ChainTarget, SyncChain, SyncChainDebugState, SyncChainFns} from "./chain.js";
 import {updateChains} from "./utils/index.js";
@@ -231,6 +238,49 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       custodyConfig: this.chain.custodyConfig,
       seenTimestampSec: Date.now() / 1000,
     });
+
+    const segmentBlocks = blocks.filter((b) => b.hasBlock()).sort((a, b) => a.slot - b.slot);
+    const envelopeSlots = payloadEnvelopes
+      ? Array.from(payloadEnvelopes.entries())
+          .filter(([, pi]) => pi.hasPayloadEnvelope())
+          .map(([slot]) => slot)
+          .sort((a, b) => a - b)
+      : [];
+    this.logger.verbose("downloadByRange batch ready", {
+      peer: peer.peerId,
+      blockSlots: prettyPrintIndices(segmentBlocks.map((b) => b.slot)),
+      envelopeSlots: prettyPrintIndices(envelopeSlots),
+      ...batch.getMetadata(),
+    });
+
+    if (segmentBlocks.length > 1) {
+      try {
+        assertLinearChainSegment(this.config, segmentBlocks, payloadEnvelopes, null);
+      } catch (err) {
+        if (err instanceof BlockError) {
+          this.logger.debug(
+            "downloadByRange segment validation failed",
+            {
+              peer: peer.peerId,
+              reason: err.type.code,
+              slot: err.signedBlock.message.slot,
+              detail: JSON.stringify(err.type),
+              ...batch.getMetadata(),
+            },
+            err
+          );
+          // with this error, the peer will be penalized inside SyncChain
+          throw new DownloadByRangeError({
+            code: DownloadByRangeErrorCode.INVALID_CHAIN_SEGMENT,
+            slot: err.signedBlock.message.slot,
+            reason: err.type.code,
+          });
+        }
+
+        throw err;
+      }
+    }
+
     return {result: {blocks, payloadEnvelopes}, warnings};
   };
 

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -1155,6 +1155,9 @@ export enum DownloadByRangeErrorCode {
 
   /** Envelope beaconBlockRoot does not match the block's root */
   INVALID_ENVELOPE_BEACON_BLOCK_ROOT = "DOWNLOAD_BY_RANGE_ERROR_INVALID_ENVELOPE_BEACON_BLOCK_ROOT",
+
+  /** Block segment + envelopes failed chain-segment linearity / FULL-chain checks */
+  INVALID_CHAIN_SEGMENT = "DOWNLOAD_BY_RANGE_ERROR_INVALID_CHAIN_SEGMENT",
 }
 
 export type DownloadByRangeErrorType =
@@ -1252,6 +1255,11 @@ export type DownloadByRangeErrorType =
       slot: Slot;
       expected: string;
       actual: string;
+    }
+  | {
+      code: DownloadByRangeErrorCode.INVALID_CHAIN_SEGMENT;
+      slot: Slot;
+      reason: string;
     };
 
 export class DownloadByRangeError extends LodestarError<DownloadByRangeErrorType> {}

--- a/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
@@ -1,0 +1,132 @@
+import {describe, expect, it} from "vitest";
+import {createChainForkConfig} from "@lodestar/config";
+import {chainConfig} from "@lodestar/config/default";
+import {ForkName} from "@lodestar/params";
+import {SignedBeaconBlock, Slot, gloas, ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {BlockInputNoData} from "../../../../../src/chain/blocks/blockInput/blockInput.js";
+import {BlockInputSource} from "../../../../../src/chain/blocks/blockInput/types.js";
+import {PayloadEnvelopeInput} from "../../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
+import {PayloadEnvelopeInputSource} from "../../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
+import {assertLinearChainSegment} from "../../../../../src/chain/blocks/utils/chainSegment.js";
+import {BlockErrorCode} from "../../../../../src/chain/errors/index.js";
+import {expectThrowsLodestarError} from "../../../../utils/errors.js";
+
+describe("chain / blocks / utils / chainSegment / assertLinearChainSegment with parentBlock=null", () => {
+  const config = createChainForkConfig({...chainConfig, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
+  const seenTimestampSec = Date.now() / 1000;
+
+  function gloasBlockInput(slot: Slot, parentRoot: Uint8Array, bidParentBlockHash: Uint8Array): BlockInputNoData {
+    const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+    block.message.slot = slot;
+    block.message.parentRoot = parentRoot;
+    block.message.body.signedExecutionPayloadBid.message.parentBlockHash = bidParentBlockHash;
+    const blockRootHex = toRootHex(ssz.gloas.BeaconBlock.hashTreeRoot(block.message));
+    return BlockInputNoData.createFromBlock({
+      block: block as SignedBeaconBlock<typeof ForkName.gloas>,
+      blockRootHex,
+      forkName: ForkName.gloas,
+      daOutOfRange: false,
+      seenTimestampSec,
+      source: BlockInputSource.byRange,
+      peerIdStr: "peer",
+    });
+  }
+
+  function payloadInputFor(blockInput: BlockInputNoData, payloadBlockHash: Uint8Array): PayloadEnvelopeInput {
+    const block = blockInput.getBlock();
+    const payloadInput = PayloadEnvelopeInput.createFromBlock({
+      blockRootHex: blockInput.blockRootHex,
+      block: block as SignedBeaconBlock<typeof ForkName.gloas>,
+      forkName: ForkName.gloas,
+      sampledColumns: [],
+      custodyColumns: [],
+      timeCreatedSec: seenTimestampSec,
+      daOutOfRange: false,
+    });
+    const envelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    envelope.message.beaconBlockRoot = ssz.gloas.BeaconBlock.hashTreeRoot(block.message as gloas.BeaconBlock);
+    envelope.message.payload.slotNumber = block.message.slot;
+    envelope.message.payload.blockHash = payloadBlockHash;
+    payloadInput.addPayloadEnvelope({
+      envelope,
+      source: PayloadEnvelopeInputSource.byRange,
+      seenTimestampSec,
+      peerIdStr: "peer",
+    });
+    return payloadInput;
+  }
+
+  it("passes for a single-block segment with parentBlock=null (no checks fire)", () => {
+    const bi = gloasBlockInput(10, Buffer.alloc(32, 0xaa), Buffer.alloc(32, 0xbb));
+    const {warnings} = assertLinearChainSegment(config, [bi], null, null);
+    expect(warnings).toBe(null);
+  });
+
+  it("throws NON_LINEAR_PARENT_ROOTS when block[1].parentRoot does not match block[0].root", () => {
+    const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), Buffer.alloc(32, 0xbb));
+    const bi2 = gloasBlockInput(11, Buffer.alloc(32, 0xcc), Buffer.alloc(32, 0xbb));
+    expectThrowsLodestarError(
+      () => assertLinearChainSegment(config, [bi1, bi2], null, null),
+      BlockErrorCode.NON_LINEAR_PARENT_ROOTS
+    );
+  });
+
+  it("throws NON_LINEAR_SLOTS when slots are not strictly increasing", () => {
+    const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), Buffer.alloc(32, 0xbb));
+    const b1Root = ssz.gloas.BeaconBlock.hashTreeRoot(bi1.getBlock().message as gloas.BeaconBlock);
+    const bi2 = gloasBlockInput(10, b1Root, Buffer.alloc(32, 0xbb));
+    expectThrowsLodestarError(
+      () => assertLinearChainSegment(config, [bi1, bi2], null, null),
+      BlockErrorCode.NON_LINEAR_SLOTS
+    );
+  });
+
+  it("throws PARENT_PAYLOAD_UNKNOWN when FULL envelope's payload hash does not match next block's bid parentBlockHash", () => {
+    const firstExecHash = Buffer.alloc(32, 0x11);
+    const correctNextExecHash = Buffer.alloc(32, 0x22);
+    const mismatchedNextExecHash = Buffer.alloc(32, 0x99);
+
+    const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), firstExecHash);
+    const b1Root = ssz.gloas.BeaconBlock.hashTreeRoot(bi1.getBlock().message as gloas.BeaconBlock);
+    const bi2 = gloasBlockInput(11, b1Root, mismatchedNextExecHash);
+
+    const pi1 = payloadInputFor(bi1, correctNextExecHash);
+    const envelopes = new Map<Slot, PayloadEnvelopeInput>([[10, pi1]]);
+
+    expectThrowsLodestarError(
+      () => assertLinearChainSegment(config, [bi1, bi2], envelopes, null),
+      BlockErrorCode.PARENT_PAYLOAD_UNKNOWN
+    );
+  });
+
+  it("passes for an EMPTY→EMPTY segment (no envelopes) without a parent", () => {
+    // First block's bid check is skipped (currentExecHash starts null); from there no envelopes,
+    // so chain stays "unseeded" — no further checks can fire.
+    const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), Buffer.alloc(32, 0xbb));
+    const b1Root = ssz.gloas.BeaconBlock.hashTreeRoot(bi1.getBlock().message as gloas.BeaconBlock);
+    const bi2 = gloasBlockInput(11, b1Root, Buffer.alloc(32, 0xcc));
+
+    const {warnings} = assertLinearChainSegment(config, [bi1, bi2], null, null);
+    expect(warnings).toBe(null);
+  });
+
+  it("passes for a valid FULL→FULL segment", () => {
+    const exec1 = Buffer.alloc(32, 0x11);
+    const exec2 = Buffer.alloc(32, 0x22);
+
+    const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), Buffer.alloc(32, 0x99));
+    const b1Root = ssz.gloas.BeaconBlock.hashTreeRoot(bi1.getBlock().message as gloas.BeaconBlock);
+    const bi2 = gloasBlockInput(11, b1Root, exec1);
+
+    const pi1 = payloadInputFor(bi1, exec1);
+    const pi2 = payloadInputFor(bi2, exec2);
+    const envelopes = new Map<Slot, PayloadEnvelopeInput>([
+      [10, pi1],
+      [11, pi2],
+    ]);
+
+    const {warnings} = assertLinearChainSegment(config, [bi1, bi2], envelopes, null);
+    expect(warnings).toBe(null);
+  });
+});


### PR DESCRIPTION
**Motivation**

- we only valid chain segment in processBlocks(), we should have validated earlier right after we download it

**Description**

- enhance `assertLinearChainSegment()` with an optional `parentBlock`
- call it right after we download a range segment
- add logs penalize peer

**AI Assistance Disclosure**

Made with Claude