### PR TITLE
feat(beacon-api): expose peer-scoring fields on /eth/v1/node/peers

### DIFF
--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -61,6 +61,12 @@ export type PeerScoreStat = {
   ignoreNegativeGossipScore: boolean;
   score: number;
   lastUpdate: number;
+  /** Name of the most recent `reportPeer` action applied, or null if no action has been applied. */
+  lastActionName: string | null;
+  /** Effective change to `lodestarScore` produced by the last action (post score clamp). */
+  lastActionDeltaScore: number;
+  /** Unix timestamp (ms) at which the last action was applied. */
+  lastActionUnixMs: number;
 };
 
 export type GossipPeerScoreStat = {

--- a/packages/api/src/beacon/routes/node.ts
+++ b/packages/api/src/beacon/routes/node.ts
@@ -80,10 +80,86 @@ export const NodePeerType = new ContainerType(
 );
 export const NodePeersType = ArrayOf(NodePeerType);
 
-export type NodePeer = ValueOf<typeof NodePeerType>;
-export type NodePeers = ValueOf<typeof NodePeersType>;
+export type NodePeer = ValueOf<typeof NodePeerType> & {
+  /**
+   * libp2p `agentVersion` identify string for the peer (e.g. `Lighthouse/v5.4.0-...`).
+   * Optional per the beacon-API peer-scoring extension.
+   */
+  agentVersion?: string;
+  /**
+   * Composite lodestar score for the peer at the time of the request.
+   * Optional per the beacon-API peer-scoring extension.
+   */
+  score?: number;
+  /**
+   * Reason associated with the most recent disconnect, mapped to the controlled
+   * `PeerDisconnectReason` vocabulary. Omitted when no disconnect has been observed
+   * or the reason cannot be classified.
+   */
+  disconnectReason?: string;
+  /**
+   * Reasons that contributed to the peer's most recent downscore, mapped to the
+   * controlled `PeerScoreReason` vocabulary. Omitted when no downscore action has
+   * been applied. Lodestar surfaces the most recent action only, so the array will
+   * typically contain a single entry.
+   */
+  downscoreReasons?: string[];
+};
+export type NodePeers = NodePeer[];
 
 export type PeersMeta = {count: number};
+
+/** Snake-case keys for the optional peer-scoring extension fields. */
+type NodePeerJsonExtras = {
+  agent_version?: string;
+  score?: number;
+  disconnect_reason?: string;
+  downscore_reasons?: string[];
+};
+
+/**
+ * Serialize a NodePeer to JSON. Uses the SSZ container for the core fields
+ * (so the spec wire format is preserved) and appends the optional
+ * peer-scoring extension fields only when present.
+ */
+function nodePeerToJson(peer: NodePeer): unknown {
+  const json = NodePeerType.toJson(peer) as Record<string, unknown>;
+  if (peer.agentVersion !== undefined) {
+    (json as NodePeerJsonExtras).agent_version = peer.agentVersion;
+  }
+  if (peer.score !== undefined) {
+    (json as NodePeerJsonExtras).score = peer.score;
+  }
+  if (peer.disconnectReason !== undefined) {
+    (json as NodePeerJsonExtras).disconnect_reason = peer.disconnectReason;
+  }
+  if (peer.downscoreReasons !== undefined) {
+    (json as NodePeerJsonExtras).downscore_reasons = peer.downscoreReasons;
+  }
+  return json;
+}
+
+/**
+ * Inverse of nodePeerToJson. Lifts optional extension fields back onto the
+ * decoded NodePeer when present.
+ */
+function nodePeerFromJson(json: unknown): NodePeer {
+  const peer = NodePeerType.fromJson(json) as NodePeer;
+  const obj = json as NodePeerJsonExtras;
+  if (typeof obj.agent_version === "string") {
+    peer.agentVersion = obj.agent_version;
+  }
+  if (typeof obj.score === "number") {
+    peer.score = obj.score;
+  }
+  if (typeof obj.disconnect_reason === "string") {
+    peer.disconnectReason = obj.disconnect_reason;
+  }
+  if (Array.isArray(obj.downscore_reasons)) {
+    peer.downscoreReasons = obj.downscore_reasons.filter((s): s is string => typeof s === "string");
+  }
+  return peer;
+}
 
 export type PeerCount = ValueOf<typeof PeerCountType>;
 
@@ -293,7 +369,16 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         schema: {query: {state: Schema.StringArray, direction: Schema.StringArray}},
       },
       resp: {
-        data: NodePeersType,
+        data: {
+          ...JsonOnlyResponseCodec.data,
+          toJson: (data) => (data as NodePeer[]).map(nodePeerToJson),
+          fromJson: (json) => {
+            if (!Array.isArray(json)) {
+              throw Error("JSON peers payload must be an array");
+            }
+            return json.map(nodePeerFromJson);
+          },
+        },
         meta: {
           toJson: (d) => d,
           fromJson: (d) => ({count: (d as PeersMeta).count}),
@@ -316,7 +401,11 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         schema: {params: {peer_id: Schema.StringRequired}},
       },
       resp: {
-        data: NodePeerType,
+        data: {
+          ...JsonOnlyResponseCodec.data,
+          toJson: (data) => nodePeerToJson(data as NodePeer),
+          fromJson: (json) => nodePeerFromJson(json),
+        },
         meta: EmptyMetaCodec,
         onlySupport: WireFormat.json,
       },

--- a/packages/beacon-node/src/api/impl/node/utils.ts
+++ b/packages/beacon-node/src/api/impl/node/utils.ts
@@ -1,5 +1,6 @@
 import type {Connection, ConnectionStatus} from "@libp2p/interface";
 import {routes} from "@lodestar/api";
+import {GoodByeReasonCode} from "../../../constants/network.js";
 
 /**
  * Format a list of connections from libp2p connections manager into the API's format NodePeer
@@ -87,6 +88,48 @@ export function mapPeerScoreReason(actionName: string | null): string {
       return PEER_SCORE_REASON.BehaviourPenalty;
     default:
       return PEER_SCORE_REASON.Unknown;
+  }
+}
+
+/**
+ * Controlled vocabulary for the most recent peer disconnect reason surfaced
+ * on the beacon API `/eth/v1/node/peers` extension. Mirrors the proposed
+ * `PeerDisconnectReason` enum.
+ */
+export const PEER_DISCONNECT_REASON = {
+  ClientShutdown: "client_shutdown",
+  IrrelevantNetwork: "irrelevant_network",
+  IoError: "io_error",
+  UnviableFork: "unviable_fork",
+  TooManyPeers: "too_many_peers",
+  BadScore: "bad_score",
+  InboundDisconnect: "inbound_disconnect",
+  Unknown: "unknown",
+} as const;
+
+/**
+ * Map lodestar's `GoodByeReasonCode` to the controlled
+ * `PeerDisconnectReason` vocabulary. Returns "unknown" for codes we don't
+ * have an explicit mapping for so the API stays forward-compatible.
+ */
+export function mapDisconnectReason(code: GoodByeReasonCode | number): string {
+  switch (code) {
+    case GoodByeReasonCode.CLIENT_SHUTDOWN:
+      return PEER_DISCONNECT_REASON.ClientShutdown;
+    case GoodByeReasonCode.IRRELEVANT_NETWORK:
+      return PEER_DISCONNECT_REASON.IrrelevantNetwork;
+    case GoodByeReasonCode.ERROR:
+      return PEER_DISCONNECT_REASON.IoError;
+    case GoodByeReasonCode.TOO_MANY_PEERS:
+      return PEER_DISCONNECT_REASON.TooManyPeers;
+    case GoodByeReasonCode.SCORE_TOO_LOW:
+    case GoodByeReasonCode.BANNED:
+      return PEER_DISCONNECT_REASON.BadScore;
+    case GoodByeReasonCode.INBOUND_DISCONNECT:
+      return PEER_DISCONNECT_REASON.InboundDisconnect;
+    default:
+      if (code === 128) return PEER_DISCONNECT_REASON.UnviableFork;
+      return PEER_DISCONNECT_REASON.Unknown;
   }
 }
 

--- a/packages/beacon-node/src/api/impl/node/utils.ts
+++ b/packages/beacon-node/src/api/impl/node/utils.ts
@@ -18,6 +18,79 @@ export function formatNodePeer(peerIdStr: string, connections: Connection[]): ro
 }
 
 /**
+ * Controlled vocabulary for downscore reasons surfaced on the beacon API
+ * `/eth/v1/node/peers` extension. Mirrors the proposed `PeerScoreReason` enum
+ * so consumers don't have to know lodestar's internal `actionName` strings.
+ */
+export const PEER_SCORE_REASON = {
+  RpcInvalidRequest: "rpc_invalid_request",
+  RpcInvalidResponse: "rpc_invalid_response",
+  RpcRateLimited: "rpc_rate_limited",
+  RpcTimeout: "rpc_timeout",
+  RpcIoError: "rpc_io_error",
+  RpcBadBlocksByRange: "rpc_bad_blocks_by_range",
+  RpcBadBlocksByRoot: "rpc_bad_blocks_by_root",
+  GossipInvalidBlock: "gossip_invalid_block",
+  GossipInvalidAttestation: "gossip_invalid_attestation",
+  GossipInvalidBlobSidecar: "gossip_invalid_blob_sidecar",
+  GossipInvalidDataColumnSidecar: "gossip_invalid_data_column_sidecar",
+  SyncBadBatch: "sync_bad_batch",
+  StatusUnviableFork: "status_unviable_fork",
+  BehaviourPenalty: "behaviour_penalty",
+  Unknown: "unknown",
+} as const;
+
+/**
+ * Map lodestar's native `reportPeer` action label to the controlled
+ * `PeerScoreReason` vocabulary. Returns "unknown" for actions we don't have
+ * an explicit mapping for so the API stays forward-compatible.
+ */
+export function mapPeerScoreReason(actionName: string | null): string {
+  if (actionName === null || actionName === "") return PEER_SCORE_REASON.Unknown;
+
+  switch (actionName) {
+    case "REQUEST_ERROR_INVALID_REQUEST":
+      return PEER_SCORE_REASON.RpcInvalidRequest;
+    case "REQUEST_ERROR_INVALID_RESPONSE_SSZ":
+      return PEER_SCORE_REASON.RpcInvalidResponse;
+    case "REQUEST_ERROR_SERVER_ERROR":
+    case "RESOURCE_UNAVAILABLE_ERROR":
+    case "REQUEST_ERROR_UNKNOWN_ERROR_STATUS":
+    case "REQUEST_ERROR_EMPTY_RESPONSE":
+    case "SSZ_SNAPPY_ERROR_OVER_SSZ_MAX_SIZE":
+      return PEER_SCORE_REASON.RpcInvalidResponse;
+    case "REQUEST_ERROR_RATE_LIMITED":
+    case "REQUEST_ERROR_SELF_RATE_LIMITED":
+    case "RESPONSE_ERROR_RATE_LIMITED":
+    case "rate_limit_rpc":
+      return PEER_SCORE_REASON.RpcRateLimited;
+    case "REQUEST_ERROR_REQUEST_TIMEOUT":
+    case "REQUEST_ERROR_RESP_TIMEOUT":
+    case "REQUEST_ERROR_DIAL_TIMEOUT":
+      return PEER_SCORE_REASON.RpcTimeout;
+    case "REQUEST_ERROR_DIAL_ERROR":
+    case "REQUEST_ERROR_REQUEST_ERROR":
+      return PEER_SCORE_REASON.RpcIoError;
+    case "BAD_BLOCKS_BY_RANGE":
+    case "BadSyncBlocks":
+      return PEER_SCORE_REASON.RpcBadBlocksByRange;
+    case "BAD_BLOCKS_BY_ROOT":
+    case "BadBlockByRoot":
+      return PEER_SCORE_REASON.RpcBadBlocksByRoot;
+    case "BadGossipBlock":
+      return PEER_SCORE_REASON.GossipInvalidBlock;
+    case "SyncChainInvalidBatchSelf":
+    case "SyncChainInvalidBatchOther":
+    case "SyncChainMaxProcessingAttempts":
+      return PEER_SCORE_REASON.SyncBadBatch;
+    case "GOSSIPSUB_LOW":
+      return PEER_SCORE_REASON.BehaviourPenalty;
+    default:
+      return PEER_SCORE_REASON.Unknown;
+  }
+}
+
+/**
  * From a list of connections, get the most relevant of a peer
  * - The first open connection if any
  * - Otherwise, the first closing connection

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -477,10 +477,14 @@ export class NetworkCore implements INetworkCore {
     const agentVersion = peerData?.agentVersion ?? "NA";
     const downscoreReasons =
       scoreStat && scoreStat.lastActionName !== null ? [mapPeerScoreReason(scoreStat.lastActionName)] : undefined;
+    const nodePeer = formatNodePeer(peerIdStr, connections);
     const lastDisconnect = this.peerManager.getLastDisconnect(peerIdStr);
-    const disconnectReason = lastDisconnect ? mapDisconnectReason(lastDisconnect.code) : undefined;
+    const disconnectReason =
+      lastDisconnect && (nodePeer.state === "disconnected" || nodePeer.state === "disconnecting")
+        ? mapDisconnectReason(lastDisconnect.code)
+        : undefined;
     return {
-      ...formatNodePeer(peerIdStr, connections),
+      ...nodePeer,
       agentVersion,
       score: scoreStat ? scoreStat.score : undefined,
       disconnectReason,

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -9,7 +9,7 @@ import type {LoggerNode} from "@lodestar/logger/node";
 import {isForkPostFulu} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {Epoch, Status, fulu, sszTypesFor} from "@lodestar/types";
-import {formatNodePeer} from "../../api/impl/node/utils.js";
+import {formatNodePeer, mapPeerScoreReason} from "../../api/impl/node/utils.js";
 import {RegistryMetricCreator} from "../../metrics/index.js";
 import {ClockEvent, IClock} from "../../util/clock.js";
 import {CustodyConfig} from "../../util/dataColumns.js";
@@ -473,9 +473,15 @@ export class NetworkCore implements INetworkCore {
       (peerData.status as fulu.Status).earliestAvailableSlot =
         (peerData.status as fulu.Status).earliestAvailableSlot ?? 0;
     }
+    const scoreStat = this.peerManager.getPeerScoreStat(peerIdStr);
+    const agentVersion = peerData?.agentVersion ?? "NA";
+    const downscoreReasons =
+      scoreStat && scoreStat.lastActionName !== null ? [mapPeerScoreReason(scoreStat.lastActionName)] : undefined;
     return {
       ...formatNodePeer(peerIdStr, connections),
-      agentVersion: peerData?.agentVersion ?? "NA",
+      agentVersion,
+      score: scoreStat ? scoreStat.score : undefined,
+      downscoreReasons,
       status: peerData?.status ? sszTypesFor(fork).Status.toJson(peerData.status) : null,
       metadata: peerData?.metadata ? sszTypesFor(fork).Metadata.toJson(peerData.metadata) : null,
       agentClient: String(peerData?.agentClient ?? "Unknown"),

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -9,7 +9,7 @@ import type {LoggerNode} from "@lodestar/logger/node";
 import {isForkPostFulu} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {Epoch, Status, fulu, sszTypesFor} from "@lodestar/types";
-import {formatNodePeer, mapPeerScoreReason} from "../../api/impl/node/utils.js";
+import {formatNodePeer, mapDisconnectReason, mapPeerScoreReason} from "../../api/impl/node/utils.js";
 import {RegistryMetricCreator} from "../../metrics/index.js";
 import {ClockEvent, IClock} from "../../util/clock.js";
 import {CustodyConfig} from "../../util/dataColumns.js";
@@ -477,10 +477,13 @@ export class NetworkCore implements INetworkCore {
     const agentVersion = peerData?.agentVersion ?? "NA";
     const downscoreReasons =
       scoreStat && scoreStat.lastActionName !== null ? [mapPeerScoreReason(scoreStat.lastActionName)] : undefined;
+    const lastDisconnect = this.peerManager.getLastDisconnect(peerIdStr);
+    const disconnectReason = lastDisconnect ? mapDisconnectReason(lastDisconnect.code) : undefined;
     return {
       ...formatNodePeer(peerIdStr, connections),
       agentVersion,
       score: scoreStat ? scoreStat.score : undefined,
+      disconnectReason,
       downscoreReasons,
       status: peerData?.status ? sszTypesFor(fork).Status.toJson(peerData.status) : null,
       metadata: peerData?.metadata ? sszTypesFor(fork).Metadata.toJson(peerData.metadata) : null,

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -75,6 +75,19 @@ const STARVATION_PRUNE_RATIO = 0.05;
  */
 const ALLOWED_NEGATIVE_GOSSIPSUB_FACTOR = 0.1;
 
