### PR TITLE
fix: cache pending deposit signature verifications

### DIFF
--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -84,6 +84,9 @@ export const defaultSkipOpts: SkipOpts = {
   skippedTests: [
     // TODO-GLOAS: re-enable after gloas light client is implemented
     /\/gloas_fork$/,
+    // TODOGLOAS: re-enable after upgrading to v1.7.0-alpha.8
+    // (which includes #5254). https://github.com/ethereum/consensus-specs/pull/5254
+    /^gloas\/fork\/fork\/pyspec_tests\/fork_invalid_validator_deposit_followed_by_builder_credentials$/,
   ],
   // TODO GLOAS: Investigate why networking tests are failing since alpha.5
   skippedRunners: ["fast_confirmation", "networking"],

--- a/packages/state-transition/src/block/processDepositRequest.ts
+++ b/packages/state-transition/src/block/processDepositRequest.ts
@@ -1,10 +1,10 @@
-import {BeaconConfig} from "@lodestar/config";
 import {FAR_FUTURE_EPOCH, ForkSeq, UNSET_DEPOSIT_REQUESTS_START_INDEX} from "@lodestar/params";
-import {BLSPubkey, Bytes32, PubkeyHex, UintNum64, electra, ssz} from "@lodestar/types";
+import {BLSPubkey, Bytes32, UintNum64, electra, ssz} from "@lodestar/types";
 import {toPubkeyHex} from "@lodestar/utils";
 import {CachedBeaconStateElectra, CachedBeaconStateGloas} from "../types.js";
 import {findBuilderIndexByPubkey, isBuilderWithdrawalCredential} from "../util/gloas.js";
 import {computeEpochAtSlot, isValidatorKnown} from "../util/index.js";
+import {PendingDepositsLookup} from "../util/pendingDepositsLookup.js";
 import {isValidDepositSignature} from "./processDeposit.js";
 
 /**
@@ -76,53 +76,60 @@ function addBuilderToRegistry(
   }
 }
 
-// TODO GLOAS: pendingValidatorPubkeys cache is currently naive and has room for improvement.
-// Currently the cache lives in process_block, but we should put it in epochCache or elsewhere that has longer
-// lifetime to avoid duplicated deposit signature computation
+// TODO GLOAS: the PendingDepositsLookup is currently scoped to a single envelope of
+// deposit-requests. We can track it as ephemeral within EpochCache and transfer to the next block
+// transition to reuse cached signature verifications.
 // See https://github.com/ChainSafe/lodestar/issues/9181
 export function processDepositRequest(
   fork: ForkSeq,
   state: CachedBeaconStateElectra | CachedBeaconStateGloas,
   depositRequest: electra.DepositRequest,
-  pendingValidatorPubkeysCache?: Set<PubkeyHex>
+  pendingDepositsLookup?: PendingDepositsLookup
 ): void {
   const {pubkey, withdrawalCredentials, amount, signature} = depositRequest;
 
-  // Check if this is a builder or validator deposit
   if (fork >= ForkSeq.gloas) {
     const stateGloas = state as CachedBeaconStateGloas;
-    const pendingValidatorPubkeys =
-      pendingValidatorPubkeysCache ?? getPendingValidatorPubkeys(state.config, stateGloas);
+    const lookup = pendingDepositsLookup ?? PendingDepositsLookup.build(stateGloas);
     const pubkeyHex = toPubkeyHex(pubkey);
     const builderIndex = findBuilderIndexByPubkey(stateGloas, pubkey);
     const validatorIndex = state.epochCtx.getValidatorIndex(pubkey);
 
-    // Regardless of the withdrawal credentials prefix, if a builder/validator
-    // already exists with this pubkey, apply the deposit to their balance
     const isBuilder = builderIndex !== null;
     const isValidator = isValidatorKnown(state, validatorIndex);
-    const isPendingValidator = pendingValidatorPubkeys.has(pubkeyHex);
 
-    if (isBuilder || (isBuilderWithdrawalCredential(withdrawalCredentials) && !isValidator && !isPendingValidator)) {
-      // Apply builder deposits immediately
+    if (isBuilder) {
+      // Top up an existing builder regardless of withdrawal credential prefix
       applyDepositForBuilder(stateGloas, pubkey, withdrawalCredentials, amount, signature, state.slot);
       return;
     }
 
-    // Keep the shared cache in sync: if this deposit has a valid signature, subsequent
-    // deposit requests for the same pubkey in this envelope must see it as a pending validator
+    // Only check the (expensive) "pending validator" condition when needed
     if (
-      pendingValidatorPubkeysCache &&
+      isBuilderWithdrawalCredential(withdrawalCredentials) &&
       !isValidator &&
-      !isPendingValidator &&
-      isValidDepositSignature(state.config, pubkey, withdrawalCredentials, amount, signature)
+      !lookup.hasPendingValidator(state.config, pubkeyHex)
     ) {
-      pendingValidatorPubkeys.add(pubkeyHex);
+      applyDepositForBuilder(stateGloas, pubkey, withdrawalCredentials, amount, signature, state.slot);
+      return;
     }
+
+    const pendingDeposit = ssz.electra.PendingDeposit.toViewDU({
+      pubkey,
+      withdrawalCredentials,
+      amount,
+      signature,
+      slot: state.slot,
+    });
+    // Keep the lookup in sync with state.pendingDeposits so later deposit-requests
+    // in the same envelope see this deposit
+    lookup.add(pendingDeposit, pubkeyHex);
+    state.pendingDeposits.push(pendingDeposit);
+    return;
   }
 
-  // Only set deposit_requests_start_index in Electra fork, not Gloas
-  if (fork < ForkSeq.gloas && state.depositRequestsStartIndex === UNSET_DEPOSIT_REQUESTS_START_INDEX) {
+  // Pre-Gloas (Electra) path
+  if (state.depositRequestsStartIndex === UNSET_DEPOSIT_REQUESTS_START_INDEX) {
     state.depositRequestsStartIndex = depositRequest.index;
   }
 
@@ -135,29 +142,4 @@ export function processDepositRequest(
     slot: state.slot,
   });
   state.pendingDeposits.push(pendingDeposit);
-}
-
-/**
- * Build a set of pubkeys (hex-encoded) from pending deposits that have valid signatures.
- * This is computed once and passed to each processDepositRequest call to avoid
- * repeatedly iterating state.pendingDeposits.
- *
- * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.3/specs/gloas/beacon-chain.md#new-is_pending_validator
- */
-export function getPendingValidatorPubkeys(config: BeaconConfig, state: CachedBeaconStateGloas): Set<PubkeyHex> {
-  const result = new Set<PubkeyHex>();
-  for (const pendingDeposit of state.pendingDeposits.getAllReadonly()) {
-    if (
-      isValidDepositSignature(
-        config,
-        pendingDeposit.pubkey,
-        pendingDeposit.withdrawalCredentials,
-        pendingDeposit.amount,
-        pendingDeposit.signature
-      )
-    ) {
-      result.add(toPubkeyHex(pendingDeposit.pubkey));
-    }
-  }
-  return result;
 }

--- a/packages/state-transition/src/block/processParentExecutionPayload.ts
+++ b/packages/state-transition/src/block/processParentExecutionPayload.ts
@@ -3,8 +3,9 @@ import {BeaconBlock, electra, ssz} from "@lodestar/types";
 import {byteArrayEquals, toRootHex} from "@lodestar/utils";
 import {CachedBeaconStateGloas} from "../types.js";
 import {computeEpochAtSlot} from "../util/epoch.js";
+import {PendingDepositsLookup} from "../util/pendingDepositsLookup.js";
 import {processConsolidationRequest} from "./processConsolidationRequest.js";
-import {getPendingValidatorPubkeys, processDepositRequest} from "./processDepositRequest.js";
+import {processDepositRequest} from "./processDepositRequest.js";
 import {processWithdrawalRequest} from "./processWithdrawalRequest.js";
 
 /**
@@ -54,9 +55,9 @@ export function applyParentExecutionPayload(state: CachedBeaconStateGloas, reque
   // Process execution requests from parent's payload. The execution
   // requests are processed at state.slot (child's slot), not the parent's slot.
   if (requests.deposits.length > 0) {
-    const pendingValidatorPubkeys = getPendingValidatorPubkeys(state.config, state);
+    const pendingDepositsLookup = PendingDepositsLookup.build(state);
     for (const deposit of requests.deposits) {
-      processDepositRequest(fork, state, deposit, pendingValidatorPubkeys);
+      processDepositRequest(fork, state, deposit, pendingDepositsLookup);
     }
   }
 

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -108,48 +108,38 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
       continue;
     }
 
-    // Top up a builder created in a previous iteration; no `is_pending_validator` check
-    // since the new builder could only have been created after that check returned false.
-    if (builderPubkeys.has(pubkeyHex)) {
-      applyDepositForBuilder(
-        state,
-        deposit.pubkey,
-        deposit.withdrawalCredentials,
-        deposit.amount,
-        deposit.signature,
-        deposit.slot
-      );
-      continue;
-    }
-
-    // Builder-credential deposit for a pubkey not yet seen as a builder. Defer to the
-    // pending queue if a valid validator deposit for this pubkey is already pending;
-    // otherwise create/top up the builder.
-    if (isBuilderWithdrawalCredential(deposit.withdrawalCredentials)) {
+    // `applyDepositForBuilder` can mutate the state and add a builder to the registry, so
+    // the set of builder pubkeys must be recomputed each iteration. `builderPubkeys` stands
+    // in for the spec's `[b.pubkey for b in state.builders]`: `state.builders` starts empty
+    // at the fork, so every builder is one added in a previous iteration of this loop.
+    if (!builderPubkeys.has(pubkeyHex)) {
+      // Deposits for non-builders stay in the pending queue. If there is a valid pending
+      // deposit for a new validator with this pubkey, keep this deposit in the pending
+      // queue to be applied to that validator later.
+      if (!isBuilderWithdrawalCredential(deposit.withdrawalCredentials)) {
+        pendingDeposits.push(deposit);
+        pendingDepositsLookup.add(deposit, pubkeyHex);
+        continue;
+      }
       if (pendingDepositsLookup.hasPendingValidator(state.config, pubkeyHex)) {
         pendingDeposits.push(deposit);
         pendingDepositsLookup.add(deposit, pubkeyHex);
         continue;
       }
-
-      const buildersLenBefore = state.builders.length;
-      applyDepositForBuilder(
-        state,
-        deposit.pubkey,
-        deposit.withdrawalCredentials,
-        deposit.amount,
-        deposit.signature,
-        deposit.slot
-      );
-      if (state.builders.length > buildersLenBefore) {
-        builderPubkeys.add(pubkeyHex);
-      }
-      continue;
     }
 
-    // Validator-credential deposit for a new pubkey: keep it in the pending queue.
-    pendingDeposits.push(deposit);
-    pendingDepositsLookup.add(deposit, pubkeyHex);
+    const buildersLenBefore = state.builders.length;
+    applyDepositForBuilder(
+      state,
+      deposit.pubkey,
+      deposit.withdrawalCredentials,
+      deposit.amount,
+      deposit.signature,
+      deposit.slot
+    );
+    if (state.builders.length > buildersLenBefore) {
+      builderPubkeys.add(pubkeyHex);
+    }
   }
 
   state.pendingDeposits = pendingDeposits;

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -1,12 +1,12 @@
 import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
-import {toHex} from "@lodestar/utils";
-import {isValidDepositSignature} from "../block/processDeposit.js";
+import {toPubkeyHex} from "@lodestar/utils";
 import {applyDepositForBuilder} from "../block/processDepositRequest.js";
 import {getCachedBeaconState} from "../cache/stateCache.js";
 import {CachedBeaconStateFulu, CachedBeaconStateGloas} from "../types.js";
 import {initializePtcWindow, isBuilderWithdrawalCredential} from "../util/gloas.js";
 import {isValidatorKnown} from "../util/index.js";
+import {PendingDepositsLookup} from "../util/pendingDepositsLookup.js";
 
 /**
  * Upgrade a state from Fulu to Gloas.
@@ -89,30 +89,49 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/fork.md#new-onboard_builders_from_pending_deposits
  */
 function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void {
-  // Track pubkeys of new validators to keep their deposits pending
-  const validatorPubkeys = new Set<string>();
-
   // Track pubkeys of new builders added when applying deposits
   const builderPubkeys = new Set<string>();
 
-  const remainingPendingDeposits = ssz.electra.PendingDeposits.defaultViewDU();
+  const pendingDeposits = ssz.electra.PendingDeposits.defaultViewDU();
+  const pendingDepositsLookup = PendingDepositsLookup.buildEmpty();
+
   for (let i = 0; i < state.pendingDeposits.length; i++) {
     const deposit = state.pendingDeposits.getReadonly(i);
 
     const validatorIndex = state.epochCtx.getValidatorIndex(deposit.pubkey);
-    const pubkeyHex = toHex(deposit.pubkey);
+    const pubkeyHex = toPubkeyHex(deposit.pubkey);
 
-    // Deposits for existing validators stay in pending queue
-    if (isValidatorKnown(state, validatorIndex) || validatorPubkeys.has(pubkeyHex)) {
-      remainingPendingDeposits.push(deposit);
+    // Deposits for existing validators stay in the pending queue
+    if (isValidatorKnown(state, validatorIndex)) {
+      pendingDeposits.push(deposit);
+      pendingDepositsLookup.add(deposit, pubkeyHex);
       continue;
     }
 
-    // If the pubkey is associated with a builder that was created in a previous iteration
-    // or it is a builder deposit, try to apply the deposit to the new/existing builder
-    const isExistingBuilder = builderPubkeys.has(pubkeyHex);
-    const hasBuilderCredentials = isBuilderWithdrawalCredential(deposit.withdrawalCredentials);
-    if (isExistingBuilder || hasBuilderCredentials) {
+    // Top up a builder created in a previous iteration; no `is_pending_validator` check
+    // since the new builder could only have been created after that check returned false.
+    if (builderPubkeys.has(pubkeyHex)) {
+      applyDepositForBuilder(
+        state,
+        deposit.pubkey,
+        deposit.withdrawalCredentials,
+        deposit.amount,
+        deposit.signature,
+        deposit.slot
+      );
+      continue;
+    }
+
+    // Builder-credential deposit for a pubkey not yet seen as a builder. Defer to the
+    // pending queue if a valid validator deposit for this pubkey is already pending;
+    // otherwise create/top up the builder.
+    if (isBuilderWithdrawalCredential(deposit.withdrawalCredentials)) {
+      if (pendingDepositsLookup.hasPendingValidator(state.config, pubkeyHex)) {
+        pendingDeposits.push(deposit);
+        pendingDepositsLookup.add(deposit, pubkeyHex);
+        continue;
+      }
+
       const buildersLenBefore = state.builders.length;
       applyDepositForBuilder(
         state,
@@ -122,30 +141,16 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
         deposit.signature,
         deposit.slot
       );
-      // Track newly added builders for subsequent iterations
-      if (!isExistingBuilder && state.builders.length > buildersLenBefore) {
+      if (state.builders.length > buildersLenBefore) {
         builderPubkeys.add(pubkeyHex);
       }
       continue;
     }
 
-    // If there is a pending deposit for a new validator that has a valid signature, track the
-    // pubkey so that subsequent builder deposits for the same pubkey stay in pending (applied to
-    // the validator later) rather than creating a builder. Deposits with invalid signatures are
-    // dropped here since they would fail in apply_pending_deposit anyway.
-    if (
-      isValidDepositSignature(
-        state.config,
-        deposit.pubkey,
-        deposit.withdrawalCredentials,
-        deposit.amount,
-        deposit.signature
-      )
-    ) {
-      validatorPubkeys.add(pubkeyHex);
-      remainingPendingDeposits.push(deposit);
-    }
+    // Validator-credential deposit for a new pubkey: keep it in the pending queue.
+    pendingDeposits.push(deposit);
+    pendingDepositsLookup.add(deposit, pubkeyHex);
   }
 
-  state.pendingDeposits = remainingPendingDeposits;
+  state.pendingDeposits = pendingDeposits;
 }

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -129,6 +129,8 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
     }
 
     const buildersLenBefore = state.builders.length;
+    // TODO GLOAS: handle 20k 1ETH deposits on time
+    // there is a note in the spec https://github.com/ethereum/consensus-specs/pull/5227
     applyDepositForBuilder(
       state,
       deposit.pubkey,

--- a/packages/state-transition/src/util/index.ts
+++ b/packages/state-transition/src/util/index.ts
@@ -18,6 +18,7 @@ export * from "./genesis.js";
 export * from "./gloas.js";
 export * from "./interop.js";
 export * from "./loadState/index.js";
+export * from "./pendingDepositsLookup.js";
 export * from "./rootCache.js";
 export * from "./seed.js";
 export * from "./shuffling.js";

--- a/packages/state-transition/src/util/pendingDepositsLookup.ts
+++ b/packages/state-transition/src/util/pendingDepositsLookup.ts
@@ -1,0 +1,105 @@
+import {BeaconConfig} from "@lodestar/config";
+import {PubkeyHex, electra} from "@lodestar/types";
+import {toPubkeyHex} from "@lodestar/utils";
+import {isValidDepositSignature} from "../block/processDeposit.js";
+import {CachedBeaconStateGloas} from "../types.js";
+
+type PendingDepositsValidation = {
+  hasValidSignature: boolean;
+  validatedCount: number;
+};
+
+/**
+ * Mutable lookup for the pending-deposit sequence used by builder-routing logic.
+ *
+ * This is to implement the spec's `is_pending_validator(pending_deposits, pubkey)` lazily:
+ * deposits are grouped by pubkey without verifying signatures, and BLS verification is
+ * deferred until a builder deposit needs to know whether the same pubkey already has a
+ * valid pending validator deposit.
+ *
+ * Call `add()` whenever a deposit is appended to the represented sequence. A cached `true`
+ * result short-circuits all subsequent checks for that pubkey; a cached `false` records
+ * how many deposits were already verified, so appending a new deposit only verifies the
+ * newly-appended tail rather than re-running BLS on previously-invalid entries.
+ */
+export class PendingDepositsLookup {
+  private constructor(
+    private readonly depositsByPubkey: Map<PubkeyHex, electra.PendingDeposit[]>,
+    private readonly validationCache: Map<PubkeyHex, PendingDepositsValidation>
+  ) {}
+
+  /** Build an empty lookup for a sequence that will be populated incrementally. */
+  static buildEmpty(): PendingDepositsLookup {
+    return new PendingDepositsLookup(new Map(), new Map());
+  }
+
+  /**
+   * Build a pubkey -> pending-deposits lookup from `state.pendingDeposits`.
+   * No BLS work is done here; signature verification happens lazily in `hasPendingValidator`.
+   */
+  static build(state: CachedBeaconStateGloas): PendingDepositsLookup {
+    const lookup = PendingDepositsLookup.buildEmpty();
+    for (const pendingDeposit of state.pendingDeposits.getAllReadonly()) {
+      lookup.add(pendingDeposit);
+    }
+    return lookup;
+  }
+
+  /**
+   * Append a pending deposit to the represented sequence.
+   * Pass `pubkeyHex` if the caller has already computed it.
+   */
+  add(pendingDeposit: electra.PendingDeposit, pubkeyHex?: PubkeyHex): void {
+    const key = pubkeyHex ?? toPubkeyHex(pendingDeposit.pubkey);
+    const existing = this.depositsByPubkey.get(key);
+    if (existing) {
+      existing.push(pendingDeposit);
+    } else {
+      this.depositsByPubkey.set(key, [pendingDeposit]);
+    }
+  }
+
+  /**
+   * Returns true if any pending deposit for `pubkeyHex` has a valid BLS deposit signature.
+   * Memoizes the result in `validationCache` so repeated checks for the same pubkey
+   * within a block only verify deposits that have not already been checked.
+   */
+  hasPendingValidator(config: BeaconConfig, pubkeyHex: PubkeyHex): boolean {
+    const validation = this.validationCache.get(pubkeyHex);
+    if (validation?.hasValidSignature === true) {
+      return true;
+    }
+
+    const deposits = this.depositsByPubkey.get(pubkeyHex);
+    if (deposits === undefined) {
+      return false;
+    }
+
+    // hasValidSignature is false or undefined; resume from the last validatedCount so
+    // previously-checked invalid deposits are not re-verified.
+    const startIndex = validation?.validatedCount ?? 0;
+    if (startIndex === deposits.length) {
+      // Nothing new to check; the cached false result still holds.
+      return false;
+    }
+
+    for (let i = startIndex; i < deposits.length; i++) {
+      const deposit = deposits[i];
+      if (
+        isValidDepositSignature(
+          config,
+          deposit.pubkey,
+          deposit.withdrawalCredentials,
+          deposit.amount,
+          deposit.signature
+        )
+      ) {
+        this.validationCache.set(pubkeyHex, {hasValidSignature: true, validatedCount: i + 1});
+        return true;
+      }
+    }
+
+    this.validationCache.set(pubkeyHex, {hasValidSignature: false, validatedCount: deposits.length});
+    return false;
+  }
+}

--- a/packages/state-transition/test/unit/util/pendingDepositsLookup.test.ts
+++ b/packages/state-transition/test/unit/util/pendingDepositsLookup.test.ts
@@ -1,0 +1,146 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {createBeaconConfig} from "@lodestar/config";
+import {config as chainConfig} from "@lodestar/config/default";
+import {electra, ssz} from "@lodestar/types";
+import {toPubkeyHex} from "@lodestar/utils";
+
+const isValidDepositSignatureMock = vi.hoisted(() =>
+  vi.fn(
+    (
+      _config: unknown,
+      _pubkey: Uint8Array,
+      _withdrawalCredentials: Uint8Array,
+      _amount: number,
+      signature: Uint8Array
+    ) => signature[0] === 1
+  )
+);
+
+vi.mock("../../../src/block/processDeposit.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/block/processDeposit.js")>();
+  return {
+    ...actual,
+    isValidDepositSignature: isValidDepositSignatureMock,
+  };
+});
+
+const {createCachedBeaconStateTest} = await import("../../../src/testUtils/state.js");
+const {PendingDepositsLookup} = await import("../../../src/util/pendingDepositsLookup.js");
+
+describe("PendingDepositsLookup", () => {
+  const config = createBeaconConfig(chainConfig, Buffer.alloc(32));
+
+  beforeEach(() => {
+    isValidDepositSignatureMock.mockClear();
+  });
+
+  function createPendingDeposit(pubkeySeed: number, signatureSeed: number): electra.PendingDeposit {
+    return {
+      pubkey: Buffer.alloc(48, pubkeySeed),
+      withdrawalCredentials: Buffer.alloc(32),
+      amount: 32_000_000_000,
+      signature: Buffer.alloc(96, signatureSeed),
+      slot: 0,
+    };
+  }
+
+  it("returns false for an empty lookup without checking signatures", () => {
+    const lookup = PendingDepositsLookup.buildEmpty();
+    const pubkeyHex = toPubkeyHex(createPendingDeposit(1, 0).pubkey);
+
+    expect(lookup.hasPendingValidator(config, pubkeyHex)).toBe(false);
+    expect(isValidDepositSignatureMock).not.toHaveBeenCalled();
+  });
+
+  it("memoizes a false result when no deposits are appended", () => {
+    const lookup = PendingDepositsLookup.buildEmpty();
+    const deposit0 = createPendingDeposit(1, 0);
+    const deposit1 = createPendingDeposit(1, 0);
+    const pubkeyHex = toPubkeyHex(deposit0.pubkey);
+
+    lookup.add(deposit0);
+    lookup.add(deposit1);
+
+    expect(lookup.hasPendingValidator(config, pubkeyHex)).toBe(false);
+    expect(isValidDepositSignatureMock).toHaveBeenCalledTimes(2);
+
+    expect(lookup.hasPendingValidator(config, pubkeyHex)).toBe(false);
+    expect(isValidDepositSignatureMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("validates only newly appended deposits after a cached false result", () => {
+    const lookup = PendingDepositsLookup.buildEmpty();
+    const deposit0 = createPendingDeposit(1, 0);
+    const deposit1 = createPendingDeposit(1, 0);
+    const deposit2 = createPendingDeposit(1, 1);
+    const pubkeyHex = toPubkeyHex(deposit0.pubkey);
+
+    lookup.add(deposit0);
+    lookup.add(deposit1);
+    expect(lookup.hasPendingValidator(config, pubkeyHex)).toBe(false);
+    expect(isValidDepositSignatureMock).toHaveBeenCalledTimes(2);
+
+    lookup.add(deposit2);
+    expect(lookup.hasPendingValidator(config, pubkeyHex)).toBe(true);
+    expect(isValidDepositSignatureMock).toHaveBeenCalledTimes(3);
+    expect(isValidDepositSignatureMock).toHaveBeenLastCalledWith(
+      config,
+      deposit2.pubkey,
+      deposit2.withdrawalCredentials,
+      deposit2.amount,
+      deposit2.signature
+    );
+  });
+
+  it("does not validate appended deposits after a valid signature is cached", () => {
+    const lookup = PendingDepositsLookup.buildEmpty();
+    const deposit0 = createPendingDeposit(1, 0);
+    const deposit1 = createPendingDeposit(1, 1);
+    const deposit2 = createPendingDeposit(1, 0);
+    const pubkeyHex = toPubkeyHex(deposit0.pubkey);
+
+    lookup.add(deposit0);
+    lookup.add(deposit1);
+    expect(lookup.hasPendingValidator(config, pubkeyHex)).toBe(true);
+    expect(isValidDepositSignatureMock).toHaveBeenCalledTimes(2);
+
+    lookup.add(deposit2);
+    expect(lookup.hasPendingValidator(config, pubkeyHex)).toBe(true);
+    expect(isValidDepositSignatureMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches validation independently for each pubkey", () => {
+    const lookup = PendingDepositsLookup.buildEmpty();
+    const depositA = createPendingDeposit(1, 0);
+    const depositB = createPendingDeposit(2, 1);
+    const pubkeyHexA = toPubkeyHex(depositA.pubkey);
+    const pubkeyHexB = toPubkeyHex(depositB.pubkey);
+
+    lookup.add(depositA);
+    lookup.add(depositB);
+
+    expect(lookup.hasPendingValidator(config, pubkeyHexA)).toBe(false);
+    expect(isValidDepositSignatureMock).toHaveBeenCalledTimes(1);
+
+    expect(lookup.hasPendingValidator(config, pubkeyHexB)).toBe(true);
+    expect(isValidDepositSignatureMock).toHaveBeenCalledTimes(2);
+
+    expect(lookup.hasPendingValidator(config, pubkeyHexA)).toBe(false);
+    expect(isValidDepositSignatureMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("builds from state.pendingDeposits without checking signatures", () => {
+    const state = createCachedBeaconStateTest(ssz.gloas.BeaconState.defaultViewDU(), chainConfig, {
+      skipSyncCommitteeCache: true,
+      skipSyncPubkeys: true,
+    });
+    const deposit = createPendingDeposit(1, 1);
+    state.pendingDeposits.push(ssz.electra.PendingDeposit.toViewDU(deposit));
+
+    const lookup = PendingDepositsLookup.build(state);
+
+    expect(isValidDepositSignatureMock).not.toHaveBeenCalled();
+    expect(lookup.hasPendingValidator(state.config, toPubkeyHex(deposit.pubkey))).toBe(true);
+    expect(isValidDepositSignatureMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -6963,8 +6963,8 @@
 
 - name: is_pending_validator#gloas
   sources:
-    - file: packages/state-transition/src/block/processDepositRequest.ts
-      search: export function getPendingValidatorPubkeys
+    - file: packages/state-transition/src/util/pendingDepositsLookup.ts
+      search: "hasPendingValidator(config: BeaconConfig, pubkeyHex: PubkeyHex): boolean {"
   spec: |
     <spec fn="is_pending_validator" fork="gloas" hash="9b409bab">
     def is_pending_validator(state: BeaconState, pubkey: BLSPubkey) -> bool:


### PR DESCRIPTION
**Motivation**

- Implements [ethereum/consensus-specs#5254](https://github.com/ethereum/consensus-specs/pull/5254). Avoid eager BLS signature verification of the whole `pending_deposits` queue when onboarding builders at the Gloas fork transition.
- Also improve `processDepositRequest()` in Gloas to avoid eager BLS signature verification of the whole `pending_deposits` queue. This does not need a spec change.

**Description**

- implement `PendingDepositsLookup` grouped by pubkey, track verified deposits so we will never do it again. This is also a preparation when we move it to EpochCache or higher level cache.
- Reworks `onboardBuildersFromPendingDeposits` at the Fulu→Gloas fork transition to mirror the new spec structure. Behavior change from the spec PR: invalid-signature validator deposits now stay in the pending queue (previously dropped).
- Threads a shared lookup through `applyParentExecutionPayload → processDepositRequest` so successive deposit-requests in the same envelope share verification results. The lookup is kept as a faithful mirror of `state.pendingDeposits`.
- Adds unit tests for `PendingDepositsLookup`.

**AI Assistance Disclosure**

Used Claude Code.