### PR TITLE
feat: add proposer preferences

### DIFF
--- a/packages/api/src/beacon/routes/beacon/pool.ts
+++ b/packages/api/src/beacon/routes/beacon/pool.ts
@@ -6,6 +6,7 @@ import {
   ForkPreElectra,
   MAX_PAYLOAD_ATTESTATIONS,
   PTC_SIZE,
+  SLOTS_PER_EPOCH,
   isForkPostElectra,
 } from "@lodestar/params";
 import {
@@ -46,7 +47,12 @@ const SignedBLSToExecutionChangeListType = ArrayOf(ssz.capella.SignedBLSToExecut
 const SyncCommitteeMessageListType = ArrayOf(ssz.altair.SyncCommitteeMessage);
 const PayloadAttestationListType = ArrayOf(ssz.gloas.PayloadAttestation, MAX_PAYLOAD_ATTESTATIONS);
 const PayloadAttestationMessageListType = ArrayOf(ssz.gloas.PayloadAttestationMessage, PTC_SIZE);
-const SignedProposerPreferencesListType = ArrayOf(ssz.gloas.SignedProposerPreferences);
+// 2 * SLOTS_PER_EPOCH max normally; getAll() may return up to 3 * SLOTS_PER_EPOCH during non-finality
+const MAX_PROPOSER_PREFERENCES_PER_REQUEST = 3 * SLOTS_PER_EPOCH;
+const SignedProposerPreferencesListType = ArrayOf(
+  ssz.gloas.SignedProposerPreferences,
+  MAX_PROPOSER_PREFERENCES_PER_REQUEST
+);
 
 type AttestationListPhase0 = ValueOf<typeof AttestationListTypePhase0>;
 type AttestationListElectra = ValueOf<typeof AttestationListTypeElectra>;

--- a/packages/api/src/beacon/routes/beacon/pool.ts
+++ b/packages/api/src/beacon/routes/beacon/pool.ts
@@ -46,6 +46,7 @@ const SignedBLSToExecutionChangeListType = ArrayOf(ssz.capella.SignedBLSToExecut
 const SyncCommitteeMessageListType = ArrayOf(ssz.altair.SyncCommitteeMessage);
 const PayloadAttestationListType = ArrayOf(ssz.gloas.PayloadAttestation, MAX_PAYLOAD_ATTESTATIONS);
 const PayloadAttestationMessageListType = ArrayOf(ssz.gloas.PayloadAttestationMessage, PTC_SIZE);
+const SignedProposerPreferencesListType = ArrayOf(ssz.gloas.SignedProposerPreferences);
 
 type AttestationListPhase0 = ValueOf<typeof AttestationListTypePhase0>;
 type AttestationListElectra = ValueOf<typeof AttestationListTypeElectra>;
@@ -61,6 +62,7 @@ type SignedBLSToExecutionChangeList = ValueOf<typeof SignedBLSToExecutionChangeL
 type SyncCommitteeMessageList = ValueOf<typeof SyncCommitteeMessageListType>;
 type PayloadAttestationList = ValueOf<typeof PayloadAttestationListType>;
 type PayloadAttestationMessageList = ValueOf<typeof PayloadAttestationMessageListType>;
+type SignedProposerPreferencesList = ValueOf<typeof SignedProposerPreferencesListType>;
 
 export type Endpoints = {
   /**
@@ -96,6 +98,18 @@ export type Endpoints = {
     {slot?: Slot},
     {query: {slot?: number}},
     PayloadAttestationList,
+    VersionMeta
+  >;
+
+  /**
+   * Get signed proposer preferences from operations pool
+   * Retrieves proposer preferences known by the node but not necessarily incorporated into any block.
+   */
+  getPoolProposerPreferences: Endpoint<
+    "GET",
+    {slot?: Slot},
+    {query: {slot?: number}},
+    SignedProposerPreferencesList,
     VersionMeta
   >;
 
@@ -279,6 +293,18 @@ export type Endpoints = {
     EmptyResponseData,
     EmptyMeta
   >;
+
+  /**
+   * Submit signed proposer preferences
+   * Submits signed proposer preferences to the beacon node.
+   */
+  submitSignedProposerPreferences: Endpoint<
+    "POST",
+    {signedProposerPreferences: SignedProposerPreferencesList},
+    {body: unknown; headers: {[MetaHeader.Version]: string}},
+    EmptyResponseData,
+    EmptyMeta
+  >;
 };
 
 export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoints> {
@@ -319,6 +345,19 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       },
       resp: {
         data: PayloadAttestationListType,
+        meta: VersionCodec,
+      },
+    },
+    getPoolProposerPreferences: {
+      url: "/eth/v1/beacon/pool/proposer_preferences",
+      method: "GET",
+      req: {
+        writeReq: ({slot}) => ({query: {slot}}),
+        parseReq: ({query}) => ({slot: query.slot}),
+        schema: {query: {slot: Schema.Uint}},
+      },
+      resp: {
+        data: SignedProposerPreferencesListType,
         meta: VersionCodec,
       },
     },
@@ -566,6 +605,33 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqSsz: ({body, headers}) => {
           toForkName(fromHeaders(headers, MetaHeader.Version));
           return {payloadAttestationMessages: PayloadAttestationMessageListType.deserialize(body)};
+        },
+        schema: {
+          body: Schema.ObjectArray,
+          headers: {[MetaHeader.Version]: Schema.String},
+        },
+      },
+      resp: EmptyResponseCodec,
+    },
+    submitSignedProposerPreferences: {
+      url: "/eth/v1/beacon/pool/proposer_preferences",
+      method: "POST",
+      req: {
+        writeReqJson: ({signedProposerPreferences}) => ({
+          body: SignedProposerPreferencesListType.toJson(signedProposerPreferences),
+          headers: {[MetaHeader.Version]: ForkName.gloas},
+        }),
+        parseReqJson: ({body, headers}) => {
+          toForkName(fromHeaders(headers, MetaHeader.Version));
+          return {signedProposerPreferences: SignedProposerPreferencesListType.fromJson(body)};
+        },
+        writeReqSsz: ({signedProposerPreferences}) => ({
+          body: SignedProposerPreferencesListType.serialize(signedProposerPreferences),
+          headers: {[MetaHeader.Version]: ForkName.gloas},
+        }),
+        parseReqSsz: ({body, headers}) => {
+          toForkName(fromHeaders(headers, MetaHeader.Version));
+          return {signedProposerPreferences: SignedProposerPreferencesListType.deserialize(body)};
         },
         schema: {
           body: Schema.ObjectArray,

--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -108,6 +108,8 @@ export enum EventType {
   executionPayloadAvailable = "execution_payload_available",
   /** The node has received a `SignedExecutionPayloadBid` (from P2P or API) that passes gossip validation on the `execution_payload_bid` topic */
   executionPayloadBid = "execution_payload_bid",
+  /** The node has received a `SignedProposerPreferences` (from P2P or API) that passes gossip validation on the `proposer_preferences` topic */
+  proposerPreferences = "proposer_preferences",
 }
 
 export const eventTypes: {[K in EventType]: K} = {
@@ -132,6 +134,7 @@ export const eventTypes: {[K in EventType]: K} = {
   [EventType.executionPayloadGossip]: EventType.executionPayloadGossip,
   [EventType.executionPayloadAvailable]: EventType.executionPayloadAvailable,
   [EventType.executionPayloadBid]: EventType.executionPayloadBid,
+  [EventType.proposerPreferences]: EventType.proposerPreferences,
 };
 
 export type EventData = {
@@ -199,6 +202,7 @@ export type EventData = {
     blockRoot: RootHex;
   };
   [EventType.executionPayloadBid]: {version: ForkName; data: gloas.SignedExecutionPayloadBid};
+  [EventType.proposerPreferences]: {version: ForkName; data: gloas.SignedProposerPreferences};
 };
 
 export type BeaconEvent = {[K in EventType]: {type: K; message: EventData[K]}}[EventType];
@@ -395,6 +399,7 @@ export function getTypeByEvent(config: ChainForkConfig): {[K in EventType]: Type
       {jsonCase: "eth2"}
     ),
     [EventType.executionPayloadBid]: WithVersion((fork) => getPostGloasForkTypes(fork).SignedExecutionPayloadBid),
+    [EventType.proposerPreferences]: WithVersion((fork) => getPostGloasForkTypes(fork).SignedProposerPreferences),
 
     [EventType.lightClientOptimisticUpdate]: WithVersion(
       (fork) => getPostAltairForkTypes(fork).LightClientOptimisticUpdate

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -131,6 +131,10 @@ export const testData: GenericServerTestCases<Endpoints> = {
     args: {slot: 1},
     res: {data: [ssz.gloas.PayloadAttestation.defaultValue()], meta: {version: ForkName.gloas}},
   },
+  getPoolProposerPreferences: {
+    args: {slot: 1},
+    res: {data: [ssz.gloas.SignedProposerPreferences.defaultValue()], meta: {version: ForkName.gloas}},
+  },
   getPoolAttesterSlashings: {
     args: undefined,
     res: {data: [ssz.phase0.AttesterSlashing.defaultValue()]},
@@ -185,6 +189,10 @@ export const testData: GenericServerTestCases<Endpoints> = {
   },
   submitPayloadAttestationMessages: {
     args: {payloadAttestationMessages: [ssz.gloas.PayloadAttestationMessage.defaultValue()]},
+    res: undefined,
+  },
+  submitSignedProposerPreferences: {
+    args: {signedProposerPreferences: [ssz.gloas.SignedProposerPreferences.defaultValue()]},
     res: undefined,
   },
 

--- a/packages/api/test/unit/beacon/testData/events.ts
+++ b/packages/api/test/unit/beacon/testData/events.ts
@@ -291,6 +291,20 @@ export const eventTestData: EventData = {
     slot: 10,
     blockRoot: "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf",
   },
+  [EventType.proposerPreferences]: {
+    version: ForkName.gloas,
+    data: ssz.gloas.SignedProposerPreferences.fromJson({
+      message: {
+        dependent_root: "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+        proposal_slot: "10",
+        validator_index: "42",
+        fee_recipient: "0x0000000000000000000000000000000000000000",
+        gas_limit: "30000000",
+      },
+      signature:
+        "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505",
+    }),
+  },
   [EventType.executionPayloadBid]: {
     version: ForkName.gloas,
     data: ssz.gloas.SignedExecutionPayloadBid.fromJson({

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -1,6 +1,7 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {
+  ForkName,
   ForkPostElectra,
   ForkPreElectra,
   SYNC_COMMITTEE_SUBNET_SIZE,
@@ -16,12 +17,15 @@ import {
   GossipAction,
   PayloadAttestationError,
   PayloadAttestationErrorCode,
+  ProposerPreferencesError,
+  ProposerPreferencesErrorCode,
   SyncCommitteeError,
 } from "../../../../chain/errors/index.js";
 import {validateApiAttesterSlashing} from "../../../../chain/validation/attesterSlashing.js";
 import {validateApiBlsToExecutionChange} from "../../../../chain/validation/blsToExecutionChange.js";
 import {toElectraSingleAttestation, validateApiAttestation} from "../../../../chain/validation/index.js";
 import {validateApiPayloadAttestationMessage} from "../../../../chain/validation/payloadAttestationMessage.js";
+import {validateGossipProposerPreferences} from "../../../../chain/validation/proposerPreferences.js";
 import {validateApiProposerSlashing} from "../../../../chain/validation/proposerSlashing.js";
 import {validateApiSyncCommittee} from "../../../../chain/validation/syncCommittee.js";
 import {validateApiVoluntaryExit} from "../../../../chain/validation/voluntaryExit.js";
@@ -79,6 +83,55 @@ export function getBeaconPoolApi({
       }
 
       return {data: chain.payloadAttestationPool.getAll(slot), meta: {version: fork}};
+    },
+
+    async getPoolProposerPreferences({slot}) {
+      const fork = chain.config.getForkName(slot ?? chain.clock.currentSlot);
+      if (!isForkPostGloas(fork)) {
+        throw new ApiError(400, `Proposer preferences pool is not supported before Gloas fork=${fork}`);
+      }
+
+      return {data: chain.proposerPreferencesPool.getAll(slot), meta: {version: fork}};
+    },
+
+    async submitSignedProposerPreferences({signedProposerPreferences}) {
+      const failures: FailureList = [];
+
+      await Promise.all(
+        signedProposerPreferences.map(async (signed, i) => {
+          try {
+            await validateGossipProposerPreferences(chain, signed);
+
+            chain.proposerPreferencesPool.add(signed);
+            await network.publishProposerPreferences(signed);
+            chain.emitter.emit(routes.events.EventType.proposerPreferences, {
+              version: ForkName.gloas,
+              data: signed,
+            });
+          } catch (e) {
+            const logCtx = {
+              slot: signed.message.proposalSlot,
+              validatorIndex: signed.message.validatorIndex,
+              dependentRoot: toRootHex(signed.message.dependentRoot),
+            };
+
+            if (e instanceof ProposerPreferencesError && e.type.code === ProposerPreferencesErrorCode.ALREADY_KNOWN) {
+              logger.debug("Ignoring known signed proposer preferences", logCtx);
+              return;
+            }
+
+            failures.push({index: i, message: (e as Error).message});
+            logger.verbose(`Error on submitSignedProposerPreferences [${i}]`, logCtx, e as Error);
+            if (e instanceof ProposerPreferencesError && e.action === GossipAction.REJECT) {
+              chain.persistInvalidSszValue(ssz.gloas.SignedProposerPreferences, signed, "api_reject");
+            }
+          }
+        })
+      );
+
+      if (failures.length > 0) {
+        throw new IndexedError("Error processing signed proposer preferences", failures);
+      }
     },
 
     async getPoolAttesterSlashings() {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -88,6 +88,7 @@ import {
   ExecutionPayloadBidPool,
   OpPool,
   PayloadAttestationPool,
+  ProposerPreferencesPool,
   SyncCommitteeMessagePool,
   SyncContributionAndProofPool,
 } from "./opPools/index.js";
@@ -180,6 +181,7 @@ export class BeaconChain implements IBeaconChain {
   readonly syncContributionAndProofPool;
   readonly executionPayloadBidPool: ExecutionPayloadBidPool;
   readonly payloadAttestationPool: PayloadAttestationPool;
+  readonly proposerPreferencesPool = new ProposerPreferencesPool();
   readonly opPool: OpPool;
 
   // Gossip seen cache
@@ -1462,6 +1464,7 @@ export class BeaconChain implements IBeaconChain {
     this.executionPayloadBidPool.prune(slot);
     this.seenExecutionPayloadBids.prune(slot);
     this.seenProposerPreferences.prune(slot);
+    this.proposerPreferencesPool.prune(slot);
     this.seenAttestationDatas.onSlot(slot);
     this.reprocessController.onSlot(slot);
 

--- a/packages/beacon-node/src/chain/errors/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/errors/executionPayloadBid.ts
@@ -11,6 +11,9 @@ export enum ExecutionPayloadBidErrorCode {
   UNKNOWN_BLOCK_ROOT = "EXECUTION_PAYLOAD_BID_ERROR_UNKNOWN_BLOCK_ROOT",
   INVALID_SLOT = "EXECUTION_PAYLOAD_BID_ERROR_INVALID_SLOT",
   INVALID_SIGNATURE = "EXECUTION_PAYLOAD_BID_ERROR_INVALID_SIGNATURE",
+  NO_MATCHING_PROPOSER_PREFERENCES = "EXECUTION_PAYLOAD_BID_ERROR_NO_MATCHING_PROPOSER_PREFERENCES",
+  PROPOSER_PREFERENCES_FEE_RECIPIENT_MISMATCH = "EXECUTION_PAYLOAD_BID_ERROR_PROPOSER_PREFERENCES_FEE_RECIPIENT_MISMATCH",
+  PROPOSER_PREFERENCES_GAS_LIMIT_MISMATCH = "EXECUTION_PAYLOAD_BID_ERROR_PROPOSER_PREFERENCES_GAS_LIMIT_MISMATCH",
 }
 
 export type ExecutionPayloadBidErrorType =
@@ -36,6 +39,24 @@ export type ExecutionPayloadBidErrorType =
     }
   | {code: ExecutionPayloadBidErrorCode.UNKNOWN_BLOCK_ROOT; parentBlockRoot: RootHex}
   | {code: ExecutionPayloadBidErrorCode.INVALID_SLOT; builderIndex: BuilderIndex; slot: Slot}
-  | {code: ExecutionPayloadBidErrorCode.INVALID_SIGNATURE; builderIndex: BuilderIndex; slot: Slot};
+  | {code: ExecutionPayloadBidErrorCode.INVALID_SIGNATURE; builderIndex: BuilderIndex; slot: Slot}
+  | {
+      code: ExecutionPayloadBidErrorCode.NO_MATCHING_PROPOSER_PREFERENCES;
+      slot: Slot;
+      parentBlockRoot: RootHex;
+      dependentRoot: RootHex;
+    }
+  | {
+      code: ExecutionPayloadBidErrorCode.PROPOSER_PREFERENCES_FEE_RECIPIENT_MISMATCH;
+      builderIndex: BuilderIndex;
+      bidFeeRecipient: string;
+      expectedFeeRecipient: string;
+    }
+  | {
+      code: ExecutionPayloadBidErrorCode.PROPOSER_PREFERENCES_GAS_LIMIT_MISMATCH;
+      builderIndex: BuilderIndex;
+      bidGasLimit: number;
+      expectedGasLimit: number;
+    };
 
 export class ExecutionPayloadBidError extends GossipActionError<ExecutionPayloadBidErrorType> {}

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -47,6 +47,7 @@ import {
   ExecutionPayloadBidPool,
   OpPool,
   PayloadAttestationPool,
+  ProposerPreferencesPool,
   SyncCommitteeMessagePool,
   SyncContributionAndProofPool,
 } from "./opPools/index.js";
@@ -124,6 +125,7 @@ export interface IBeaconChain {
   readonly syncContributionAndProofPool: SyncContributionAndProofPool;
   readonly executionPayloadBidPool: ExecutionPayloadBidPool;
   readonly payloadAttestationPool: PayloadAttestationPool;
+  readonly proposerPreferencesPool: ProposerPreferencesPool;
   readonly opPool: OpPool;
 
   // Gossip seen cache

--- a/packages/beacon-node/src/chain/opPools/index.ts
+++ b/packages/beacon-node/src/chain/opPools/index.ts
@@ -3,5 +3,6 @@ export {AttestationPool} from "./attestationPool.js";
 export {ExecutionPayloadBidPool} from "./executionPayloadBidPool.js";
 export {OpPool} from "./opPool.js";
 export {PayloadAttestationPool} from "./payloadAttestationPool.js";
+export {ProposerPreferencesPool} from "./proposerPreferencesPool.js";
 export {SyncCommitteeMessagePool} from "./syncCommitteeMessagePool.js";
 export {SyncContributionAndProofPool} from "./syncContributionAndProofPool.js";

--- a/packages/beacon-node/src/chain/opPools/proposerPreferencesPool.ts
+++ b/packages/beacon-node/src/chain/opPools/proposerPreferencesPool.ts
@@ -1,0 +1,59 @@
+import {RootHex, Slot, gloas} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+
+/**
+ * Pool of validated `SignedProposerPreferences` indexed by `(slot, dependent_root)`.
+ *
+ * The primary consumer is `validateExecutionPayloadBid`, which looks up the matching
+ * preferences via `get(bid.slot, dependent_root)` to enforce the IGNORE-existence and
+ * REJECT-equality rules from the gloas spec. The beacon API `/pool/proposer_preferences`
+ * GET endpoint reads from the same pool via `getAll`.
+ *
+ * `validator_index` is intentionally not part of the key: gossip validation enforces
+ * `proposers[proposalSlot % SLOTS_PER_EPOCH] === validatorIndex` against the shuffling
+ * implied by `dependent_root`, so once a preference has been validated `(slot, dependent_root)`
+ * already pins down the validator.
+ */
+export class ProposerPreferencesPool {
+  private readonly bySlot = new Map<Slot, Map<RootHex, gloas.SignedProposerPreferences>>();
+
+  /** Lookup for bid validation: matches `(bid.slot, get_proposer_dependent_root(parent_state, ...))`. */
+  get(slot: Slot, dependentRootHex: RootHex): gloas.SignedProposerPreferences | null {
+    return this.bySlot.get(slot)?.get(dependentRootHex) ?? null;
+  }
+
+  add(signed: gloas.SignedProposerPreferences): void {
+    const {proposalSlot, dependentRoot} = signed.message;
+    const rootHex = toRootHex(dependentRoot);
+    let byRoot = this.bySlot.get(proposalSlot);
+    if (!byRoot) {
+      byRoot = new Map();
+      this.bySlot.set(proposalSlot, byRoot);
+    }
+    byRoot.set(rootHex, signed);
+  }
+
+  /** API read-out: flatten across branches, optionally filtered by slot. */
+  getAll(slot?: Slot): gloas.SignedProposerPreferences[] {
+    if (slot !== undefined) {
+      const byRoot = this.bySlot.get(slot);
+      return byRoot ? Array.from(byRoot.values()) : [];
+    }
+    const out: gloas.SignedProposerPreferences[] = [];
+    for (const byRoot of this.bySlot.values()) {
+      for (const v of byRoot.values()) out.push(v);
+    }
+    return out;
+  }
+
+  /**
+   * Entries are only load-bearing while `proposal_slot >= current_slot`. Once the slot has
+   * passed the `[IGNORE] proposal_slot > current_slot` gossip rule takes over, so drop them
+   * on each slot tick.
+   */
+  prune(currentSlot: Slot): void {
+    for (const slot of this.bySlot.keys()) {
+      if (slot < currentSlot) this.bySlot.delete(slot);
+    }
+  }
+}

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -1,13 +1,14 @@
 import {PublicKey} from "@chainsafe/blst";
 import {
   computeEpochAtSlot,
+  computeStartSlotAtEpoch,
   createSingleSignatureSetFromComponents,
   getExecutionPayloadBidSigningRoot,
   isActiveBuilder,
   isStatePostGloas,
 } from "@lodestar/state-transition";
 import {gloas} from "@lodestar/types";
-import {toRootHex} from "@lodestar/utils";
+import {byteArrayEquals, toHex, toRootHex} from "@lodestar/utils";
 import {ExecutionPayloadBidError, ExecutionPayloadBidErrorCode, GossipAction} from "../errors/index.js";
 import {IBeaconChain} from "../index.js";
 import {RegenCaller} from "../regen/index.js";
@@ -48,12 +49,34 @@ async function validateExecutionPayloadBid(
     });
   }
 
-  // [IGNORE] A `SignedProposerPreferences` matching `bid.slot` and the bid's branch has been
-  // seen — i.e. `proposal_slot == bid.slot` AND `dependent_root ==
-  // get_proposer_dependent_root(parent_state, compute_epoch_at_slot(bid.slot))`,
-  // where `parent_state` is the post-state of `bid.parent_block_root`.
-  // This is the message referenced as `proposer_preferences` in the following REJECT rules.
-  // TODO GLOAS: Implement once a ProposerPreferencesPool exists.
+  // [IGNORE] `bid.parent_block_root` is the hash tree root of a known beacon block in fork choice.
+  // Moved earlier than the spec ordering so we can call `forkChoice.getAncestor` to derive
+  // the dependent root for the proposer-preferences lookup below.
+  if (!chain.forkChoice.hasBlock(bid.parentBlockRoot)) {
+    throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
+      code: ExecutionPayloadBidErrorCode.UNKNOWN_BLOCK_ROOT,
+      parentBlockRoot: parentBlockRootHex,
+    });
+  }
+
+  // [IGNORE] A `SignedProposerPreferences` matching `bid.slot` and the bid's branch has been seen
+  // — i.e. `proposal_slot == bid.slot` AND `dependent_root` equals the proposer-shuffling decision
+  // root for the bid's branch and epoch. Derived via fork-choice ancestor lookup: the block at the
+  // last slot of `epoch - 1` reached from `bid.parent_block_root`.
+  const bidEpoch = computeEpochAtSlot(bid.slot);
+  const dependentRootHex = chain.forkChoice.getAncestor(
+    parentBlockRootHex,
+    computeStartSlotAtEpoch(bidEpoch) - 1
+  ).blockRoot;
+  const proposerPreferences = chain.proposerPreferencesPool.get(bid.slot, dependentRootHex);
+  if (proposerPreferences === null) {
+    throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
+      code: ExecutionPayloadBidErrorCode.NO_MATCHING_PROPOSER_PREFERENCES,
+      slot: bid.slot,
+      parentBlockRoot: parentBlockRootHex,
+      dependentRoot: dependentRootHex,
+    });
+  }
 
   // [REJECT] `bid.builder_index` is a valid/active builder index -- i.e.
   // `is_active_builder(state, bid.builder_index)` returns `True`.
@@ -75,10 +98,25 @@ async function validateExecutionPayloadBid(
   }
 
   // [REJECT] `bid.fee_recipient == proposer_preferences.fee_recipient`.
+  if (!byteArrayEquals(bid.feeRecipient, proposerPreferences.message.feeRecipient)) {
+    throw new ExecutionPayloadBidError(GossipAction.REJECT, {
+      code: ExecutionPayloadBidErrorCode.PROPOSER_PREFERENCES_FEE_RECIPIENT_MISMATCH,
+      builderIndex: bid.builderIndex,
+      bidFeeRecipient: toHex(bid.feeRecipient),
+      expectedFeeRecipient: toHex(proposerPreferences.message.feeRecipient),
+    });
+  }
+
   // [REJECT] `bid.gas_limit == proposer_preferences.gas_limit`.
-  // Both compared against the matching `proposer_preferences` defined above (same branch
-  // via dependent_root, same proposal_slot).
-  // TODO GLOAS: Implement once a ProposerPreferencesPool exists.
+  const bidGasLimit = Number(bid.gasLimit);
+  if (bidGasLimit !== proposerPreferences.message.gasLimit) {
+    throw new ExecutionPayloadBidError(GossipAction.REJECT, {
+      code: ExecutionPayloadBidErrorCode.PROPOSER_PREFERENCES_GAS_LIMIT_MISMATCH,
+      builderIndex: bid.builderIndex,
+      bidGasLimit,
+      expectedGasLimit: proposerPreferences.message.gasLimit,
+    });
+  }
 
   // [REJECT] The length of KZG commitments is less than or equal to the limitation defined in the
   // consensus layer -- i.e. validate that
@@ -127,15 +165,6 @@ async function validateExecutionPayloadBid(
   // [IGNORE] `bid.parent_block_hash` is the block hash of a known execution
   // payload in fork choice.
   // TODO GLOAS: implement this
-
-  // [IGNORE] `bid.parent_block_root` is the hash tree root of a known beacon
-  // block in fork choice.
-  if (!chain.forkChoice.hasBlock(bid.parentBlockRoot)) {
-    throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
-      code: ExecutionPayloadBidErrorCode.UNKNOWN_BLOCK_ROOT,
-      parentBlockRoot: parentBlockRootHex,
-    });
-  }
 
   // [REJECT] `signed_execution_payload_bid.signature` is valid with respect to the `bid.builder_index`.
   const signatureSet = createSingleSignatureSetFromComponents(

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -1,7 +1,6 @@
 import {PublicKey} from "@chainsafe/blst";
 import {
   computeEpochAtSlot,
-  computeStartSlotAtEpoch,
   createSingleSignatureSetFromComponents,
   getExecutionPayloadBidSigningRoot,
   isActiveBuilder,
@@ -9,6 +8,7 @@ import {
 } from "@lodestar/state-transition";
 import {gloas} from "@lodestar/types";
 import {byteArrayEquals, toHex, toRootHex} from "@lodestar/utils";
+import {getShufflingDependentRoot} from "../../util/dependentRoot.js";
 import {ExecutionPayloadBidError, ExecutionPayloadBidErrorCode, GossipAction} from "../errors/index.js";
 import {IBeaconChain} from "../index.js";
 import {RegenCaller} from "../regen/index.js";
@@ -50,24 +50,45 @@ async function validateExecutionPayloadBid(
   }
 
   // [IGNORE] `bid.parent_block_root` is the hash tree root of a known beacon block in fork choice.
-  // Moved earlier than the spec ordering so we can call `forkChoice.getAncestor` to derive
-  // the dependent root for the proposer-preferences lookup below.
-  if (!chain.forkChoice.hasBlock(bid.parentBlockRoot)) {
+  // Moved earlier than the spec ordering so we can derive the proposer dependent root for the
+  // proposer-preferences lookup below from a known fork-choice block.
+  const parentBlock = chain.forkChoice.getBlockHexDefaultStatus(parentBlockRootHex);
+  if (parentBlock === null) {
     throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
       code: ExecutionPayloadBidErrorCode.UNKNOWN_BLOCK_ROOT,
       parentBlockRoot: parentBlockRootHex,
     });
   }
 
-  // [IGNORE] A `SignedProposerPreferences` matching `bid.slot` and the bid's branch has been seen
-  // — i.e. `proposal_slot == bid.slot` AND `dependent_root` equals the proposer-shuffling decision
-  // root for the bid's branch and epoch. Derived via fork-choice ancestor lookup: the block at the
-  // last slot of `epoch - 1` reached from `bid.parent_block_root`.
+  // [IGNORE] A `SignedProposerPreferences` matching `bid.slot` and the bid's branch has been
+  // seen — i.e. `proposal_slot == bid.slot` AND `dependent_root ==
+  // get_proposer_dependent_root(parent_state, compute_epoch_at_slot(bid.slot))`.
   const bidEpoch = computeEpochAtSlot(bid.slot);
-  const dependentRootHex = chain.forkChoice.getAncestor(
-    parentBlockRootHex,
-    computeStartSlotAtEpoch(bidEpoch) - 1
-  ).blockRoot;
+  // gloas is always post-Fulu, so `get_proposer_dependent_root` is the post-Fulu (deterministic
+  // proposer lookahead) form `block_root_at(start_slot(epoch - MIN_SEED_LOOKAHEAD) - 1)` with
+  // `MIN_SEED_LOOKAHEAD == 1` — identical to the attester-shuffling dependent root for the same
+  // epoch (both 1-epoch lookahead), hence `getShufflingDependentRoot`. `null` on a
+  // unknown/finalized-pruned ancestor or genesis edge → degrade to IGNORE below instead of
+  // letting a raw `ForkChoiceError` escape the `GossipActionError` contract.
+  const dependentRootHex = (() => {
+    try {
+      return getShufflingDependentRoot(chain.forkChoice, bidEpoch, computeEpochAtSlot(parentBlock.slot), parentBlock);
+    } catch {
+      return null;
+    }
+  })();
+
+  if (dependentRootHex === null) {
+    // Could not derive the dependent root for this branch (unknown/finalized-pruned ancestor,
+    // genesis edge, etc.) → definitionally no matching `SignedProposerPreferences`.
+    throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
+      code: ExecutionPayloadBidErrorCode.NO_MATCHING_PROPOSER_PREFERENCES,
+      slot: bid.slot,
+      parentBlockRoot: parentBlockRootHex,
+      dependentRoot: "unknown",
+    });
+  }
+
   const proposerPreferences = chain.proposerPreferencesPool.get(bid.slot, dependentRootHex);
   if (proposerPreferences === null) {
     throw new ExecutionPayloadBidError(GossipAction.IGNORE, {

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -114,6 +114,7 @@ export interface INetwork extends INetworkCorePublic {
   publishLightClientOptimisticUpdate(update: LightClientOptimisticUpdate): Promise<number>;
   publishSignedExecutionPayloadEnvelope(signedEnvelope: gloas.SignedExecutionPayloadEnvelope): Promise<number>;
   publishPayloadAttestationMessage(payloadAttestationMessage: gloas.PayloadAttestationMessage): Promise<number>;
+  publishProposerPreferences(signedProposerPreferences: gloas.SignedProposerPreferences): Promise<number>;
 
   // Debug
   dumpGossipQueue(gossipType: GossipType): Promise<PendingGossipsubMessage[]>;

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -526,6 +526,17 @@ export class Network implements INetwork {
     );
   }
 
+  async publishProposerPreferences(signedProposerPreferences: gloas.SignedProposerPreferences): Promise<number> {
+    const epoch = computeEpochAtSlot(signedProposerPreferences.message.proposalSlot);
+    const boundary = this.config.getForkBoundaryAtEpoch(epoch);
+
+    return this.publishGossip<GossipType.proposer_preferences>(
+      {type: GossipType.proposer_preferences, boundary},
+      signedProposerPreferences,
+      {ignoreDuplicatePublishError: true}
+    );
+  }
+
   private async publishGossip<K extends GossipType>(
     topic: GossipTopicMap[K],
     object: GossipTypeMap[K],

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1237,6 +1237,12 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       const {serializedData} = gossipData;
       const signedProposerPreferences = sszDeserialize(topic, serializedData);
       await validateGossipProposerPreferences(chain, signedProposerPreferences);
+
+      chain.proposerPreferencesPool.add(signedProposerPreferences);
+      chain.emitter.emit(routes.events.EventType.proposerPreferences, {
+        version: ForkName.gloas,
+        data: signedProposerPreferences,
+      });
     },
   };
 }

--- a/packages/beacon-node/src/util/dependentRoot.ts
+++ b/packages/beacon-node/src/util/dependentRoot.ts
@@ -2,45 +2,49 @@ import {EpochDifference, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {Epoch, RootHex} from "@lodestar/types";
 
 /**
- * Get dependent root of a shuffling given attestation epoch and head block.
+ * Get dependent root of a shuffling given a message epoch and a proto block.
+ *
+ * Pre-gloas, this is used for attestation validation
+ * Post-gloas, this is also used for execution_payload_bid validation because post-fulu,
+ * a dependent root of a proposal duties is 1-epoch look ahead (instead of 0 as of pre-fulu)
  */
 export function getShufflingDependentRoot(
   forkChoice: IForkChoice,
-  attEpoch: Epoch,
-  blockEpoch: Epoch,
-  attHeadBlock: ProtoBlock
+  msgEpoch: Epoch,
+  protoBlockEpoch: Epoch,
+  protoBlock: ProtoBlock
 ): RootHex {
   let shufflingDependentRoot: RootHex;
-  if (blockEpoch === attEpoch) {
+  if (protoBlockEpoch === msgEpoch) {
     // current shuffling, this is equivalent to `headState.currentShuffling`
-    // given blockEpoch = attEpoch = n
+    // given protoBlockEpoch = msgEpoch = n
     //        epoch:       (n-2)   (n-1)     n     (n+1)
     //               |-------|-------|-------|-------|
-    // attHeadBlock     ------------------------^
+    // protoBlock       ------------------------^
     // shufflingDependentRoot ------^
-    shufflingDependentRoot = forkChoice.getDependentRoot(attHeadBlock, EpochDifference.previous);
-  } else if (blockEpoch === attEpoch - 1) {
+    shufflingDependentRoot = forkChoice.getDependentRoot(protoBlock, EpochDifference.previous);
+  } else if (protoBlockEpoch === msgEpoch - 1) {
     // next shuffling, this is equivalent to `headState.nextShuffling`
-    // given blockEpoch = n-1, attEpoch = n
+    // given protoBlockEpoch = n-1, msgEpoch = n
     //        epoch:       (n-2)   (n-1)     n     (n+1)
     //               |-------|-------|-------|-------|
-    // attHeadBlock     -------------------^
+    // protoBlock       -------------------^
     // shufflingDependentRoot ------^
-    shufflingDependentRoot = forkChoice.getDependentRoot(attHeadBlock, EpochDifference.current);
-  } else if (blockEpoch < attEpoch - 1) {
+    shufflingDependentRoot = forkChoice.getDependentRoot(protoBlock, EpochDifference.current);
+  } else if (protoBlockEpoch < msgEpoch - 1) {
     // this never happens with default chain option of maxSkipSlots = 32, however we still need to handle it
     // check the verifyHeadBlockAndTargetRoot() function above
-    // given blockEpoch = n-2, attEpoch = n
+    // given protoBlockEpoch = n-2, msgEpoch = n
     //        epoch:       (n-2)   (n-1)     n     (n+1)
     //               |-------|-------|-------|-------|
-    // attHeadBlock     -----------^
+    // protoBlock       -----------^
     // shufflingDependentRoot -----^
-    shufflingDependentRoot = attHeadBlock.blockRoot;
+    shufflingDependentRoot = protoBlock.blockRoot;
     // use lodestar_gossip_attestation_head_slot_to_attestation_slot metric to track this case
   } else {
-    // blockEpoch > attEpoch
+    // protoBlockEpoch > msgEpoch
     // should not happen, handled in verifyAttestationTargetRoot
-    throw Error(`attestation epoch ${attEpoch} is before head block epoch ${blockEpoch}`);
+    throw Error(`message epoch ${msgEpoch} is before proto block epoch ${protoBlockEpoch}`);
   }
 
   return shufflingDependentRoot;

--- a/packages/beacon-node/test/unit/chain/opPools/proposerPreferencesPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/proposerPreferencesPool.test.ts
@@ -1,0 +1,79 @@
+import {beforeEach, describe, expect, it} from "vitest";
+import {toHexString} from "@chainsafe/ssz";
+import {gloas} from "@lodestar/types";
+import {ProposerPreferencesPool} from "../../../../src/chain/opPools/proposerPreferencesPool.js";
+
+describe("chain / opPools / ProposerPreferencesPool", () => {
+  const makePrefs = (
+    proposalSlot: number,
+    validatorIndex: number,
+    dependentRoot: Uint8Array
+  ): gloas.SignedProposerPreferences => ({
+    message: {
+      dependentRoot,
+      proposalSlot,
+      validatorIndex,
+      feeRecipient: Buffer.alloc(20, 0xab),
+      gasLimit: 30_000_000,
+    },
+    signature: Buffer.alloc(96, 0),
+  });
+
+  const rootA = Buffer.alloc(32, 0xa);
+  const rootB = Buffer.alloc(32, 0xb);
+  const rootAHex = toHexString(rootA);
+  const rootBHex = toHexString(rootB);
+
+  let pool: ProposerPreferencesPool;
+  beforeEach(() => {
+    pool = new ProposerPreferencesPool();
+  });
+
+  it("returns null for missing slot", () => {
+    expect(pool.get(10, rootAHex)).toBeNull();
+  });
+
+  it("returns the entry after add", () => {
+    const prefs = makePrefs(10, 1, rootA);
+    pool.add(prefs);
+    expect(pool.get(10, rootAHex)).toBe(prefs);
+  });
+
+  it("returns null for unknown dependent_root at a known slot", () => {
+    pool.add(makePrefs(10, 1, rootA));
+    expect(pool.get(10, rootBHex)).toBeNull();
+  });
+
+  it("isolates entries by dependent_root at the same slot", () => {
+    const a = makePrefs(10, 1, rootA);
+    const b = makePrefs(10, 2, rootB);
+    pool.add(a);
+    pool.add(b);
+    expect(pool.get(10, rootAHex)).toBe(a);
+    expect(pool.get(10, rootBHex)).toBe(b);
+  });
+
+  it("getAll(slot) returns all branch entries for that slot only", () => {
+    pool.add(makePrefs(10, 1, rootA));
+    pool.add(makePrefs(10, 2, rootB));
+    pool.add(makePrefs(11, 3, rootA));
+    expect(pool.getAll(10)).toHaveLength(2);
+  });
+
+  it("getAll() flattens across all slots", () => {
+    pool.add(makePrefs(10, 1, rootA));
+    pool.add(makePrefs(11, 2, rootA));
+    pool.add(makePrefs(12, 3, rootB));
+    expect(pool.getAll()).toHaveLength(3);
+  });
+
+  it("prune drops slots < currentSlot but retains currentSlot and later", () => {
+    pool.add(makePrefs(10, 1, rootA));
+    pool.add(makePrefs(11, 2, rootA));
+    pool.add(makePrefs(12, 3, rootA));
+    pool.prune(11);
+    expect(pool.get(10, rootAHex)).toBeNull();
+    expect(pool.get(11, rootAHex)).not.toBeNull();
+    expect(pool.get(12, rootAHex)).not.toBeNull();
+  });
+});

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -52,18 +52,12 @@ export class BlockProposingService {
     private readonly api: ApiClient,
     private readonly clock: IClock,
     private readonly validatorStore: ValidatorStore,
+    dutiesService: BlockDutiesService,
     private readonly metrics: Metrics | null,
     private readonly opts: BlockProposalOpts
   ) {
-    this.dutiesService = new BlockDutiesService(
-      config,
-      logger,
-      api,
-      clock,
-      validatorStore,
-      metrics,
-      this.notifyBlockProductionFn
-    );
+    this.dutiesService = dutiesService;
+    this.dutiesService.setNotifyBlockProductionFn(this.notifyBlockProductionFn);
   }
 
   removeDutiesForKey(pubkey: PubkeyHex): void {

--- a/packages/validator/src/services/blockDuties.ts
+++ b/packages/validator/src/services/blockDuties.ts
@@ -20,12 +20,12 @@ const HISTORICAL_DUTIES_EPOCHS = 2;
 const GENESIS_EPOCH = 0;
 export const GENESIS_SLOT = 0;
 
-type BlockDutyAtEpoch = {dependentRoot: RootHex; data: routes.validator.ProposerDuty[]};
+export type BlockDutyAtEpoch = {dependentRoot: RootHex; data: routes.validator.ProposerDuty[]};
 type NotifyBlockProductionFn = (slot: Slot, proposers: BLSPubkey[]) => void;
 
 export class BlockDutiesService {
   /** Notify the block service if it should produce a block. */
-  private readonly notifyBlockProductionFn: NotifyBlockProductionFn;
+  private notifyBlockProductionFn: NotifyBlockProductionFn = () => {};
   /** Maps an epoch to all *local* proposers in this epoch. Notably, this does not contain
       proposals for any validators which are not registered locally. */
   private readonly proposers = new Map<Epoch, BlockDutyAtEpoch>();
@@ -36,11 +36,8 @@ export class BlockDutiesService {
     private readonly api: ApiClient,
     private readonly clock: IClock,
     private readonly validatorStore: ValidatorStore,
-    private readonly metrics: Metrics | null,
-    notifyBlockProductionFn: NotifyBlockProductionFn
+    private readonly metrics: Metrics | null
   ) {
-    this.notifyBlockProductionFn = notifyBlockProductionFn;
-
     // TODO: Instead of polling every CLOCK_SLOT, poll every CLOCK_EPOCH and track re-org events
     //       only then re-fetch the block duties. Make sure most clients (including Lodestar)
     //       properly emit the re-org event
@@ -51,6 +48,14 @@ export class BlockDutiesService {
         metrics.proposerDutiesEpochCount.set(this.proposers.size);
       });
     }
+  }
+
+  /**
+   * Late-bind the production callback. Allows the duties service to be constructed
+   * before the consumer that handles proposal production.
+   */
+  setNotifyBlockProductionFn(notifyBlockProductionFn: NotifyBlockProductionFn): void {
+    this.notifyBlockProductionFn = notifyBlockProductionFn;
   }
 
   /**
@@ -73,6 +78,16 @@ export class BlockDutiesService {
     }
 
     return Array.from(publicKeys.values());
+  }
+
+  /**
+   * Returns the cached `{dependentRoot, data}` entry for `epoch`, or `undefined` if duties
+   * for that epoch are not yet known. Consumers can detect a proposer-shuffling change
+   * (e.g. after a reorg) by observing a different `dependentRoot` than the one they last
+   * read for the same epoch.
+   */
+  getProposersAtEpoch(epoch: Epoch): BlockDutyAtEpoch | undefined {
+    return this.proposers.get(epoch);
   }
 
   removeDutiesForKey(pubkey: PubkeyHex): void {

--- a/packages/validator/src/services/proposerPreferences.ts
+++ b/packages/validator/src/services/proposerPreferences.ts
@@ -1,0 +1,124 @@
+import {ApiClient} from "@lodestar/api";
+import {ChainForkConfig} from "@lodestar/config";
+import {SLOTS_PER_EPOCH, isForkPostGloas} from "@lodestar/params";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {Epoch, RootHex, Slot, gloas} from "@lodestar/types";
+import {fromHex, toPubkeyHex} from "@lodestar/utils";
+import {Metrics} from "../metrics.js";
+import {IClock, LoggerVc} from "../util/index.js";
+import {BlockDutiesService} from "./blockDuties.js";
+import {ValidatorStore} from "./validatorStore.js";
+
+/**
+ * Submit a proposer's `SignedProposerPreferences` this many slots before the proposal slot.
+ *
+ * Earlier submission means more reorg-triggered resubmits (and gossip flood); later
+ * submission risks missing the bid-auction window for this proposal slot. The bid for
+ * slot S typically arrives at slot S-1, so we want preferences propagated to the network
+ * and consumed by builders before then. SLOTS_PER_EPOCH / 4 (8 slots @ 32 SPE, ~96s @ 12s
+ * slots) gives ample margin while bounding redundant resubmits.
+ */
+const SUBMIT_BEFORE_PROPOSAL_SLOTS = Math.floor(SLOTS_PER_EPOCH / 4);
+
+/** Per-epoch tracking of preferences already submitted under the current dependent_root. */
+type SubmittedAtEpoch = {dependentRoot: RootHex; slots: Set<Slot>};
+
+/**
+ * Signs and submits `SignedProposerPreferences` for any local validator that will propose
+ * within the next `SUBMIT_BEFORE_PROPOSAL_SLOTS`. Re-submits automatically when the proposer
+ * dependent root for an epoch shifts (e.g. after a reorg) — detected by comparing the cached
+ * `dependentRoot` reported by `BlockDutiesService` against the one we last submitted under.
+ *
+ * No-op pre-gloas.
+ */
+export class ProposerPreferencesService {
+  private readonly submitted = new Map<Epoch, SubmittedAtEpoch>();
+
+  constructor(
+    private readonly config: ChainForkConfig,
+    private readonly logger: LoggerVc,
+    private readonly api: ApiClient,
+    clock: IClock,
+    private readonly validatorStore: ValidatorStore,
+    private readonly blockDutiesService: BlockDutiesService,
+    _metrics: Metrics | null
+  ) {
+    clock.runEverySlot(this.runProposerPreferencesTask);
+  }
+
+  private runProposerPreferencesTask = async (slot: Slot): Promise<void> => {
+    if (!isForkPostGloas(this.config.getForkName(slot))) {
+      return;
+    }
+
+    const currentEpoch = computeEpochAtSlot(slot);
+    const batch: gloas.SignedProposerPreferences[] = [];
+    // Track which `(submission, slot)` pairs are pending an API submission so we can mark
+    // them only after the network call succeeds. Marking before would silently drop a
+    // preference on transient API failure (no retry until dependent_root shifts).
+    const pending: {submission: SubmittedAtEpoch; slot: Slot}[] = [];
+
+    for (const epoch of [currentEpoch, currentEpoch + 1]) {
+      const dutiesAtEpoch = this.blockDutiesService.getProposersAtEpoch(epoch);
+      if (!dutiesAtEpoch) continue;
+
+      // Reset submission tracking if the dependent root for this epoch has shifted
+      // (e.g. due to a reorg). Any previously-submitted preferences are now stale.
+      let submission = this.submitted.get(epoch);
+      if (submission === undefined || submission.dependentRoot !== dutiesAtEpoch.dependentRoot) {
+        if (submission !== undefined) {
+          this.logger.info("Proposer-shuffling dependent root shifted; resubmitting preferences", {
+            epoch,
+            priorDependentRoot: submission.dependentRoot,
+            dependentRoot: dutiesAtEpoch.dependentRoot,
+          });
+        }
+        submission = {dependentRoot: dutiesAtEpoch.dependentRoot, slots: new Set()};
+        this.submitted.set(epoch, submission);
+      }
+
+      const dependentRootBytes = fromHex(dutiesAtEpoch.dependentRoot);
+
+      for (const duty of dutiesAtEpoch.data) {
+        if (duty.slot <= slot) continue;
+        if (duty.slot > slot + SUBMIT_BEFORE_PROPOSAL_SLOTS) continue;
+        if (submission.slots.has(duty.slot)) continue;
+
+        try {
+          const pubkeyHex = toPubkeyHex(duty.pubkey);
+          const signed = await this.validatorStore.signProposerPreferences(
+            duty,
+            dependentRootBytes,
+            this.validatorStore.getFeeRecipient(pubkeyHex),
+            this.validatorStore.getGasLimit(pubkeyHex),
+            slot
+          );
+          batch.push(signed);
+          pending.push({submission, slot: duty.slot});
+        } catch (e) {
+          this.logger.error(
+            "Error signing proposer preferences",
+            {slot: duty.slot, validatorIndex: duty.validatorIndex},
+            e as Error
+          );
+        }
+      }
+    }
+
+    if (batch.length === 0) {
+      return;
+    }
+
+    try {
+      await this.api.beacon.submitSignedProposerPreferences({signedProposerPreferences: batch});
+      // Only mark as submitted after the API call succeeds; a thrown error leaves the
+      // slot eligible for retry on the next tick.
+      for (const {submission, slot: submittedSlot} of pending) {
+        submission.slots.add(submittedSlot);
+      }
+      this.logger.debug("Submitted signed proposer preferences", {count: batch.length});
+    } catch (e) {
+      this.logger.error("Error submitting signed proposer preferences", {count: batch.length}, e as Error);
+    }
+  };
+}

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -9,6 +9,7 @@ import {
   DOMAIN_BEACON_BUILDER,
   DOMAIN_BEACON_PROPOSER,
   DOMAIN_CONTRIBUTION_AND_PROOF,
+  DOMAIN_PROPOSER_PREFERENCES,
   DOMAIN_PTC_ATTESTER,
   DOMAIN_RANDAO,
   DOMAIN_SELECTION_PROOF,
@@ -700,6 +701,42 @@ export class ValidatorStore {
     return {
       validatorIndex: duty.validatorIndex,
       data,
+      signature: await this.getSignature(duty.pubkey, signingRoot, signingSlot, signableMessage),
+    };
+  }
+
+  async signProposerPreferences(
+    duty: routes.validator.ProposerDuty,
+    dependentRoot: Uint8Array,
+    feeRecipient: ExecutionAddress,
+    gasLimit: number,
+    currentSlot: Slot
+  ): Promise<gloas.SignedProposerPreferences> {
+    if (duty.slot <= currentSlot) {
+      throw Error(`Not signing proposer preferences for past slot ${duty.slot} (current ${currentSlot})`);
+    }
+
+    this.assertDoppelgangerSafe(duty.pubkey);
+
+    const message: gloas.ProposerPreferences = {
+      dependentRoot,
+      proposalSlot: duty.slot,
+      validatorIndex: duty.validatorIndex,
+      feeRecipient: fromHex(feeRecipient),
+      gasLimit,
+    };
+
+    const signingSlot = duty.slot;
+    const domain = this.config.getDomain(signingSlot, DOMAIN_PROPOSER_PREFERENCES);
+    const signingRoot = computeSigningRoot(ssz.gloas.ProposerPreferences, message, domain);
+
+    const signableMessage: SignableMessage = {
+      type: SignableMessageType.PROPOSER_PREFERENCES,
+      data: message,
+    };
+
+    return {
+      message,
       signature: await this.getSignature(duty.pubkey, signingRoot, signingSlot, signableMessage),
     };
   }

--- a/packages/validator/src/util/externalSignerClient.ts
+++ b/packages/validator/src/util/externalSignerClient.ts
@@ -35,6 +35,7 @@ export enum SignableMessageType {
   VALIDATOR_REGISTRATION = "VALIDATOR_REGISTRATION",
   EXECUTION_PAYLOAD_ENVELOPE = "EXECUTION_PAYLOAD_ENVELOPE",
   PAYLOAD_ATTESTATION = "PAYLOAD_ATTESTATION",
+  PROPOSER_PREFERENCES = "PROPOSER_PREFERENCES",
 }
 
 const AggregationSlotType = new ContainerType({
@@ -85,7 +86,8 @@ export type SignableMessage =
   | {type: SignableMessageType.SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF; data: altair.ContributionAndProof}
   | {type: SignableMessageType.VALIDATOR_REGISTRATION; data: ValidatorRegistrationV1}
   | {type: SignableMessageType.EXECUTION_PAYLOAD_ENVELOPE; data: gloas.ExecutionPayloadEnvelope}
-  | {type: SignableMessageType.PAYLOAD_ATTESTATION; data: gloas.PayloadAttestationData};
+  | {type: SignableMessageType.PAYLOAD_ATTESTATION; data: gloas.PayloadAttestationData}
+  | {type: SignableMessageType.PROPOSER_PREFERENCES; data: gloas.ProposerPreferences};
 
 const requiresForkInfo: Record<SignableMessageType, boolean> = {
   [SignableMessageType.AGGREGATION_SLOT]: true,
@@ -102,6 +104,7 @@ const requiresForkInfo: Record<SignableMessageType, boolean> = {
   [SignableMessageType.VALIDATOR_REGISTRATION]: false,
   [SignableMessageType.EXECUTION_PAYLOAD_ENVELOPE]: true,
   [SignableMessageType.PAYLOAD_ATTESTATION]: true,
+  [SignableMessageType.PROPOSER_PREFERENCES]: true,
 };
 
 type Web3SignerSerializedRequest = {
@@ -279,6 +282,9 @@ function serializerSignableMessagePayload(config: BeaconConfig, payload: Signabl
 
     case SignableMessageType.PAYLOAD_ATTESTATION:
       return {payload_attestation: ssz.gloas.PayloadAttestationData.toJson(payload.data)};
+
+    case SignableMessageType.PROPOSER_PREFERENCES:
+      return {proposer_preferences: ssz.gloas.ProposerPreferences.toJson(payload.data)};
   }
 }
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -9,12 +9,14 @@ import {Metrics} from "./metrics.js";
 import {MetaDataRepository} from "./repositories/metaDataRepository.js";
 import {AttestationService} from "./services/attestation.js";
 import {BlockProposingService} from "./services/block.js";
+import {BlockDutiesService} from "./services/blockDuties.js";
 import {ChainHeaderTracker} from "./services/chainHeaderTracker.js";
 import {DoppelgangerService} from "./services/doppelgangerService.js";
 import {ValidatorEventEmitter} from "./services/emitter.js";
 import {ExternalSignerOptions, pollExternalSignerPubkeys} from "./services/externalSignerSync.js";
 import {IndicesService} from "./services/indices.js";
 import {pollBuilderValidatorRegistration, pollPrepareBeaconProposer} from "./services/prepareBeaconProposer.js";
+import {ProposerPreferencesService} from "./services/proposerPreferences.js";
 import {PtcService} from "./services/ptc.js";
 import {SyncCommitteeService} from "./services/syncCommittee.js";
 import {SyncingStatusTracker} from "./services/syncingStatusTracker.js";
@@ -233,10 +235,21 @@ export class Validator {
     const chainHeaderTracker = new ChainHeaderTracker(config, logger, api, emitter);
     const syncingStatusTracker = new SyncingStatusTracker(logger, api, clock, metrics);
 
-    const blockProposingService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, metrics, {
-      broadcastValidation: opts.broadcastValidation ?? defaultOptions.broadcastValidation,
-      blindedLocal: opts.blindedLocal ?? defaultOptions.blindedLocal,
-    });
+    const blockDutiesService = new BlockDutiesService(config, loggerVc, api, clock, validatorStore, metrics);
+
+    const blockProposingService = new BlockProposingService(
+      config,
+      loggerVc,
+      api,
+      clock,
+      validatorStore,
+      blockDutiesService,
+      metrics,
+      {
+        broadcastValidation: opts.broadcastValidation ?? defaultOptions.broadcastValidation,
+        blindedLocal: opts.blindedLocal ?? defaultOptions.blindedLocal,
+      }
+    );
 
     const attestationService = new AttestationService(
       loggerVc,
@@ -281,6 +294,8 @@ export class Validator {
         distributedAggregationSelection: opts.distributed,
       }
     );
+
+    new ProposerPreferencesService(config, loggerVc, api, clock, validatorStore, blockDutiesService, metrics);
 
     return new Validator({
       opts,

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -8,6 +8,7 @@ import {ForkName} from "@lodestar/params";
 import {ProducedBlockSource, ssz} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {BlockProposingService} from "../../../src/services/block.js";
+import {BlockDutiesService} from "../../../src/services/blockDuties.js";
 import {ValidatorStore} from "../../../src/services/validatorStore.js";
 import {getApiClientStub, mockApiResponse} from "../../utils/apiStub.js";
 import {ClockMock} from "../../utils/clock.js";
@@ -54,7 +55,8 @@ describe("BlockDutiesService", () => {
     );
 
     const clock = new ClockMock();
-    const blockService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, null, {
+    const dutiesService = new BlockDutiesService(config, loggerVc, api, clock, validatorStore, null);
+    const blockService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, dutiesService, null, {
       broadcastValidation: routes.beacon.BroadcastValidation.consensus,
       blindedLocal: false,
     });
@@ -127,7 +129,8 @@ describe("BlockDutiesService", () => {
     );
 
     const clock = new ClockMock();
-    const blockService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, null, {
+    const dutiesService = new BlockDutiesService(config, loggerVc, api, clock, validatorStore, null);
+    const blockService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, dutiesService, null, {
       broadcastValidation: routes.beacon.BroadcastValidation.consensus,
       blindedLocal: true,
     });

--- a/packages/validator/test/unit/services/blockDuties.test.ts
+++ b/packages/validator/test/unit/services/blockDuties.test.ts
@@ -44,15 +44,8 @@ describe("BlockDutiesService", () => {
     const notifyBlockProductionFn = vi.fn(); // Returns void
 
     const clock = new ClockMock();
-    const dutiesService = new BlockDutiesService(
-      config,
-      loggerVc,
-      api,
-      clock,
-      validatorStore,
-      null,
-      notifyBlockProductionFn
-    );
+    const dutiesService = new BlockDutiesService(config, loggerVc, api, clock, validatorStore, null);
+    dutiesService.setNotifyBlockProductionFn(notifyBlockProductionFn);
 
     // Trigger clock onSlot for slot 0
     await clock.tickSlotFns(0, controller.signal);
@@ -75,15 +68,8 @@ describe("BlockDutiesService", () => {
 
     // Clock will call runAttesterDutiesTasks() immediately
     const clock = new ClockMock();
-    const dutiesService = new BlockDutiesService(
-      config,
-      loggerVc,
-      api,
-      clock,
-      validatorStore,
-      null,
-      notifyBlockProductionFn
-    );
+    const dutiesService = new BlockDutiesService(config, loggerVc, api, clock, validatorStore, null);
+    dutiesService.setNotifyBlockProductionFn(notifyBlockProductionFn);
 
     // Trigger clock onSlot for slot 0
     api.validator.getProposerDuties.mockResolvedValue(
@@ -128,15 +114,8 @@ describe("BlockDutiesService", () => {
     const notifyBlockProductionFn = vi.fn(); // Returns void
 
     const clock = new ClockMock();
-    const dutiesService = new BlockDutiesService(
-      config,
-      loggerVc,
-      api,
-      clock,
-      validatorStore,
-      null,
-      notifyBlockProductionFn
-    );
+    const dutiesService = new BlockDutiesService(config, loggerVc, api, clock, validatorStore, null);
+    dutiesService.setNotifyBlockProductionFn(notifyBlockProductionFn);
 
     // Trigger clock onSlot for slot 0
     await clock.tickSlotFns(0, controller.signal);


### PR DESCRIPTION
**Motivation**

- gloas

**Description**

- Add proposer preferences API endpoints https://github.com/ethereum/beacon-APIs/pull/593
- Add proposer preferences pool
- Use proposer preference during execution bid gossip validation
- Add proposer preference validator service (publish `SLOTS_PER_EPOCH / 4` slots before proposal)

**AI Assistance Disclosure**

- claude assistance