### PR TITLE
fix: use finalized block slot as envelope by range archive boundary

### DIFF
--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
@@ -20,9 +20,9 @@ export async function* onExecutionPayloadEnvelopesByRange(
   }
 
   const finalized = db.executionPayloadEnvelopeArchive;
-  const finalizedSlot = chain.forkChoice.getFinalizedCheckpointSlot();
-  // The current finalized block's envelope is still in the hot db; archive migration happens
-  // in the next finalization run (see migrateExecutionPayloadEnvelopesFromHotToColdDb).
+  // Use the finalized block's actual slot as the checkpoint epoch-boundary slot may be skipped
+  const finalizedSlot = chain.forkChoice.getFinalizedBlock().slot;
+  // The finalized block's envelope stays in the hot db until the next finalization run
   const archiveMaxSlot = finalizedSlot - 1;
 
   // Finalized range of envelopes


### PR DESCRIPTION
**Disclaimer:** this was opened by Claude
--- 

**Motivation**

`onExecutionPayloadEnvelopesByRange` derived the archive/hot serving boundary
from `getFinalizedCheckpointSlot()`, i.e. the epoch-boundary slot. When that slot
is skipped (a missed proposal at the epoch boundary), the finalized block sits at
an earlier slot whose envelope is still in the hot db. That envelope was then
served by neither path:

- the archive loop streams only what has been migrated, and the finalized block's
  envelope is migrated on the *next* finalization run
- the head-chain loop only serves slots above the (too-high) boundary

leaving a gap in the response.

**Description**

Use `getFinalizedBlock().slot` for the boundary, which is the actual finalized
block slot and `<=` the checkpoint slot. This matches `blobSidecarsByRange` and
`dataColumnSidecarsByRange`, and the head-chain loop then correctly serves the
finalized block's envelope (cache -> hot -> archive fallback).
