### PR TITLE
fix: include ethrex EX client code and restore CL commit suffix in gloas graffiti

### DIFF
--- a/packages/api/src/beacon/routes/node.ts
+++ b/packages/api/src/beacon/routes/node.ts
@@ -108,6 +108,7 @@ export enum ClientCode {
   BU = "BU", // besu
   EJ = "EJ", // ethereumJS
   EG = "EG", // erigon
+  EX = "EX", // ethrex
   GE = "GE", // go-ethereum
   GR = "GR", // grandine
   LH = "LH", // lighthouse

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -925,7 +925,7 @@ export function getValidatorApi(
       metrics?.blockProductionRequests.inc({source});
 
       const graffitiBytes = toGraffitiBytes(
-        graffiti ?? getDefaultGraffiti(getLodestarClientVersion(), chain.executionEngine.clientVersion, {})
+        graffiti ?? getDefaultGraffiti(getLodestarClientVersion(opts), chain.executionEngine.clientVersion, opts)
       );
       const commonBlockBodyPromise = chain.produceCommonBlockBody({
         slot,


### PR DESCRIPTION
## Summary

Fixes two issues with auto-graffiti for blocks proposed by Lodestar:

1. **Ethrex EL code mapped to `XX`.** `ClientCode` is missing an `EX` entry, so `engine_getClientVersionV1` responses from Ethrex (`code: "EX"`) fall through to `ClientCode.XX` in `http.ts:getClientVersion`. Result on chain: `XX2123LS...` instead of `EX2123LS...`. Adds `EX = "EX", // ethrex`.

2. **CL commit suffix dropped in `produceBlockV4` (Gloas).** The pre-Gloas path (`produceBlockV3`) calls `getLodestarClientVersion(opts)` so `commit` is populated; the Gloas path calls `getLodestarClientVersion()` with no argument, leaving `commit` as `""`. `getDefaultGraffiti` then produces 8-byte `<EL><EL_commit><LS>` instead of the intended 12-byte `<EL><EL_commit><LS><LS_commit>`. Result on chain: `NMd654LS` / `XX2123LS` for every post-Gloas Lodestar block, regardless of EL pair. Aligns the Gloas call site with the pre-Gloas one by passing the in-scope `opts: ApiOptions`.

Observed on a glamsterdam-devnet-4 kurtosis enclave (Lodestar v1.42.0 \`a07e25c\`, \`gloas_fork_epoch=1\`, \`preset=minimal\`). Pre-Gloas first block from a Lodestar+Ethrex pair: graffiti \`XX2123LSa07e\`. All later post-Gloas slots from the same proposer: \`XX2123LS\`. Nethermind+Lodestar pairs show the same truncation: \`NMd654LS\`.

## Test plan
- [x] Existing \`graffiti.test.ts\` and \`metadata.test.ts\` still pass (no behavior change in those units)
- [ ] Manual: rebuild + re-run kurtosis enclave with Ethrex+Lodestar, confirm graffiti is \`EX<el_commit>LS<ls_commit>\` (12 bytes) for post-Gloas slots