### PR TITLE
fix(ci): set registry-url for OIDC publish under pnpm v11

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -4,6 +4,10 @@ inputs:
   node:
     description: Node version
     required: true
+  registry-url:
+    description: npm registry URL to write into .npmrc (required for OIDC publish jobs)
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -14,6 +18,7 @@ runs:
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{inputs.node}}
+        registry-url: ${{inputs.registry-url}}
         check-latest: true
         # Due to a known issue we have to disable package caching for now
         # https://github.com/pnpm/pnpm/issues/6234

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -66,6 +66,10 @@ jobs:
       - uses: "./.github/actions/setup-and-build"
         with:
           node: 24
+          # Required for OIDC publish under pnpm v11 — without registry-url
+          # setup-node skips writing the registry to .npmrc and the npm OIDC
+          # auth flow rejects the token. Matches publish-dev.yml's setup.
+          registry-url: "https://registry.npmjs.org"
 
       - name: Generate changelog
         run: node scripts/generate_changelog.mjs ${{ needs.tag.outputs.prev_tag }} ${{ needs.tag.outputs.tag }} CHANGELOG.md

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -72,6 +72,10 @@ jobs:
       - uses: "./.github/actions/setup-and-build"
         with:
           node: 24
+          # Required for OIDC publish under pnpm v11 — without registry-url
+          # setup-node skips writing the registry to .npmrc and the npm OIDC
+          # auth flow rejects the token. Matches publish-dev.yml's setup.
+          registry-url: "https://registry.npmjs.org"
 
       - name: Generate changelog
         run: node scripts/generate_changelog.mjs ${{ needs.tag.outputs.prev_tag }} ${{ needs.tag.outputs.tag }} CHANGELOG.md


### PR DESCRIPTION
## Summary
- After #9299 bumped pnpm 10 → 11, the v1.43.0-rc.4 publish to npm fails with `400 OIDC publish authorize: Invalid token` (run [25822436356/job/75867664400](https://github.com/ChainSafe/lodestar/actions/runs/25822436356/job/75867664400)). The GitHub OIDC JWT itself is being issued (the `/idtoken/...` fetch returns 200) and the npm Trusted Publisher entry still matches the JWT's `workflow_ref` (`publish.yml`), so the regression is somewhere between us and `libnpmpublish`.
- Diffing rc.2 (success, pnpm 10, 2026-05-11) vs rc.4 (failure, pnpm 11, 2026-05-13) the npm publish toolchain is byte-identical: `libnpmpublish@11.1.3`, `npm-registry-fetch@19.1.1`, `@lerna-lite/publish@4.9.4`. The only meaningful gap is that our shared `setup-and-build` composite calls `actions/setup-node` **without** `registry-url`, so no `registry=…` line is written to `.npmrc`. `publish-dev.yml` (which has kept working through pnpm v11) calls setup-node inline with `registry-url: \"https://registry.npmjs.org\"`. Under pnpm v10 the OIDC auth flow tolerated the missing registry config; pnpm v11's stricter pre-script install pass appears to surface it.

## Description
- Add an optional `registry-url` input to `.github/actions/setup-and-build/action.yml`, default empty so existing callers (benchmark, binaries, test, test-sim, docs-check, nightly-spec-tests) are unaffected.
- Pass `registry-url: \"https://registry.npmjs.org\"` from `publish-rc.yml` and `publish-stable.yml` only. This brings their setup-node configuration in line with `publish-dev.yml`.

This is a targeted fix — if it doesn't fully resolve the OIDC rejection, fallback plan is to revert #9299 on a throwaway RC tag and confirm pnpm v11 is the cause vs an npm-side change.

## Test plan
- [ ] Re-tag `v1.43.0-rc.5` from a branch containing this change and verify the **Publish to NPM & Github** job completes without `OIDC publish authorize: Invalid token`.
- [ ] Confirm no regression in jobs using `setup-and-build` without `registry-url`: benchmark, binaries, test, test-sim, docs-check, nightly-spec-tests should pass on this branch's PR run.

## AI Assistance Disclosure
- [x] AI-assisted: Claude Code helped trace the rc.2 vs rc.4 publish-job log diff, eliminate the toolchain/Trusted-Publisher-mismatch theories, and isolate `registry-url` as the only meaningful config gap between publish-dev (works) and publish-rc (fails) under pnpm v11. All changes were reviewed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)