### PR TITLE
fix: ptc gossip to dedup by slot not by epoch

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -554,7 +554,7 @@ export class BeaconChain implements IBeaconChain {
       //   seenAggregators = single aggregator index, not participants of the aggregate
       this.seenAggregators.isKnown(epoch, index) ||
       //   seenPayloadAttesters = single signer of payload attestation message
-      this.seenPayloadAttesters.isKnown(epoch, index) ||
+      this.seenPayloadAttesters.isKnownAtEpoch(epoch, index) ||
       //   seenBlockProposers = single block proposer
       this.seenBlockProposers.seenAtEpoch(epoch, index)
     );
@@ -1462,6 +1462,7 @@ export class BeaconChain implements IBeaconChain {
     this.aggregatedAttestationPool.prune(slot);
     this.syncCommitteeMessagePool.prune(slot);
     this.seenSyncCommitteeMessages.prune(slot);
+    this.seenPayloadAttesters.prune(slot);
     this.payloadAttestationPool.prune(slot);
     this.executionPayloadBidPool.prune(slot);
     this.seenExecutionPayloadBids.prune(slot);
@@ -1490,7 +1491,7 @@ export class BeaconChain implements IBeaconChain {
 
     this.seenAttesters.prune(epoch);
     this.seenAggregators.prune(epoch);
-    this.seenPayloadAttesters.prune(epoch);
+    this.seenPayloadAttesters.pruneEpoch(epoch);
     this.seenAggregatedAttestations.prune(epoch);
     this.seenBlockAttesters.prune(epoch);
     this.beaconProposerCache.prune(epoch);

--- a/packages/beacon-node/src/chain/opPools/payloadAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/payloadAttestationPool.ts
@@ -178,9 +178,9 @@ function aggregateMessageInto(
   validatorCommitteeIndices: number[],
   aggregate: AggregateFast
 ): InsertOutcome {
-  // Gossip dedup via `seenPayloadAttesters` is keyed by (epoch, validatorIndex), so the same
-  // validator's message is never processed twice — all of its bits are set together or none.
-  // Checking the first index is sufficient.
+  // Gossip dedup via `seenPayloadAttesters` is keyed by (slot, validatorIndex), so the same
+  // validator's message is never processed twice in the same slot — all of its bits are set
+  // together or none. Checking the first index is sufficient.
   if (aggregate.aggregationBits.get(validatorCommitteeIndices[0]) === true) {
     return InsertOutcome.AlreadyKnown;
   }

--- a/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
@@ -1,4 +1,5 @@
-import {Epoch, ValidatorIndex} from "@lodestar/types";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {Epoch, Slot, ValidatorIndex} from "@lodestar/types";
 import {MapDef} from "@lodestar/utils";
 
 // How many *non future* epochs we intend to keep for SeenAttesters.
@@ -58,6 +59,60 @@ export class SeenAttesters {
 export class SeenAggregators extends SeenAttesters {}
 
 /**
- * Keeps a cache to filter payload attestations from the same attesters in the same epoch
+ * Maximum number of slots retained in the per-slot dedup map for PayloadAttestationMessage.
+ *
+ * Gossip validation enforces `data.slot == current_slot` (with MAXIMUM_GOSSIP_CLOCK_DISPARITY),
+ * so we only need a small window around the current slot. Mirrors `SeenSyncCommitteeMessages`.
  */
-export class SeenPayloadAttesters extends SeenAttesters {}
+const PAYLOAD_ATTESTER_MAX_SLOTS_IN_CACHE = 3;
+
+/**
+ * Caches for PayloadAttestationMessage gossip. Two parallel structures, written atomically
+ * by `add(slot, validatorIndex)`:
+ *
+ *  - `validatorIndexesBySlot` — per-slot dedup. The gloas spec requires "first valid message
+ *    received from the validator with index `validator_index`", and the validator emits ONE
+ *    message per slot regardless of how many PTC seats it holds (multi-seat fan-out happens
+ *    at pool aggregation, see `payloadAttestationPool`). A second message from the same
+ *    validator at the same slot conflicts on `payload_present`/`blob_data_available` and
+ *    must be IGNORED. Same validator at a *different* slot in the same epoch is independent
+ *    and must be accepted.
+ *
+ *  - `validatorIndexesByEpoch` — per-epoch liveness signal consumed by `validatorSeenAtEpoch`
+ *    for the validator liveness API, which queries epochs in `currentEpoch-1 .. currentEpoch+1`.
+ */
+export class SeenPayloadAttesters {
+  private readonly validatorIndexesBySlot = new MapDef<Slot, Set<ValidatorIndex>>(() => new Set<ValidatorIndex>());
+  private readonly validatorIndexesByEpoch = new MapDef<Epoch, Set<ValidatorIndex>>(() => new Set<ValidatorIndex>());
+  private lowestPermissibleEpoch: Epoch = 0;
+
+  isKnown(slot: Slot, validatorIndex: ValidatorIndex): boolean {
+    return this.validatorIndexesBySlot.get(slot)?.has(validatorIndex) === true;
+  }
+
+  isKnownAtEpoch(epoch: Epoch, validatorIndex: ValidatorIndex): boolean {
+    return this.validatorIndexesByEpoch.get(epoch)?.has(validatorIndex) === true;
+  }
+
+  add(slot: Slot, validatorIndex: ValidatorIndex): void {
+    this.validatorIndexesBySlot.getOrDefault(slot).add(validatorIndex);
+    this.validatorIndexesByEpoch.getOrDefault(Math.floor(slot / SLOTS_PER_EPOCH)).add(validatorIndex);
+  }
+
+  prune(clockSlot: Slot): void {
+    for (const slot of this.validatorIndexesBySlot.keys()) {
+      if (slot < clockSlot - PAYLOAD_ATTESTER_MAX_SLOTS_IN_CACHE) {
+        this.validatorIndexesBySlot.delete(slot);
+      }
+    }
+  }
+
+  pruneEpoch(currentEpoch: Epoch): void {
+    this.lowestPermissibleEpoch = Math.max(currentEpoch - EPOCH_LOOKBACK_LIMIT, 0);
+    for (const epoch of this.validatorIndexesByEpoch.keys()) {
+      if (epoch < this.lowestPermissibleEpoch) {
+        this.validatorIndexesByEpoch.delete(epoch);
+      }
+    }
+  }
+}

--- a/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
@@ -95,8 +95,12 @@ export class SeenPayloadAttesters {
   }
 
   add(slot: Slot, validatorIndex: ValidatorIndex): void {
+    const epoch = Math.floor(slot / SLOTS_PER_EPOCH);
+    if (epoch < this.lowestPermissibleEpoch) {
+      throw Error(`EpochTooLow ${epoch} < ${this.lowestPermissibleEpoch}`);
+    }
     this.validatorIndexesBySlot.getOrDefault(slot).add(validatorIndex);
-    this.validatorIndexesByEpoch.getOrDefault(Math.floor(slot / SLOTS_PER_EPOCH)).add(validatorIndex);
+    this.validatorIndexesByEpoch.getOrDefault(epoch).add(validatorIndex);
   }
 
   prune(clockSlot: Slot): void {

--- a/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
+++ b/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
@@ -1,5 +1,4 @@
 import {
-  computeEpochAtSlot,
   createSingleSignatureSetFromComponents,
   getPayloadAttestationDataSigningRoot,
   isStatePostGloas,
@@ -35,7 +34,6 @@ async function validatePayloadAttestationMessage(
   prioritizeBls = false
 ): Promise<PayloadAttestationValidationResult> {
   const {data, validatorIndex} = payloadAttestationMessage;
-  const epoch = computeEpochAtSlot(data.slot);
 
   // [IGNORE] The message's slot is for the current slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance), i.e. `data.slot == current_slot`.
   if (!chain.clock.isCurrentSlotGivenGossipDisparity(data.slot)) {
@@ -48,8 +46,10 @@ async function validatePayloadAttestationMessage(
 
   // [IGNORE] The `payload_attestation_message` is the first valid message received
   // from the validator with index `payload_attestation_message.validator_index`.
-  // A single validator can participate PTC at most once per epoch
-  if (chain.seenPayloadAttesters.isKnown(epoch, validatorIndex)) {
+  // It is possible that a validator can participate in PTC more than one time per
+  // slot and per epoch. However only first message of a validator in the same slot will be accepted.
+  // A message from the same validator at a different slot in the same epoch is independent and accepted.
+  if (chain.seenPayloadAttesters.isKnown(data.slot, validatorIndex)) {
     throw new PayloadAttestationError(GossipAction.IGNORE, {
       code: PayloadAttestationErrorCode.PAYLOAD_ATTESTATION_ALREADY_KNOWN,
       validatorIndex,
@@ -113,7 +113,7 @@ async function validatePayloadAttestationMessage(
   }
 
   // Valid
-  chain.seenPayloadAttesters.add(epoch, validatorIndex);
+  chain.seenPayloadAttesters.add(data.slot, validatorIndex);
 
   return {
     attDataRootHex: toRootHex(ssz.gloas.PayloadAttestationData.hashTreeRoot(data)),

--- a/packages/beacon-node/test/unit/chain/seenCache/payloadAttesters.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/payloadAttesters.test.ts
@@ -1,0 +1,102 @@
+import {describe, expect, it} from "vitest";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {SeenPayloadAttesters} from "../../../../src/chain/seenCache/index.js";
+
+const MAX_SLOTS_IN_CACHE = 3;
+const EPOCH_LOOKBACK_LIMIT = 2;
+
+describe("chain / seenCache / SeenPayloadAttesters", () => {
+  const validatorIndex = 100;
+  const otherValidator = 101;
+  // Use a slot late in an epoch so we can test "same epoch, different slot" within one epoch.
+  const slot = SLOTS_PER_EPOCH * 10 + 1;
+  const epoch = Math.floor(slot / SLOTS_PER_EPOCH);
+
+  it("dedups by (slot, validatorIndex)", () => {
+    const cache = new SeenPayloadAttesters();
+    expect(cache.isKnown(slot, validatorIndex)).toBe(false);
+    cache.add(slot, validatorIndex);
+    expect(cache.isKnown(slot, validatorIndex)).toBe(true);
+    // Different validator at same slot is independent.
+    expect(cache.isKnown(slot, otherValidator)).toBe(false);
+  });
+
+  it("accepts the same validator at different slots in the same epoch", () => {
+    const cache = new SeenPayloadAttesters();
+    const slot1 = slot;
+    const slot2 = slot + 1;
+    expect(Math.floor(slot1 / SLOTS_PER_EPOCH)).toBe(Math.floor(slot2 / SLOTS_PER_EPOCH));
+
+    cache.add(slot1, validatorIndex);
+    expect(cache.isKnown(slot1, validatorIndex)).toBe(true);
+    // Same validator, different slot in the same epoch: must NOT be deduped.
+    expect(cache.isKnown(slot2, validatorIndex)).toBe(false);
+
+    cache.add(slot2, validatorIndex);
+    expect(cache.isKnown(slot2, validatorIndex)).toBe(true);
+  });
+
+  it("populates the epoch liveness map when add() is called", () => {
+    const cache = new SeenPayloadAttesters();
+    expect(cache.isKnownAtEpoch(epoch, validatorIndex)).toBe(false);
+    cache.add(slot, validatorIndex);
+    expect(cache.isKnownAtEpoch(epoch, validatorIndex)).toBe(true);
+    expect(cache.isKnownAtEpoch(epoch + 1, validatorIndex)).toBe(false);
+  });
+
+  it("prune(slot) evicts old slot entries but preserves epoch liveness", () => {
+    const cache = new SeenPayloadAttesters();
+    cache.add(slot, validatorIndex);
+    expect(cache.isKnown(slot, validatorIndex)).toBe(true);
+
+    cache.prune(slot + MAX_SLOTS_IN_CACHE + 1);
+    // Slot map evicted.
+    expect(cache.isKnown(slot, validatorIndex)).toBe(false);
+    // Epoch map outlives the slot map.
+    expect(cache.isKnownAtEpoch(epoch, validatorIndex)).toBe(true);
+  });
+
+  it("prune(slot) keeps slot entries within the lookback window", () => {
+    const cache = new SeenPayloadAttesters();
+    for (let i = 0; i < MAX_SLOTS_IN_CACHE; i++) {
+      cache.add(slot + i, validatorIndex);
+    }
+    // prune at the highest slot in the window: oldest (`slot`) should still be retained
+    // because the prune condition is `slot < clockSlot - MAX_SLOTS_IN_CACHE`.
+    cache.prune(slot + MAX_SLOTS_IN_CACHE);
+    expect(cache.isKnown(slot, validatorIndex)).toBe(true);
+    expect(cache.isKnown(slot + MAX_SLOTS_IN_CACHE - 1, validatorIndex)).toBe(true);
+  });
+
+  it("pruneEpoch(epoch) evicts epoch entries outside the lookback window", () => {
+    const cache = new SeenPayloadAttesters();
+    cache.add(slot, validatorIndex);
+    expect(cache.isKnownAtEpoch(epoch, validatorIndex)).toBe(true);
+
+    cache.pruneEpoch(epoch + EPOCH_LOOKBACK_LIMIT + 1);
+    expect(cache.isKnownAtEpoch(epoch, validatorIndex)).toBe(false);
+  });
+
+  it("pruneEpoch(epoch) keeps epoch entries within the lookback window", () => {
+    const cache = new SeenPayloadAttesters();
+    cache.add(slot, validatorIndex);
+
+    cache.pruneEpoch(epoch + EPOCH_LOOKBACK_LIMIT);
+    expect(cache.isKnownAtEpoch(epoch, validatorIndex)).toBe(true);
+  });
+
+  it("prune and pruneEpoch operate on independent maps", () => {
+    const cache = new SeenPayloadAttesters();
+    cache.add(slot, validatorIndex);
+
+    // Heavy slot prune does not touch epoch liveness.
+    cache.prune(slot + MAX_SLOTS_IN_CACHE + 100);
+    expect(cache.isKnown(slot, validatorIndex)).toBe(false);
+    expect(cache.isKnownAtEpoch(epoch, validatorIndex)).toBe(true);
+
+    // Epoch prune does not resurrect slot entries.
+    cache.pruneEpoch(epoch + EPOCH_LOOKBACK_LIMIT + 1);
+    expect(cache.isKnown(slot, validatorIndex)).toBe(false);
+    expect(cache.isKnownAtEpoch(epoch, validatorIndex)).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow up on #9369 . Unlike attester, a validator can participate in PTC more than one time per slot and per epoch. Currently our `SeenPayloadAttesters` assumes only one payload attestation message from a validator per epoch. 

This PR updates it so it is per slot