### PR TITLE
chore: log missing payload in ExecutionPayloadEnvelopesByRoot

### DIFF
--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
@@ -44,9 +44,9 @@ export async function* onExecutionPayloadEnvelopesByRoot(
     } else {
       chain.logger.debug("Cannot serve ExecutionPayloadEnvelopesByRoot: envelope not found", {
         slot,
+        root: rootHex,
         peer: prettyPrintPeerId(peerId),
         client: peerClient,
-        root: rootHex,
       });
     }
   }

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
@@ -1,14 +1,18 @@
+import {PeerId} from "@libp2p/interface";
 import {ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {toRootHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
 import {IBeaconDb} from "../../../db/index.js";
 import {ExecutionPayloadEnvelopesByRootRequest} from "../../../util/types.js";
+import {prettyPrintPeerId} from "../../util.js";
 
 export async function* onExecutionPayloadEnvelopesByRoot(
   requestBody: ExecutionPayloadEnvelopesByRootRequest,
   chain: IBeaconChain,
-  db: IBeaconDb
+  db: IBeaconDb,
+  peerId: PeerId,
+  peerClient: string
 ): AsyncIterable<ResponseOutgoing> {
   // The gloas req/resp spec uses MIN_EPOCHS_FOR_BLOCK_REQUESTS to define the minimum range peers MUST serve.
   // Archival nodes may still serve older retained payloads to allow genesis sync.
@@ -20,6 +24,14 @@ export async function* onExecutionPayloadEnvelopesByRoot(
     const slot = block ? block.slot : await db.blockArchive.getSlotByRoot(root);
 
     if (slot === null) {
+      chain.logger.debug(
+        "Cannot serve ExecutionPayloadEnvelopesByRoot: block root not in fork choice or block archive",
+        {
+          root: rootHex,
+          peer: prettyPrintPeerId(peerId),
+          client: peerClient,
+        }
+      );
       continue;
     }
 
@@ -29,6 +41,13 @@ export async function* onExecutionPayloadEnvelopesByRoot(
         data: envelopeBytes,
         boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(slot)),
       };
+    } else {
+      chain.logger.debug("Cannot serve ExecutionPayloadEnvelopesByRoot: envelope not found", {
+        slot,
+        peer: prettyPrintPeerId(peerId),
+        client: peerClient,
+        root: rootHex,
+      });
     }
   }
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -70,9 +70,9 @@ export function getReqRespHandlers({db, chain}: {db: IBeaconDb; chain: IBeaconCh
       return onDataColumnSidecarsByRoot(body, chain, db, peerId, peerClient);
     },
 
-    [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: (req) => {
+    [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: (req, peerId, peerClient) => {
       const body = ExecutionPayloadEnvelopesByRootRequestType(chain.config).deserialize(req.data);
-      return onExecutionPayloadEnvelopesByRoot(body, chain, db);
+      return onExecutionPayloadEnvelopesByRoot(body, chain, db, peerId, peerClient);
     },
     [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: (req) => {
       const body = ssz.gloas.ExecutionPayloadEnvelopesByRangeRequest.deserialize(req.data);


### PR DESCRIPTION
**Motivation**

In glamsterdam-devnet-4, Prysm was not able to fetch an envelope by root from our node (https://discord.com/channels/595666850260713488/1508479832596418692/1509536577217626183). When a peer requests a payload by root that we don't serve, the handler drops it silently — no way to tell why or which peer.

**Description**

Add `debug` logs (with peer, client, root) when `ExecutionPayloadEnvelopesByRoot` serves nothing for a requested root, distinguishing the two cases:
- block root not in fork choice or block archive (slot unresolved)
- envelope not found despite a resolved slot

**AI Assistance Disclosure**

- Used Claude Code to implement this change.