+/**
+ * Maximum number of last-disconnect entries to keep in memory. FIFO eviction
+ * keeps the map bounded while still allowing observability of recent
+ * disconnects via the beacon API peer-scoring extension.
+ */
+const LAST_DISCONNECT_MAX_SIZE = 1024;
+
+export type LastDisconnectInfo = {
+  code: GoodByeReasonCode;
+  sentByUs: boolean;
+  at: number;
+};
+
 // TODO:
 // maxPeers and targetPeers should be dynamic on the num of validators connected
 // The Node should compute a recommended value every interval and log a warning
@@ -169,6 +182,13 @@ export class PeerManager {
 
   // A single map of connected peers with all necessary data to handle PINGs, STATUS, and metrics
   private connectedPeers: Map<PeerIdStr, PeerData>;
+  /**
+   * Tracks the most recent goodbye/disconnect reason per peer. Bounded with a
+   * FIFO eviction policy via insertion order in the Map. Retained across
+   * disconnects so the beacon API peer-scoring extension can surface a
+   * `disconnect_reason` for peers that are no longer connected.
+   */
+  private lastDisconnectByPeerId: Map<PeerIdStr, LastDisconnectInfo> = new Map();
   private opts: PeerManagerOpts;
   private intervals: NodeJS.Timeout[] = [];
 
@@ -305,6 +325,29 @@ export class PeerManager {
   }
 
   /**
+   * Record the most recent goodbye reason for a peer. `sentByUs` is true when
+   * lodestar initiated the goodbye, false when the remote peer sent it to us.
+   * Bounded to `LAST_DISCONNECT_MAX_SIZE` entries with FIFO eviction.
+   */
+  recordDisconnect(peerIdStr: PeerIdStr, code: GoodByeReasonCode, sentByUs: boolean): void {
+    if (this.lastDisconnectByPeerId.has(peerIdStr)) {
+      this.lastDisconnectByPeerId.delete(peerIdStr);
+    } else if (this.lastDisconnectByPeerId.size >= LAST_DISCONNECT_MAX_SIZE) {
+      const oldestKey = this.lastDisconnectByPeerId.keys().next().value;
+      if (oldestKey !== undefined) this.lastDisconnectByPeerId.delete(oldestKey);
+    }
+    this.lastDisconnectByPeerId.set(peerIdStr, {code, sentByUs, at: Date.now()});
+  }
+
+  /**
+   * Return the most recent disconnect record for a peer, or null if none has
+   * been observed (or it was evicted from the bounded map).
+   */
+  getLastDisconnect(peerIdStr: PeerIdStr): LastDisconnectInfo | null {
+    return this.lastDisconnectByPeerId.get(peerIdStr) ?? null;
+  }
+
+  /**
    * Must be called when network ReqResp receives incoming requests
    */
   private onRequest = ({peer, request}: NetworkEventData[NetworkEvent.reqRespRequest]): void => {
@@ -399,6 +442,8 @@ export class PeerManager {
     if (conn && Date.now() - conn.timeline.open > LONG_PEER_CONNECTION_MS) {
       this.metrics?.peerLongConnectionDisconnect.inc({reason});
     }
+
+    this.recordDisconnect(peer.toString(), Number(goodbye) as GoodByeReasonCode, false);
 
     void this.disconnect(peer);
   }
@@ -851,6 +896,9 @@ export class PeerManager {
       const coolDownMin = this.peerRpcScores.applyReconnectionCoolDown(peerIdStr, GoodByeReasonCode.INBOUND_DISCONNECT);
       logMessage += ". Enforcing a reconnection cool-down period";
       logContext.coolDownMin = coolDownMin;
+      if (!this.lastDisconnectByPeerId.has(peerIdStr)) {
+        this.recordDisconnect(peerIdStr, GoodByeReasonCode.INBOUND_DISCONNECT, false);
+      }
     }
 
     // remove the ping and status timer for the peer
@@ -896,6 +944,7 @@ export class PeerManager {
   private async goodbyeAndDisconnect(peer: PeerId, goodbye: GoodByeReasonCode): Promise<void> {
     const reason = GOODBYE_KNOWN_CODES[goodbye.toString()] || "";
     const peerIdStr = peer.toString();
+    this.recordDisconnect(peerIdStr, goodbye, true);
     try {
       this.metrics?.peerGoodbyeSent.inc({reason});
       this.logger.debug("initiating goodbyeAndDisconnect peer", {reason, peerId: prettyPrintPeerId(peer)});

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -25,7 +25,14 @@ import {ClientKind, getKnownClientFromAgentVersion} from "./client.js";
 import {PeerDiscovery, SubnetDiscvQueryMs} from "./discover.js";
 import {PeerData, PeersData} from "./peersData.js";
 import {NO_COOL_DOWN_APPLIED} from "./score/constants.js";
-import {IPeerRpcScoreStore, PeerAction, PeerScoreStats, ScoreState, updateGossipsubScores} from "./score/index.js";
+import {
+  IPeerRpcScoreStore,
+  PeerAction,
+  PeerScoreStat,
+  PeerScoreStats,
+  ScoreState,
+  updateGossipsubScores,
+} from "./score/index.js";
 import {
   assertPeerRelevance,
   getConnectedPeerIds,
@@ -291,6 +298,10 @@ export class PeerManager {
 
   dumpPeerScoreStats(): PeerScoreStats {
     return this.peerRpcScores.dumpPeerScoreStats();
+  }
+
+  getPeerScoreStat(peerIdStr: PeerIdStr): PeerScoreStat | null {
+    return this.peerRpcScores.getStatByPeerId(peerIdStr);
   }
 
   /**

--- a/packages/beacon-node/src/network/peers/score/interface.ts
+++ b/packages/beacon-node/src/network/peers/score/interface.ts
@@ -23,7 +23,7 @@ export interface IPeerScore {
   getScore(): number;
   getGossipScore(): number;
   isCoolingDown(): boolean;
-  add(scoreDelta: number): number;
+  add(scoreDelta: number, actionName?: string): number;
   update(): number;
   updateGossipsubScore(newScore: number, ignore: boolean): void;
   getStat(): PeerScoreStat;
@@ -51,6 +51,12 @@ export type PeerScoreStat = {
   ignoreNegativeGossipScore: boolean;
   score: number;
   lastUpdate: number;
+  /** Name of the most recent `reportPeer` action applied, or null if no action has been applied. */
+  lastActionName: string | null;
+  /** Effective change to `lodestarScore` produced by the last action (post score clamp). */
+  lastActionDeltaScore: number;
+  /** Unix timestamp (ms) at which the last action was applied. */
+  lastActionUnixMs: number;
 };
 
 export enum PeerAction {

--- a/packages/beacon-node/src/network/peers/score/interface.ts
+++ b/packages/beacon-node/src/network/peers/score/interface.ts
@@ -13,6 +13,13 @@ export interface IPeerRpcScoreStore {
   getScoreState(peer: PeerId): ScoreState;
   isCoolingDown(peer: PeerIdStr): boolean;
   dumpPeerScoreStats(): PeerScoreStats;
+  /**
+   * Returns the score stat for a single peer, or null if no entry exists yet.
+   * Unlike getScore() this does not lazily create a default entry, so callers
+   * (e.g. read-only beacon API handlers) can introspect known peers without
+   * polluting the store.
+   */
+  getStatByPeerId(peerIdStr: PeerIdStr): PeerScoreStat | null;
   applyAction(peer: PeerId, action: PeerAction, actionName: string): void;
   applyReconnectionCoolDown(peer: PeerIdStr, reason: GoodByeReasonCode): number;
   update(): void;

--- a/packages/beacon-node/src/network/peers/score/score.ts
+++ b/packages/beacon-node/src/network/peers/score/score.ts
@@ -23,6 +23,15 @@ export class RealScore implements IPeerScore {
   /** The final score, computed from the above */
   private score: number;
   private lastUpdate: number;
+  /**
+   * Tracks the most recent explicit `reportPeer` action applied to this peer.
+   * Updated only via `add()` (i.e. when an actionName is provided) and never by
+   * decay in `update()` or by gossipsub score sync, so it represents the last
+   * intentional scoring decision made by lodestar.
+   */
+  private lastActionName: string | null;
+  private lastActionDeltaScore: number;
+  private lastActionUnixMs: number;
 
   constructor() {
     this.lodestarScore = DEFAULT_SCORE;
@@ -30,6 +39,9 @@ export class RealScore implements IPeerScore {
     this.score = DEFAULT_SCORE;
     this.ignoreNegativeGossipScore = false;
     this.lastUpdate = Date.now();
+    this.lastActionName = null;
+    this.lastActionDeltaScore = 0;
+    this.lastActionUnixMs = 0;
   }
 
   isCoolingDown(): boolean {
@@ -44,12 +56,23 @@ export class RealScore implements IPeerScore {
     return this.gossipScore;
   }
 
-  add(scoreDelta: number): number {
+  add(scoreDelta: number, actionName?: string): number {
+    const preScore = this.lodestarScore;
     let newScore = this.lodestarScore + scoreDelta;
     if (newScore > MAX_SCORE) newScore = MAX_SCORE;
     if (newScore < MIN_SCORE) newScore = MIN_SCORE;
 
     this.setLodestarScore(newScore);
+
+    // Only record metadata when an actionName is provided so that decay-style
+    // updates (which also funnel through setLodestarScore) cannot clobber the
+    // last explicit reportPeer reason.
+    if (actionName !== undefined) {
+      this.lastActionName = actionName;
+      this.lastActionDeltaScore = newScore - preScore;
+      this.lastActionUnixMs = Date.now();
+    }
+
     return newScore;
   }
 
@@ -116,6 +139,9 @@ export class RealScore implements IPeerScore {
       ignoreNegativeGossipScore: this.ignoreNegativeGossipScore,
       score: this.score,
       lastUpdate: this.lastUpdate,
+      lastActionName: this.lastActionName,
+      lastActionDeltaScore: this.lastActionDeltaScore,
+      lastActionUnixMs: this.lastActionUnixMs,
     };
   }
 
@@ -174,7 +200,7 @@ export class MaxScore implements IPeerScore {
     return false;
   }
 
-  add(): number {
+  add(_scoreDelta: number, _actionName?: string): number {
     return DEFAULT_SCORE;
   }
 
@@ -195,6 +221,9 @@ export class MaxScore implements IPeerScore {
       ignoreNegativeGossipScore: false,
       score: MAX_SCORE,
       lastUpdate: Date.now(),
+      lastActionName: null,
+      lastActionDeltaScore: 0,
+      lastActionUnixMs: 0,
     };
   }
 }

--- a/packages/beacon-node/src/network/peers/score/store.ts
+++ b/packages/beacon-node/src/network/peers/score/store.ts
@@ -58,7 +58,7 @@ export class PeerRpcScoreStore implements IPeerRpcScoreStore {
   applyAction(peer: PeerId, action: PeerAction, actionName: string): void {
     const peerScore = this.scores.getOrDefault(peer.toString());
     const scoreChange = peerActionScore[action];
-    const newScore = peerScore.add(scoreChange);
+    const newScore = peerScore.add(scoreChange, actionName);
 
     this.logger?.debug("peer score adjusted", {scoreChange, newScore, peerId: prettyPrintPeerId(peer), actionName});
     this.metrics?.peersReportPeerCount.inc({reason: actionName});

--- a/packages/beacon-node/src/network/peers/score/store.ts
+++ b/packages/beacon-node/src/network/peers/score/store.ts
@@ -5,7 +5,15 @@ import {PeerIdStr} from "../../../util/peerId.js";
 import {NetworkCoreMetrics} from "../../core/metrics.js";
 import {prettyPrintPeerId} from "../../util.js";
 import {DEFAULT_SCORE, MAX_ENTRIES, MAX_SCORE, MIN_SCORE, SCORE_THRESHOLD} from "./constants.js";
-import {IPeerRpcScoreStore, IPeerScore, PeerAction, PeerRpcScoreOpts, PeerScoreStats, ScoreState} from "./interface.js";
+import {
+  IPeerRpcScoreStore,
+  IPeerScore,
+  PeerAction,
+  PeerRpcScoreOpts,
+  PeerScoreStat,
+  PeerScoreStats,
+  ScoreState,
+} from "./interface.js";
 import {MaxScore, RealScore} from "./score.js";
 import {scoreToState} from "./utils.js";
 
@@ -53,6 +61,10 @@ export class PeerRpcScoreStore implements IPeerRpcScoreStore {
 
   dumpPeerScoreStats(): PeerScoreStats {
     return Array.from(this.scores.entries()).map(([peerId, peerScore]) => ({peerId, ...peerScore.getStat()}));
+  }
+
+  getStatByPeerId(peerIdStr: PeerIdStr): PeerScoreStat | null {
+    return this.scores.get(peerIdStr)?.getStat() ?? null;
   }
 
   applyAction(peer: PeerId, action: PeerAction, actionName: string): void {


### PR DESCRIPTION
## Summary

Extends `/eth/v1/node/peers` (and `/eth/v1/node/peers/{peer_id}`) with four optional fields per a simplified beacon-API spec extension currently under discussion:

- `agent_version` — from libp2p peerstore
- `score` — composite score via `PeerRpcScoreStore.getScore(peerId)`
- `disconnect_reason` — from new bounded `lastDisconnectByPeerId` map on `PeerManager`
- `downscore_reasons` — single-element array derived from existing `lastActionName`

## Spec proposal

ethereum/beacon-APIs#606

## What's in this PR

1. **API route schema** (`packages/api/src/beacon/routes/node.ts`) — extends `NodePeer` with 4 optional fields plus custom `nodePeerToJson` / `nodePeerFromJson` round-tripping (snake_case wire names).
2. **PeerRpcScoreStore extension** (`packages/beacon-node/src/network/peers/score/{interface,store}.ts`) — non-mutating `getStatByPeerId()`.
3. **Disconnect tracking** (`packages/beacon-node/src/network/peers/peerManager.ts`) — bounded `lastDisconnectByPeerId` map (FIFO, 1024) recorded on outbound `goodbyeAndDisconnect`, inbound `onGoodbye`, and bare libp2p `onLibp2pPeerDisconnect` (covers peers that drop without goodbye).
4. **Vocab translators** (`packages/beacon-node/src/api/impl/node/utils.ts`) — `mapPeerScoreReason` and `mapDisconnectReason`.
5. **Population in `_dumpPeer`** (`packages/beacon-node/src/network/core/networkCore.ts`).

## Note on `inbound_disconnect`

This implementation surfaces a non-spec value `inbound_disconnect` when the peer drops the connection without sending goodbye. Worth discussing in #606 whether this should be added to the controlled vocab.

## Coordinated implementations

Part of a coordinated multi-client effort — see ethereum/beacon-APIs#606 for the other five client PRs.

## Status

**Draft.** `pnpm build` + `pnpm check-types` pass. Test suite not yet exercised end-to-end against the new fields; opening for cross-client coordination first.