### PR TITLE
fix(ci): install caxa via npx to unblock binary release under pnpm v11

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -39,8 +39,7 @@ jobs:
           node: 24
       - run: |
           mkdir -p dist
-          pnpm add -g @chainsafe/caxa@3.0.6
-          npx caxa -m "Unpacking Lodestar binary, please wait..." -e "dashboards/**" -e "docs/**" -D -p "pnpm clean:nm && pnpm install --frozen-lockfile --prod" --input . --output "lodestar" -- "{{caxa}}/node_modules/.bin/node" "--max-old-space-size=8192" "{{caxa}}/packages/cli/bin/lodestar.js"
+          npx -y -p @chainsafe/caxa@3.0.6 caxa -m "Unpacking Lodestar binary, please wait..." -e "dashboards/**" -e "docs/**" -D -p "pnpm clean:nm && pnpm install --frozen-lockfile --prod" --input . --output "lodestar" -- "{{caxa}}/node_modules/.bin/node" "--max-old-space-size=8192" "{{caxa}}/packages/cli/bin/lodestar.js"
           tar -czf "dist/lodestar-${{ inputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz" "lodestar"
       - name: Upload binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

The `v1.43.0-rc.3` binary release ([run 25820616462](https://github.com/ChainSafe/lodestar/actions/runs/25820616462/job/75862747635)) fails at the `pnpm add -g @chainsafe/caxa@3.0.6` step in `.github/workflows/binaries.yml` with:

```
ERROR  The configured global bin directory "/home/runner/setup-pnpm/node_modules/.bin/bin" is not in PATH
Run "pnpm setup" to update your shell configuration.
```

### Root cause

#9299 bumped pnpm v10 → v11 and `pnpm/action-setup` v4 → v5. action-setup v5 still exports `PNPM_HOME=/home/runner/setup-pnpm/node_modules/.bin` and puts *that exact dir* on `PATH`, but pnpm v11's `pnpm add -g` now resolves the global bin as `$PNPM_HOME/bin` (a subdirectory), which is not on `PATH`, so it aborts before caxa is ever installed.

`publish-rc.yml` / `publish-stable.yml` are the only callers of `binaries.yml`, which is why this only surfaced now on the v1.43.0-rc.3 publish — `unstable` CI doesn't exercise this path.

### Fix

The `pnpm add -g` line was redundant — the very next line is `npx caxa ...`, which already fetches caxa on demand. Drop the global install and inline the version pin with `npx -y -p @chainsafe/caxa@3.0.6 caxa ...` so we never touch the pnpm global bin path.

```diff
- pnpm add -g @chainsafe/caxa@3.0.6
- npx caxa -m "Unpacking Lodestar binary, please wait..." ...
+ npx -y -p @chainsafe/caxa@3.0.6 caxa -m "Unpacking Lodestar binary, please wait..." ...
```

## Test plan

- [ ] Re-run `Build binaries` workflow with `version: v1.43.0-rc.3` (workflow_dispatch) against this branch to verify amd64 + arm64 builds complete and the sanity-check binary step passes.
- [ ] Confirm tarball naming and `lodestar dev` smoke-test inside the artifact are unchanged.

## AI Assistance Disclosure

- [x] AI-assisted: diagnosed the pnpm v11 / action-setup v5 global-bin PATH mismatch from the failed job log and drafted the fix. Reviewed before commit.

🤖 Generated with AI assistance