### PR TITLE
fix: upgrade playwright to 1.60.0 to unblock browser tests CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,8 +175,14 @@ jobs:
       - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install
-        run: pnpm playwright install
+        run: pnpm playwright install chromium chromium-headless-shell firefox
+        timeout-minutes: 15
       - name: Browser tests
         run: |
           export DISPLAY=':99.0'

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "inquirer": "^9.1.5",
     "libp2p": "3.1.6",
     "node-gyp": "^9.4.0",
-    "playwright": "^1.56.1",
+    "playwright": "^1.60.0",
     "prettier": "^3.2.5",
     "pretty-format": "^29.7.0",
     "semver": "^7.7.3",
@@ -83,5 +83,10 @@
     "dns-over-http-resolver": "^2.1.1",
     "loupe": "^2.3.6",
     "elliptic": ">=6.6.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "playwright": "^1.60.0"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,10 +83,5 @@
     "dns-over-http-resolver": "^2.1.1",
     "loupe": "^2.3.6",
     "elliptic": ">=6.6.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "playwright": "^1.60.0"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: 4.0.7(vite@6.1.6(@types/node@24.10.1)(yaml@2.8.2))(vitest@4.0.7)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.0.7(playwright@1.56.1)(vite@6.1.6(@types/node@24.10.1)(yaml@2.8.2))(vitest@4.0.7)
+        version: 4.0.7(playwright@1.60.0)(vite@6.1.6(@types/node@24.10.1)(yaml@2.8.2))(vitest@4.0.7)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.0.7(@vitest/browser@4.0.7(vite@6.1.6(@types/node@24.10.1)(yaml@2.8.2))(vitest@4.0.7))(vitest@4.0.7)
@@ -103,8 +103,8 @@ importers:
         specifier: ^9.4.0
         version: 9.4.1
       playwright:
-        specifier: ^1.56.1
-        version: 1.56.1
+        specifier: ^1.60.0
+        version: 1.60.0
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -5237,23 +5237,13 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.56.1:
-    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.56.1:
-    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8828,11 +8818,11 @@ snapshots:
 
   '@vekexasia/bigint-buffer2@1.1.1': {}
 
-  '@vitest/browser-playwright@4.0.7(playwright@1.56.1)(vite@6.1.6(@types/node@24.10.1)(yaml@2.8.2))(vitest@4.0.7)':
+  '@vitest/browser-playwright@4.0.7(playwright@1.60.0)(vite@6.1.6(@types/node@24.10.1)(yaml@2.8.2))(vitest@4.0.7)':
     dependencies:
       '@vitest/browser': 4.0.7(vite@6.1.6(@types/node@24.10.1)(yaml@2.8.2))(vitest@4.0.7)
       '@vitest/mocker': 4.0.7(vite@6.1.6(@types/node@24.10.1)(yaml@2.8.2))
-      playwright: 1.56.1
+      playwright: 1.60.0
       tinyrainbow: 3.0.3
       vitest: 4.0.7(@types/node@24.10.1)(@vitest/browser-playwright@4.0.7)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -8841,11 +8831,11 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser-playwright@4.0.7(playwright@1.59.1)(vite@6.1.6(@types/node@25.4.0)(yaml@2.8.2))(vitest@4.0.7)':
+  '@vitest/browser-playwright@4.0.7(playwright@1.60.0)(vite@6.1.6(@types/node@25.4.0)(yaml@2.8.2))(vitest@4.0.7)':
     dependencies:
       '@vitest/browser': 4.0.7(vite@6.1.6(@types/node@25.4.0)(yaml@2.8.2))(vitest@4.0.7)
       '@vitest/mocker': 4.0.7(vite@6.1.6(@types/node@25.4.0)(yaml@2.8.2))
-      playwright: 1.59.1
+      playwright: 1.60.0
       tinyrainbow: 3.0.3
       vitest: 4.0.7(@types/node@25.4.0)(@vitest/browser-playwright@4.0.7)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -11526,23 +11516,13 @@ snapshots:
       exsolve: 1.0.7
       pathe: 2.0.3
 
-  playwright-core@1.56.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright-core@1.59.1:
-    optional: true
-
-  playwright@1.56.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.56.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
-
-  playwright@1.59.1:
-    dependencies:
-      playwright-core: 1.59.1
-    optionalDependencies:
-      fsevents: 2.3.2
-    optional: true
 
   pngjs@7.0.0: {}
 
@@ -12448,7 +12428,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.1
-      '@vitest/browser-playwright': 4.0.7(playwright@1.56.1)(vite@6.1.6(@types/node@24.10.1)(yaml@2.8.2))(vitest@4.0.7)
+      '@vitest/browser-playwright': 4.0.7(playwright@1.60.0)(vite@6.1.6(@types/node@24.10.1)(yaml@2.8.2))(vitest@4.0.7)
     transitivePeerDependencies:
       - jiti
       - less
@@ -12487,7 +12467,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.4.0
-      '@vitest/browser-playwright': 4.0.7(playwright@1.59.1)(vite@6.1.6(@types/node@25.4.0)(yaml@2.8.2))(vitest@4.0.7)
+      '@vitest/browser-playwright': 4.0.7(playwright@1.60.0)(vite@6.1.6(@types/node@25.4.0)(yaml@2.8.2))(vitest@4.0.7)
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## Summary

- Browser Tests CI has been hanging for ~6h on every PR run, hitting GitHub Actions' default job timeout.
- Root cause: `pnpm playwright install` hangs after Chromium download completes due to a yauzl zip extraction lifecycle regression in Node 24.16.0+ ([microsoft/playwright#40724](https://github.com/microsoft/playwright/issues/40724)). Our CI runs Node v24.16.0, so it hits this bug. Fixed upstream in playwright 1.60.0 via [microsoft/playwright#40747](https://github.com/microsoft/playwright/pull/40747).

Additional CI hardening:
- Cache `~/.cache/ms-playwright` keyed on `pnpm-lock.yaml` hash so subsequent runs skip the download entirely.
- Install only the browsers we actually use: `chromium`, `chromium-headless-shell`, `firefox` (skips webkit + ffmpeg).
- Add `timeout-minutes: 15` so any future install hang fails fast instead of consuming a 6h job slot.

## Test plan

- [x] `pnpm install` resolves all `playwright` / `playwright-core` entries in `pnpm-lock.yaml` to `1.60.0`
- [x] `pnpm playwright install chromium chromium-headless-shell firefox` completes without hang locally
- [x] `pnpm test:browsers` passes locally (52 files, 606/606 tests, ~60s) on darwin/arm64
- [X] Browser Tests CI job completes successfully (verified on this PR)

## AI disclosure

This change was investigated and implemented with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)