### PR TITLE
fix: handle post-gloas empty blocks in data columns by range

### DIFF
--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
@@ -1,5 +1,6 @@
 import {PeerId} from "@libp2p/interface";
 import {ChainConfig} from "@lodestar/config";
+import {PayloadStatus} from "@lodestar/fork-choice";
 import {ForkSeq, GENESIS_SLOT} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
@@ -104,6 +105,11 @@ export async function* onDataColumnSidecarsByRange(
 
       // Must include only columns in the range requested
       if (block.slot > archiveMaxSlot && block.slot >= startSlot && block.slot < endSlot) {
+        // Post-gloas, columns exist only for FULL blocks (pre-gloas blocks are always FULL)
+        if (block.payloadStatus !== PayloadStatus.FULL) {
+          continue;
+        }
+
         // Note: Here the forkChoice head may change due to a re-org, so the headChain reflects the canonical chain
         // at the time of the start of the request. Spec is clear the chain of columns must be consistent, but on
         // re-org there's no need to abort the request

--- a/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
+++ b/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
@@ -1,4 +1,5 @@
 import {LogData} from "@lodestar/logger";
+import {ForkSeq} from "@lodestar/params";
 import {RespStatus, ResponseError} from "@lodestar/reqresp";
 import {ColumnIndex, Slot} from "@lodestar/types";
 import {prettyBytes, prettyPrintIndices, toRootHex} from "@lodestar/utils";
@@ -37,6 +38,13 @@ export async function handleColumnSidecarUnavailability({
   }
 
   chain.logger.debug("dataColumnSidecar requested unavailable", logData);
+
+  // Post-gloas, columns exist only for FULL blocks; a finalized block is FULL if its envelope was
+  // archived. Bid blobsCount is unreliable here since an EMPTY block's bid may still commit to blobs
+  if (blockRoot === undefined && chain.config.getForkSeq(slot) >= ForkSeq.gloas) {
+    const envelopeBytes = await db.executionPayloadEnvelopeArchive.getBinary(slot);
+    if (!envelopeBytes) return;
+  }
 
   const blockBytes = blockRoot ? await db.block.getBinary(blockRoot) : await db.blockArchive.getBinary(slot);
   if (!blockBytes) {


### PR DESCRIPTION
**Disclaimer:** this was opened by Claude
--- 

**Motivation**

Post-gloas, data columns exist only for FULL blocks (the payload, and thus its
columns, is revealed via the execution payload envelope). An EMPTY block's bid may
still commit to blobs, so a missing column for an EMPTY block is not a
data-availability gap. `onDataColumnSidecarsByRange` did not account for this in
either serving path, causing it to falsely increment
`lodestar_data_columns_missing_custody_columns_count` and log spurious
"within custody but not available" warnings for ranges containing EMPTY blocks.

**Description**

- Non-finalized loop: it probed every block regardless of payload status, routing
  EMPTY blocks through `handleColumnSidecarUnavailability`. Skip non-FULL blocks,
  matching `executionPayloadEnvelopesByRange` (pre-gloas blocks are always FULL, so
  this is a no-op there).
- Finalized loop: `handleColumnSidecarUnavailability` decided severity from the
  block's bid blob count, which is unreliable post-gloas. A finalized block is FULL
  iff its envelope was migrated to the archive, so treat a finalized block with no
  archived envelope as EMPTY and skip the unavailability accounting.
