### PR TITLE
fix: handle ptc votes from same duplicated validators

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -258,7 +258,7 @@ export function getBeaconPoolApi({
           try {
             const validateFn = () => validateApiPayloadAttestationMessage(chain, payloadAttestationMessage);
             const {slot, beaconBlockRoot} = payloadAttestationMessage.data;
-            const {attDataRootHex, validatorCommitteeIndex} = await validateGossipFnRetryUnknownRoot(
+            const {attDataRootHex, validatorCommitteeIndices} = await validateGossipFnRetryUnknownRoot(
               validateFn,
               network,
               chain,
@@ -269,13 +269,13 @@ export function getBeaconPoolApi({
             const insertOutcome = chain.payloadAttestationPool.add(
               payloadAttestationMessage,
               attDataRootHex,
-              validatorCommitteeIndex
+              validatorCommitteeIndices
             );
             metrics?.opPool.payloadAttestationPool.apiInsertOutcome.inc({insertOutcome});
 
             chain.forkChoice.notifyPtcMessages(
               toRootHex(payloadAttestationMessage.data.beaconBlockRoot),
-              [validatorCommitteeIndex],
+              validatorCommitteeIndices,
               payloadAttestationMessage.data.payloadPresent
             );
 

--- a/packages/beacon-node/src/chain/opPools/payloadAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/payloadAttestationPool.ts
@@ -57,7 +57,7 @@ export class PayloadAttestationPool {
   add(
     message: gloas.PayloadAttestationMessage,
     payloadAttDataRootHex: RootHex,
-    validatorCommitteeIndex: number
+    validatorCommitteeIndices: number[]
   ): InsertOutcome {
     const slot = message.data.slot;
     const lowestPermissibleSlot = this.lowestPermissibleSlot;
@@ -85,10 +85,10 @@ export class PayloadAttestationPool {
     const aggregate = aggregateByDataRoot.get(payloadAttDataRootHex);
     if (aggregate) {
       // Aggregate msg into aggregate
-      return aggregateMessageInto(message, validatorCommitteeIndex, aggregate);
+      return aggregateMessageInto(message, validatorCommitteeIndices, aggregate);
     }
     // Create a new aggregate with data
-    aggregateByDataRoot.set(payloadAttDataRootHex, messageToAggregate(message, validatorCommitteeIndex));
+    aggregateByDataRoot.set(payloadAttDataRootHex, messageToAggregate(message, validatorCommitteeIndices));
 
     return InsertOutcome.NewData;
   }
@@ -150,25 +150,49 @@ export class PayloadAttestationPool {
   }
 }
 
-function messageToAggregate(message: gloas.PayloadAttestationMessage, validatorCommitteeIndex: number): AggregateFast {
+function messageToAggregate(
+  message: gloas.PayloadAttestationMessage,
+  validatorCommitteeIndices: number[]
+): AggregateFast {
+  const aggregationBits = BitArray.fromBitLen(PTC_SIZE);
+  for (const index of validatorCommitteeIndices) {
+    aggregationBits.set(index, true);
+  }
+  const sig = signatureFromBytesNoCheck(message.signature);
+  // The validator signed once but occupies `validatorCommitteeIndices.length` PTC positions.
+  // Verification aggregates the pubkey once per set bit, so the signature must be aggregated
+  // the same number of times for the BLS check to balance — same pattern as sync committee.
+  const signature =
+    validatorCommitteeIndices.length === 1
+      ? sig
+      : aggregateSignatures(new Array(validatorCommitteeIndices.length).fill(sig));
   return {
-    aggregationBits: BitArray.fromSingleBit(PTC_SIZE, validatorCommitteeIndex),
+    aggregationBits,
     data: message.data,
-    signature: signatureFromBytesNoCheck(message.signature),
+    signature,
   };
 }
 
 function aggregateMessageInto(
   message: gloas.PayloadAttestationMessage,
-  validatorCommitteeIndex: number,
+  validatorCommitteeIndices: number[],
   aggregate: AggregateFast
 ): InsertOutcome {
-  if (aggregate.aggregationBits.get(validatorCommitteeIndex) === true) {
+  // Gossip dedup via `seenPayloadAttesters` is keyed by (epoch, validatorIndex), so the same
+  // validator's message is never processed twice — all of its bits are set together or none.
+  // Checking the first index is sufficient.
+  if (aggregate.aggregationBits.get(validatorCommitteeIndices[0]) === true) {
     return InsertOutcome.AlreadyKnown;
   }
 
-  aggregate.aggregationBits.set(validatorCommitteeIndex, true);
-  aggregate.signature = aggregateSignatures([aggregate.signature, signatureFromBytesNoCheck(message.signature)]);
+  for (const index of validatorCommitteeIndices) {
+    aggregate.aggregationBits.set(index, true);
+  }
+  const sig = signatureFromBytesNoCheck(message.signature);
+  aggregate.signature = aggregateSignatures([
+    aggregate.signature,
+    ...new Array(validatorCommitteeIndices.length).fill(sig),
+  ]);
 
   return InsertOutcome.Aggregated;
 }

--- a/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
+++ b/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
@@ -11,7 +11,7 @@ import {IBeaconChain} from "../index.js";
 
 export type PayloadAttestationValidationResult = {
   attDataRootHex: RootHex;
-  validatorCommitteeIndex: number;
+  validatorCommitteeIndices: number[];
 };
 
 export async function validateApiPayloadAttestationMessage(
@@ -80,9 +80,11 @@ async function validatePayloadAttestationMessage(
   // [REJECT] The message's validator index is within the payload committee in
   // `get_ptc(state, data.slot)`. The `state` is the head state corresponding to
   // processing the block up to the current slot as determined by the fork choice.
-  const validatorCommitteeIndex = state.getIndexInPayloadTimelinessCommittee(validatorIndex, data.slot);
+  // The validator may occupy multiple PTC positions because `compute_ptc` samples
+  // by effective balance — collect all of them so duplicate votes are counted.
+  const validatorCommitteeIndices = state.getIndicesInPayloadTimelinessCommittee(validatorIndex, data.slot);
 
-  if (validatorCommitteeIndex === -1) {
+  if (validatorCommitteeIndices.length === 0) {
     throw new PayloadAttestationError(GossipAction.REJECT, {
       code: PayloadAttestationErrorCode.INVALID_ATTESTER,
       attesterIndex: validatorIndex,
@@ -115,6 +117,6 @@ async function validatePayloadAttestationMessage(
 
   return {
     attDataRootHex: toRootHex(ssz.gloas.PayloadAttestationData.hashTreeRoot(data)),
-    validatorCommitteeIndex,
+    validatorCommitteeIndices,
   };
 }

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1197,7 +1197,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         const insertOutcome = chain.payloadAttestationPool.add(
           payloadAttestationMessage,
           validationResult.attDataRootHex,
-          validationResult.validatorCommitteeIndex
+          validationResult.validatorCommitteeIndices
         );
         metrics?.opPool.payloadAttestationPool.gossipInsertOutcome.inc({insertOutcome});
       } catch (e) {
@@ -1205,7 +1205,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       }
       chain.forkChoice.notifyPtcMessages(
         toRootHex(payloadAttestationMessage.data.beaconBlockRoot),
-        [validationResult.validatorCommitteeIndex],
+        validationResult.validatorCommitteeIndices,
         payloadAttestationMessage.data.payloadPresent
       );
     },

--- a/packages/beacon-node/test/unit/chain/opPools/payloadAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/payloadAttestationPool.test.ts
@@ -1,0 +1,85 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {SecretKey} from "@chainsafe/blst";
+import {toHexString} from "@chainsafe/ssz";
+import {createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {PTC_SIZE, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {gloas, ssz} from "@lodestar/types";
+import {PayloadAttestationPool} from "../../../../src/chain/opPools/payloadAttestationPool.js";
+import {InsertOutcome} from "../../../../src/chain/opPools/types.js";
+import {getMockedClock} from "../../../mocks/clock.js";
+
+describe("chain / opPools / PayloadAttestationPool", () => {
+  const config = createChainForkConfig({
+    ...defaultChainConfig,
+    GLOAS_FORK_EPOCH: 0,
+  });
+  const clockStub = getMockedClock();
+  vi.spyOn(clockStub, "slotWithPastTolerance").mockReturnValue(0);
+
+  const slot = SLOTS_PER_EPOCH;
+  const beaconBlockRoot = Buffer.alloc(32, 1);
+  const sk = SecretKey.fromBytes(Buffer.alloc(32, 9));
+  const data: gloas.PayloadAttestationData = {
+    beaconBlockRoot,
+    slot,
+    payloadPresent: true,
+    blobDataAvailable: true,
+  };
+  const signature = sk.sign(ssz.gloas.PayloadAttestationData.hashTreeRoot(data)).toBytes();
+  const message: gloas.PayloadAttestationMessage = {
+    data,
+    validatorIndex: 42,
+    signature,
+  };
+  const attDataRootHex = toHexString(ssz.gloas.PayloadAttestationData.hashTreeRoot(data));
+
+  let pool: PayloadAttestationPool;
+
+  beforeEach(() => {
+    pool = new PayloadAttestationPool(config, clockStub);
+  });
+
+  it("sets every duplicate PTC position when a validator occupies multiple seats", () => {
+    const duplicateIndices = [2, 5, 7];
+    const outcome = pool.add(message, attDataRootHex, duplicateIndices);
+    expect(outcome).toBe(InsertOutcome.NewData);
+
+    const [aggregate] = pool.getPayloadAttestationsForBlock(toHexString(beaconBlockRoot), slot);
+    expect(aggregate).toBeDefined();
+    for (let i = 0; i < PTC_SIZE; i++) {
+      expect(aggregate.aggregationBits.get(i)).toBe(duplicateIndices.includes(i));
+    }
+    expect(aggregate.aggregationBits.getTrueBitIndexes()).toEqual(duplicateIndices);
+  });
+
+  it("re-adding the same validator with overlapping indices is a no-op (AlreadyKnown)", () => {
+    const duplicateIndices = [3, 11];
+    expect(pool.add(message, attDataRootHex, duplicateIndices)).toBe(InsertOutcome.NewData);
+    expect(pool.add(message, attDataRootHex, duplicateIndices)).toBe(InsertOutcome.AlreadyKnown);
+  });
+
+  it("aggregates two distinct validators into one PayloadAttestation", () => {
+    const indicesA = [1, 4];
+    const indicesB = [6];
+    expect(pool.add(message, attDataRootHex, indicesA)).toBe(InsertOutcome.NewData);
+
+    const otherSk = SecretKey.fromBytes(Buffer.alloc(32, 7));
+    const otherMessage: gloas.PayloadAttestationMessage = {
+      data,
+      validatorIndex: 99,
+      signature: otherSk.sign(ssz.gloas.PayloadAttestationData.hashTreeRoot(data)).toBytes(),
+    };
+    expect(pool.add(otherMessage, attDataRootHex, indicesB)).toBe(InsertOutcome.Aggregated);
+
+    const [aggregate] = pool.getPayloadAttestationsForBlock(toHexString(beaconBlockRoot), slot);
+    expect(aggregate.aggregationBits.getTrueBitIndexes()).toEqual([...indicesA, ...indicesB].sort((a, b) => a - b));
+  });
+
+  it("treats a validator at a single position as before (single bit, no extra aggregation)", () => {
+    const outcome = pool.add(message, attDataRootHex, [4]);
+    expect(outcome).toBe(InsertOutcome.NewData);
+
+    const [aggregate] = pool.getPayloadAttestationsForBlock(toHexString(beaconBlockRoot), slot);
+    expect(aggregate.aggregationBits.getTrueBitIndexes()).toEqual([4]);
+  });
+});

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -423,16 +423,27 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
     throw new Error(`PTC committees are not available for epoch=${epoch}`);
   }
   /**
-   * Return the index of the validator in the PTC committee for the given slot.
-   * return -1 if validator is not in the PTC committee for the given slot.
+   * Return all positions of the validator in the PTC committee for the given slot.
+   *
+   * `compute_ptc` samples by effective balance and may place the same validator at multiple
+   * positions, so a validator can have more than one index. Returns an empty array if the
+   * validator is not in the PTC for the given slot.
+   *
+   * Spec: gloas/fork-choice.md#new-on_payload_attestation_message
    */
-  getIndexInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number {
+  getIndicesInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number[] {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
       throw new Error("PTC committees are not supported before Gloas");
     }
 
     const ptcCommittee = (this.cachedState as CachedBeaconStateGloas).epochCtx.getPayloadTimelinessCommittee(slot);
-    return ptcCommittee.indexOf(validatorIndex);
+    const indices: number[] = [];
+    for (let i = 0; i < ptcCommittee.length; i++) {
+      if (ptcCommittee[i] === validatorIndex) {
+        indices.push(i);
+      }
+    }
+    return indices;
   }
 
   // Shuffling and committees

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -253,7 +253,7 @@ export interface IBeaconStateViewGloas extends IBeaconStateViewFulu {
   getBuilder(index: BuilderIndex): gloas.Builder;
   canBuilderCoverBid(builderIndex: BuilderIndex, bidAmount: number): boolean;
   getEpochPTCs(epoch: Epoch): Uint32Array[];
-  getIndexInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number;
+  getIndicesInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number[];
   /**
    * Clone the state and apply parent execution payload effects.
    * Used during block production and prepareNextSlot so that withdrawals and


### PR DESCRIPTION
**Motivation**

Follow consensus-specs PR https://github.com/ethereum/consensus-specs/pull/5222.

`compute_ptc` samples PTC seats by effective balance and may place the same validator at multiple positions in a slot's PTC.
The previous `on_payload_attestation_message` recorded the vote only at `ptc.index(validator_index)` (first occurrence), leaving the other duplicate seats as `None`.
With enough duplicates this can make `PAYLOAD_TIMELY_THRESHOLD = PTC_SIZE // 2` unreachable, particularly in testnets with many `0x02` validators.
Sync committee already counts duplicate votes; PTC should match.

**Description**

- replace `getIndexInPayloadTimelinessCommittee` with `getIndicesInPayloadTimelinessCommittee` returning every PTC position a validator occupies
- handle `PayloadAttestationPool.add()` to support multiple validator committee indices

**AI Assistance Disclosure**

Used Claude Code.
