### PR TITLE
fix: limit `shouldBuildOnFull()` checks to the previous slot

### DIFF
--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -170,7 +170,7 @@ export class PrepareNextSlotScheduler {
         let stateAfterParentPayload: IBeaconStateViewBellatrix = updatedPrepareState;
         if (isStatePostGloas(updatedPrepareState)) {
           // Spec: should_build_on_full(store, head) — see produceBlockBody.ts for context.
-          if (this.chain.forkChoice.shouldBuildOnFull(updatedHead)) {
+          if (this.chain.forkChoice.shouldBuildOnFull(updatedHead, prepareSlot)) {
             parentBlockHash = updatedPrepareState.latestExecutionPayloadBid.blockHash;
             // Skip applying parent payload unless we're proposing the next slot or have to emit payload_attributes events
             if (feeRecipient !== undefined || this.chain.opts.emitPayloadAttributes === true) {

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -278,7 +278,7 @@ export async function produceBlockBody<T extends BlockType>(
     // Spec: should_build_on_full(store, head). `parentBlock` is the proposer's head
     // (set by chain.getProposerHead(slot)). Returns false when the PTC majority
     // signalled the blob data is not available, forcing a build on EMPTY (reorg).
-    const isBuildingOnFull = this.forkChoice.shouldBuildOnFull(parentBlock);
+    const isBuildingOnFull = this.forkChoice.shouldBuildOnFull(parentBlock, blockSlot);
     if (isBuildingOnFull) {
       parentBlockHash = currentState.latestExecutionPayloadBid.blockHash;
       parentExecutionRequests = await this.getParentExecutionRequests(parentBlock.slot, parentBlock.blockRoot);

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -319,8 +319,8 @@ export class ForkChoice implements IForkChoice {
   }
 
   /** Spec: should_build_on_full(store, head) */
-  shouldBuildOnFull(head: ProtoBlock): boolean {
-    return this.protoArray.shouldBuildOnFull(head);
+  shouldBuildOnFull(head: ProtoBlock, slot: Slot): boolean {
+    return this.protoArray.shouldBuildOnFull(head, slot);
   }
 
   /**

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -256,7 +256,7 @@ export interface IForkChoice {
   getBlockHexAndBlockHash(blockRoot: RootHex, blockHash: RootHex): ProtoBlock | null;
   shouldExtendPayload(blockRoot: RootHex): boolean;
   /** Spec: should_build_on_full(store, head) */
-  shouldBuildOnFull(head: ProtoBlock): boolean;
+  shouldBuildOnFull(head: ProtoBlock, slot: Slot): boolean;
   getFinalizedBlock(): ProtoBlock;
   getJustifiedBlock(): ProtoBlock;
   getFinalizedCheckpointSlot(): Slot;

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -760,11 +760,14 @@ export class ProtoArray {
    * The proposer is forced to build on the EMPTY variant (effectively reorging)
    * when the PTC majority voted that the blob data is not available.
    */
-  shouldBuildOnFull(head: ProtoBlock): boolean {
+  shouldBuildOnFull(head: ProtoBlock, slot: Slot): boolean {
     if (head.payloadStatus === PayloadStatus.PENDING) {
       throw new Error("shouldBuildOnFull called with PENDING head");
     }
     if (head.payloadStatus === PayloadStatus.EMPTY) return false;
+    // The PTC data availability view is only consulted for a head from the previous slot.
+    // For an earlier head the empty/full variant has already been resolved by weight in getHead.
+    if (head.slot + 1 !== slot) return true;
     return !this.isPayloadDataNotAvailable(head.blockRoot);
   }
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -765,9 +765,11 @@ export class ProtoArray {
       throw new Error("shouldBuildOnFull called with PENDING head");
     }
     if (head.payloadStatus === PayloadStatus.EMPTY) return false;
+
     // The PTC data availability view is only consulted for a head from the previous slot.
     // For an earlier head the empty/full variant has already been resolved by weight in getHead.
     if (head.slot + 1 !== slot) return true;
+
     return !this.isPayloadDataNotAvailable(head.blockRoot);
   }
 

--- a/packages/fork-choice/test/unit/protoArray/gloas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/gloas.test.ts
@@ -1019,7 +1019,7 @@ describe("Gloas Fork Choice", () => {
       const head = makeHead(PayloadStatus.FULL);
       const overThreshold = Math.floor(PTC_SIZE / 2) + 1;
       const indices = Array.from({length: overThreshold}, (_, i) => i);
-      protoArray.notifyPtcMessages("0x02", indices, true, false);
+      protoArray.notifyPtcMessages("0x02", indices, false, false);
       expect(protoArray.shouldBuildOnFull(head, head.slot + 2)).toBe(true);
     });
   });

--- a/packages/fork-choice/test/unit/protoArray/gloas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/gloas.test.ts
@@ -600,7 +600,7 @@ describe("Gloas Fork Choice", () => {
       expect(protoArray.isPayloadTimely("0x02")).toBe(false);
 
       // notifyPtcMessages should be no-op
-      expect(() => protoArray.notifyPtcMessages("0x02", gloasForkSlot, [0], true, true)).not.toThrow();
+      expect(() => protoArray.notifyPtcMessages("0x02", gloasForkSlot - 1, [0], true, true)).not.toThrow();
     });
   });
 
@@ -1029,7 +1029,7 @@ describe("Gloas Fork Choice", () => {
       const head = makeHead(PayloadStatus.FULL);
       const overThreshold = Math.floor(PTC_SIZE / 2) + 1;
       const indices = Array.from({length: overThreshold}, (_, i) => i);
-      protoArray.notifyPtcMessages("0x02", gloasForkSlot, indices, true, false);
+      protoArray.notifyPtcMessages("0x02", head.slot, indices, true, false);
       expect(protoArray.shouldBuildOnFull(head, head.slot + 1)).toBe(false);
     });
 
@@ -1037,14 +1037,14 @@ describe("Gloas Fork Choice", () => {
       const head = makeHead(PayloadStatus.FULL);
       const atThreshold = Math.floor(PTC_SIZE / 2);
       const indices = Array.from({length: atThreshold}, (_, i) => i);
-      protoArray.notifyPtcMessages("0x02", gloasForkSlot, indices, true, false);
+      protoArray.notifyPtcMessages("0x02", head.slot, indices, true, false);
       expect(protoArray.shouldBuildOnFull(head, head.slot + 1)).toBe(true);
     });
 
     it("returns true when many PTC members did not vote and few NO votes are below threshold", () => {
       // Guards against None being miscounted as NO — would force a spurious reorg.
       const head = makeHead(PayloadStatus.FULL);
-      protoArray.notifyPtcMessages("0x02", gloasForkSlot, [0], true, false);
+      protoArray.notifyPtcMessages("0x02", head.slot, [0], true, false);
       expect(protoArray.shouldBuildOnFull(head, head.slot + 1)).toBe(true);
     });
 
@@ -1052,7 +1052,7 @@ describe("Gloas Fork Choice", () => {
       const head = makeHead(PayloadStatus.FULL);
       const overThreshold = Math.floor(PTC_SIZE / 2) + 1;
       const indices = Array.from({length: overThreshold}, (_, i) => i);
-      protoArray.notifyPtcMessages("0x02", gloasForkSlot, indices, false, false);
+      protoArray.notifyPtcMessages("0x02", head.slot, indices, false, false);
       expect(protoArray.shouldBuildOnFull(head, head.slot + 2)).toBe(true);
     });
   });

--- a/packages/fork-choice/test/unit/protoArray/gloas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/gloas.test.ts
@@ -978,18 +978,18 @@ describe("Gloas Fork Choice", () => {
 
     it("throws when head is PENDING", () => {
       const head = makeHead(PayloadStatus.PENDING);
-      expect(() => protoArray.shouldBuildOnFull(head)).toThrow(/PENDING/);
+      expect(() => protoArray.shouldBuildOnFull(head, head.slot + 1)).toThrow(/PENDING/);
     });
 
     it("returns false when head is EMPTY", () => {
       const head = makeHead(PayloadStatus.EMPTY);
-      expect(protoArray.shouldBuildOnFull(head)).toBe(false);
+      expect(protoArray.shouldBuildOnFull(head, head.slot + 1)).toBe(false);
     });
 
     it("returns true when head is FULL and no DA NO votes", () => {
       const head = makeHead(PayloadStatus.FULL);
       // No votes at all — isPayloadDataNotAvailable returns false → build on full
-      expect(protoArray.shouldBuildOnFull(head)).toBe(true);
+      expect(protoArray.shouldBuildOnFull(head, head.slot + 1)).toBe(true);
     });
 
     it("returns false when head is FULL and DA NO votes exceed threshold (reorg trigger)", () => {
@@ -997,7 +997,7 @@ describe("Gloas Fork Choice", () => {
       const overThreshold = Math.floor(PTC_SIZE / 2) + 1;
       const indices = Array.from({length: overThreshold}, (_, i) => i);
       protoArray.notifyPtcMessages("0x02", indices, true, false);
-      expect(protoArray.shouldBuildOnFull(head)).toBe(false);
+      expect(protoArray.shouldBuildOnFull(head, head.slot + 1)).toBe(false);
     });
 
     it("returns true when head is FULL and DA NO votes exactly at threshold (>, not >=)", () => {
@@ -1005,14 +1005,22 @@ describe("Gloas Fork Choice", () => {
       const atThreshold = Math.floor(PTC_SIZE / 2);
       const indices = Array.from({length: atThreshold}, (_, i) => i);
       protoArray.notifyPtcMessages("0x02", indices, true, false);
-      expect(protoArray.shouldBuildOnFull(head)).toBe(true);
+      expect(protoArray.shouldBuildOnFull(head, head.slot + 1)).toBe(true);
     });
 
     it("returns true when many PTC members did not vote and few NO votes are below threshold", () => {
       // Guards against None being miscounted as NO — would force a spurious reorg.
       const head = makeHead(PayloadStatus.FULL);
       protoArray.notifyPtcMessages("0x02", [0], true, false);
-      expect(protoArray.shouldBuildOnFull(head)).toBe(true);
+      expect(protoArray.shouldBuildOnFull(head, head.slot + 1)).toBe(true);
+    });
+
+    it("returns true for a FULL head that is not from the previous slot, even with PTC voting against it", () => {
+      const head = makeHead(PayloadStatus.FULL);
+      const overThreshold = Math.floor(PTC_SIZE / 2) + 1;
+      const indices = Array.from({length: overThreshold}, (_, i) => i);
+      protoArray.notifyPtcMessages("0x02", indices, true, false);
+      expect(protoArray.shouldBuildOnFull(head, head.slot + 2)).toBe(true);
     });
   });
 


### PR DESCRIPTION
see https://github.com/ethereum/consensus-specs/pull/5309 and related issue https://github.com/ChainSafe/lodestar/issues/9415