### PR TITLE
feat: ssz engine API transport

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -692,6 +692,9 @@ export async function prepareExecutionPayload(
       parentBlockHash,
       feeRecipient: suggestedFeeRecipient,
     });
+    if (ForkSeq[fork] >= ForkSeq.gloas) {
+      attributes.targetGasLimit = getTargetGasLimit(chain, state, state.slot, parentBlockRoot, parentBlockHash);
+    }
 
     payloadId = await chain.executionEngine.notifyForkchoiceUpdate(
       fork,
@@ -793,6 +796,43 @@ export function getPayloadAttributesForSSE(
     payloadAttributes,
   };
   return ssePayloadAttributes;
+}
+
+function getTargetGasLimit(
+  chain: {
+    forkChoice: IForkChoice;
+    proposerPreferencesPool: {
+      get(slot: Slot, dependentRootHex: RootHex): gloas.SignedProposerPreferences | null;
+    };
+  },
+  prepareState: IBeaconStateViewBellatrix,
+  prepareSlot: Slot,
+  parentBlockRoot: Root,
+  parentBlockHash: Bytes32
+): number {
+  const fallback = isStatePostGloas(prepareState)
+    ? Number(prepareState.latestExecutionPayloadBid.gasLimit)
+    : prepareState.latestExecutionPayloadHeader.gasLimit;
+  const parentBlockRootHex = toRootHex(parentBlockRoot);
+  const parentBlock =
+    chain.forkChoice.getBlockHexAndBlockHash(parentBlockRootHex, toRootHex(parentBlockHash)) ??
+    chain.forkChoice.getBlockHexDefaultStatus(parentBlockRootHex);
+
+  if (parentBlock === null) {
+    return fallback;
+  }
+
+  try {
+    const dependentRootHex = getShufflingDependentRoot(
+      chain.forkChoice,
+      computeEpochAtSlot(prepareSlot),
+      computeEpochAtSlot(parentBlock.slot),
+      parentBlock
+    );
+    return chain.proposerPreferencesPool.get(prepareSlot, dependentRootHex)?.message.targetGasLimit ?? fallback;
+  } catch {
+    return fallback;
+  }
 }
 
 function preparePayloadAttributes(

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -95,6 +95,16 @@ export type ExecutionEngineHttpOpts = {
    * Lodestar commit to be used for `ClientVersion`
    */
   commit?: string;
+  /**
+   * EIP-8161 / ethereum/execution-apis#764: opt-in to the binary SSZ-REST
+   * Engine API transport.
+   *
+   * When enabled, the CL probes each Engine call against the SSZ-REST
+   * endpoints first and falls back to JSON-RPC on network errors. Off by
+   * default until the spec stabilises and ELs we test against advertise
+   * support consistently.
+   */
+  sszRest?: boolean;
 };
 
 export const defaultExecutionEngineHttpOpts: ExecutionEngineHttpOpts = {
@@ -189,19 +199,21 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     this.logger = logger;
     this.metrics = metrics ?? null;
 
-    // EIP-8161: Initialize SSZ-REST client using the same Engine API URL.
+    // EIP-8161: Initialize SSZ-REST client only when the flag is set.
     // SSZ-REST routes are served on the same port under /engine/* paths.
-    {
-      const engineUrl = opts?.urls?.[0] ?? "http://localhost:8551";
+    if (opts?.sszRest) {
+      const engineUrl = opts.urls?.[0] ?? "http://localhost:8551";
       const baseUrl = engineUrl.replace(/\/+$/, "");
       this.sszRestClient = new SszRestClient({
         baseUrl,
-        jwtSecretHex: opts?.jwtSecretHex,
-        jwtId: opts?.jwtId,
-        jwtVersion: opts?.jwtVersion,
-        timeout: opts?.timeout,
+        jwtSecretHex: opts.jwtSecretHex,
+        jwtId: opts.jwtId,
+        jwtVersion: opts.jwtVersion,
+        timeout: opts.timeout,
       });
       this.logger.info("SSZ-REST Engine API transport enabled (EIP-8161)", {url: baseUrl});
+    } else {
+      this.sszRestClient = null;
     }
 
     this.rpc.emitter.on(JsonRpcHttpClientEvent.ERROR, ({error}) => {

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -203,7 +203,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     // SSZ-REST routes are served on the same port under /engine/* paths.
     if (opts?.sszRest) {
       const engineUrl = opts.urls?.[0] ?? "http://localhost:8551";
-      const baseUrl = engineUrl.replace(/\/+$/, "");
+      const baseUrl = stripTrailingSlashes(engineUrl);
       this.sszRestClient = new SszRestClient({
         baseUrl,
         jwtSecretHex: opts.jwtSecretHex,
@@ -828,6 +828,14 @@ export class ExecutionEngineHttp implements IExecutionEngine {
 
     this.state = newState;
   }
+}
+
+// Linear-time trailing-slash strip. Avoids /\/+$/ which CodeQL flags as a
+// polynomial-backtracking regex (js/polynomial-redos).
+function stripTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 0x2f /* '/' */) end--;
+  return end === s.length ? s : s.slice(0, end);
 }
 
 type EngineRequestKey = keyof EngineApiRpcParamTypes;

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -1,6 +1,6 @@
 import {Logger} from "@lodestar/logger";
 import {ForkName, ForkPostFulu, ForkPreFulu, ForkSeq, SLOTS_PER_EPOCH, isForkPostFulu} from "@lodestar/params";
-import {BlobsBundle, ExecutionPayload, ExecutionRequests, Root, RootHex, Wei, ssz as sszCodecs} from "@lodestar/types";
+import {BlobsBundle, ExecutionPayload, ExecutionRequests, Root, RootHex, Wei} from "@lodestar/types";
 import {BlobAndProof} from "@lodestar/types/deneb";
 import {BlobAndProofV2} from "@lodestar/types/fulu";
 import {fromHex, strip0xPrefix} from "@lodestar/utils";
@@ -30,13 +30,17 @@ import {PayloadIdCache} from "./payloadIdCache.js";
 import {SszRestClient, isSszRestNetworkError} from "./sszRestClient.js";
 import {
   decodeForkchoiceUpdatedResponse,
-  decodeGetBlobsResponse,
+  decodeGetBlobsV1Response,
+  decodeGetBlobsV2Response,
   decodeGetPayloadResponse,
   decodePayloadStatus,
   encodeForkchoiceUpdatedRequest,
   encodeGetBlobsRequest,
-  encodeGetPayloadRequest,
   encodeNewPayloadRequest,
+  forkchoiceUpdatedVersion,
+  getBlobsVersion,
+  getPayloadVersion,
+  newPayloadVersion,
 } from "./sszRestEncoding.js";
 import {
   BLOB_AND_PROOF_V2_RPC_BYTES,
@@ -248,25 +252,26 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     // EIP-8161: Try SSZ-REST first, fall back to JSON-RPC on network errors
     if (this.sszRestClient) {
       try {
-        const version =
-          ForkSeq[fork] >= ForkSeq.fulu ? 5 : ForkSeq[fork] >= ForkSeq.electra ? 4 : ForkSeq[fork] >= ForkSeq.deneb ? 3 : ForkSeq[fork] >= ForkSeq.capella ? 2 : 1;
-        const path = `/engine/v${version}/payloads`;
-        const body = encodeNewPayloadRequest(fork, executionPayload, versionedHashes, parentBlockRoot, executionRequests);
+        const path = `/engine/v${newPayloadVersion(fork)}/payloads`;
+        const body = encodeNewPayloadRequest(
+          fork,
+          executionPayload,
+          versionedHashes,
+          parentBlockRoot,
+          executionRequests
+        );
         const resp = await this.sszRestClient.doRequest(path, body);
-        const decoded = decodePayloadStatus(resp);
-        const status = decoded.status as ExecutionPayloadStatus;
+        const {status, latestValidHash, validationError} = decodePayloadStatus(resp);
         this.updateEngineState(getExecutionEngineState({payloadStatus: status, oldState: this.state}));
 
         switch (status) {
           case ExecutionPayloadStatus.VALID:
-            return {status, latestValidHash: decoded.latestValidHash ?? "0x0", validationError: null};
+            return {status, latestValidHash: latestValidHash ?? "0x0", validationError: null};
           case ExecutionPayloadStatus.INVALID:
-            return {status, latestValidHash: decoded.latestValidHash, validationError: decoded.validationError};
+            return {status, latestValidHash, validationError};
           case ExecutionPayloadStatus.SYNCING:
           case ExecutionPayloadStatus.ACCEPTED:
             return {status, latestValidHash: null, validationError: null};
-          case ExecutionPayloadStatus.INVALID_BLOCK_HASH:
-            return {status, latestValidHash: null, validationError: decoded.validationError ?? "Malformed block"};
           default:
             return {
               status: ExecutionPayloadStatus.ELERROR,
@@ -418,15 +423,17 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     // EIP-8161: Try SSZ-REST first, fall back to JSON-RPC on network errors
     if (this.sszRestClient) {
       try {
-        const version = ForkSeq[fork] >= ForkSeq.deneb ? 3 : ForkSeq[fork] >= ForkSeq.capella ? 2 : 1;
-        const path = `/engine/v${version}/forkchoice`;
-        const headBytes = fromHex(headBlockHash);
-        const safeBytes = fromHex(safeBlockHash);
-        const finalizedBytes = fromHex(finalizedBlockHash);
-        const body = encodeForkchoiceUpdatedRequest(headBytes, safeBytes, finalizedBytes, payloadAttributes);
+        const path = `/engine/v${forkchoiceUpdatedVersion(fork)}/forkchoice`;
+        const body = encodeForkchoiceUpdatedRequest(
+          fork,
+          fromHex(headBlockHash),
+          fromHex(safeBlockHash),
+          fromHex(finalizedBlockHash),
+          payloadAttributes
+        );
         const resp = await this.sszRestClient.doRequest(path, body);
         const decoded = decodeForkchoiceUpdatedResponse(resp);
-        const status = decoded.payloadStatus.status as ExecutionPayloadStatus;
+        const {status, validationError} = decoded.payloadStatus;
 
         this.updateEngineState(getExecutionEngineState({payloadStatus: status, oldState: this.state}));
         this.metrics?.engineNotifyForkchoiceUpdateResult.inc({result: status});
@@ -436,13 +443,13 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         switch (status) {
           case ExecutionPayloadStatus.VALID:
             if (payloadAttributesRpc) {
-              if (!decoded.payloadId || decoded.payloadId === "0x") {
-                throw Error(`Received invalid payloadId=${decoded.payloadId}`);
+              if (decoded.payloadId === null) {
+                throw Error("Received null payloadId when payload attributes were provided");
               }
               this.payloadIdCache.add({headBlockHash, finalizedBlockHash, ...payloadAttributesRpc}, decoded.payloadId);
               void this.prunePayloadIdCache();
             }
-            return decoded.payloadId !== "0x" ? decoded.payloadId : null;
+            return decoded.payloadId;
 
           case ExecutionPayloadStatus.SYNCING:
             if (payloadAttributes) {
@@ -453,7 +460,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
           case ExecutionPayloadStatus.INVALID:
             throw Error(
               `Invalid ${payloadAttributes ? "prepare payload" : "forkchoice request"}, validationError=${
-                decoded.payloadStatus.validationError ?? ""
+                validationError ?? ""
               }`
             );
 
@@ -462,7 +469,9 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         }
       } catch (e) {
         if (isSszRestNetworkError(e)) {
-          this.logger.debug("SSZ-REST forkchoiceUpdate failed, falling back to JSON-RPC", {error: (e as Error).message});
+          this.logger.debug("SSZ-REST forkchoiceUpdate failed, falling back to JSON-RPC", {
+            error: (e as Error).message,
+          });
         } else {
           throw e;
         }
@@ -551,28 +560,14 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     // EIP-8161: Try SSZ-REST first, fall back to JSON-RPC on network errors
     if (this.sszRestClient) {
       try {
-        const version =
-          ForkSeq[fork] >= ForkSeq.fulu ? 5 : ForkSeq[fork] >= ForkSeq.electra ? 4 : ForkSeq[fork] >= ForkSeq.deneb ? 3 : ForkSeq[fork] >= ForkSeq.capella ? 2 : 1;
-        const path = `/engine/v${version}/payloads/${payloadId}`;
+        const path = `/engine/v${getPayloadVersion(fork)}/payloads/${payloadId}`;
         const resp = await this.sszRestClient.doGetRequest(path);
-        const decoded = decodeGetPayloadResponse(resp);
-
-        // The executionPayloadSsz needs to be parsed back through the JSON-RPC parseExecutionPayload path
-        // For now, we return the raw SSZ and let the caller handle it.
-        // Actually, we can deserialize the SSZ payload using @lodestar/types
-        const executionPayload = deserializeExecutionPayloadSsz(fork, decoded.executionPayloadSsz);
-        const executionPayloadValue = decoded.blockValue;
-        const blobsBundle =
-          decoded.blobsBundleSsz.length > 0 ? deserializeBlobsBundleSsz(decoded.blobsBundleSsz) : undefined;
-        const executionRequests =
-          decoded.executionRequestsSsz.length > 0
-            ? deserializeExecutionRequestsSsz(decoded.executionRequestsSsz)
-            : undefined;
+        const decoded = decodeGetPayloadResponse(fork, resp);
         return {
-          executionPayload,
-          executionPayloadValue,
-          blobsBundle,
-          executionRequests,
+          executionPayload: decoded.executionPayload,
+          executionPayloadValue: decoded.blockValue,
+          blobsBundle: decoded.blobsBundle,
+          executionRequests: decoded.executionRequests,
           shouldOverrideBuilder: decoded.shouldOverrideBuilder,
         };
       } catch (e) {
@@ -669,15 +664,22 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     // EIP-8161: Try SSZ-REST first for getBlobs, fall back to JSON-RPC on network errors
     if (this.sszRestClient) {
       try {
-        const version = isForkPostFulu(fork) ? 2 : 1;
+        const version = getBlobsVersion(fork);
         const path = `/engine/v${version}/blobs`;
         const body = encodeGetBlobsRequest(versionedHashes);
         const resp = await this.sszRestClient.doRequest(path, body);
-        const decoded = decodeGetBlobsResponse(resp);
-        return decoded.map((item) => ({
-          blob: item.blob,
-          proof: item.kzgProof,
-        }));
+        // HTTP 204 (syncing, or any missing blob in v2) maps to null per spec.
+        if (resp.length === 0) {
+          return null;
+        }
+        if (version === 1) {
+          // Spec v1 returns only the blobs that were found (potentially shorter
+          // than the request). Pad with nulls so the result aligns with the
+          // request indices, matching the JSON-RPC v1 contract.
+          const found = decodeGetBlobsV1Response(resp);
+          return versionedHashes.map((_, i) => found[i] ?? null);
+        }
+        return decodeGetBlobsV2Response(resp);
       } catch (e) {
         if (isSszRestNetworkError(e)) {
           this.logger.debug("SSZ-REST getBlobs failed, falling back to JSON-RPC", {error: (e as Error).message});
@@ -814,32 +816,6 @@ export class ExecutionEngineHttp implements IExecutionEngine {
 
     this.state = newState;
   }
-}
-
-/**
- * Deserialize an ExecutionPayload from SSZ bytes using the appropriate
- * @lodestar/types codec for the given fork. Used by the SSZ-REST getPayload path.
- */
-function deserializeExecutionPayloadSsz(fork: ForkName, data: Uint8Array): ExecutionPayload {
-  const forkSeq = ForkSeq[fork];
-  if (forkSeq >= ForkSeq.electra) {
-    return sszCodecs.electra.ExecutionPayload.deserialize(data);
-  }
-  if (forkSeq >= ForkSeq.deneb) {
-    return sszCodecs.deneb.ExecutionPayload.deserialize(data);
-  }
-  if (forkSeq >= ForkSeq.capella) {
-    return sszCodecs.capella.ExecutionPayload.deserialize(data);
-  }
-  return sszCodecs.bellatrix.ExecutionPayload.deserialize(data);
-}
-
-function deserializeBlobsBundleSsz(data: Uint8Array): BlobsBundle {
-  return sszCodecs.deneb.BlobsBundle.deserialize(data);
-}
-
-function deserializeExecutionRequestsSsz(data: Uint8Array): ExecutionRequests {
-  return sszCodecs.electra.ExecutionRequests.deserialize(data);
 }
 
 type EngineRequestKey = keyof EngineApiRpcParamTypes;

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -32,11 +32,13 @@ import {
   decodeForkchoiceUpdatedResponse,
   decodeGetBlobsV1Response,
   decodeGetBlobsV2Response,
+  decodeGetClientVersionResponse,
   decodeGetPayloadResponse,
   decodePayloadBodiesV1Response,
   decodePayloadStatus,
   encodeForkchoiceUpdatedRequest,
   encodeGetBlobsRequest,
+  encodeGetClientVersionRequest,
   encodeGetPayloadBodiesByHashRequest,
   encodeGetPayloadBodiesByRangeRequest,
   encodeNewPayloadRequest,
@@ -166,6 +168,7 @@ const supportedSszRestEndpoints = [
   "POST /engine/v3/forkchoice",
   "POST /engine/v4/forkchoice",
   "POST /engine/v2/blobs",
+  "POST /engine/v1/client/version",
 ];
 
 /**
@@ -892,17 +895,12 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   }
 
   private async getClientVersion(clientVersion: ClientVersion): Promise<ClientVersion[]> {
-    const method = "engine_getClientVersionV1";
-
-    const response = await this.rpc.fetchWithRetries<
-      EngineApiRpcReturnTypes[typeof method],
-      EngineApiRpcParamTypes[typeof method]
-    >({method, params: [{...clientVersion, commit: `0x${clientVersion.commit}`}]}, getClientVersionOpts);
-
-    const clientVersions = response.map((cv) => {
-      const code = cv.code in ClientCode ? ClientCode[cv.code as keyof typeof ClientCode] : ClientCode.XX;
-      return {code, name: cv.name, version: cv.version, commit: strip0xPrefix(cv.commit)};
-    });
+    const clientVersions = (await this.fetchClientVersions(clientVersion)).map((cv) => ({
+      code: cv.code in ClientCode ? ClientCode[cv.code as keyof typeof ClientCode] : ClientCode.XX,
+      name: cv.name,
+      version: cv.version,
+      commit: strip0xPrefix(cv.commit),
+    }));
 
     if (clientVersions.length === 0) {
       throw Error("Received empty client versions array");
@@ -912,6 +910,38 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     this.logger.debug("Execution client version updated", this.clientVersion);
 
     return clientVersions;
+  }
+
+  private async fetchClientVersions(
+    clientVersion: ClientVersion
+  ): Promise<{code: string; name: string; version: string; commit: string}[]> {
+    if (this.sszRestClient) {
+      const path = "/engine/v1/client/version";
+      const endpoint = `POST ${path}`;
+      if (!(await this.supportsSszRestEndpoint(endpoint))) {
+        this.logger.debug("SSZ-REST getClientVersion endpoint not advertised, using JSON-RPC", {endpoint});
+      } else {
+        try {
+          const body = encodeGetClientVersionRequest(clientVersion);
+          const resp = await this.sszRestClient.doRequest(path, body);
+          return decodeGetClientVersionResponse(resp);
+        } catch (e) {
+          if (isSszRestNetworkError(e)) {
+            this.logger.debug("SSZ-REST getClientVersion failed, falling back to JSON-RPC", {
+              error: (e as Error).message,
+            });
+          } else {
+            throw e;
+          }
+        }
+      }
+    }
+
+    const method = "engine_getClientVersionV1";
+    return this.rpc.fetchWithRetries<EngineApiRpcReturnTypes[typeof method], EngineApiRpcParamTypes[typeof method]>(
+      {method, params: [{...clientVersion, commit: `0x${clientVersion.commit}`}]},
+      getClientVersionOpts
+    );
   }
 
   private updateEngineState(newState: ExecutionEngineState): void {

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -1,9 +1,9 @@
 import {Logger} from "@lodestar/logger";
 import {ForkName, ForkPostFulu, ForkPreFulu, ForkSeq, SLOTS_PER_EPOCH, isForkPostFulu} from "@lodestar/params";
-import {BlobsBundle, ExecutionPayload, ExecutionRequests, Root, RootHex, Wei} from "@lodestar/types";
+import {BlobsBundle, ExecutionPayload, ExecutionRequests, Root, RootHex, Wei, ssz as sszCodecs} from "@lodestar/types";
 import {BlobAndProof} from "@lodestar/types/deneb";
 import {BlobAndProofV2} from "@lodestar/types/fulu";
-import {strip0xPrefix} from "@lodestar/utils";
+import {fromHex, strip0xPrefix} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
 import {EPOCHS_PER_BATCH} from "../../sync/constants.js";
 import {getLodestarClientVersion} from "../../util/metadata.js";
@@ -27,6 +27,17 @@ import {
   ReqOpts,
 } from "./jsonRpcHttpClient.js";
 import {PayloadIdCache} from "./payloadIdCache.js";
+import {SszRestClient, isSszRestNetworkError} from "./sszRestClient.js";
+import {
+  decodeForkchoiceUpdatedResponse,
+  decodeGetBlobsResponse,
+  decodeGetPayloadResponse,
+  decodePayloadStatus,
+  encodeForkchoiceUpdatedRequest,
+  encodeGetBlobsRequest,
+  encodeGetPayloadRequest,
+  encodeNewPayloadRequest,
+} from "./sszRestEncoding.js";
 import {
   BLOB_AND_PROOF_V2_RPC_BYTES,
   EngineApiRpcParamTypes,
@@ -139,6 +150,10 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   clientVersion?: ClientVersion | null;
 
   readonly payloadIdCache = new PayloadIdCache();
+
+  /** EIP-8161: SSZ-REST client, null if not configured */
+  private readonly sszRestClient: SszRestClient | null;
+
   /**
    * A queue to serialize the fcUs and newPayloads calls:
    *
@@ -169,6 +184,21 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     );
     this.logger = logger;
     this.metrics = metrics ?? null;
+
+    // EIP-8161: Initialize SSZ-REST client using the same Engine API URL.
+    // SSZ-REST routes are served on the same port under /engine/* paths.
+    {
+      const engineUrl = opts?.urls?.[0] ?? "http://localhost:8551";
+      const baseUrl = engineUrl.replace(/\/+$/, "");
+      this.sszRestClient = new SszRestClient({
+        baseUrl,
+        jwtSecretHex: opts?.jwtSecretHex,
+        jwtId: opts?.jwtId,
+        jwtVersion: opts?.jwtVersion,
+        timeout: opts?.timeout,
+      });
+      this.logger.info("SSZ-REST Engine API transport enabled (EIP-8161)", {url: baseUrl});
+    }
 
     this.rpc.emitter.on(JsonRpcHttpClientEvent.ERROR, ({error}) => {
       this.updateEngineState(getExecutionEngineState({payloadError: error, oldState: this.state}));
@@ -215,6 +245,44 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     parentBlockRoot?: Root,
     executionRequests?: ExecutionRequests
   ): Promise<ExecutePayloadResponse> {
+    // EIP-8161: Try SSZ-REST first, fall back to JSON-RPC on network errors
+    if (this.sszRestClient) {
+      try {
+        const version =
+          ForkSeq[fork] >= ForkSeq.fulu ? 5 : ForkSeq[fork] >= ForkSeq.electra ? 4 : ForkSeq[fork] >= ForkSeq.deneb ? 3 : ForkSeq[fork] >= ForkSeq.capella ? 2 : 1;
+        const path = `/engine/v${version}/payloads`;
+        const body = encodeNewPayloadRequest(fork, executionPayload, versionedHashes, parentBlockRoot, executionRequests);
+        const resp = await this.sszRestClient.doRequest(path, body);
+        const decoded = decodePayloadStatus(resp);
+        const status = decoded.status as ExecutionPayloadStatus;
+        this.updateEngineState(getExecutionEngineState({payloadStatus: status, oldState: this.state}));
+
+        switch (status) {
+          case ExecutionPayloadStatus.VALID:
+            return {status, latestValidHash: decoded.latestValidHash ?? "0x0", validationError: null};
+          case ExecutionPayloadStatus.INVALID:
+            return {status, latestValidHash: decoded.latestValidHash, validationError: decoded.validationError};
+          case ExecutionPayloadStatus.SYNCING:
+          case ExecutionPayloadStatus.ACCEPTED:
+            return {status, latestValidHash: null, validationError: null};
+          case ExecutionPayloadStatus.INVALID_BLOCK_HASH:
+            return {status, latestValidHash: null, validationError: decoded.validationError ?? "Malformed block"};
+          default:
+            return {
+              status: ExecutionPayloadStatus.ELERROR,
+              latestValidHash: null,
+              validationError: `Invalid EL status on executePayload: ${status}`,
+            };
+        }
+      } catch (e) {
+        if (isSszRestNetworkError(e)) {
+          this.logger.debug("SSZ-REST newPayload failed, falling back to JSON-RPC", {error: (e as Error).message});
+        } else {
+          throw e;
+        }
+      }
+    }
+
     const method =
       ForkSeq[fork] >= ForkSeq.gloas
         ? "engine_newPayloadV5"
@@ -347,6 +415,60 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     finalizedBlockHash: RootHex,
     payloadAttributes?: PayloadAttributes
   ): Promise<PayloadId | null> {
+    // EIP-8161: Try SSZ-REST first, fall back to JSON-RPC on network errors
+    if (this.sszRestClient) {
+      try {
+        const version = ForkSeq[fork] >= ForkSeq.deneb ? 3 : ForkSeq[fork] >= ForkSeq.capella ? 2 : 1;
+        const path = `/engine/v${version}/forkchoice`;
+        const headBytes = fromHex(headBlockHash);
+        const safeBytes = fromHex(safeBlockHash);
+        const finalizedBytes = fromHex(finalizedBlockHash);
+        const body = encodeForkchoiceUpdatedRequest(headBytes, safeBytes, finalizedBytes, payloadAttributes);
+        const resp = await this.sszRestClient.doRequest(path, body);
+        const decoded = decodeForkchoiceUpdatedResponse(resp);
+        const status = decoded.payloadStatus.status as ExecutionPayloadStatus;
+
+        this.updateEngineState(getExecutionEngineState({payloadStatus: status, oldState: this.state}));
+        this.metrics?.engineNotifyForkchoiceUpdateResult.inc({result: status});
+
+        const payloadAttributesRpc = payloadAttributes ? serializePayloadAttributes(payloadAttributes) : undefined;
+
+        switch (status) {
+          case ExecutionPayloadStatus.VALID:
+            if (payloadAttributesRpc) {
+              if (!decoded.payloadId || decoded.payloadId === "0x") {
+                throw Error(`Received invalid payloadId=${decoded.payloadId}`);
+              }
+              this.payloadIdCache.add({headBlockHash, finalizedBlockHash, ...payloadAttributesRpc}, decoded.payloadId);
+              void this.prunePayloadIdCache();
+            }
+            return decoded.payloadId !== "0x" ? decoded.payloadId : null;
+
+          case ExecutionPayloadStatus.SYNCING:
+            if (payloadAttributes) {
+              throw Error("Execution Layer Syncing");
+            }
+            return null;
+
+          case ExecutionPayloadStatus.INVALID:
+            throw Error(
+              `Invalid ${payloadAttributes ? "prepare payload" : "forkchoice request"}, validationError=${
+                decoded.payloadStatus.validationError ?? ""
+              }`
+            );
+
+          default:
+            throw Error(`Unknown status ${status}`);
+        }
+      } catch (e) {
+        if (isSszRestNetworkError(e)) {
+          this.logger.debug("SSZ-REST forkchoiceUpdate failed, falling back to JSON-RPC", {error: (e as Error).message});
+        } else {
+          throw e;
+        }
+      }
+    }
+
     // Once on capella, should this need to be permanently switched to v2 when payload attrs
     // not provided
     const method =
@@ -426,6 +548,42 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     executionRequests?: ExecutionRequests;
     shouldOverrideBuilder?: boolean;
   }> {
+    // EIP-8161: Try SSZ-REST first, fall back to JSON-RPC on network errors
+    if (this.sszRestClient) {
+      try {
+        const version =
+          ForkSeq[fork] >= ForkSeq.fulu ? 5 : ForkSeq[fork] >= ForkSeq.electra ? 4 : ForkSeq[fork] >= ForkSeq.deneb ? 3 : ForkSeq[fork] >= ForkSeq.capella ? 2 : 1;
+        const path = `/engine/v${version}/payloads/${payloadId}`;
+        const resp = await this.sszRestClient.doGetRequest(path);
+        const decoded = decodeGetPayloadResponse(resp);
+
+        // The executionPayloadSsz needs to be parsed back through the JSON-RPC parseExecutionPayload path
+        // For now, we return the raw SSZ and let the caller handle it.
+        // Actually, we can deserialize the SSZ payload using @lodestar/types
+        const executionPayload = deserializeExecutionPayloadSsz(fork, decoded.executionPayloadSsz);
+        const executionPayloadValue = decoded.blockValue;
+        const blobsBundle =
+          decoded.blobsBundleSsz.length > 0 ? deserializeBlobsBundleSsz(decoded.blobsBundleSsz) : undefined;
+        const executionRequests =
+          decoded.executionRequestsSsz.length > 0
+            ? deserializeExecutionRequestsSsz(decoded.executionRequestsSsz)
+            : undefined;
+        return {
+          executionPayload,
+          executionPayloadValue,
+          blobsBundle,
+          executionRequests,
+          shouldOverrideBuilder: decoded.shouldOverrideBuilder,
+        };
+      } catch (e) {
+        if (isSszRestNetworkError(e)) {
+          this.logger.debug("SSZ-REST getPayload failed, falling back to JSON-RPC", {error: (e as Error).message});
+        } else {
+          throw e;
+        }
+      }
+    }
+
     let method: keyof EngineApiRpcReturnTypes;
     switch (fork) {
       case ForkName.phase0:
@@ -507,6 +665,28 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     versionedHashes: VersionedHashes
   ): Promise<BlobAndProofV2[] | (BlobAndProof | null)[] | null> {
     assertReqSizeLimit(versionedHashes.length, MAX_VERSIONED_HASHES);
+
+    // EIP-8161: Try SSZ-REST first for getBlobs, fall back to JSON-RPC on network errors
+    if (this.sszRestClient) {
+      try {
+        const version = isForkPostFulu(fork) ? 2 : 1;
+        const path = `/engine/v${version}/blobs`;
+        const body = encodeGetBlobsRequest(versionedHashes);
+        const resp = await this.sszRestClient.doRequest(path, body);
+        const decoded = decodeGetBlobsResponse(resp);
+        return decoded.map((item) => ({
+          blob: item.blob,
+          proof: item.kzgProof,
+        }));
+      } catch (e) {
+        if (isSszRestNetworkError(e)) {
+          this.logger.debug("SSZ-REST getBlobs failed, falling back to JSON-RPC", {error: (e as Error).message});
+        } else {
+          throw e;
+        }
+      }
+    }
+
     const versionedHashesHex = versionedHashes.map(bytesToData);
     if (isForkPostFulu(fork)) {
       return await this.getBlobsV2(versionedHashesHex);
@@ -634,6 +814,32 @@ export class ExecutionEngineHttp implements IExecutionEngine {
 
     this.state = newState;
   }
+}
+
+/**
+ * Deserialize an ExecutionPayload from SSZ bytes using the appropriate
+ * @lodestar/types codec for the given fork. Used by the SSZ-REST getPayload path.
+ */
+function deserializeExecutionPayloadSsz(fork: ForkName, data: Uint8Array): ExecutionPayload {
+  const forkSeq = ForkSeq[fork];
+  if (forkSeq >= ForkSeq.electra) {
+    return sszCodecs.electra.ExecutionPayload.deserialize(data);
+  }
+  if (forkSeq >= ForkSeq.deneb) {
+    return sszCodecs.deneb.ExecutionPayload.deserialize(data);
+  }
+  if (forkSeq >= ForkSeq.capella) {
+    return sszCodecs.capella.ExecutionPayload.deserialize(data);
+  }
+  return sszCodecs.bellatrix.ExecutionPayload.deserialize(data);
+}
+
+function deserializeBlobsBundleSsz(data: Uint8Array): BlobsBundle {
+  return sszCodecs.deneb.BlobsBundle.deserialize(data);
+}
+
+function deserializeExecutionRequestsSsz(data: Uint8Array): ExecutionRequests {
+  return sszCodecs.electra.ExecutionRequests.deserialize(data);
 }
 
 type EngineRequestKey = keyof EngineApiRpcParamTypes;

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -33,9 +33,12 @@ import {
   decodeGetBlobsV1Response,
   decodeGetBlobsV2Response,
   decodeGetPayloadResponse,
+  decodePayloadBodiesV1Response,
   decodePayloadStatus,
   encodeForkchoiceUpdatedRequest,
   encodeGetBlobsRequest,
+  encodeGetPayloadBodiesByHashRequest,
+  encodeGetPayloadBodiesByRangeRequest,
   encodeNewPayloadRequest,
   forkchoiceUpdatedVersion,
   getBlobsVersion,
@@ -156,6 +159,8 @@ const supportedSszRestEndpoints = [
   "GET /engine/v4/payloads/{payload_id}",
   "GET /engine/v5/payloads/{payload_id}",
   "GET /engine/v6/payloads/{payload_id}",
+  "POST /engine/v1/payloads/bodies/by-hash",
+  "POST /engine/v1/payloads/bodies/by-range",
   "POST /engine/v1/forkchoice",
   "POST /engine/v2/forkchoice",
   "POST /engine/v3/forkchoice",
@@ -691,8 +696,31 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   }
 
   async getPayloadBodiesByHash(_fork: ForkName, blockHashes: RootHex[]): Promise<(ExecutionPayloadBody | null)[]> {
-    const method = "engine_getPayloadBodiesByHashV1";
     assertReqSizeLimit(blockHashes.length, 32);
+
+    if (this.sszRestClient) {
+      const path = "/engine/v1/payloads/bodies/by-hash";
+      const endpoint = `POST ${path}`;
+      if (!(await this.supportsSszRestEndpoint(endpoint))) {
+        this.logger.debug("SSZ-REST getPayloadBodiesByHash endpoint not advertised, using JSON-RPC", {endpoint});
+      } else {
+        try {
+          const body = encodeGetPayloadBodiesByHashRequest(blockHashes.map((h) => fromHex(h)));
+          const resp = await this.sszRestClient.doRequest(path, body);
+          return decodePayloadBodiesV1Response(resp);
+        } catch (e) {
+          if (isSszRestNetworkError(e)) {
+            this.logger.debug("SSZ-REST getPayloadBodiesByHash failed, falling back to JSON-RPC", {
+              error: (e as Error).message,
+            });
+          } else {
+            throw e;
+          }
+        }
+      }
+    }
+
+    const method = "engine_getPayloadBodiesByHashV1";
     const response = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
@@ -705,8 +733,31 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     startBlockNumber: number,
     blockCount: number
   ): Promise<(ExecutionPayloadBody | null)[]> {
-    const method = "engine_getPayloadBodiesByRangeV1";
     assertReqSizeLimit(blockCount, 32);
+
+    if (this.sszRestClient) {
+      const path = "/engine/v1/payloads/bodies/by-range";
+      const endpoint = `POST ${path}`;
+      if (!(await this.supportsSszRestEndpoint(endpoint))) {
+        this.logger.debug("SSZ-REST getPayloadBodiesByRange endpoint not advertised, using JSON-RPC", {endpoint});
+      } else {
+        try {
+          const body = encodeGetPayloadBodiesByRangeRequest(startBlockNumber, blockCount);
+          const resp = await this.sszRestClient.doRequest(path, body);
+          return decodePayloadBodiesV1Response(resp);
+        } catch (e) {
+          if (isSszRestNetworkError(e)) {
+            this.logger.debug("SSZ-REST getPayloadBodiesByRange failed, falling back to JSON-RPC", {
+              error: (e as Error).message,
+            });
+          } else {
+            throw e;
+          }
+        }
+      }
+    }
+
+    const method = "engine_getPayloadBodiesByRangeV1";
     const start = numToQuantity(startBlockNumber);
     const count = numToQuantity(blockCount);
     const response = await this.rpc.fetchWithRetries<

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -160,7 +160,6 @@ const supportedSszRestEndpoints = [
   "POST /engine/v2/forkchoice",
   "POST /engine/v3/forkchoice",
   "POST /engine/v4/forkchoice",
-  "POST /engine/v1/blobs",
   "POST /engine/v2/blobs",
 ];
 

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -167,6 +167,7 @@ const supportedSszRestEndpoints = [
   "POST /engine/v2/forkchoice",
   "POST /engine/v3/forkchoice",
   "POST /engine/v4/forkchoice",
+  "POST /engine/v1/blobs",
   "POST /engine/v2/blobs",
   "POST /engine/v1/client/version",
 ];
@@ -802,9 +803,11 @@ export class ExecutionEngineHttp implements IExecutionEngine {
             return null;
           }
           if (version === 1) {
-            // Spec v1 returns only the blobs that were found (potentially shorter
-            // than the request). Pad with nulls so the result aligns with the
-            // request indices, matching the JSON-RPC v1 contract.
+            // Spec v1 returns a flat list of found blobs with no per-element
+            // nullability — potentially shorter than the request. Map missing
+            // slots to null to keep the result indexable by request position
+            // (matches the JSON-RPC v1 contract). This assumes ELs return
+            // results in request order with trailing missing entries.
             const found = decodeGetBlobsV1Response(resp);
             return versionedHashes.map((_, i) => found[i] ?? null);
           }

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -7,7 +7,7 @@ import {fromHex, strip0xPrefix} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
 import {EPOCHS_PER_BATCH} from "../../sync/constants.js";
 import {getLodestarClientVersion} from "../../util/metadata.js";
-import {JobItemQueue} from "../../util/queue/index.js";
+import {JobFnQueue} from "../../util/queue/index.js";
 import {
   ClientCode,
   ClientVersion,
@@ -99,10 +99,11 @@ export type ExecutionEngineHttpOpts = {
    * EIP-8161 / ethereum/execution-apis#764: opt-in to the binary SSZ-REST
    * Engine API transport.
    *
-   * When enabled, the CL probes each Engine call against the SSZ-REST
-   * endpoints first and falls back to JSON-RPC on network errors. Off by
-   * default until the spec stabilises and ELs we test against advertise
-   * support consistently.
+   * When enabled, the CL negotiates SSZ-REST endpoint support through
+   * engine_exchangeCapabilities, uses binary SSZ for mutually advertised
+   * endpoints, and falls back to JSON-RPC on network errors. Off by default
+   * until the spec stabilises and ELs we test against advertise support
+   * consistently.
    */
   sszRest?: boolean;
 };
@@ -141,6 +142,27 @@ const getPayloadBodiesByRangeOpts: ReqOpts = {routeId: "getPayloadBodiesByRange"
 const getBlobsV1Opts: ReqOpts = {routeId: "getBlobsV1"};
 const getBlobsV2Opts: ReqOpts = {routeId: "getBlobsV2"};
 const getClientVersionOpts: ReqOpts = {routeId: "getClientVersion"};
+const exchangeCapabilitiesOpts: ReqOpts = {routeId: "exchangeCapabilities", retries: 1};
+
+const supportedSszRestEndpoints = [
+  "POST /engine/v1/payloads",
+  "POST /engine/v2/payloads",
+  "POST /engine/v3/payloads",
+  "POST /engine/v4/payloads",
+  "POST /engine/v5/payloads",
+  "GET /engine/v1/payloads/{payload_id}",
+  "GET /engine/v2/payloads/{payload_id}",
+  "GET /engine/v3/payloads/{payload_id}",
+  "GET /engine/v4/payloads/{payload_id}",
+  "GET /engine/v5/payloads/{payload_id}",
+  "GET /engine/v6/payloads/{payload_id}",
+  "POST /engine/v1/forkchoice",
+  "POST /engine/v2/forkchoice",
+  "POST /engine/v3/forkchoice",
+  "POST /engine/v4/forkchoice",
+  "POST /engine/v1/blobs",
+  "POST /engine/v2/blobs",
+];
 
 /**
  * based on Ethereum JSON-RPC API and inherits the following properties of this standard:
@@ -167,6 +189,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
 
   /** EIP-8161: SSZ-REST client, null if not configured */
   private readonly sszRestClient: SszRestClient | null;
+  private readonly sszRestCapabilities: Promise<Set<string>> | null;
 
   /**
    * A queue to serialize the fcUs and newPayloads calls:
@@ -177,22 +200,14 @@ export class ExecutionEngineHttp implements IExecutionEngine {
    * the order of new payloads and fcUs is pretty important to EL, this queue will serialize the calls in the
    * order with which we make them.
    */
-  private readonly rpcFetchQueue: JobItemQueue<[EngineRequest], EngineResponse>;
-
-  private jobQueueProcessor = async ({method, params, methodOpts}: EngineRequest): Promise<EngineResponse> => {
-    return this.rpc.fetchWithRetries<EngineApiRpcReturnTypes[typeof method], EngineApiRpcParamTypes[typeof method]>(
-      {method, params},
-      methodOpts
-    );
-  };
+  private readonly rpcFetchQueue: JobFnQueue;
 
   constructor(
     private readonly rpc: IJsonRpcHttpClient,
     {metrics, signal, logger}: ExecutionEngineModules,
     private readonly opts?: ExecutionEngineHttpOpts
   ) {
-    this.rpcFetchQueue = new JobItemQueue<[EngineRequest], EngineResponse>(
-      this.jobQueueProcessor,
+    this.rpcFetchQueue = new JobFnQueue(
       {maxLength: QUEUE_MAX_LENGTH, maxConcurrency: 1, noYieldIfOneItem: true, signal},
       metrics?.engineHttpProcessorQueue
     );
@@ -211,9 +226,11 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         jwtVersion: opts.jwtVersion,
         timeout: opts.timeout,
       });
+      this.sszRestCapabilities = this.exchangeSszRestCapabilities();
       this.logger.info("SSZ-REST Engine API transport enabled (EIP-8161)", {url: baseUrl});
     } else {
       this.sszRestClient = null;
+      this.sszRestCapabilities = null;
     }
 
     this.rpc.emitter.on(JsonRpcHttpClientEvent.ERROR, ({error}) => {
@@ -230,6 +247,36 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       }
       this.updateEngineState(getExecutionEngineState({targetState: ExecutionEngineState.ONLINE, oldState: this.state}));
     });
+  }
+
+  private async exchangeSszRestCapabilities(): Promise<Set<string>> {
+    const method = "engine_exchangeCapabilities";
+    try {
+      const response = await this.rpc.fetchWithRetries<
+        EngineApiRpcReturnTypes[typeof method],
+        EngineApiRpcParamTypes[typeof method]
+      >({method, params: [supportedSszRestEndpoints]}, exchangeCapabilitiesOpts);
+
+      return new Set(response.filter((capability) => supportedSszRestEndpoints.includes(capability)));
+    } catch (e) {
+      this.logger.debug("Unable to exchange SSZ-REST Engine API capabilities", {}, e as Error);
+      return new Set();
+    }
+  }
+
+  private async supportsSszRestEndpoint(endpoint: string): Promise<boolean> {
+    return (await this.sszRestCapabilities)?.has(endpoint) ?? false;
+  }
+
+  private async fetchQueued<K extends EngineRequestKey>(
+    request: EngineRequest<K>
+  ): Promise<EngineApiRpcReturnTypes[K]> {
+    return this.rpcFetchQueue.push(() =>
+      this.rpc.fetchWithRetries<EngineApiRpcReturnTypes[K], EngineApiRpcParamTypes[K]>(
+        {method: request.method, params: request.params},
+        request.methodOpts
+      )
+    );
   }
 
   /**
@@ -263,53 +310,50 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   ): Promise<ExecutePayloadResponse> {
     // EIP-8161: Try SSZ-REST first, fall back to JSON-RPC on network errors
     if (this.sszRestClient) {
-      try {
-        const path = `/engine/v${newPayloadVersion(fork)}/payloads`;
-        const body = encodeNewPayloadRequest(
-          fork,
-          executionPayload,
-          versionedHashes,
-          parentBlockRoot,
-          executionRequests
-        );
-        const resp = await this.sszRestClient.doRequest(path, body);
-        const {status, latestValidHash, validationError} = decodePayloadStatus(resp);
-        this.updateEngineState(getExecutionEngineState({payloadStatus: status, oldState: this.state}));
+      const path = `/engine/v${newPayloadVersion(fork)}/payloads`;
+      const endpoint = `POST ${path}`;
+      if (!(await this.supportsSszRestEndpoint(endpoint))) {
+        this.logger.debug("SSZ-REST newPayload endpoint not advertised, using JSON-RPC", {endpoint});
+      } else {
+        try {
+          const body = encodeNewPayloadRequest(
+            fork,
+            executionPayload,
+            versionedHashes,
+            parentBlockRoot,
+            executionRequests
+          );
+          const resp = await this.rpcFetchQueue.push<Uint8Array>(async () => {
+            if (!this.sszRestClient) throw Error("SSZ-REST client not configured");
+            return this.sszRestClient.doRequest(path, body);
+          });
+          const {status, latestValidHash, validationError} = decodePayloadStatus(resp);
+          this.updateEngineState(getExecutionEngineState({payloadStatus: status, oldState: this.state}));
 
-        switch (status) {
-          case ExecutionPayloadStatus.VALID:
-            return {status, latestValidHash: latestValidHash ?? "0x0", validationError: null};
-          case ExecutionPayloadStatus.INVALID:
-            return {status, latestValidHash, validationError};
-          case ExecutionPayloadStatus.SYNCING:
-          case ExecutionPayloadStatus.ACCEPTED:
-            return {status, latestValidHash: null, validationError: null};
-          default:
-            return {
-              status: ExecutionPayloadStatus.ELERROR,
-              latestValidHash: null,
-              validationError: `Invalid EL status on executePayload: ${status}`,
-            };
-        }
-      } catch (e) {
-        if (isSszRestNetworkError(e)) {
-          this.logger.debug("SSZ-REST newPayload failed, falling back to JSON-RPC", {error: (e as Error).message});
-        } else {
-          throw e;
+          switch (status) {
+            case ExecutionPayloadStatus.VALID:
+              return {status, latestValidHash: latestValidHash ?? "0x0", validationError: null};
+            case ExecutionPayloadStatus.INVALID:
+              return {status, latestValidHash, validationError};
+            case ExecutionPayloadStatus.SYNCING:
+            case ExecutionPayloadStatus.ACCEPTED:
+              return {status, latestValidHash: null, validationError: null};
+            default:
+              return {
+                status: ExecutionPayloadStatus.ELERROR,
+                latestValidHash: null,
+                validationError: `Invalid EL status on executePayload: ${status}`,
+              };
+          }
+        } catch (e) {
+          if (isSszRestNetworkError(e)) {
+            this.logger.debug("SSZ-REST newPayload failed, falling back to JSON-RPC", {error: (e as Error).message});
+          } else {
+            throw e;
+          }
         }
       }
     }
-
-    const method =
-      ForkSeq[fork] >= ForkSeq.gloas
-        ? "engine_newPayloadV5"
-        : ForkSeq[fork] >= ForkSeq.electra
-          ? "engine_newPayloadV4"
-          : ForkSeq[fork] >= ForkSeq.deneb
-            ? "engine_newPayloadV3"
-            : ForkSeq[fork] >= ForkSeq.capella
-              ? "engine_newPayloadV2"
-              : "engine_newPayloadV1";
 
     const serializedExecutionPayload = serializeExecutionPayload(fork, executionPayload);
 
@@ -357,7 +401,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     }
 
     const {status, latestValidHash, validationError} = await (
-      this.rpcFetchQueue.push(engineRequest) as Promise<EngineApiRpcReturnTypes[typeof method]>
+      this.fetchQueued(engineRequest) as Promise<EngineApiRpcReturnTypes["engine_newPayloadV1"]>
     ).catch((e: Error) => {
       if (e instanceof HttpRpcError || e instanceof ErrorJsonRpcResponse) {
         return {status: ExecutionPayloadStatus.ELERROR, latestValidHash: null, validationError: e.message};
@@ -434,58 +478,69 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   ): Promise<PayloadId | null> {
     // EIP-8161: Try SSZ-REST first, fall back to JSON-RPC on network errors
     if (this.sszRestClient) {
-      try {
-        const path = `/engine/v${forkchoiceUpdatedVersion(fork)}/forkchoice`;
-        const body = encodeForkchoiceUpdatedRequest(
-          fork,
-          fromHex(headBlockHash),
-          fromHex(safeBlockHash),
-          fromHex(finalizedBlockHash),
-          payloadAttributes
-        );
-        const resp = await this.sszRestClient.doRequest(path, body);
-        const decoded = decodeForkchoiceUpdatedResponse(resp);
-        const {status, validationError} = decoded.payloadStatus;
-
-        this.updateEngineState(getExecutionEngineState({payloadStatus: status, oldState: this.state}));
-        this.metrics?.engineNotifyForkchoiceUpdateResult.inc({result: status});
-
-        const payloadAttributesRpc = payloadAttributes ? serializePayloadAttributes(payloadAttributes) : undefined;
-
-        switch (status) {
-          case ExecutionPayloadStatus.VALID:
-            if (payloadAttributesRpc) {
-              if (decoded.payloadId === null) {
-                throw Error("Received null payloadId when payload attributes were provided");
-              }
-              this.payloadIdCache.add({headBlockHash, finalizedBlockHash, ...payloadAttributesRpc}, decoded.payloadId);
-              void this.prunePayloadIdCache();
-            }
-            return decoded.payloadId;
-
-          case ExecutionPayloadStatus.SYNCING:
-            if (payloadAttributes) {
-              throw Error("Execution Layer Syncing");
-            }
-            return null;
-
-          case ExecutionPayloadStatus.INVALID:
-            throw Error(
-              `Invalid ${payloadAttributes ? "prepare payload" : "forkchoice request"}, validationError=${
-                validationError ?? ""
-              }`
-            );
-
-          default:
-            throw Error(`Unknown status ${status}`);
-        }
-      } catch (e) {
-        if (isSszRestNetworkError(e)) {
-          this.logger.debug("SSZ-REST forkchoiceUpdate failed, falling back to JSON-RPC", {
-            error: (e as Error).message,
+      const path = `/engine/v${forkchoiceUpdatedVersion(fork)}/forkchoice`;
+      const endpoint = `POST ${path}`;
+      if (!(await this.supportsSszRestEndpoint(endpoint))) {
+        this.logger.debug("SSZ-REST forkchoiceUpdate endpoint not advertised, using JSON-RPC", {endpoint});
+      } else {
+        try {
+          const body = encodeForkchoiceUpdatedRequest(
+            fork,
+            fromHex(headBlockHash),
+            fromHex(safeBlockHash),
+            fromHex(finalizedBlockHash),
+            payloadAttributes
+          );
+          const resp = await this.rpcFetchQueue.push<Uint8Array>(async () => {
+            if (!this.sszRestClient) throw Error("SSZ-REST client not configured");
+            return this.sszRestClient.doRequest(path, body);
           });
-        } else {
-          throw e;
+          const decoded = decodeForkchoiceUpdatedResponse(resp);
+          const {status, validationError} = decoded.payloadStatus;
+
+          this.updateEngineState(getExecutionEngineState({payloadStatus: status, oldState: this.state}));
+          this.metrics?.engineNotifyForkchoiceUpdateResult.inc({result: status});
+
+          const payloadAttributesRpc = payloadAttributes ? serializePayloadAttributes(payloadAttributes) : undefined;
+
+          switch (status) {
+            case ExecutionPayloadStatus.VALID:
+              if (payloadAttributesRpc) {
+                if (decoded.payloadId === null) {
+                  throw Error("Received null payloadId when payload attributes were provided");
+                }
+                this.payloadIdCache.add(
+                  {headBlockHash, finalizedBlockHash, ...payloadAttributesRpc},
+                  decoded.payloadId
+                );
+                void this.prunePayloadIdCache();
+              }
+              return decoded.payloadId;
+
+            case ExecutionPayloadStatus.SYNCING:
+              if (payloadAttributes) {
+                throw Error("Execution Layer Syncing");
+              }
+              return null;
+
+            case ExecutionPayloadStatus.INVALID:
+              throw Error(
+                `Invalid ${payloadAttributes ? "prepare payload" : "forkchoice request"}, validationError=${
+                  validationError ?? ""
+                }`
+              );
+
+            default:
+              throw Error(`Unknown status ${status}`);
+          }
+        } catch (e) {
+          if (isSszRestNetworkError(e)) {
+            this.logger.debug("SSZ-REST forkchoiceUpdate failed, falling back to JSON-RPC", {
+              error: (e as Error).message,
+            });
+          } else {
+            throw e;
+          }
         }
       }
     }
@@ -506,7 +561,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     const fcUReqOpts =
       payloadAttributes !== undefined ? forkchoiceUpdatedV1Opts : {...forkchoiceUpdatedV1Opts, retries: 0};
 
-    const request = this.rpcFetchQueue.push({
+    const request = this.fetchQueued({
       method,
       params: [{headBlockHash, safeBlockHash, finalizedBlockHash}, payloadAttributesRpc],
       methodOpts: fcUReqOpts,
@@ -571,22 +626,27 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   }> {
     // EIP-8161: Try SSZ-REST first, fall back to JSON-RPC on network errors
     if (this.sszRestClient) {
-      try {
-        const path = `/engine/v${getPayloadVersion(fork)}/payloads/${payloadId}`;
-        const resp = await this.sszRestClient.doGetRequest(path);
-        const decoded = decodeGetPayloadResponse(fork, resp);
-        return {
-          executionPayload: decoded.executionPayload,
-          executionPayloadValue: decoded.blockValue,
-          blobsBundle: decoded.blobsBundle,
-          executionRequests: decoded.executionRequests,
-          shouldOverrideBuilder: decoded.shouldOverrideBuilder,
-        };
-      } catch (e) {
-        if (isSszRestNetworkError(e)) {
-          this.logger.debug("SSZ-REST getPayload failed, falling back to JSON-RPC", {error: (e as Error).message});
-        } else {
-          throw e;
+      const pathPrefix = `/engine/v${getPayloadVersion(fork)}/payloads`;
+      const endpoint = `GET ${pathPrefix}/{payload_id}`;
+      if (!(await this.supportsSszRestEndpoint(endpoint))) {
+        this.logger.debug("SSZ-REST getPayload endpoint not advertised, using JSON-RPC", {endpoint});
+      } else {
+        try {
+          const resp = await this.sszRestClient.doGetRequest(`${pathPrefix}/${payloadId}`);
+          const decoded = decodeGetPayloadResponse(fork, resp);
+          return {
+            executionPayload: decoded.executionPayload,
+            executionPayloadValue: decoded.blockValue,
+            blobsBundle: decoded.blobsBundle,
+            executionRequests: decoded.executionRequests,
+            shouldOverrideBuilder: decoded.shouldOverrideBuilder,
+          };
+        } catch (e) {
+          if (isSszRestNetworkError(e)) {
+            this.logger.debug("SSZ-REST getPayload failed, falling back to JSON-RPC", {error: (e as Error).message});
+          } else {
+            throw e;
+          }
         }
       }
     }
@@ -675,28 +735,33 @@ export class ExecutionEngineHttp implements IExecutionEngine {
 
     // EIP-8161: Try SSZ-REST first for getBlobs, fall back to JSON-RPC on network errors
     if (this.sszRestClient) {
-      try {
-        const version = getBlobsVersion(fork);
-        const path = `/engine/v${version}/blobs`;
-        const body = encodeGetBlobsRequest(versionedHashes);
-        const resp = await this.sszRestClient.doRequest(path, body);
-        // HTTP 204 (syncing, or any missing blob in v2) maps to null per spec.
-        if (resp.length === 0) {
-          return null;
-        }
-        if (version === 1) {
-          // Spec v1 returns only the blobs that were found (potentially shorter
-          // than the request). Pad with nulls so the result aligns with the
-          // request indices, matching the JSON-RPC v1 contract.
-          const found = decodeGetBlobsV1Response(resp);
-          return versionedHashes.map((_, i) => found[i] ?? null);
-        }
-        return decodeGetBlobsV2Response(resp);
-      } catch (e) {
-        if (isSszRestNetworkError(e)) {
-          this.logger.debug("SSZ-REST getBlobs failed, falling back to JSON-RPC", {error: (e as Error).message});
-        } else {
-          throw e;
+      const version = getBlobsVersion(fork);
+      const path = `/engine/v${version}/blobs`;
+      const endpoint = `POST ${path}`;
+      if (!(await this.supportsSszRestEndpoint(endpoint))) {
+        this.logger.debug("SSZ-REST getBlobs endpoint not advertised, using JSON-RPC", {endpoint});
+      } else {
+        try {
+          const body = encodeGetBlobsRequest(versionedHashes);
+          const resp = await this.sszRestClient.doRequest(path, body);
+          // HTTP 204 (syncing, or any missing blob in v2) maps to null per spec.
+          if (resp.length === 0) {
+            return null;
+          }
+          if (version === 1) {
+            // Spec v1 returns only the blobs that were found (potentially shorter
+            // than the request). Pad with nulls so the result aligns with the
+            // request indices, matching the JSON-RPC v1 contract.
+            const found = decodeGetBlobsV1Response(resp);
+            return versionedHashes.map((_, i) => found[i] ?? null);
+          }
+          return decodeGetBlobsV2Response(resp);
+        } catch (e) {
+          if (isSszRestNetworkError(e)) {
+            this.logger.debug("SSZ-REST getBlobs failed, falling back to JSON-RPC", {error: (e as Error).message});
+          } else {
+            throw e;
+          }
         }
       }
     }
@@ -842,6 +907,4 @@ type EngineRequestKey = keyof EngineApiRpcParamTypes;
 type EngineRequestByKey = {
   [K in EngineRequestKey]: {method: K; params: EngineApiRpcParamTypes[K]; methodOpts: ReqOpts};
 };
-type EngineRequest = EngineRequestByKey[EngineRequestKey];
-type EngineResponseByKey = {[K in EngineRequestKey]: EngineApiRpcReturnTypes[K]};
-type EngineResponse = EngineResponseByKey[EngineRequestKey];
+type EngineRequest<K extends EngineRequestKey = EngineRequestKey> = EngineRequestByKey[K];

--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -146,9 +146,16 @@ export class ExecutionEngineMockBackend implements JsonRpcBackend {
       engine_getPayloadBodiesByHashV1: this.getPayloadBodiesByHash.bind(this),
       engine_getPayloadBodiesByRangeV1: this.getPayloadBodiesByRange.bind(this),
       engine_getClientVersionV1: this.getClientVersionV1.bind(this),
+      engine_exchangeCapabilities: this.exchangeCapabilities.bind(this),
       engine_getBlobsV1: this.getBlobs.bind(this),
       engine_getBlobsV2: this.getBlobsV2.bind(this),
     };
+  }
+
+  private exchangeCapabilities(
+    capabilities: EngineApiRpcParamTypes["engine_exchangeCapabilities"][0]
+  ): EngineApiRpcReturnTypes["engine_exchangeCapabilities"] {
+    return capabilities;
   }
 
   private getPayloadBodiesByHash(

--- a/packages/beacon-node/src/execution/engine/sszRestClient.ts
+++ b/packages/beacon-node/src/execution/engine/sszRestClient.ts
@@ -66,8 +66,8 @@ export class SszRestClient {
   private readonly timeout: number;
 
   constructor(opts: SszRestClientOpts) {
-    // Strip trailing slash for consistent path joining
-    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    // Trailing slash normalisation is the caller's responsibility.
+    this.baseUrl = opts.baseUrl;
     this.jwtSecret = opts.jwtSecretHex ? fromHex(opts.jwtSecretHex) : undefined;
     this.jwtId = opts.jwtId;
     this.jwtVersion = opts.jwtVersion;

--- a/packages/beacon-node/src/execution/engine/sszRestClient.ts
+++ b/packages/beacon-node/src/execution/engine/sszRestClient.ts
@@ -1,0 +1,150 @@
+import {fetch, isFetchError} from "@lodestar/utils";
+import {JwtClaim, encodeJwtToken} from "./jwt.js";
+import {HTTP_CONNECTION_ERROR_CODES, HTTP_FATAL_ERROR_CODES} from "./utils.js";
+
+export interface SszRestClientOpts {
+  baseUrl: string;
+  jwtSecretHex?: string;
+  jwtId?: string;
+  jwtVersion?: string;
+  /** Request timeout in milliseconds. Defaults to 12000 */
+  timeout?: number;
+}
+
+/**
+ * Error thrown when the SSZ-REST endpoint returns a non-200 response.
+ * The EL returns JSON error bodies of the form {"code": N, "message": "..."}.
+ */
+export class SszRestError extends Error {
+  readonly code: number;
+  constructor(code: number, message: string) {
+    super(`SSZ-REST error ${code}: ${message}`);
+    this.code = code;
+  }
+}
+
+/**
+ * Determines whether an error is a network-level error (DNS failure, connection
+ * refused, timeout, etc.) that should trigger a fallback to JSON-RPC rather than
+ * being propagated directly to the caller.
+ */
+export function isSszRestNetworkError(e: unknown): boolean {
+  if (e instanceof SszRestError) {
+    // HTTP errors from the SSZ-REST endpoint (e.g. 404) indicate the
+    // endpoint doesn't support this path — fall back to JSON-RPC.
+    return true;
+  }
+  // Node.js fetch errors (ECONNREFUSED, ENOTFOUND, etc.)
+  if (isFetchError(e)) {
+    const allCodes = [...HTTP_FATAL_ERROR_CODES, ...HTTP_CONNECTION_ERROR_CODES];
+    return allCodes.includes((e as {code: string}).code);
+  }
+  // TypeError is thrown by fetch on DNS resolution failure in some runtimes
+  if (e instanceof TypeError) {
+    return true;
+  }
+  // AbortError from timeout
+  if (e instanceof DOMException && e.name === "AbortError") {
+    return true;
+  }
+  return false;
+}
+
+const DEFAULT_TIMEOUT = 12_000;
+
+/**
+ * SSZ-REST HTTP client for EIP-8161 Engine API transport.
+ *
+ * Sends binary (application/octet-stream) POST requests and receives binary
+ * responses. JWT authentication is supported identically to the JSON-RPC client.
+ */
+export class SszRestClient {
+  private readonly baseUrl: string;
+  private readonly jwtSecret: Uint8Array | undefined;
+  private readonly jwtId: string | undefined;
+  private readonly jwtVersion: string | undefined;
+  private readonly timeout: number;
+
+  constructor(opts: SszRestClientOpts) {
+    // Strip trailing slash for consistent path joining
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.jwtSecret = opts.jwtSecretHex ? hexToBytes(opts.jwtSecretHex) : undefined;
+    this.jwtId = opts.jwtId;
+    this.jwtVersion = opts.jwtVersion;
+    this.timeout = opts.timeout ?? DEFAULT_TIMEOUT;
+  }
+
+  /**
+   * POST binary body to `baseUrl + path` and return the response as Uint8Array.
+   *
+   * - Content-Type: application/octet-stream
+   * - Authorization: Bearer <jwt> (when jwtSecret is configured)
+   * - On 200: returns response body as Uint8Array
+   * - On non-200: attempts to parse JSON error body and throws SszRestError
+   */
+  async doRequest(path: string, body: Uint8Array): Promise<Uint8Array> {
+    return this._fetch(path, "POST", body);
+  }
+
+  /**
+   * GET request (no body) to `baseUrl + path` and return the response as Uint8Array.
+   * Used for getPayload where payload_id is in the URL path.
+   */
+  async doGetRequest(path: string): Promise<Uint8Array> {
+    return this._fetch(path, "GET", undefined);
+  }
+
+  private async _fetch(path: string, method: string, body: Uint8Array | undefined): Promise<Uint8Array> {
+    const url = `${this.baseUrl}${path}`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const headers: Record<string, string> = {
+        Accept: "application/octet-stream",
+      };
+      if (body) {
+        headers["Content-Type"] = "application/octet-stream";
+      }
+
+      if (this.jwtSecret) {
+        const jwtClaim: JwtClaim = {
+          iat: Math.floor(Date.now() / 1000),
+          id: this.jwtId,
+          clv: this.jwtVersion,
+        };
+        const token = encodeJwtToken(jwtClaim, this.jwtSecret);
+        headers.Authorization = `Bearer ${token}`;
+      }
+
+      const res = await fetch(url, {
+        method,
+        body: body ? (body as unknown as BodyInit) : undefined,
+        headers,
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        // Error responses use text/plain per execution-apis SSZ spec
+        const code = res.status;
+        const message = await res.text().catch(() => res.statusText);
+        throw new SszRestError(code, message);
+      }
+
+      const arrayBuf = await res.arrayBuffer();
+      return new Uint8Array(arrayBuf);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+/** Convert a hex string (with or without 0x prefix) to Uint8Array */
+function hexToBytes(hex: string): Uint8Array {
+  const stripped = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const bytes = new Uint8Array(stripped.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(stripped.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}

--- a/packages/beacon-node/src/execution/engine/sszRestClient.ts
+++ b/packages/beacon-node/src/execution/engine/sszRestClient.ts
@@ -30,14 +30,16 @@ export class SszRestError extends Error {
  */
 export function isSszRestNetworkError(e: unknown): boolean {
   if (e instanceof SszRestError) {
-    // HTTP errors from the SSZ-REST endpoint (e.g. 404) indicate the
-    // endpoint doesn't support this path — fall back to JSON-RPC.
-    return true;
+    // HTTP responses carry Engine API semantics in the SSZ-REST spec. Once an
+    // endpoint has been negotiated, do not hide malformed SSZ, auth failures,
+    // unknown payload IDs, invalid forkchoice state, or EL errors by retrying
+    // the same operation through JSON-RPC.
+    return false;
   }
   // Node.js fetch errors (ECONNREFUSED, ENOTFOUND, etc.)
   if (isFetchError(e)) {
     const allCodes = [...HTTP_FATAL_ERROR_CODES, ...HTTP_CONNECTION_ERROR_CODES];
-    return allCodes.includes((e as {code: string}).code);
+    return allCodes.includes((e as {code: string}).code) || (e as {code: string}).code === "ERR_ABORTED";
   }
   // TypeError is thrown by fetch on DNS resolution failure in some runtimes
   if (e instanceof TypeError) {

--- a/packages/beacon-node/src/execution/engine/sszRestClient.ts
+++ b/packages/beacon-node/src/execution/engine/sszRestClient.ts
@@ -1,4 +1,4 @@
-import {fetch, isFetchError} from "@lodestar/utils";
+import {fetch, fromHex, isFetchError} from "@lodestar/utils";
 import {JwtClaim, encodeJwtToken} from "./jwt.js";
 import {HTTP_CONNECTION_ERROR_CODES, HTTP_FATAL_ERROR_CODES} from "./utils.js";
 
@@ -68,7 +68,7 @@ export class SszRestClient {
   constructor(opts: SszRestClientOpts) {
     // Strip trailing slash for consistent path joining
     this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
-    this.jwtSecret = opts.jwtSecretHex ? hexToBytes(opts.jwtSecretHex) : undefined;
+    this.jwtSecret = opts.jwtSecretHex ? fromHex(opts.jwtSecretHex) : undefined;
     this.jwtId = opts.jwtId;
     this.jwtVersion = opts.jwtVersion;
     this.timeout = opts.timeout ?? DEFAULT_TIMEOUT;
@@ -137,14 +137,4 @@ export class SszRestClient {
       clearTimeout(timeout);
     }
   }
-}
-
-/** Convert a hex string (with or without 0x prefix) to Uint8Array */
-function hexToBytes(hex: string): Uint8Array {
-  const stripped = hex.startsWith("0x") ? hex.slice(2) : hex;
-  const bytes = new Uint8Array(stripped.length / 2);
-  for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(stripped.substring(i * 2, i * 2 + 2), 16);
-  }
-  return bytes;
 }

--- a/packages/beacon-node/src/execution/engine/sszRestEncoding.ts
+++ b/packages/beacon-node/src/execution/engine/sszRestEncoding.ts
@@ -7,6 +7,7 @@ import {
   ForkSeq,
   MAX_BLOB_COMMITMENTS_PER_BLOCK,
   MAX_BYTES_PER_TRANSACTION,
+  MAX_TRANSACTIONS_PER_PAYLOAD,
   WITHDRAWAL_REQUEST_TYPE,
 } from "@lodestar/params";
 import {ExecutionPayload, ExecutionRequests, RootHex, ssz} from "@lodestar/types";
@@ -250,6 +251,35 @@ const GetBlobsV2Response = new ContainerType(
 );
 
 // ---------------------------------------------------------------------------
+// Payload bodies (Shanghai)
+// ---------------------------------------------------------------------------
+
+const MAX_PAYLOAD_BODIES_REQUEST = 32;
+const TransactionsList = new ListCompositeType(TransactionBytes, MAX_TRANSACTIONS_PER_PAYLOAD);
+
+const ExecutionPayloadBodyV1Container = new ContainerType(
+  {transactions: TransactionsList, withdrawals: ssz.capella.Withdrawals},
+  {typeName: "ExecutionPayloadBodyV1"}
+);
+// Nullable wrapper: 0 elements = unknown block, 1 element = known block.
+const ExecutionPayloadBodyV1Optional = new ListCompositeType(ExecutionPayloadBodyV1Container, 1);
+
+const PayloadBodiesV1Response = new ContainerType(
+  {payloadBodies: new ListCompositeType(ExecutionPayloadBodyV1Optional, MAX_PAYLOAD_BODIES_REQUEST)},
+  {typeName: "PayloadBodiesV1Response"}
+);
+
+const GetPayloadBodiesByHashV1Request = new ContainerType(
+  {blockHashes: new ListCompositeType(Bytes32, MAX_PAYLOAD_BODIES_REQUEST)},
+  {typeName: "GetPayloadBodiesByHashV1Request"}
+);
+
+const GetPayloadBodiesByRangeV1Request = new ContainerType(
+  {start: ssz.UintNum64, count: ssz.UintNum64},
+  {typeName: "GetPayloadBodiesByRangeV1Request"}
+);
+
+// ---------------------------------------------------------------------------
 // Fork → version mapping
 // ---------------------------------------------------------------------------
 
@@ -474,6 +504,14 @@ export function encodeGetBlobsRequest(versionedHashes: VersionedHashes): Uint8Ar
   return GetBlobsRequest.serialize({blobVersionedHashes: versionedHashes});
 }
 
+export function encodeGetPayloadBodiesByHashRequest(blockHashes: Uint8Array[]): Uint8Array {
+  return GetPayloadBodiesByHashV1Request.serialize({blockHashes});
+}
+
+export function encodeGetPayloadBodiesByRangeRequest(start: number, count: number): Uint8Array {
+  return GetPayloadBodiesByRangeV1Request.serialize({start, count});
+}
+
 export function encodeExchangeCapabilities(capabilities: string[]): Uint8Array {
   const encoder = new TextEncoder();
   return ExchangeCapabilitiesContainer.serialize({
@@ -605,6 +643,24 @@ export function decodeGetBlobsV1Response(data: Uint8Array): BlobAndProof[] {
 export function decodeGetBlobsV2Response(data: Uint8Array): BlobAndProofV2[] {
   const parsed = GetBlobsV2Response.deserialize(data);
   return parsed.blobsAndProofs.map((item) => ({blob: item.blob, proofs: item.proofs}));
+}
+
+export interface DecodedExecutionPayloadBody {
+  transactions: Uint8Array[];
+  withdrawals: import("@lodestar/types").capella.Withdrawals;
+}
+
+/**
+ * Spec PayloadBodiesV1Response wraps each entry in List[Body, 1] for per-element
+ * nullability: 0 elements = unknown block, 1 element = known block.
+ */
+export function decodePayloadBodiesV1Response(data: Uint8Array): (DecodedExecutionPayloadBody | null)[] {
+  const parsed = PayloadBodiesV1Response.deserialize(data);
+  return parsed.payloadBodies.map((wrapper) => {
+    if (wrapper.length === 0) return null;
+    const body = wrapper[0];
+    return {transactions: body.transactions, withdrawals: body.withdrawals};
+  });
 }
 
 export function decodeExchangeCapabilities(data: Uint8Array): string[] {

--- a/packages/beacon-node/src/execution/engine/sszRestEncoding.ts
+++ b/packages/beacon-node/src/execution/engine/sszRestEncoding.ts
@@ -355,9 +355,31 @@ export function forkchoiceUpdatedVersion(fork: ForkName): 1 | 2 | 3 | 4 {
 
 /**
  * REST endpoint version for `engine_getBlobs`.
- * Cancun=v1, Osaka=v2 (all-or-nothing variant — matches Lodestar's existing
- * JSON-RPC v2 contract). The spec also defines a v3 with per-element
- * nullability, but Lodestar's IExecutionEngine signature is all-or-nothing.
+ *
+ *   Cancun (deneb) → v1
+ *   Osaka  (fulu)  → v2
+ *
+ * Osaka also defines v3 (`List[List[BlobAndProofV2, 1], MAX]`, per-element
+ * nullable) alongside v2 (all-or-nothing — HTTP 204 when any blob is
+ * missing). Lodestar picks v2 deliberately:
+ *
+ *   1. `IExecutionEngine.getBlobs` post-Fulu returns
+ *      `BlobAndProofV2[] | null` — all-or-nothing by design. v2 maps onto
+ *      it directly; v3 would require either changing the interface to
+ *      `(BlobAndProofV2 | null)[]` or a collapse step that throws v3's
+ *      per-element information away.
+ *   2. The JSON-RPC path uses `engine_getBlobsV2`. Keeping the same version
+ *      on SSZ-REST avoids transport-asymmetric semantics for the same
+ *      logical operation.
+ *   3. Spec guidance (osaka.md `engine_getBlobsV3`): "For an all-or-nothing
+ *      query style, refer to `engine_getBlobsV2`."
+ *   4. `deserializeBlobAndProofsV2IntoBytes` reuses caller-supplied buffers
+ *      on the block-production hot path; that optimisation assumes
+ *      all-or-nothing semantics.
+ *
+ * Revisit if Lodestar grows a consumer that benefits from per-element
+ * granularity (e.g. parallel EL+gossip blob fetching). Nethermind and
+ * Erigon ELs both serve v2 alongside v3, so picking v2 has no interop cost.
  */
 export function getBlobsVersion(fork: ForkName): 1 | 2 {
   return ForkSeq[fork] >= ForkSeq.fulu ? 2 : 1;

--- a/packages/beacon-node/src/execution/engine/sszRestEncoding.ts
+++ b/packages/beacon-node/src/execution/engine/sszRestEncoding.ts
@@ -1,608 +1,613 @@
-/**
- * SSZ-REST (EIP-8161) encoding and decoding functions for the Engine API.
- *
- * All multi-byte integers are little-endian (LE). DataView is used for reading
- * and writing to ensure correctness regardless of platform endianness.
- */
-
-import {ByteListType, ContainerType, ListCompositeType} from "@chainsafe/ssz";
-import {ForkName, ForkSeq} from "@lodestar/params";
+import {ByteListType, ByteVectorType, ContainerType, ListCompositeType, UintNumberType} from "@chainsafe/ssz";
 import {
-  ExecutionPayload,
-  ExecutionRequests,
-  Root,
-  ssz,
-  bellatrix,
-  capella,
-  deneb,
-  electra,
-} from "@lodestar/types";
-import {PayloadAttributes, VersionedHashes} from "./interface.js";
+  CELLS_PER_EXT_BLOB,
+  CONSOLIDATION_REQUEST_TYPE,
+  DEPOSIT_REQUEST_TYPE,
+  ForkName,
+  ForkSeq,
+  MAX_BLOB_COMMITMENTS_PER_BLOCK,
+  MAX_BYTES_PER_TRANSACTION,
+  WITHDRAWAL_REQUEST_TYPE,
+} from "@lodestar/params";
+import {ExecutionPayload, ExecutionRequests, RootHex, ssz} from "@lodestar/types";
+import type {BlobAndProof} from "@lodestar/types/deneb";
+import type {BlobAndProofV2} from "@lodestar/types/fulu";
+import {fromHex, toHex} from "@lodestar/utils";
+import {ExecutionPayloadStatus, PayloadAttributes, VersionedHashes} from "./interface.js";
+import {PayloadId} from "./payloadIdCache.js";
 
-// SSZ type: Container { capabilities: List[List[uint8, 64], 128] }
-const Capability = new ByteListType(64);
-const ExchangeCapabilitiesRequest = new ContainerType({
-  capabilities: new ListCompositeType(Capability, 128),
-});
+// Spec constants from ethereum/execution-apis#764 not exported by @lodestar/params.
+const MAX_BLOB_HASHES_REQUEST = 128;
+const MAX_EXECUTION_REQUESTS = 256;
+const MAX_ERROR_MESSAGE_LENGTH = 1024;
+const MAX_CAPABILITY_NAME_LENGTH = 64;
+const MAX_CAPABILITIES = 64;
+const BLOB_SIZE = 131072;
 
 // ---------------------------------------------------------------------------
-// Helper functions
+// Primitives
 // ---------------------------------------------------------------------------
 
-function writeUint32LE(buf: Uint8Array, offset: number, value: number): void {
-  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
-  view.setUint32(offset, value, true);
+const Uint8 = new UintNumberType(1);
+const Bytes8 = new ByteVectorType(8);
+const Bytes20 = new ByteVectorType(20);
+const Bytes32 = new ByteVectorType(32);
+const Bytes48 = new ByteVectorType(48);
+
+// Nullable wrapper: spec encodes `T or null` as `List[T, 1]` — 0 = absent, 1 = present.
+const NullableHash = new ListCompositeType(Bytes32, 1);
+const NullablePayloadId = new ListCompositeType(Bytes8, 1);
+
+const ValidationErrorBytes = new ByteListType(MAX_ERROR_MESSAGE_LENGTH);
+const TransactionBytes = new ByteListType(MAX_BYTES_PER_TRANSACTION);
+
+const VersionedHashesList = new ListCompositeType(Bytes32, MAX_BLOB_COMMITMENTS_PER_BLOCK);
+const BlobHashesRequest = new ListCompositeType(Bytes32, MAX_BLOB_HASHES_REQUEST);
+
+// `execution_requests` is a flat list of opaque byte-lists; each element is
+// `type_byte || ssz_bytes`. CL forwards them to the EL without parsing.
+const ExecutionRequestsList = new ListCompositeType(TransactionBytes, MAX_EXECUTION_REQUESTS);
+
+// ---------------------------------------------------------------------------
+// Fork-independent containers
+// ---------------------------------------------------------------------------
+
+const PayloadStatusV1 = new ContainerType(
+  {status: Uint8, latestValidHash: NullableHash, validationError: ValidationErrorBytes},
+  {typeName: "PayloadStatusV1"}
+);
+
+const ForkchoiceStateV1 = new ContainerType(
+  {headBlockHash: Bytes32, safeBlockHash: Bytes32, finalizedBlockHash: Bytes32},
+  {typeName: "ForkchoiceStateV1"}
+);
+
+const ForkchoiceUpdatedResponseV1 = new ContainerType(
+  {payloadStatus: PayloadStatusV1, payloadId: NullablePayloadId},
+  {typeName: "ForkchoiceUpdatedResponseV1"}
+);
+
+const ExchangeCapabilitiesContainer = new ContainerType(
+  {capabilities: new ListCompositeType(new ByteListType(MAX_CAPABILITY_NAME_LENGTH), MAX_CAPABILITIES)},
+  {typeName: "ExchangeCapabilities"}
+);
+
+// ---------------------------------------------------------------------------
+// PayloadAttributes (one container per fork)
+//
+// We cannot reuse `ssz.{fork}.PayloadAttributes` from @lodestar/types because
+// they declare `suggestedFeeRecipient: stringType` — a JSON-only marker that
+// throws on SSZ serialization.
+// ---------------------------------------------------------------------------
+
+const PayloadAttributesV1Container = new ContainerType(
+  {timestamp: ssz.UintNum64, prevRandao: Bytes32, suggestedFeeRecipient: Bytes20},
+  {typeName: "PayloadAttributesV1"}
+);
+
+const PayloadAttributesV2Container = new ContainerType(
+  {...PayloadAttributesV1Container.fields, withdrawals: ssz.capella.Withdrawals},
+  {typeName: "PayloadAttributesV2"}
+);
+
+const PayloadAttributesV3Container = new ContainerType(
+  {...PayloadAttributesV2Container.fields, parentBeaconBlockRoot: Bytes32},
+  {typeName: "PayloadAttributesV3"}
+);
+
+const PayloadAttributesV4Container = new ContainerType(
+  {...PayloadAttributesV3Container.fields, slotNumber: ssz.UintNum64, targetGasLimit: ssz.UintNum64},
+  {typeName: "PayloadAttributesV4"}
+);
+
+const PayloadAttributesV1Optional = new ListCompositeType(PayloadAttributesV1Container, 1);
+const PayloadAttributesV2Optional = new ListCompositeType(PayloadAttributesV2Container, 1);
+const PayloadAttributesV3Optional = new ListCompositeType(PayloadAttributesV3Container, 1);
+const PayloadAttributesV4Optional = new ListCompositeType(PayloadAttributesV4Container, 1);
+
+// ---------------------------------------------------------------------------
+// NewPayload request containers (per version)
+// ---------------------------------------------------------------------------
+
+const NewPayloadV1Request = new ContainerType(
+  {executionPayload: ssz.bellatrix.ExecutionPayload},
+  {typeName: "NewPayloadV1Request"}
+);
+
+const NewPayloadV2Request = new ContainerType(
+  {executionPayload: ssz.capella.ExecutionPayload},
+  {typeName: "NewPayloadV2Request"}
+);
+
+const NewPayloadV3Request = new ContainerType(
+  {
+    executionPayload: ssz.deneb.ExecutionPayload,
+    expectedBlobVersionedHashes: VersionedHashesList,
+    parentBeaconBlockRoot: Bytes32,
+  },
+  {typeName: "NewPayloadV3Request"}
+);
+
+const NewPayloadV4Request = new ContainerType(
+  {
+    executionPayload: ssz.deneb.ExecutionPayload,
+    expectedBlobVersionedHashes: VersionedHashesList,
+    parentBeaconBlockRoot: Bytes32,
+    executionRequests: ExecutionRequestsList,
+  },
+  {typeName: "NewPayloadV4Request"}
+);
+
+const NewPayloadV5Request = new ContainerType(
+  {
+    executionPayload: ssz.gloas.ExecutionPayload,
+    expectedBlobVersionedHashes: VersionedHashesList,
+    parentBeaconBlockRoot: Bytes32,
+    executionRequests: ExecutionRequestsList,
+  },
+  {typeName: "NewPayloadV5Request"}
+);
+
+// ---------------------------------------------------------------------------
+// ForkchoiceUpdated request containers
+// ---------------------------------------------------------------------------
+
+const ForkchoiceUpdatedV1Request = new ContainerType(
+  {forkchoiceState: ForkchoiceStateV1, payloadAttributes: PayloadAttributesV1Optional},
+  {typeName: "ForkchoiceUpdatedV1Request"}
+);
+
+const ForkchoiceUpdatedV2Request = new ContainerType(
+  {forkchoiceState: ForkchoiceStateV1, payloadAttributes: PayloadAttributesV2Optional},
+  {typeName: "ForkchoiceUpdatedV2Request"}
+);
+
+const ForkchoiceUpdatedV3Request = new ContainerType(
+  {forkchoiceState: ForkchoiceStateV1, payloadAttributes: PayloadAttributesV3Optional},
+  {typeName: "ForkchoiceUpdatedV3Request"}
+);
+
+const ForkchoiceUpdatedV4Request = new ContainerType(
+  {forkchoiceState: ForkchoiceStateV1, payloadAttributes: PayloadAttributesV4Optional},
+  {typeName: "ForkchoiceUpdatedV4Request"}
+);
+
+// ---------------------------------------------------------------------------
+// GetPayload response containers
+// ---------------------------------------------------------------------------
+
+const GetPayloadResponseV2 = new ContainerType(
+  {executionPayload: ssz.capella.ExecutionPayload, blockValue: ssz.UintBn256},
+  {typeName: "GetPayloadResponseV2"}
+);
+
+const GetPayloadResponseV3 = new ContainerType(
+  {
+    executionPayload: ssz.deneb.ExecutionPayload,
+    blockValue: ssz.UintBn256,
+    blobsBundle: ssz.deneb.BlobsBundle,
+    shouldOverrideBuilder: ssz.Boolean,
+  },
+  {typeName: "GetPayloadResponseV3"}
+);
+
+const GetPayloadResponseV4 = new ContainerType(
+  {
+    executionPayload: ssz.deneb.ExecutionPayload,
+    blockValue: ssz.UintBn256,
+    blobsBundle: ssz.deneb.BlobsBundle,
+    shouldOverrideBuilder: ssz.Boolean,
+    executionRequests: ExecutionRequestsList,
+  },
+  {typeName: "GetPayloadResponseV4"}
+);
+
+const GetPayloadResponseV5 = new ContainerType(
+  {
+    executionPayload: ssz.deneb.ExecutionPayload,
+    blockValue: ssz.UintBn256,
+    blobsBundle: ssz.fulu.BlobsBundle,
+    shouldOverrideBuilder: ssz.Boolean,
+    executionRequests: ExecutionRequestsList,
+  },
+  {typeName: "GetPayloadResponseV5"}
+);
+
+const GetPayloadResponseV6 = new ContainerType(
+  {
+    executionPayload: ssz.gloas.ExecutionPayload,
+    blockValue: ssz.UintBn256,
+    blobsBundle: ssz.fulu.BlobsBundle,
+    shouldOverrideBuilder: ssz.Boolean,
+    executionRequests: ExecutionRequestsList,
+  },
+  {typeName: "GetPayloadResponseV6"}
+);
+
+// ---------------------------------------------------------------------------
+// GetBlobs request / response containers
+// ---------------------------------------------------------------------------
+
+const GetBlobsRequest = new ContainerType({blobVersionedHashes: BlobHashesRequest}, {typeName: "GetBlobsRequest"});
+
+const BlobBytes = new ByteVectorType(BLOB_SIZE);
+
+const BlobAndProofV1Container = new ContainerType({blob: BlobBytes, proof: Bytes48}, {typeName: "BlobAndProofV1"});
+
+const BlobAndProofV2Container = new ContainerType(
+  {blob: BlobBytes, proofs: new ListCompositeType(Bytes48, CELLS_PER_EXT_BLOB)},
+  {typeName: "BlobAndProofV2"}
+);
+
+const GetBlobsV1Response = new ContainerType(
+  {blobsAndProofs: new ListCompositeType(BlobAndProofV1Container, MAX_BLOB_HASHES_REQUEST)},
+  {typeName: "GetBlobsV1Response"}
+);
+
+const GetBlobsV2Response = new ContainerType(
+  {blobsAndProofs: new ListCompositeType(BlobAndProofV2Container, MAX_BLOB_HASHES_REQUEST)},
+  {typeName: "GetBlobsV2Response"}
+);
+
+// ---------------------------------------------------------------------------
+// Fork → version mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * REST endpoint version for `engine_newPayload`.
+ * Spec: Paris=v1, Shanghai=v2, Cancun=v3, Prague=v4, Amsterdam=v5.
+ * Osaka (Fulu) does not bump the newPayload version.
+ */
+export function newPayloadVersion(fork: ForkName): 1 | 2 | 3 | 4 | 5 {
+  const seq = ForkSeq[fork];
+  if (seq >= ForkSeq.gloas) return 5;
+  if (seq >= ForkSeq.electra) return 4;
+  if (seq >= ForkSeq.deneb) return 3;
+  if (seq >= ForkSeq.capella) return 2;
+  return 1;
 }
 
-function readUint32LE(buf: Uint8Array, offset: number): number {
-  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
-  return view.getUint32(offset, true);
+/**
+ * REST endpoint version for `engine_getPayload`.
+ * Spec: Paris=v1, Shanghai=v2, Cancun=v3, Prague=v4, Osaka=v5, Amsterdam=v6.
+ */
+export function getPayloadVersion(fork: ForkName): 1 | 2 | 3 | 4 | 5 | 6 {
+  const seq = ForkSeq[fork];
+  if (seq >= ForkSeq.gloas) return 6;
+  if (seq >= ForkSeq.fulu) return 5;
+  if (seq >= ForkSeq.electra) return 4;
+  if (seq >= ForkSeq.deneb) return 3;
+  if (seq >= ForkSeq.capella) return 2;
+  return 1;
 }
 
-function writeUint64LE(buf: Uint8Array, offset: number, value: bigint): void {
-  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
-  view.setBigUint64(offset, value, true);
+/**
+ * REST endpoint version for `engine_forkchoiceUpdated`.
+ * Spec: Paris=v1, Shanghai=v2, Cancun=v3, Amsterdam=v4.
+ */
+export function forkchoiceUpdatedVersion(fork: ForkName): 1 | 2 | 3 | 4 {
+  const seq = ForkSeq[fork];
+  if (seq >= ForkSeq.gloas) return 4;
+  if (seq >= ForkSeq.deneb) return 3;
+  if (seq >= ForkSeq.capella) return 2;
+  return 1;
 }
 
-function readUint64LE(buf: Uint8Array, offset: number): bigint {
-  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
-  return view.getBigUint64(offset, true);
+/**
+ * REST endpoint version for `engine_getBlobs`.
+ * Cancun=v1, Osaka=v2 (all-or-nothing variant — matches Lodestar's existing
+ * JSON-RPC v2 contract). The spec also defines a v3 with per-element
+ * nullability, but Lodestar's IExecutionEngine signature is all-or-nothing.
+ */
+export function getBlobsVersion(fork: ForkName): 1 | 2 {
+  return ForkSeq[fork] >= ForkSeq.fulu ? 2 : 1;
 }
 
-function writeUint256LE(buf: Uint8Array, offset: number, value: bigint): void {
-  // Write 256-bit LE as 4x 64-bit LE words
-  for (let i = 0; i < 4; i++) {
-    writeUint64LE(buf, offset + i * 8, value & 0xffffffffffffffffn);
-    value >>= 64n;
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildExecutionRequestsList(executionRequests: ExecutionRequests): Uint8Array[] {
+  const items: Uint8Array[] = [];
+  const prefix = (typeByte: number, body: Uint8Array): Uint8Array => {
+    const out = new Uint8Array(1 + body.length);
+    out[0] = typeByte;
+    out.set(body, 1);
+    return out;
+  };
+  if (executionRequests.deposits.length > 0) {
+    items.push(prefix(DEPOSIT_REQUEST_TYPE, ssz.electra.DepositRequests.serialize(executionRequests.deposits)));
   }
+  if (executionRequests.withdrawals.length > 0) {
+    items.push(
+      prefix(WITHDRAWAL_REQUEST_TYPE, ssz.electra.WithdrawalRequests.serialize(executionRequests.withdrawals))
+    );
+  }
+  if (executionRequests.consolidations.length > 0) {
+    items.push(
+      prefix(CONSOLIDATION_REQUEST_TYPE, ssz.electra.ConsolidationRequests.serialize(executionRequests.consolidations))
+    );
+  }
+  return items;
 }
 
-function readUint256LE(buf: Uint8Array, offset: number): bigint {
-  let result = 0n;
-  for (let i = 3; i >= 0; i--) {
-    result = (result << 64n) | readUint64LE(buf, offset + i * 8);
+function parseExecutionRequestsList(items: Uint8Array[]): ExecutionRequests {
+  const result: ExecutionRequests = {deposits: [], withdrawals: [], consolidations: []};
+  for (const item of items) {
+    if (item.length === 0) throw Error("Execution request with empty data");
+    const type = item[0];
+    const body = item.subarray(1);
+    switch (type) {
+      case DEPOSIT_REQUEST_TYPE:
+        result.deposits = ssz.electra.DepositRequests.deserialize(body);
+        break;
+      case WITHDRAWAL_REQUEST_TYPE:
+        result.withdrawals = ssz.electra.WithdrawalRequests.deserialize(body);
+        break;
+      case CONSOLIDATION_REQUEST_TYPE:
+        result.consolidations = ssz.electra.ConsolidationRequests.deserialize(body);
+        break;
+      default:
+        throw Error(`Unknown execution request type=${type}`);
+    }
   }
   return result;
 }
 
-const textEncoder = new TextEncoder();
-const textDecoder = new TextDecoder();
-
-// ---------------------------------------------------------------------------
-// Encode functions
-// ---------------------------------------------------------------------------
-
-/**
- * Encode ForkchoiceState: headBlockHash(32) + safeBlockHash(32) + finalizedBlockHash(32) = 96 bytes
- */
-export function encodeForkchoiceState(
-  headBlockHash: Uint8Array,
-  safeBlockHash: Uint8Array,
-  finalizedBlockHash: Uint8Array
-): Uint8Array {
-  const buf = new Uint8Array(96);
-  buf.set(headBlockHash, 0);
-  buf.set(safeBlockHash, 32);
-  buf.set(finalizedBlockHash, 64);
-  return buf;
+function buildPayloadAttributesValue(fork: ForkName, attrs: PayloadAttributes): Record<string, unknown> {
+  const seq = ForkSeq[fork];
+  const base = {
+    timestamp: attrs.timestamp,
+    prevRandao: attrs.prevRandao,
+    suggestedFeeRecipient: fromHex(attrs.suggestedFeeRecipient),
+  };
+  if (seq < ForkSeq.capella) return base;
+  const v2 = {...base, withdrawals: attrs.withdrawals ?? []};
+  if (seq < ForkSeq.deneb) return v2;
+  if (attrs.parentBeaconBlockRoot === undefined) {
+    throw Error(`parentBeaconBlockRoot required in PayloadAttributes for fork=${fork}`);
+  }
+  const v3 = {...v2, parentBeaconBlockRoot: attrs.parentBeaconBlockRoot};
+  if (seq < ForkSeq.gloas) return v3;
+  if (attrs.slotNumber === undefined) {
+    throw Error(`slotNumber required in PayloadAttributes for fork=${fork}`);
+  }
+  // targetGasLimit is in the spec PR but not yet plumbed through Lodestar's PayloadAttributes.
+  // Encode 0 so the on-wire shape matches the spec; revisit when the field lands.
+  return {...v3, slotNumber: attrs.slotNumber, targetGasLimit: 0};
 }
 
-/**
- * Encode a ForkchoiceUpdated request.
- *
- * Layout: ForkchoiceState(96 fixed) + attributes_offset(4) + List[PayloadAttributes, 1]
- *
- * List[PayloadAttributes, 1]: empty = absent; offset(4) + element data = present
- * (PayloadAttributes is variable-size, so the list uses a 4-byte item offset)
- *
- * PayloadAttributes V3: timestamp(8) + prevRandao(32) + suggestedFeeRecipient(20)
- *   + withdrawals_offset(4) + parentBeaconBlockRoot(32) + withdrawals list
- *
- * Each withdrawal: index(8) + validatorIndex(8) + address(20) + amount(8) = 44 bytes
- */
+function statusByteToEnum(byte: number): ExecutionPayloadStatus {
+  switch (byte) {
+    case 0:
+      return ExecutionPayloadStatus.VALID;
+    case 1:
+      return ExecutionPayloadStatus.INVALID;
+    case 2:
+      return ExecutionPayloadStatus.SYNCING;
+    case 3:
+      return ExecutionPayloadStatus.ACCEPTED;
+    default:
+      throw Error(`Unknown payload status byte=${byte}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public encoders
+// ---------------------------------------------------------------------------
+
+export function encodeNewPayloadRequest(
+  fork: ForkName,
+  executionPayload: ExecutionPayload,
+  versionedHashes?: VersionedHashes,
+  parentBeaconBlockRoot?: Uint8Array,
+  executionRequests?: ExecutionRequests
+): Uint8Array {
+  const version = newPayloadVersion(fork);
+
+  if (version === 1) {
+    return NewPayloadV1Request.serialize({executionPayload} as never);
+  }
+  if (version === 2) {
+    return NewPayloadV2Request.serialize({executionPayload} as never);
+  }
+
+  if (versionedHashes === undefined || parentBeaconBlockRoot === undefined) {
+    throw Error(`versionedHashes and parentBeaconBlockRoot required for newPayload v${version}`);
+  }
+
+  if (version === 3) {
+    return NewPayloadV3Request.serialize({
+      executionPayload,
+      expectedBlobVersionedHashes: versionedHashes,
+      parentBeaconBlockRoot,
+    } as never);
+  }
+
+  if (executionRequests === undefined) {
+    throw Error(`executionRequests required for newPayload v${version}`);
+  }
+  const requestsList = buildExecutionRequestsList(executionRequests);
+
+  if (version === 4) {
+    return NewPayloadV4Request.serialize({
+      executionPayload,
+      expectedBlobVersionedHashes: versionedHashes,
+      parentBeaconBlockRoot,
+      executionRequests: requestsList,
+    } as never);
+  }
+
+  return NewPayloadV5Request.serialize({
+    executionPayload,
+    expectedBlobVersionedHashes: versionedHashes,
+    parentBeaconBlockRoot,
+    executionRequests: requestsList,
+  } as never);
+}
+
 export function encodeForkchoiceUpdatedRequest(
+  fork: ForkName,
   headBlockHash: Uint8Array,
   safeBlockHash: Uint8Array,
   finalizedBlockHash: Uint8Array,
   attributes?: PayloadAttributes
 ): Uint8Array {
-  // Fixed part: 96 (forkchoice state) + 4 (attributes offset) = 100
-  const FIXED_SIZE = 100;
+  const version = forkchoiceUpdatedVersion(fork);
+  const forkchoiceState = {headBlockHash, safeBlockHash, finalizedBlockHash};
+  const payloadAttributes = attributes ? [buildPayloadAttributesValue(fork, attributes)] : [];
 
-  if (!attributes) {
-    // No attributes: offset points to end (empty list)
-    const buf = new Uint8Array(FIXED_SIZE);
-    buf.set(headBlockHash, 0);
-    buf.set(safeBlockHash, 32);
-    buf.set(finalizedBlockHash, 64);
-    writeUint32LE(buf, 96, FIXED_SIZE);
-    return buf;
+  switch (version) {
+    case 1:
+      return ForkchoiceUpdatedV1Request.serialize({forkchoiceState, payloadAttributes} as never);
+    case 2:
+      return ForkchoiceUpdatedV2Request.serialize({forkchoiceState, payloadAttributes} as never);
+    case 3:
+      return ForkchoiceUpdatedV3Request.serialize({forkchoiceState, payloadAttributes} as never);
+    case 4:
+      return ForkchoiceUpdatedV4Request.serialize({forkchoiceState, payloadAttributes} as never);
   }
-
-  // Encode PayloadAttributes
-  const feeRecipientBytes = hexToBytes20(attributes.suggestedFeeRecipient);
-  const withdrawals = attributes.withdrawals ?? [];
-  const parentBeaconBlockRoot = attributes.parentBeaconBlockRoot;
-
-  // PayloadAttributes fixed part: timestamp(8) + prevRandao(32) + suggestedFeeRecipient(20)
-  //   + withdrawals_offset(4) + parentBeaconBlockRoot(32) = 96
-  const ATTR_FIXED = 96;
-  const withdrawalsSize = withdrawals.length * 44;
-  const attrTotalSize = ATTR_FIXED + withdrawalsSize;
-
-  // Total: FIXED_SIZE + 4 (list item offset) + attrTotalSize
-  const totalSize = FIXED_SIZE + 4 + attrTotalSize;
-  const buf = new Uint8Array(totalSize);
-
-  // ForkchoiceState
-  buf.set(headBlockHash, 0);
-  buf.set(safeBlockHash, 32);
-  buf.set(finalizedBlockHash, 64);
-
-  // Offset to attributes list data
-  writeUint32LE(buf, 96, FIXED_SIZE);
-
-  // List[PayloadAttributes, 1] with 1 element: item offset(4) + element data
-  let pos = FIXED_SIZE;
-  writeUint32LE(buf, pos, 4); // offset to element data (past the single item offset)
-  pos += 4;
-
-  // PayloadAttributes element data
-  writeUint64LE(buf, pos, BigInt(attributes.timestamp));
-  pos += 8;
-  buf.set(attributes.prevRandao, pos);
-  pos += 32;
-  buf.set(feeRecipientBytes, pos);
-  pos += 20;
-  // withdrawals_offset: relative to element start
-  writeUint32LE(buf, pos, ATTR_FIXED);
-  pos += 4;
-  if (parentBeaconBlockRoot) {
-    buf.set(parentBeaconBlockRoot, pos);
-  }
-  pos += 32;
-
-  // Withdrawals
-  for (const w of withdrawals) {
-    writeUint64LE(buf, pos, BigInt(w.index));
-    pos += 8;
-    writeUint64LE(buf, pos, BigInt(w.validatorIndex));
-    pos += 8;
-    buf.set(w.address, pos);
-    pos += 20;
-    writeUint64LE(buf, pos, BigInt(w.amount));
-    pos += 8;
-  }
-
-  return buf;
 }
 
-/**
- * Encode a NewPayload request.
- *
- * V1/V2: just the ExecutionPayload SSZ bytes
- * V3: payload_offset(4) + hashes_offset(4) + parentBeaconBlockRoot(32 fixed) + payload SSZ + hashes (32 each)
- * V4: V3 layout + requests_offset(4) + execution_requests SSZ
- */
-export function encodeNewPayloadRequest(
-  fork: ForkName,
-  executionPayload: ExecutionPayload,
-  versionedHashes?: VersionedHashes,
-  parentBeaconBlockRoot?: Root,
-  executionRequests?: ExecutionRequests
-): Uint8Array {
-  // Serialize the execution payload using lodestar SSZ codecs
-  const payloadSsz = serializeExecutionPayloadSsz(fork, executionPayload);
-
-  const forkSeq = ForkSeq[fork];
-
-  if (forkSeq < ForkSeq.deneb) {
-    // V1/V2: just the raw payload bytes
-    return payloadSsz;
-  }
-
-  if (!versionedHashes) throw Error("versionedHashes required for deneb+");
-  if (!parentBeaconBlockRoot) throw Error("parentBeaconBlockRoot required for deneb+");
-
-  const hashesBytes = versionedHashes.length * 32;
-
-  if (forkSeq >= ForkSeq.electra && executionRequests) {
-    // V4: payload_offset(4) + hashes_offset(4) + parentBeaconBlockRoot(32) + requests_offset(4) = 44 fixed
-    const FIXED_SIZE = 44;
-
-    const requestsSsz = serializeExecutionRequestsSsz(executionRequests);
-
-    const payloadOffset = FIXED_SIZE;
-    const hashesOffset = payloadOffset + payloadSsz.length;
-    const requestsOffset = hashesOffset + hashesBytes;
-
-    const totalSize = requestsOffset + requestsSsz.length;
-    const buf = new Uint8Array(totalSize);
-
-    writeUint32LE(buf, 0, payloadOffset);
-    writeUint32LE(buf, 4, hashesOffset);
-    buf.set(parentBeaconBlockRoot, 8);
-    writeUint32LE(buf, 40, requestsOffset);
-
-    buf.set(payloadSsz, payloadOffset);
-
-    let pos = hashesOffset;
-    for (const hash of versionedHashes) {
-      buf.set(hash, pos);
-      pos += 32;
-    }
-
-    buf.set(requestsSsz, requestsOffset);
-    return buf;
-  }
-
-  // V3: payload_offset(4) + hashes_offset(4) + parentBeaconBlockRoot(32) = 40 fixed
-  const FIXED_SIZE = 40;
-  const payloadOffset = FIXED_SIZE;
-  const hashesOffset = payloadOffset + payloadSsz.length;
-
-  const totalSize = hashesOffset + hashesBytes;
-  const buf = new Uint8Array(totalSize);
-
-  writeUint32LE(buf, 0, payloadOffset);
-  writeUint32LE(buf, 4, hashesOffset);
-  buf.set(parentBeaconBlockRoot, 8);
-
-  buf.set(payloadSsz, payloadOffset);
-
-  let pos = hashesOffset;
-  for (const hash of versionedHashes) {
-    buf.set(hash, pos);
-    pos += 32;
-  }
-
-  return buf;
-}
-
-/**
- * Encode a GetPayload request: just the 8-byte payload ID.
- */
-export function encodeGetPayloadRequest(payloadId: Uint8Array): Uint8Array {
-  if (payloadId.length !== 8) {
-    throw Error(`Invalid payloadId length ${payloadId.length}, expected 8`);
-  }
-  return payloadId;
-}
-
-/**
- * Encode a GetBlobs request.
- * Container: hashes_offset(4) + concatenated 32-byte hashes
- */
 export function encodeGetBlobsRequest(versionedHashes: VersionedHashes): Uint8Array {
-  const FIXED_SIZE = 4;
-  const hashesSize = versionedHashes.length * 32;
-  const buf = new Uint8Array(FIXED_SIZE + hashesSize);
-  writeUint32LE(buf, 0, FIXED_SIZE);
-  let pos = FIXED_SIZE;
-  for (const hash of versionedHashes) {
-    buf.set(hash, pos);
-    pos += 32;
-  }
-  return buf;
+  return GetBlobsRequest.serialize({blobVersionedHashes: versionedHashes});
 }
 
-/**
- * Encode ExchangeCapabilities as SSZ Container { capabilities: List[List[uint8, 64], 128] }.
- */
 export function encodeExchangeCapabilities(capabilities: string[]): Uint8Array {
-  return ExchangeCapabilitiesRequest.serialize({
-    capabilities: capabilities.map((s) => textEncoder.encode(s)),
+  const encoder = new TextEncoder();
+  return ExchangeCapabilitiesContainer.serialize({
+    capabilities: capabilities.map((s) => encoder.encode(s)),
   });
 }
 
 // ---------------------------------------------------------------------------
-// Decode functions
+// Public decoders
 // ---------------------------------------------------------------------------
 
-/** Status byte mapping */
-const PAYLOAD_STATUS_MAP: Record<number, string> = {
-  0: "VALID",
-  1: "INVALID",
-  2: "SYNCING",
-  3: "ACCEPTED",
-  4: "INVALID_BLOCK_HASH",
-};
-
 export interface DecodedPayloadStatus {
-  status: string;
-  latestValidHash: string | null;
+  status: ExecutionPayloadStatus;
+  latestValidHash: RootHex | null;
   validationError: string | null;
 }
 
-/**
- * Decode PayloadStatus from SSZ-REST response.
- *
- * Layout:
- *   Byte 0: status (0=VALID, 1=INVALID, 2=SYNCING, 3=ACCEPTED, 4=INVALID_BLOCK_HASH)
- *   Bytes 1-4: latestValidHash offset (uint32 LE)
- *   Bytes 5-8: validationError offset (uint32 LE)
- *   Variable: latestValidHash as List[Hash32, 1] (0 bytes = absent, 32 bytes = present)
- *   Variable: validationError as UTF-8 bytes
- */
 export function decodePayloadStatus(data: Uint8Array): DecodedPayloadStatus {
-  if (data.length < 9) {
-    throw Error(`PayloadStatus too short: ${data.length} bytes, expected at least 9`);
-  }
-
-  const statusByte = data[0];
-  const status = PAYLOAD_STATUS_MAP[statusByte];
-  if (status === undefined) {
-    throw Error(`Unknown payload status byte: ${statusByte}`);
-  }
-
-  const latestValidHashOffset = readUint32LE(data, 1);
-  const validationErrorOffset = readUint32LE(data, 5);
-
-  // Decode latestValidHash: List[Hash32, 1] — 0 bytes = absent, 32 bytes = present
-  let latestValidHash: string | null = null;
-  const hashLen = validationErrorOffset - latestValidHashOffset;
-  if (hashLen === 32) {
-    const hashBytes = data.subarray(latestValidHashOffset, validationErrorOffset);
-    latestValidHash = "0x" + bytesToHex(hashBytes);
-  }
-
-  // Decode validationError
-  let validationError: string | null = null;
-  if (validationErrorOffset < data.length) {
-    const errorBytes = data.subarray(validationErrorOffset);
-    if (errorBytes.length > 0) {
-      validationError = textDecoder.decode(errorBytes);
-    }
-  }
-
-  return {status, latestValidHash, validationError};
+  const parsed = PayloadStatusV1.deserialize(data);
+  const validationError = parsed.validationError.length > 0 ? new TextDecoder().decode(parsed.validationError) : null;
+  return {
+    status: statusByteToEnum(parsed.status),
+    latestValidHash: parsed.latestValidHash.length === 1 ? toHex(parsed.latestValidHash[0]) : null,
+    validationError,
+  };
 }
 
 export interface DecodedForkchoiceUpdatedResponse {
   payloadStatus: DecodedPayloadStatus;
-  payloadId: string | null;
+  payloadId: PayloadId | null;
 }
 
-/**
- * Decode ForkchoiceUpdated response.
- *
- * Layout:
- *   Bytes 0-3: payloadStatus offset
- *   Bytes 4-7: payloadId offset
- *   Variable: payloadStatus (decoded with decodePayloadStatus)
- *   Variable: payloadId as List[Bytes8, 1] (0 bytes = absent, 8 bytes = present)
- */
 export function decodeForkchoiceUpdatedResponse(data: Uint8Array): DecodedForkchoiceUpdatedResponse {
-  if (data.length < 8) {
-    throw Error(`ForkchoiceUpdatedResponse too short: ${data.length} bytes, expected at least 8`);
-  }
-
-  const payloadStatusOffset = readUint32LE(data, 0);
-  const payloadIdOffset = readUint32LE(data, 4);
-
-  // Determine payloadStatus extent
-  const payloadStatusEnd = payloadIdOffset < data.length ? payloadIdOffset : data.length;
-  const payloadStatusBytes = data.subarray(payloadStatusOffset, payloadStatusEnd);
-  const payloadStatus = decodePayloadStatus(payloadStatusBytes);
-
-  // Decode payloadId: List[Bytes8, 1] — 0 bytes = absent, 8 bytes = present
-  let payloadId: string | null = null;
-  const pidData = data.subarray(payloadIdOffset);
-  if (pidData.length === 8) {
-    payloadId = "0x" + bytesToHex(pidData);
-  }
-
-  return {payloadStatus, payloadId};
-}
-
-export interface DecodedGetPayloadResponse {
-  /** Raw SSZ bytes of the ExecutionPayload */
-  executionPayloadSsz: Uint8Array;
-  /** Block value as bigint (uint256 LE) */
-  blockValue: bigint;
-  /** Raw SSZ bytes of the BlobsBundle, may be empty */
-  blobsBundleSsz: Uint8Array;
-  /** Whether the builder should be overridden */
-  shouldOverrideBuilder: boolean;
-  /** Raw SSZ bytes of execution requests, may be empty */
-  executionRequestsSsz: Uint8Array;
-}
-
-/**
- * Decode GetPayload response.
- *
- * Layout:
- *   Bytes 0-3:   executionPayload offset
- *   Bytes 4-35:  blockValue (uint256 LE, 32 bytes)
- *   Bytes 36-39: blobsBundle offset
- *   Byte 40:     shouldOverrideBuilder (boolean)
- *   Bytes 41-44: executionRequests offset
- *
- * Fixed header = 45 bytes (if executionRequests field present) or 41 bytes (without)
- */
-export function decodeGetPayloadResponse(data: Uint8Array): DecodedGetPayloadResponse {
-  // Determine layout based on data length and offsets
-  // Minimum: 41 bytes without executionRequests
-  if (data.length < 41) {
-    throw Error(`GetPayloadResponse too short: ${data.length} bytes, expected at least 41`);
-  }
-
-  const executionPayloadOffset = readUint32LE(data, 0);
-  const blockValue = readUint256LE(data, 4);
-  const blobsBundleOffset = readUint32LE(data, 36);
-  const shouldOverrideBuilder = data[40] !== 0;
-
-  let executionRequestsOffset: number;
-  let hasExecutionRequests = false;
-
-  // If executionPayloadOffset >= 45, we have the executionRequests offset field
-  if (executionPayloadOffset >= 45 && data.length >= 45) {
-    executionRequestsOffset = readUint32LE(data, 41);
-    hasExecutionRequests = true;
-  } else {
-    executionRequestsOffset = data.length;
-  }
-
-  // Extract regions
-  const executionPayloadSsz = data.subarray(executionPayloadOffset, blobsBundleOffset);
-  const blobsBundleEnd = hasExecutionRequests ? executionRequestsOffset : data.length;
-  const blobsBundleSsz = data.subarray(blobsBundleOffset, blobsBundleEnd);
-  const executionRequestsSsz = hasExecutionRequests ? data.subarray(executionRequestsOffset) : new Uint8Array(0);
-
+  const parsed = ForkchoiceUpdatedResponseV1.deserialize(data);
+  const validationError =
+    parsed.payloadStatus.validationError.length > 0
+      ? new TextDecoder().decode(parsed.payloadStatus.validationError)
+      : null;
   return {
-    executionPayloadSsz,
-    blockValue,
-    blobsBundleSsz,
-    shouldOverrideBuilder,
-    executionRequestsSsz,
+    payloadStatus: {
+      status: statusByteToEnum(parsed.payloadStatus.status),
+      latestValidHash:
+        parsed.payloadStatus.latestValidHash.length === 1 ? toHex(parsed.payloadStatus.latestValidHash[0]) : null,
+      validationError,
+    },
+    payloadId: parsed.payloadId.length === 1 ? toHex(parsed.payloadId[0]) : null,
   };
 }
 
-/**
- * Decode ExchangeCapabilities response (SSZ Container with List[List[uint8, 64], 128]).
- */
+export interface DecodedGetPayloadResponse {
+  executionPayload: ExecutionPayload;
+  blockValue: bigint;
+  blobsBundle?: import("@lodestar/types").BlobsBundle;
+  shouldOverrideBuilder: boolean;
+  executionRequests?: ExecutionRequests;
+}
+
+export function decodeGetPayloadResponse(fork: ForkName, data: Uint8Array): DecodedGetPayloadResponse {
+  const version = getPayloadVersion(fork);
+
+  // v1 is the raw ExecutionPayloadV1 with no wrapping container — no block
+  // value, no blobs bundle. Lodestar does not produce v1 traffic but we keep
+  // the branch for completeness.
+  if (version === 1) {
+    return {
+      executionPayload: ssz.bellatrix.ExecutionPayload.deserialize(data) as ExecutionPayload,
+      blockValue: 0n,
+      shouldOverrideBuilder: false,
+    };
+  }
+
+  if (version === 2) {
+    const parsed = GetPayloadResponseV2.deserialize(data);
+    return {
+      executionPayload: parsed.executionPayload as ExecutionPayload,
+      blockValue: parsed.blockValue,
+      shouldOverrideBuilder: false,
+    };
+  }
+
+  if (version === 3) {
+    const parsed = GetPayloadResponseV3.deserialize(data);
+    return {
+      executionPayload: parsed.executionPayload as ExecutionPayload,
+      blockValue: parsed.blockValue,
+      blobsBundle: parsed.blobsBundle,
+      shouldOverrideBuilder: parsed.shouldOverrideBuilder,
+    };
+  }
+
+  if (version === 4) {
+    const parsed = GetPayloadResponseV4.deserialize(data);
+    return {
+      executionPayload: parsed.executionPayload as ExecutionPayload,
+      blockValue: parsed.blockValue,
+      blobsBundle: parsed.blobsBundle,
+      shouldOverrideBuilder: parsed.shouldOverrideBuilder,
+      executionRequests: parseExecutionRequestsList(parsed.executionRequests),
+    };
+  }
+
+  if (version === 5) {
+    const parsed = GetPayloadResponseV5.deserialize(data);
+    return {
+      executionPayload: parsed.executionPayload as ExecutionPayload,
+      blockValue: parsed.blockValue,
+      blobsBundle: parsed.blobsBundle,
+      shouldOverrideBuilder: parsed.shouldOverrideBuilder,
+      executionRequests: parseExecutionRequestsList(parsed.executionRequests),
+    };
+  }
+
+  // v6
+  const parsed = GetPayloadResponseV6.deserialize(data);
+  return {
+    executionPayload: parsed.executionPayload as ExecutionPayload,
+    blockValue: parsed.blockValue,
+    blobsBundle: parsed.blobsBundle,
+    shouldOverrideBuilder: parsed.shouldOverrideBuilder,
+    executionRequests: parseExecutionRequestsList(parsed.executionRequests),
+  };
+}
+
+export function decodeGetBlobsV1Response(data: Uint8Array): BlobAndProof[] {
+  const parsed = GetBlobsV1Response.deserialize(data);
+  return parsed.blobsAndProofs.map((item) => ({blob: item.blob, proof: item.proof}));
+}
+
+export function decodeGetBlobsV2Response(data: Uint8Array): BlobAndProofV2[] {
+  const parsed = GetBlobsV2Response.deserialize(data);
+  return parsed.blobsAndProofs.map((item) => ({blob: item.blob, proofs: item.proofs}));
+}
+
 export function decodeExchangeCapabilities(data: Uint8Array): string[] {
-  if (data.length < 4) {
-    return [];
-  }
-  try {
-    const decoded = ExchangeCapabilitiesRequest.deserialize(data);
-    return decoded.capabilities.map((cap) => textDecoder.decode(cap));
-  } catch {
-    return [];
-  }
-}
-
-export interface DecodedBlobAndProof {
-  blob: Uint8Array;
-  kzgProof: Uint8Array;
-}
-
-/**
- * Decode GetBlobs response: returns array of {blob, kzgProof}.
- *
- * Layout: list_offset(4) + N item_offsets(4 each) + items
- * Each item: blob(131072 bytes) + proof(48 bytes)
- */
-export function decodeGetBlobsResponse(data: Uint8Array): DecodedBlobAndProof[] {
-  if (data.length < 4) {
-    return [];
-  }
-
-  const listOffset = readUint32LE(data, 0);
-  if (listOffset >= data.length) {
-    return [];
-  }
-
-  const listData = data.subarray(listOffset);
-  if (listData.length === 0) {
-    return [];
-  }
-
-  // Each blob+proof is fixed size: 131072 + 48 = 131120 bytes
-  const BLOB_SIZE = 131072;
-  const PROOF_SIZE = 48;
-  const ITEM_SIZE = BLOB_SIZE + PROOF_SIZE;
-
-  const numItems = Math.floor(listData.length / ITEM_SIZE);
-  const result: DecodedBlobAndProof[] = [];
-
-  for (let i = 0; i < numItems; i++) {
-    const itemStart = i * ITEM_SIZE;
-    result.push({
-      blob: listData.subarray(itemStart, itemStart + BLOB_SIZE),
-      kzgProof: listData.subarray(itemStart + BLOB_SIZE, itemStart + ITEM_SIZE),
-    });
-  }
-
-  return result;
-}
-
-// ---------------------------------------------------------------------------
-// SSZ serialization helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Serialize an ExecutionPayload to SSZ bytes using the @lodestar/types codec
- * appropriate for the given fork.
- */
-function serializeExecutionPayloadSsz(fork: ForkName, payload: ExecutionPayload): Uint8Array {
-  const forkSeq = ForkSeq[fork];
-  if (forkSeq >= ForkSeq.electra) {
-    return ssz.electra.ExecutionPayload.serialize(payload as unknown as electra.ExecutionPayload);
-  }
-  if (forkSeq >= ForkSeq.deneb) {
-    return ssz.deneb.ExecutionPayload.serialize(payload as unknown as deneb.ExecutionPayload);
-  }
-  if (forkSeq >= ForkSeq.capella) {
-    return ssz.capella.ExecutionPayload.serialize(payload as unknown as capella.ExecutionPayload);
-  }
-  return ssz.bellatrix.ExecutionPayload.serialize(payload as unknown as bellatrix.ExecutionPayload);
-}
-
-/**
- * Serialize ExecutionRequests to a single SSZ byte array.
- * Concatenates the type-prefixed request lists.
- */
-function serializeExecutionRequestsSsz(executionRequests: ExecutionRequests): Uint8Array {
-  const parts: Uint8Array[] = [];
-
-  if (executionRequests.deposits.length > 0) {
-    const bytes = ssz.electra.DepositRequests.serialize(executionRequests.deposits);
-    const prefixed = new Uint8Array(1 + bytes.length);
-    prefixed[0] = 0x00; // DEPOSIT_REQUEST_TYPE
-    prefixed.set(bytes, 1);
-    parts.push(prefixed);
-  }
-
-  if (executionRequests.withdrawals.length > 0) {
-    const bytes = ssz.electra.WithdrawalRequests.serialize(executionRequests.withdrawals);
-    const prefixed = new Uint8Array(1 + bytes.length);
-    prefixed[0] = 0x01; // WITHDRAWAL_REQUEST_TYPE
-    prefixed.set(bytes, 1);
-    parts.push(prefixed);
-  }
-
-  if (executionRequests.consolidations.length > 0) {
-    const bytes = ssz.electra.ConsolidationRequests.serialize(executionRequests.consolidations);
-    const prefixed = new Uint8Array(1 + bytes.length);
-    prefixed[0] = 0x02; // CONSOLIDATION_REQUEST_TYPE
-    prefixed.set(bytes, 1);
-    parts.push(prefixed);
-  }
-
-  // Concatenate
-  const totalLen = parts.reduce((sum, p) => sum + p.length, 0);
-  const result = new Uint8Array(totalLen);
-  let offset = 0;
-  for (const part of parts) {
-    result.set(part, offset);
-    offset += part.length;
-  }
-
-  return result;
-}
-
-// ---------------------------------------------------------------------------
-// Utility
-// ---------------------------------------------------------------------------
-
-function bytesToHex(bytes: Uint8Array): string {
-  let hex = "";
-  for (const b of bytes) {
-    hex += b.toString(16).padStart(2, "0");
-  }
-  return hex;
-}
-
-function hexToBytes20(hex: string): Uint8Array {
-  const stripped = hex.startsWith("0x") ? hex.slice(2) : hex;
-  if (stripped.length !== 40) {
-    throw Error(`Expected 20-byte hex address, got ${stripped.length / 2} bytes`);
-  }
-  const bytes = new Uint8Array(20);
-  for (let i = 0; i < 20; i++) {
-    bytes[i] = parseInt(stripped.substring(i * 2, i * 2 + 2), 16);
-  }
-  return bytes;
+  const parsed = ExchangeCapabilitiesContainer.deserialize(data);
+  const decoder = new TextDecoder();
+  return parsed.capabilities.map((bytes) => decoder.decode(bytes));
 }

--- a/packages/beacon-node/src/execution/engine/sszRestEncoding.ts
+++ b/packages/beacon-node/src/execution/engine/sszRestEncoding.ts
@@ -1,0 +1,608 @@
+/**
+ * SSZ-REST (EIP-8161) encoding and decoding functions for the Engine API.
+ *
+ * All multi-byte integers are little-endian (LE). DataView is used for reading
+ * and writing to ensure correctness regardless of platform endianness.
+ */
+
+import {ByteListType, ContainerType, ListCompositeType} from "@chainsafe/ssz";
+import {ForkName, ForkSeq} from "@lodestar/params";
+import {
+  ExecutionPayload,
+  ExecutionRequests,
+  Root,
+  ssz,
+  bellatrix,
+  capella,
+  deneb,
+  electra,
+} from "@lodestar/types";
+import {PayloadAttributes, VersionedHashes} from "./interface.js";
+
+// SSZ type: Container { capabilities: List[List[uint8, 64], 128] }
+const Capability = new ByteListType(64);
+const ExchangeCapabilitiesRequest = new ContainerType({
+  capabilities: new ListCompositeType(Capability, 128),
+});
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+function writeUint32LE(buf: Uint8Array, offset: number, value: number): void {
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  view.setUint32(offset, value, true);
+}
+
+function readUint32LE(buf: Uint8Array, offset: number): number {
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  return view.getUint32(offset, true);
+}
+
+function writeUint64LE(buf: Uint8Array, offset: number, value: bigint): void {
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  view.setBigUint64(offset, value, true);
+}
+
+function readUint64LE(buf: Uint8Array, offset: number): bigint {
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  return view.getBigUint64(offset, true);
+}
+
+function writeUint256LE(buf: Uint8Array, offset: number, value: bigint): void {
+  // Write 256-bit LE as 4x 64-bit LE words
+  for (let i = 0; i < 4; i++) {
+    writeUint64LE(buf, offset + i * 8, value & 0xffffffffffffffffn);
+    value >>= 64n;
+  }
+}
+
+function readUint256LE(buf: Uint8Array, offset: number): bigint {
+  let result = 0n;
+  for (let i = 3; i >= 0; i--) {
+    result = (result << 64n) | readUint64LE(buf, offset + i * 8);
+  }
+  return result;
+}
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+// ---------------------------------------------------------------------------
+// Encode functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode ForkchoiceState: headBlockHash(32) + safeBlockHash(32) + finalizedBlockHash(32) = 96 bytes
+ */
+export function encodeForkchoiceState(
+  headBlockHash: Uint8Array,
+  safeBlockHash: Uint8Array,
+  finalizedBlockHash: Uint8Array
+): Uint8Array {
+  const buf = new Uint8Array(96);
+  buf.set(headBlockHash, 0);
+  buf.set(safeBlockHash, 32);
+  buf.set(finalizedBlockHash, 64);
+  return buf;
+}
+
+/**
+ * Encode a ForkchoiceUpdated request.
+ *
+ * Layout: ForkchoiceState(96 fixed) + attributes_offset(4) + List[PayloadAttributes, 1]
+ *
+ * List[PayloadAttributes, 1]: empty = absent; offset(4) + element data = present
+ * (PayloadAttributes is variable-size, so the list uses a 4-byte item offset)
+ *
+ * PayloadAttributes V3: timestamp(8) + prevRandao(32) + suggestedFeeRecipient(20)
+ *   + withdrawals_offset(4) + parentBeaconBlockRoot(32) + withdrawals list
+ *
+ * Each withdrawal: index(8) + validatorIndex(8) + address(20) + amount(8) = 44 bytes
+ */
+export function encodeForkchoiceUpdatedRequest(
+  headBlockHash: Uint8Array,
+  safeBlockHash: Uint8Array,
+  finalizedBlockHash: Uint8Array,
+  attributes?: PayloadAttributes
+): Uint8Array {
+  // Fixed part: 96 (forkchoice state) + 4 (attributes offset) = 100
+  const FIXED_SIZE = 100;
+
+  if (!attributes) {
+    // No attributes: offset points to end (empty list)
+    const buf = new Uint8Array(FIXED_SIZE);
+    buf.set(headBlockHash, 0);
+    buf.set(safeBlockHash, 32);
+    buf.set(finalizedBlockHash, 64);
+    writeUint32LE(buf, 96, FIXED_SIZE);
+    return buf;
+  }
+
+  // Encode PayloadAttributes
+  const feeRecipientBytes = hexToBytes20(attributes.suggestedFeeRecipient);
+  const withdrawals = attributes.withdrawals ?? [];
+  const parentBeaconBlockRoot = attributes.parentBeaconBlockRoot;
+
+  // PayloadAttributes fixed part: timestamp(8) + prevRandao(32) + suggestedFeeRecipient(20)
+  //   + withdrawals_offset(4) + parentBeaconBlockRoot(32) = 96
+  const ATTR_FIXED = 96;
+  const withdrawalsSize = withdrawals.length * 44;
+  const attrTotalSize = ATTR_FIXED + withdrawalsSize;
+
+  // Total: FIXED_SIZE + 4 (list item offset) + attrTotalSize
+  const totalSize = FIXED_SIZE + 4 + attrTotalSize;
+  const buf = new Uint8Array(totalSize);
+
+  // ForkchoiceState
+  buf.set(headBlockHash, 0);
+  buf.set(safeBlockHash, 32);
+  buf.set(finalizedBlockHash, 64);
+
+  // Offset to attributes list data
+  writeUint32LE(buf, 96, FIXED_SIZE);
+
+  // List[PayloadAttributes, 1] with 1 element: item offset(4) + element data
+  let pos = FIXED_SIZE;
+  writeUint32LE(buf, pos, 4); // offset to element data (past the single item offset)
+  pos += 4;
+
+  // PayloadAttributes element data
+  writeUint64LE(buf, pos, BigInt(attributes.timestamp));
+  pos += 8;
+  buf.set(attributes.prevRandao, pos);
+  pos += 32;
+  buf.set(feeRecipientBytes, pos);
+  pos += 20;
+  // withdrawals_offset: relative to element start
+  writeUint32LE(buf, pos, ATTR_FIXED);
+  pos += 4;
+  if (parentBeaconBlockRoot) {
+    buf.set(parentBeaconBlockRoot, pos);
+  }
+  pos += 32;
+
+  // Withdrawals
+  for (const w of withdrawals) {
+    writeUint64LE(buf, pos, BigInt(w.index));
+    pos += 8;
+    writeUint64LE(buf, pos, BigInt(w.validatorIndex));
+    pos += 8;
+    buf.set(w.address, pos);
+    pos += 20;
+    writeUint64LE(buf, pos, BigInt(w.amount));
+    pos += 8;
+  }
+
+  return buf;
+}
+
+/**
+ * Encode a NewPayload request.
+ *
+ * V1/V2: just the ExecutionPayload SSZ bytes
+ * V3: payload_offset(4) + hashes_offset(4) + parentBeaconBlockRoot(32 fixed) + payload SSZ + hashes (32 each)
+ * V4: V3 layout + requests_offset(4) + execution_requests SSZ
+ */
+export function encodeNewPayloadRequest(
+  fork: ForkName,
+  executionPayload: ExecutionPayload,
+  versionedHashes?: VersionedHashes,
+  parentBeaconBlockRoot?: Root,
+  executionRequests?: ExecutionRequests
+): Uint8Array {
+  // Serialize the execution payload using lodestar SSZ codecs
+  const payloadSsz = serializeExecutionPayloadSsz(fork, executionPayload);
+
+  const forkSeq = ForkSeq[fork];
+
+  if (forkSeq < ForkSeq.deneb) {
+    // V1/V2: just the raw payload bytes
+    return payloadSsz;
+  }
+
+  if (!versionedHashes) throw Error("versionedHashes required for deneb+");
+  if (!parentBeaconBlockRoot) throw Error("parentBeaconBlockRoot required for deneb+");
+
+  const hashesBytes = versionedHashes.length * 32;
+
+  if (forkSeq >= ForkSeq.electra && executionRequests) {
+    // V4: payload_offset(4) + hashes_offset(4) + parentBeaconBlockRoot(32) + requests_offset(4) = 44 fixed
+    const FIXED_SIZE = 44;
+
+    const requestsSsz = serializeExecutionRequestsSsz(executionRequests);
+
+    const payloadOffset = FIXED_SIZE;
+    const hashesOffset = payloadOffset + payloadSsz.length;
+    const requestsOffset = hashesOffset + hashesBytes;
+
+    const totalSize = requestsOffset + requestsSsz.length;
+    const buf = new Uint8Array(totalSize);
+
+    writeUint32LE(buf, 0, payloadOffset);
+    writeUint32LE(buf, 4, hashesOffset);
+    buf.set(parentBeaconBlockRoot, 8);
+    writeUint32LE(buf, 40, requestsOffset);
+
+    buf.set(payloadSsz, payloadOffset);
+
+    let pos = hashesOffset;
+    for (const hash of versionedHashes) {
+      buf.set(hash, pos);
+      pos += 32;
+    }
+
+    buf.set(requestsSsz, requestsOffset);
+    return buf;
+  }
+
+  // V3: payload_offset(4) + hashes_offset(4) + parentBeaconBlockRoot(32) = 40 fixed
+  const FIXED_SIZE = 40;
+  const payloadOffset = FIXED_SIZE;
+  const hashesOffset = payloadOffset + payloadSsz.length;
+
+  const totalSize = hashesOffset + hashesBytes;
+  const buf = new Uint8Array(totalSize);
+
+  writeUint32LE(buf, 0, payloadOffset);
+  writeUint32LE(buf, 4, hashesOffset);
+  buf.set(parentBeaconBlockRoot, 8);
+
+  buf.set(payloadSsz, payloadOffset);
+
+  let pos = hashesOffset;
+  for (const hash of versionedHashes) {
+    buf.set(hash, pos);
+    pos += 32;
+  }
+
+  return buf;
+}
+
+/**
+ * Encode a GetPayload request: just the 8-byte payload ID.
+ */
+export function encodeGetPayloadRequest(payloadId: Uint8Array): Uint8Array {
+  if (payloadId.length !== 8) {
+    throw Error(`Invalid payloadId length ${payloadId.length}, expected 8`);
+  }
+  return payloadId;
+}
+
+/**
+ * Encode a GetBlobs request.
+ * Container: hashes_offset(4) + concatenated 32-byte hashes
+ */
+export function encodeGetBlobsRequest(versionedHashes: VersionedHashes): Uint8Array {
+  const FIXED_SIZE = 4;
+  const hashesSize = versionedHashes.length * 32;
+  const buf = new Uint8Array(FIXED_SIZE + hashesSize);
+  writeUint32LE(buf, 0, FIXED_SIZE);
+  let pos = FIXED_SIZE;
+  for (const hash of versionedHashes) {
+    buf.set(hash, pos);
+    pos += 32;
+  }
+  return buf;
+}
+
+/**
+ * Encode ExchangeCapabilities as SSZ Container { capabilities: List[List[uint8, 64], 128] }.
+ */
+export function encodeExchangeCapabilities(capabilities: string[]): Uint8Array {
+  return ExchangeCapabilitiesRequest.serialize({
+    capabilities: capabilities.map((s) => textEncoder.encode(s)),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Decode functions
+// ---------------------------------------------------------------------------
+
+/** Status byte mapping */
+const PAYLOAD_STATUS_MAP: Record<number, string> = {
+  0: "VALID",
+  1: "INVALID",
+  2: "SYNCING",
+  3: "ACCEPTED",
+  4: "INVALID_BLOCK_HASH",
+};
+
+export interface DecodedPayloadStatus {
+  status: string;
+  latestValidHash: string | null;
+  validationError: string | null;
+}
+
+/**
+ * Decode PayloadStatus from SSZ-REST response.
+ *
+ * Layout:
+ *   Byte 0: status (0=VALID, 1=INVALID, 2=SYNCING, 3=ACCEPTED, 4=INVALID_BLOCK_HASH)
+ *   Bytes 1-4: latestValidHash offset (uint32 LE)
+ *   Bytes 5-8: validationError offset (uint32 LE)
+ *   Variable: latestValidHash as List[Hash32, 1] (0 bytes = absent, 32 bytes = present)
+ *   Variable: validationError as UTF-8 bytes
+ */
+export function decodePayloadStatus(data: Uint8Array): DecodedPayloadStatus {
+  if (data.length < 9) {
+    throw Error(`PayloadStatus too short: ${data.length} bytes, expected at least 9`);
+  }
+
+  const statusByte = data[0];
+  const status = PAYLOAD_STATUS_MAP[statusByte];
+  if (status === undefined) {
+    throw Error(`Unknown payload status byte: ${statusByte}`);
+  }
+
+  const latestValidHashOffset = readUint32LE(data, 1);
+  const validationErrorOffset = readUint32LE(data, 5);
+
+  // Decode latestValidHash: List[Hash32, 1] — 0 bytes = absent, 32 bytes = present
+  let latestValidHash: string | null = null;
+  const hashLen = validationErrorOffset - latestValidHashOffset;
+  if (hashLen === 32) {
+    const hashBytes = data.subarray(latestValidHashOffset, validationErrorOffset);
+    latestValidHash = "0x" + bytesToHex(hashBytes);
+  }
+
+  // Decode validationError
+  let validationError: string | null = null;
+  if (validationErrorOffset < data.length) {
+    const errorBytes = data.subarray(validationErrorOffset);
+    if (errorBytes.length > 0) {
+      validationError = textDecoder.decode(errorBytes);
+    }
+  }
+
+  return {status, latestValidHash, validationError};
+}
+
+export interface DecodedForkchoiceUpdatedResponse {
+  payloadStatus: DecodedPayloadStatus;
+  payloadId: string | null;
+}
+
+/**
+ * Decode ForkchoiceUpdated response.
+ *
+ * Layout:
+ *   Bytes 0-3: payloadStatus offset
+ *   Bytes 4-7: payloadId offset
+ *   Variable: payloadStatus (decoded with decodePayloadStatus)
+ *   Variable: payloadId as List[Bytes8, 1] (0 bytes = absent, 8 bytes = present)
+ */
+export function decodeForkchoiceUpdatedResponse(data: Uint8Array): DecodedForkchoiceUpdatedResponse {
+  if (data.length < 8) {
+    throw Error(`ForkchoiceUpdatedResponse too short: ${data.length} bytes, expected at least 8`);
+  }
+
+  const payloadStatusOffset = readUint32LE(data, 0);
+  const payloadIdOffset = readUint32LE(data, 4);
+
+  // Determine payloadStatus extent
+  const payloadStatusEnd = payloadIdOffset < data.length ? payloadIdOffset : data.length;
+  const payloadStatusBytes = data.subarray(payloadStatusOffset, payloadStatusEnd);
+  const payloadStatus = decodePayloadStatus(payloadStatusBytes);
+
+  // Decode payloadId: List[Bytes8, 1] — 0 bytes = absent, 8 bytes = present
+  let payloadId: string | null = null;
+  const pidData = data.subarray(payloadIdOffset);
+  if (pidData.length === 8) {
+    payloadId = "0x" + bytesToHex(pidData);
+  }
+
+  return {payloadStatus, payloadId};
+}
+
+export interface DecodedGetPayloadResponse {
+  /** Raw SSZ bytes of the ExecutionPayload */
+  executionPayloadSsz: Uint8Array;
+  /** Block value as bigint (uint256 LE) */
+  blockValue: bigint;
+  /** Raw SSZ bytes of the BlobsBundle, may be empty */
+  blobsBundleSsz: Uint8Array;
+  /** Whether the builder should be overridden */
+  shouldOverrideBuilder: boolean;
+  /** Raw SSZ bytes of execution requests, may be empty */
+  executionRequestsSsz: Uint8Array;
+}
+
+/**
+ * Decode GetPayload response.
+ *
+ * Layout:
+ *   Bytes 0-3:   executionPayload offset
+ *   Bytes 4-35:  blockValue (uint256 LE, 32 bytes)
+ *   Bytes 36-39: blobsBundle offset
+ *   Byte 40:     shouldOverrideBuilder (boolean)
+ *   Bytes 41-44: executionRequests offset
+ *
+ * Fixed header = 45 bytes (if executionRequests field present) or 41 bytes (without)
+ */
+export function decodeGetPayloadResponse(data: Uint8Array): DecodedGetPayloadResponse {
+  // Determine layout based on data length and offsets
+  // Minimum: 41 bytes without executionRequests
+  if (data.length < 41) {
+    throw Error(`GetPayloadResponse too short: ${data.length} bytes, expected at least 41`);
+  }
+
+  const executionPayloadOffset = readUint32LE(data, 0);
+  const blockValue = readUint256LE(data, 4);
+  const blobsBundleOffset = readUint32LE(data, 36);
+  const shouldOverrideBuilder = data[40] !== 0;
+
+  let executionRequestsOffset: number;
+  let hasExecutionRequests = false;
+
+  // If executionPayloadOffset >= 45, we have the executionRequests offset field
+  if (executionPayloadOffset >= 45 && data.length >= 45) {
+    executionRequestsOffset = readUint32LE(data, 41);
+    hasExecutionRequests = true;
+  } else {
+    executionRequestsOffset = data.length;
+  }
+
+  // Extract regions
+  const executionPayloadSsz = data.subarray(executionPayloadOffset, blobsBundleOffset);
+  const blobsBundleEnd = hasExecutionRequests ? executionRequestsOffset : data.length;
+  const blobsBundleSsz = data.subarray(blobsBundleOffset, blobsBundleEnd);
+  const executionRequestsSsz = hasExecutionRequests ? data.subarray(executionRequestsOffset) : new Uint8Array(0);
+
+  return {
+    executionPayloadSsz,
+    blockValue,
+    blobsBundleSsz,
+    shouldOverrideBuilder,
+    executionRequestsSsz,
+  };
+}
+
+/**
+ * Decode ExchangeCapabilities response (SSZ Container with List[List[uint8, 64], 128]).
+ */
+export function decodeExchangeCapabilities(data: Uint8Array): string[] {
+  if (data.length < 4) {
+    return [];
+  }
+  try {
+    const decoded = ExchangeCapabilitiesRequest.deserialize(data);
+    return decoded.capabilities.map((cap) => textDecoder.decode(cap));
+  } catch {
+    return [];
+  }
+}
+
+export interface DecodedBlobAndProof {
+  blob: Uint8Array;
+  kzgProof: Uint8Array;
+}
+
+/**
+ * Decode GetBlobs response: returns array of {blob, kzgProof}.
+ *
+ * Layout: list_offset(4) + N item_offsets(4 each) + items
+ * Each item: blob(131072 bytes) + proof(48 bytes)
+ */
+export function decodeGetBlobsResponse(data: Uint8Array): DecodedBlobAndProof[] {
+  if (data.length < 4) {
+    return [];
+  }
+
+  const listOffset = readUint32LE(data, 0);
+  if (listOffset >= data.length) {
+    return [];
+  }
+
+  const listData = data.subarray(listOffset);
+  if (listData.length === 0) {
+    return [];
+  }
+
+  // Each blob+proof is fixed size: 131072 + 48 = 131120 bytes
+  const BLOB_SIZE = 131072;
+  const PROOF_SIZE = 48;
+  const ITEM_SIZE = BLOB_SIZE + PROOF_SIZE;
+
+  const numItems = Math.floor(listData.length / ITEM_SIZE);
+  const result: DecodedBlobAndProof[] = [];
+
+  for (let i = 0; i < numItems; i++) {
+    const itemStart = i * ITEM_SIZE;
+    result.push({
+      blob: listData.subarray(itemStart, itemStart + BLOB_SIZE),
+      kzgProof: listData.subarray(itemStart + BLOB_SIZE, itemStart + ITEM_SIZE),
+    });
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// SSZ serialization helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize an ExecutionPayload to SSZ bytes using the @lodestar/types codec
+ * appropriate for the given fork.
+ */
+function serializeExecutionPayloadSsz(fork: ForkName, payload: ExecutionPayload): Uint8Array {
+  const forkSeq = ForkSeq[fork];
+  if (forkSeq >= ForkSeq.electra) {
+    return ssz.electra.ExecutionPayload.serialize(payload as unknown as electra.ExecutionPayload);
+  }
+  if (forkSeq >= ForkSeq.deneb) {
+    return ssz.deneb.ExecutionPayload.serialize(payload as unknown as deneb.ExecutionPayload);
+  }
+  if (forkSeq >= ForkSeq.capella) {
+    return ssz.capella.ExecutionPayload.serialize(payload as unknown as capella.ExecutionPayload);
+  }
+  return ssz.bellatrix.ExecutionPayload.serialize(payload as unknown as bellatrix.ExecutionPayload);
+}
+
+/**
+ * Serialize ExecutionRequests to a single SSZ byte array.
+ * Concatenates the type-prefixed request lists.
+ */
+function serializeExecutionRequestsSsz(executionRequests: ExecutionRequests): Uint8Array {
+  const parts: Uint8Array[] = [];
+
+  if (executionRequests.deposits.length > 0) {
+    const bytes = ssz.electra.DepositRequests.serialize(executionRequests.deposits);
+    const prefixed = new Uint8Array(1 + bytes.length);
+    prefixed[0] = 0x00; // DEPOSIT_REQUEST_TYPE
+    prefixed.set(bytes, 1);
+    parts.push(prefixed);
+  }
+
+  if (executionRequests.withdrawals.length > 0) {
+    const bytes = ssz.electra.WithdrawalRequests.serialize(executionRequests.withdrawals);
+    const prefixed = new Uint8Array(1 + bytes.length);
+    prefixed[0] = 0x01; // WITHDRAWAL_REQUEST_TYPE
+    prefixed.set(bytes, 1);
+    parts.push(prefixed);
+  }
+
+  if (executionRequests.consolidations.length > 0) {
+    const bytes = ssz.electra.ConsolidationRequests.serialize(executionRequests.consolidations);
+    const prefixed = new Uint8Array(1 + bytes.length);
+    prefixed[0] = 0x02; // CONSOLIDATION_REQUEST_TYPE
+    prefixed.set(bytes, 1);
+    parts.push(prefixed);
+  }
+
+  // Concatenate
+  const totalLen = parts.reduce((sum, p) => sum + p.length, 0);
+  const result = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (const b of bytes) {
+    hex += b.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+function hexToBytes20(hex: string): Uint8Array {
+  const stripped = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (stripped.length !== 40) {
+    throw Error(`Expected 20-byte hex address, got ${stripped.length / 2} bytes`);
+  }
+  const bytes = new Uint8Array(20);
+  for (let i = 0; i < 20; i++) {
+    bytes[i] = parseInt(stripped.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}

--- a/packages/beacon-node/src/execution/engine/sszRestEncoding.ts
+++ b/packages/beacon-node/src/execution/engine/sszRestEncoding.ts
@@ -372,9 +372,10 @@ function buildPayloadAttributesValue(fork: ForkName, attrs: PayloadAttributes): 
   if (attrs.slotNumber === undefined) {
     throw Error(`slotNumber required in PayloadAttributes for fork=${fork}`);
   }
-  // targetGasLimit is in the spec PR but not yet plumbed through Lodestar's PayloadAttributes.
-  // Encode 0 so the on-wire shape matches the spec; revisit when the field lands.
-  return {...v3, slotNumber: attrs.slotNumber, targetGasLimit: 0};
+  if (attrs.targetGasLimit === undefined) {
+    throw Error(`targetGasLimit required in PayloadAttributes for fork=${fork}`);
+  }
+  return {...v3, slotNumber: attrs.slotNumber, targetGasLimit: attrs.targetGasLimit};
 }
 
 function statusByteToEnum(byte: number): ExecutionPayloadStatus {

--- a/packages/beacon-node/src/execution/engine/sszRestEncoding.ts
+++ b/packages/beacon-node/src/execution/engine/sszRestEncoding.ts
@@ -280,6 +280,36 @@ const GetPayloadBodiesByRangeV1Request = new ContainerType(
 );
 
 // ---------------------------------------------------------------------------
+// Client version (identification.md)
+// ---------------------------------------------------------------------------
+
+const MAX_CLIENT_CODE_LENGTH = 2;
+const MAX_CLIENT_NAME_LENGTH = 64;
+const MAX_CLIENT_VERSION_LENGTH = 64;
+const MAX_CLIENT_VERSIONS = 4;
+const Bytes4 = new ByteVectorType(4);
+
+const ClientVersionV1Container = new ContainerType(
+  {
+    code: new ByteListType(MAX_CLIENT_CODE_LENGTH),
+    name: new ByteListType(MAX_CLIENT_NAME_LENGTH),
+    version: new ByteListType(MAX_CLIENT_VERSION_LENGTH),
+    commit: Bytes4,
+  },
+  {typeName: "ClientVersionV1"}
+);
+
+const GetClientVersionV1Request = new ContainerType(
+  {clientVersion: ClientVersionV1Container},
+  {typeName: "GetClientVersionV1Request"}
+);
+
+const GetClientVersionV1Response = new ContainerType(
+  {versions: new ListCompositeType(ClientVersionV1Container, MAX_CLIENT_VERSIONS)},
+  {typeName: "GetClientVersionV1Response"}
+);
+
+// ---------------------------------------------------------------------------
 // Fork → version mapping
 // ---------------------------------------------------------------------------
 
@@ -510,6 +540,37 @@ export function encodeGetPayloadBodiesByHashRequest(blockHashes: Uint8Array[]): 
 
 export function encodeGetPayloadBodiesByRangeRequest(start: number, count: number): Uint8Array {
   return GetPayloadBodiesByRangeV1Request.serialize({start, count});
+}
+
+export interface SszClientVersion {
+  code: string;
+  name: string;
+  version: string;
+  /** Hex string (with or without 0x prefix) — 4 bytes. */
+  commit: string;
+}
+
+export function encodeGetClientVersionRequest(clientVersion: SszClientVersion): Uint8Array {
+  const encoder = new TextEncoder();
+  return GetClientVersionV1Request.serialize({
+    clientVersion: {
+      code: encoder.encode(clientVersion.code),
+      name: encoder.encode(clientVersion.name),
+      version: encoder.encode(clientVersion.version),
+      commit: fromHex(clientVersion.commit),
+    },
+  });
+}
+
+export function decodeGetClientVersionResponse(data: Uint8Array): SszClientVersion[] {
+  const parsed = GetClientVersionV1Response.deserialize(data);
+  const decoder = new TextDecoder();
+  return parsed.versions.map((cv) => ({
+    code: decoder.decode(cv.code),
+    name: decoder.decode(cv.name),
+    version: decoder.decode(cv.version),
+    commit: toHex(cv.commit).slice(2), // drop the `0x` prefix to match JSON-RPC path
+  }));
 }
 
 export function encodeExchangeCapabilities(capabilities: string[]): Uint8Array {

--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -98,6 +98,7 @@ export type EngineApiRpcParamTypes = {
    * Object - Instance of ClientVersion
    */
   engine_getClientVersionV1: [ClientVersionRpc];
+  engine_exchangeCapabilities: [string[]];
 
   engine_getBlobsV1: [DATA[]];
   engine_getBlobsV2: [DATA[]];
@@ -150,6 +151,7 @@ export type EngineApiRpcReturnTypes = {
   engine_getPayloadBodiesByRangeV1: (ExecutionPayloadBodyRpc | null)[];
 
   engine_getClientVersionV1: ClientVersionRpc[];
+  engine_exchangeCapabilities: string[];
 
   engine_getBlobsV1: (BlobAndProofRpc | null)[];
   engine_getBlobsV2: BlobAndProofV2Rpc[] | null;

--- a/packages/beacon-node/test/unit/executionEngine/httpSszRest.test.ts
+++ b/packages/beacon-node/test/unit/executionEngine/httpSszRest.test.ts
@@ -175,6 +175,37 @@ describe("ExecutionEngine / SSZ-REST", () => {
     expect(jsonRpcNewPayloadRequests).toBe(0);
   });
 
+  it("uses JSON-RPC for getBlobsV1 because SSZ v1 cannot preserve null positions", async () => {
+    let sszGetBlobsRequests = 0;
+    let jsonRpcGetBlobsRequests = 0;
+
+    const executionEngine = await startExecutionEngine(
+      {
+        capabilities: ["POST /engine/v1/blobs"],
+        async onJsonRpc(payload) {
+          if (payload.method === "engine_getBlobsV1") {
+            jsonRpcGetBlobsRequests++;
+            return [null];
+          }
+          return [];
+        },
+        sszRoutes: {
+          "/engine/v1/blobs": async (_req, reply) => {
+            sszGetBlobsRequests++;
+            reply.code(500).send("SSZ getBlobsV1 endpoint should not be called");
+          },
+        },
+      },
+      afterCallbacks
+    );
+
+    const response = await executionEngine.getBlobs(ForkName.deneb, [new Uint8Array(32)]);
+
+    expect(response).toEqual([null]);
+    expect(sszGetBlobsRequests).toBe(0);
+    expect(jsonRpcGetBlobsRequests).toBe(1);
+  });
+
   it("serializes SSZ newPayload and forkchoiceUpdated through the Engine queue", async () => {
     const events: string[] = [];
     let releaseNewPayload = (): void => {

--- a/packages/beacon-node/test/unit/executionEngine/httpSszRest.test.ts
+++ b/packages/beacon-node/test/unit/executionEngine/httpSszRest.test.ts
@@ -3,13 +3,16 @@ import {afterEach, describe, expect, it} from "vitest";
 import {ByteListType, ByteVectorType, ContainerType, ListCompositeType, UintNumberType} from "@chainsafe/ssz";
 import {Logger} from "@lodestar/logger";
 import {ForkName} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
 import {defaultExecutionEngineHttpOpts} from "../../../src/execution/engine/http.js";
+import {encodeForkchoiceUpdatedRequest} from "../../../src/execution/engine/sszRestEncoding.js";
 import {parseExecutionPayload} from "../../../src/execution/engine/types.js";
 import {RpcPayload} from "../../../src/execution/engine/utils.js";
 import {IExecutionEngine, initializeExecutionEngine} from "../../../src/execution/index.js";
 
 const Uint8 = new UintNumberType(1);
 const Bytes8 = new ByteVectorType(8);
+const Bytes20 = new ByteVectorType(20);
 const Bytes32 = new ByteVectorType(32);
 const NullableHash = new ListCompositeType(Bytes32, 1);
 const NullablePayloadId = new ListCompositeType(Bytes8, 1);
@@ -26,6 +29,32 @@ const ForkchoiceUpdatedResponseV1 = new ContainerType(
     payloadId: NullablePayloadId,
   },
   {typeName: "ForkchoiceUpdatedResponseV1"}
+);
+
+const ForkchoiceStateV1 = new ContainerType(
+  {headBlockHash: Bytes32, safeBlockHash: Bytes32, finalizedBlockHash: Bytes32},
+  {typeName: "ForkchoiceStateV1"}
+);
+
+const PayloadAttributesV4 = new ContainerType(
+  {
+    timestamp: ssz.UintNum64,
+    prevRandao: Bytes32,
+    suggestedFeeRecipient: Bytes20,
+    withdrawals: ssz.capella.Withdrawals,
+    parentBeaconBlockRoot: Bytes32,
+    slotNumber: ssz.UintNum64,
+    targetGasLimit: ssz.UintNum64,
+  },
+  {typeName: "PayloadAttributesV4"}
+);
+
+const ForkchoiceUpdatedV4Request = new ContainerType(
+  {
+    forkchoiceState: ForkchoiceStateV1,
+    payloadAttributes: new ListCompositeType(PayloadAttributesV4, 1),
+  },
+  {typeName: "ForkchoiceUpdatedV4Request"}
 );
 
 const executionPayloadRpc = {
@@ -62,6 +91,23 @@ describe("ExecutionEngine / SSZ-REST", () => {
       const callback = afterCallbacks.pop();
       if (callback) await callback();
     }
+  });
+
+  it("encodes targetGasLimit in forkchoiceUpdated v4 payload attributes", () => {
+    const root = new Uint8Array(32);
+    const body = encodeForkchoiceUpdatedRequest(ForkName.gloas, root, root, root, {
+      timestamp: 1,
+      prevRandao: root,
+      suggestedFeeRecipient: `0x${"11".repeat(20)}`,
+      withdrawals: [],
+      parentBeaconBlockRoot: root,
+      slotNumber: 2,
+      targetGasLimit: 30_000_000,
+    });
+
+    const parsed = ForkchoiceUpdatedV4Request.deserialize(body);
+
+    expect(parsed.payloadAttributes[0].targetGasLimit).toBe(30_000_000);
   });
 
   it("does not call SSZ endpoint unless it is advertised by engine_exchangeCapabilities", async () => {

--- a/packages/beacon-node/test/unit/executionEngine/httpSszRest.test.ts
+++ b/packages/beacon-node/test/unit/executionEngine/httpSszRest.test.ts
@@ -1,0 +1,267 @@
+import {FastifyReply, FastifyRequest, fastify} from "fastify";
+import {afterEach, describe, expect, it} from "vitest";
+import {ByteListType, ByteVectorType, ContainerType, ListCompositeType, UintNumberType} from "@chainsafe/ssz";
+import {Logger} from "@lodestar/logger";
+import {ForkName} from "@lodestar/params";
+import {defaultExecutionEngineHttpOpts} from "../../../src/execution/engine/http.js";
+import {parseExecutionPayload} from "../../../src/execution/engine/types.js";
+import {RpcPayload} from "../../../src/execution/engine/utils.js";
+import {IExecutionEngine, initializeExecutionEngine} from "../../../src/execution/index.js";
+
+const Uint8 = new UintNumberType(1);
+const Bytes8 = new ByteVectorType(8);
+const Bytes32 = new ByteVectorType(32);
+const NullableHash = new ListCompositeType(Bytes32, 1);
+const NullablePayloadId = new ListCompositeType(Bytes8, 1);
+const ValidationErrorBytes = new ByteListType(1024);
+
+const PayloadStatusV1 = new ContainerType(
+  {status: Uint8, latestValidHash: NullableHash, validationError: ValidationErrorBytes},
+  {typeName: "PayloadStatusV1"}
+);
+
+const ForkchoiceUpdatedResponseV1 = new ContainerType(
+  {
+    payloadStatus: PayloadStatusV1,
+    payloadId: NullablePayloadId,
+  },
+  {typeName: "ForkchoiceUpdatedResponseV1"}
+);
+
+const executionPayloadRpc = {
+  blockHash: "0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174",
+  parentHash: "0xa0513a503d5bd6e89a144c3268e5b7e9da9dbf63df125a360e3950a7d0d67131",
+  feeRecipient: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+  stateRoot: "0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45",
+  receiptsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+  logsBloom:
+    "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  prevRandao: "0x0000000000000000000000000000000000000000000000000000000000000000",
+  blockNumber: "0x1",
+  gasLimit: "0x989680",
+  gasUsed: "0x0",
+  timestamp: "0x5",
+  extraData: "0x",
+  baseFeePerGas: "0x7",
+  transactions: [],
+};
+
+const validExecutionPayloadRpc = {...executionPayloadRpc, logsBloom: `0x${"00".repeat(256)}`};
+
+const forkChoiceHeadData = {
+  headBlockHash: "0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174",
+  safeBlockHash: "0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174",
+  finalizedBlockHash: "0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174",
+};
+
+describe("ExecutionEngine / SSZ-REST", () => {
+  const afterCallbacks: (() => Promise<void> | void)[] = [];
+
+  afterEach(async () => {
+    while (afterCallbacks.length > 0) {
+      const callback = afterCallbacks.pop();
+      if (callback) await callback();
+    }
+  });
+
+  it("does not call SSZ endpoint unless it is advertised by engine_exchangeCapabilities", async () => {
+    let sszNewPayloadRequests = 0;
+    let jsonRpcNewPayloadRequests = 0;
+
+    const executionEngine = await startExecutionEngine(
+      {
+        capabilities: ["engine_newPayloadV1"],
+        async onJsonRpc(payload) {
+          if (payload.method === "engine_newPayloadV1") {
+            jsonRpcNewPayloadRequests++;
+            return {status: "VALID", latestValidHash: executionPayloadRpc.blockHash, validationError: null};
+          }
+          return [];
+        },
+        sszRoutes: {
+          "/engine/v1/payloads": async (_req, reply) => {
+            sszNewPayloadRequests++;
+            reply.code(500).send("SSZ endpoint should not be called");
+          },
+        },
+      },
+      afterCallbacks
+    );
+
+    await executionEngine.notifyNewPayload(
+      ForkName.bellatrix,
+      parseExecutionPayload(ForkName.bellatrix, validExecutionPayloadRpc).executionPayload
+    );
+
+    expect(sszNewPayloadRequests).toBe(0);
+    expect(jsonRpcNewPayloadRequests).toBe(1);
+  });
+
+  it("does not fall back to JSON-RPC when an advertised SSZ endpoint returns a semantic HTTP error", async () => {
+    let jsonRpcNewPayloadRequests = 0;
+
+    const executionEngine = await startExecutionEngine(
+      {
+        capabilities: ["POST /engine/v1/payloads"],
+        async onJsonRpc(payload) {
+          if (payload.method === "engine_newPayloadV1") {
+            jsonRpcNewPayloadRequests++;
+            return {status: "VALID", latestValidHash: executionPayloadRpc.blockHash, validationError: null};
+          }
+          return [];
+        },
+        sszRoutes: {
+          "/engine/v1/payloads": async (_req, reply) => {
+            reply.code(400).send("Malformed SSZ");
+          },
+        },
+      },
+      afterCallbacks
+    );
+
+    await expect(
+      executionEngine.notifyNewPayload(
+        ForkName.bellatrix,
+        parseExecutionPayload(ForkName.bellatrix, validExecutionPayloadRpc).executionPayload
+      )
+    ).rejects.toThrow("SSZ-REST error 400: Malformed SSZ");
+
+    expect(jsonRpcNewPayloadRequests).toBe(0);
+  });
+
+  it("serializes SSZ newPayload and forkchoiceUpdated through the Engine queue", async () => {
+    const events: string[] = [];
+    let releaseNewPayload = (): void => {
+      throw Error("releaseNewPayload called before request started");
+    };
+
+    const executionEngine = await startExecutionEngine(
+      {
+        capabilities: ["POST /engine/v1/payloads", "POST /engine/v1/forkchoice"],
+        sszRoutes: {
+          "/engine/v1/payloads": async (_req, reply) => {
+            events.push("newPayload:start");
+            await new Promise<void>((resolve) => {
+              releaseNewPayload = resolve;
+            });
+            events.push("newPayload:end");
+            sendSsz(reply, validPayloadStatus());
+          },
+          "/engine/v1/forkchoice": async (_req, reply) => {
+            events.push("forkchoice:start");
+            sendSsz(reply, validForkchoiceUpdatedResponse());
+          },
+        },
+      },
+      afterCallbacks
+    );
+
+    const newPayloadPromise = executionEngine.notifyNewPayload(
+      ForkName.bellatrix,
+      parseExecutionPayload(ForkName.bellatrix, validExecutionPayloadRpc).executionPayload
+    );
+
+    await waitUntil(() => events.includes("newPayload:start"));
+
+    const forkchoicePromise = executionEngine.notifyForkchoiceUpdate(
+      ForkName.bellatrix,
+      forkChoiceHeadData.headBlockHash,
+      forkChoiceHeadData.safeBlockHash,
+      forkChoiceHeadData.finalizedBlockHash
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(events).toEqual(["newPayload:start"]);
+
+    releaseNewPayload();
+    await Promise.all([newPayloadPromise, forkchoicePromise]);
+
+    expect(events).toEqual(["newPayload:start", "newPayload:end", "forkchoice:start"]);
+  });
+});
+
+type SszRouteHandler = (req: FastifyRequest, reply: FastifyReply) => Promise<void> | void;
+
+type EngineStubOpts = {
+  capabilities: string[];
+  onJsonRpc?: (payload: RpcPayload) => Promise<unknown> | unknown;
+  sszRoutes?: Partial<Record<string, SszRouteHandler>>;
+};
+
+async function startExecutionEngine(
+  opts: EngineStubOpts,
+  afterCallbacks: (() => Promise<void> | void)[]
+): Promise<IExecutionEngine> {
+  const controller = new AbortController();
+  const server = fastify({logger: false});
+
+  server.addContentTypeParser("application/octet-stream", {parseAs: "buffer"}, (_req, body, done) => {
+    done(null, body);
+  });
+
+  server.post("/", async (req) => {
+    const payload = req.body as RpcPayload;
+    if (payload.method === "engine_exchangeCapabilities") {
+      return {jsonrpc: "2.0", id: 1, result: opts.capabilities};
+    }
+    if (payload.method === "engine_getClientVersionV1") {
+      return {jsonrpc: "2.0", id: 1, result: [{code: "GE", name: "geth", version: "test", commit: "0x00000000"}]};
+    }
+    return {jsonrpc: "2.0", id: 1, result: await opts.onJsonRpc?.(payload)};
+  });
+
+  for (const [path, handler] of Object.entries(opts.sszRoutes ?? {})) {
+    if (!handler) continue;
+    server.post(path, handler);
+  }
+
+  afterCallbacks.push(async () => {
+    controller.abort();
+    await server.close();
+  });
+
+  const baseUrl = await server.listen({host: "127.0.0.1", port: 0});
+
+  return initializeExecutionEngine(
+    {
+      mode: "http",
+      urls: [baseUrl],
+      retries: defaultExecutionEngineHttpOpts.retries,
+      retryDelay: defaultExecutionEngineHttpOpts.retryDelay,
+      sszRest: true,
+    },
+    {signal: controller.signal, logger: console as unknown as Logger}
+  );
+}
+
+function validPayloadStatus(): Uint8Array {
+  return PayloadStatusV1.serialize({
+    status: 0,
+    latestValidHash: [new Uint8Array(32)],
+    validationError: new Uint8Array(),
+  });
+}
+
+function validForkchoiceUpdatedResponse(): Uint8Array {
+  return ForkchoiceUpdatedResponseV1.serialize({
+    payloadStatus: {
+      status: 0,
+      latestValidHash: [new Uint8Array(32)],
+      validationError: new Uint8Array(),
+    },
+    payloadId: [],
+  });
+}
+
+function sendSsz(reply: FastifyReply, data: Uint8Array): void {
+  reply.header("Content-Type", "application/octet-stream");
+  reply.send(Buffer.from(data));
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw Error("Timed out waiting for condition");
+}

--- a/packages/beacon-node/test/unit/executionEngine/httpSszRest.test.ts
+++ b/packages/beacon-node/test/unit/executionEngine/httpSszRest.test.ts
@@ -175,7 +175,7 @@ describe("ExecutionEngine / SSZ-REST", () => {
     expect(jsonRpcNewPayloadRequests).toBe(0);
   });
 
-  it("uses JSON-RPC for getBlobsV1 because SSZ v1 cannot preserve null positions", async () => {
+  it("pads SSZ getBlobsV1 response with null when the EL returns fewer blobs than requested", async () => {
     let sszGetBlobsRequests = 0;
     let jsonRpcGetBlobsRequests = 0;
 
@@ -192,7 +192,10 @@ describe("ExecutionEngine / SSZ-REST", () => {
         sszRoutes: {
           "/engine/v1/blobs": async (_req, reply) => {
             sszGetBlobsRequests++;
-            reply.code(500).send("SSZ getBlobsV1 endpoint should not be called");
+            // Spec v1 has no per-element nullability; we return an empty list
+            // to simulate "no blobs found" and rely on the http.ts path to pad
+            // back up to the request length.
+            sendSsz(reply, emptyGetBlobsV1Response());
           },
         },
       },
@@ -202,8 +205,8 @@ describe("ExecutionEngine / SSZ-REST", () => {
     const response = await executionEngine.getBlobs(ForkName.deneb, [new Uint8Array(32)]);
 
     expect(response).toEqual([null]);
-    expect(sszGetBlobsRequests).toBe(0);
-    expect(jsonRpcGetBlobsRequests).toBe(1);
+    expect(sszGetBlobsRequests).toBe(1);
+    expect(jsonRpcGetBlobsRequests).toBe(0);
   });
 
   it("serializes SSZ newPayload and forkchoiceUpdated through the Engine queue", async () => {
@@ -328,6 +331,18 @@ function validForkchoiceUpdatedResponse(): Uint8Array {
     },
     payloadId: [],
   });
+}
+
+const Bytes48 = new ByteVectorType(48);
+const BlobBytes = new ByteVectorType(131072);
+const BlobAndProofV1 = new ContainerType({blob: BlobBytes, proof: Bytes48}, {typeName: "BlobAndProofV1"});
+const GetBlobsV1Response = new ContainerType(
+  {blobsAndProofs: new ListCompositeType(BlobAndProofV1, 128)},
+  {typeName: "GetBlobsV1Response"}
+);
+
+function emptyGetBlobsV1Response(): Uint8Array {
+  return GetBlobsV1Response.serialize({blobsAndProofs: []});
 }
 
 function sendSsz(reply: FastifyReply, data: Uint8Array): void {

--- a/packages/cli/src/options/beaconNodeOptions/execution.ts
+++ b/packages/cli/src/options/beaconNodeOptions/execution.ts
@@ -9,6 +9,7 @@ export type ExecutionEngineArgs = {
   "execution.retries": number;
   "execution.retryDelay": number;
   "execution.engineMock"?: boolean;
+  "execution.sszRest"?: boolean;
   jwtSecret?: string;
   jwtId?: string;
 };
@@ -32,6 +33,7 @@ export function parseArgs(args: ExecutionEngineArgs): IBeaconNodeOptions["execut
      */
     jwtSecretHex: args.jwtSecret ? extractJwtHexSecret(fs.readFileSync(args.jwtSecret, "utf-8").trim()) : undefined,
     jwtId: args.jwtId,
+    sszRest: args["execution.sszRest"],
   };
 }
 
@@ -73,6 +75,14 @@ export const options: CliCommandOptions<ExecutionEngineArgs> = {
     description: "Set the execution engine to mock mode (development only)",
     type: "boolean",
     hidden: false,
+    group: "execution",
+  },
+
+  "execution.sszRest": {
+    description:
+      "Enable the experimental SSZ-REST Engine API transport (EIP-8161 / ethereum/execution-apis#764). When enabled, supported Engine API calls are first attempted as binary SSZ over REST on the same Engine port, falling back to JSON-RPC on network errors. Off by default until the spec stabilises.",
+    type: "boolean",
+    hidden: true,
     group: "execution",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/execution.ts
+++ b/packages/cli/src/options/beaconNodeOptions/execution.ts
@@ -80,7 +80,7 @@ export const options: CliCommandOptions<ExecutionEngineArgs> = {
 
   "execution.sszRest": {
     description:
-      "Enable the experimental SSZ-REST Engine API transport (EIP-8161 / ethereum/execution-apis#764). When enabled, supported Engine API calls are first attempted as binary SSZ over REST on the same Engine port, falling back to JSON-RPC on network errors. Off by default until the spec stabilises.",
+      "Enable the experimental SSZ-REST Engine API transport (EIP-8161 / ethereum/execution-apis#764). When enabled, mutually advertised Engine API endpoints use binary SSZ over REST on the same Engine port, falling back to JSON-RPC on network errors. Off by default until the spec stabilises.",
     type: "boolean",
     hidden: true,
     group: "execution",


### PR DESCRIPTION
## Summary

Implements SSZ-REST Engine API transport on the consensus layer (client side), as specified in
[ethereum/execution-apis#764](https://github.com/ethereum/execution-apis/pull/764).

- New CLI flag `--execution.sszRestUrl` to configure SSZ-REST endpoint
- SSZ-encoded request/response bodies for all Engine API methods
- Automatic fallback to JSON-RPC on network errors
- Supports: `new_payload` (v1-v5), `forkchoice_updated` (v1-v3), `get_payload` (v1-v5), `exchange_capabilities`
- Proper fork-based version selection for Deneb/Electra/Fulu

