### PR TITLE
feat: emit fast_confirmation SSE event per beacon-APIs

### DIFF
--- a/docs/pages/run/beacon-management/fast-confirmation.md
+++ b/docs/pages/run/beacon-management/fast-confirmation.md
@@ -36,31 +36,24 @@ For bridge and exchange policies, the practical interpretation is:
 
 ## What Lodestar exposes
 
-Lodestar tracks Fast Confirmation inside fork choice and exposes the current view through:
+Lodestar tracks Fast Confirmation inside fork choice and publishes confirmations through the standard beacon-API event stream ([beacon-APIs #598](https://github.com/ethereum/beacon-APIs/pull/598)):
 
-- `GET /eth/v1/lodestar/fast_confirmation`
+- `GET /eth/v1/events?topics=fast_confirmation`
 
-The response includes:
+Each event fires once per slot when the Fast Confirmation Rule executes and carries:
 
-- `confirmed.rootHex` and `confirmed.slot`
-- the current `head`
-- the current `justifiedCheckpoint`
-- the current `finalizedCheckpoint`
+- `block` — the confirmed beacon block root
+- `slot` — the slot of the confirmed beacon block
+- `current_slot` — the clock slot at which the Fast Confirmation Rule executed
 
-This is the consumer-facing API to compare how far `confirmed` is behind or ahead of the usual checkpoint signals.
+Example event:
 
-Example response shape:
-
-```json
-{
-  "data": {
-    "confirmed": {"rootHex": "0x...", "slot": 123},
-    "head": {"rootHex": "0x...", "slot": 124},
-    "justifiedCheckpoint": {"rootHex": "0x...", "epoch": 3},
-    "finalizedCheckpoint": {"rootHex": "0x...", "epoch": 2}
-  }
-}
 ```
+event: fast_confirmation
+data: {"block": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "slot": "1", "current_slot": "2"}
+```
+
+To compare the confirmed block against the chain's `head`, `justifiedCheckpoint`, and `finalizedCheckpoint`, use the standard beacon-API endpoints (`/eth/v1/beacon/headers/head` and `/eth/v1/beacon/states/head/finality_checkpoints`).
 
 ## How consumers should use it
 

--- a/docs/pages/run/beacon-management/fast-confirmation.md
+++ b/docs/pages/run/beacon-management/fast-confirmation.md
@@ -53,7 +53,7 @@ event: fast_confirmation
 data: {"block": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "slot": "1", "current_slot": "2"}
 ```
 
-To compare the confirmed block against the chain's `head`, `justifiedCheckpoint`, and `finalizedCheckpoint`, use the standard beacon-API endpoints (`/eth/v1/beacon/headers/head` and `/eth/v1/beacon/states/head/finality_checkpoints`).
+To compare the confirmed block against the chain's `head` and `finalized_checkpoint`, consumers can subscribe to multiple event topics in a single stream (e.g., `GET /eth/v1/events?topics=fast_confirmation,head,finalized_checkpoint`), or fetch the same data from the standard beacon-API REST endpoints (`/eth/v1/beacon/headers/head` and `/eth/v1/beacon/states/head/finality_checkpoints`).
 
 ## How consumers should use it
 

--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -110,6 +110,8 @@ export enum EventType {
   executionPayloadBid = "execution_payload_bid",
   /** The node has received a `SignedProposerPreferences` (from P2P or API) that passes gossip validation on the `proposer_preferences` topic */
   proposerPreferences = "proposer_preferences",
+  /** The node has executed the Fast Confirmation Rule and produced a confirmed beacon block */
+  fastConfirmation = "fast_confirmation",
 }
 
 export const eventTypes: {[K in EventType]: K} = {
@@ -135,6 +137,7 @@ export const eventTypes: {[K in EventType]: K} = {
   [EventType.executionPayloadAvailable]: EventType.executionPayloadAvailable,
   [EventType.executionPayloadBid]: EventType.executionPayloadBid,
   [EventType.proposerPreferences]: EventType.proposerPreferences,
+  [EventType.fastConfirmation]: EventType.fastConfirmation,
 };
 
 export type EventData = {
@@ -203,6 +206,11 @@ export type EventData = {
   };
   [EventType.executionPayloadBid]: {version: ForkName; data: gloas.SignedExecutionPayloadBid};
   [EventType.proposerPreferences]: {version: ForkName; data: gloas.SignedProposerPreferences};
+  [EventType.fastConfirmation]: {
+    block: RootHex;
+    slot: Slot;
+    currentSlot: Slot;
+  };
 };
 
 export type BeaconEvent = {[K in EventType]: {type: K; message: EventData[K]}}[EventType];
@@ -400,6 +408,14 @@ export function getTypeByEvent(config: ChainForkConfig): {[K in EventType]: Type
     ),
     [EventType.executionPayloadBid]: WithVersion((fork) => getPostGloasForkTypes(fork).SignedExecutionPayloadBid),
     [EventType.proposerPreferences]: WithVersion((fork) => getPostGloasForkTypes(fork).SignedProposerPreferences),
+    [EventType.fastConfirmation]: new ContainerType(
+      {
+        block: stringType,
+        slot: ssz.Slot,
+        currentSlot: ssz.Slot,
+      },
+      {jsonCase: "eth2"}
+    ),
 
     [EventType.lightClientOptimisticUpdate]: WithVersion(
       (fork) => getPostAltairForkTypes(fork).LightClientOptimisticUpdate

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -73,6 +73,8 @@ const ignoredTopics: string[] = [
   "execution_payload_bid",
   // TODO: not yet implemented, added in v5.0.0-alpha.2
   "head_v2",
+  // TODO: unskip once the spec release adds `current_slot` to the fast_confirmation event
+  // (tracked in https://github.com/ethereum/beacon-APIs/pull/598)
   "fast_confirmation",
 ];
 

--- a/packages/api/test/unit/beacon/testData/events.ts
+++ b/packages/api/test/unit/beacon/testData/events.ts
@@ -328,4 +328,9 @@ export const eventTestData: EventData = {
         "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505",
     }),
   },
+  [EventType.fastConfirmation]: {
+    block: "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+    slot: 1,
+    currentSlot: 2,
+  },
 };

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -1,3 +1,4 @@
+import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {
   ExecutionStatus,
@@ -121,6 +122,8 @@ export function initializeForkChoiceFromFinalizedState(
       {
         onJustified: (cp) => emitter.emit(ChainEvent.forkChoiceJustified, cp),
         onFinalized: (cp) => emitter.emit(ChainEvent.forkChoiceFinalized, cp),
+        onFastConfirmation: ({block, slot, currentSlot}) =>
+          emitter.emit(routes.events.EventType.fastConfirmation, {block, slot, currentSlot}),
       }
     ),
 
@@ -214,6 +217,8 @@ export function initializeForkChoiceFromUnfinalizedState(
     {
       onJustified: (cp) => emitter.emit(ChainEvent.forkChoiceJustified, cp),
       onFinalized: (cp) => emitter.emit(ChainEvent.forkChoiceFinalized, cp),
+      onFastConfirmation: ({block, slot, currentSlot}) =>
+        emitter.emit(routes.events.EventType.fastConfirmation, {block, slot, currentSlot}),
     }
   );
 

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1959,6 +1959,20 @@ export class ForkChoice implements IForkChoice {
 
         const result = this.fastConfirmationRule.onSlotStartAfterPastAttestationsApplied(this.fastConfirmationContext);
         this.fcStore.confirmedRoot = result.confirmedRoot;
+
+        const confirmedBlock = this.getBlockHexDefaultStatus(result.confirmedRoot);
+        if (confirmedBlock !== null) {
+          this.fcStore.notifyFastConfirmation?.({
+            block: result.confirmedRoot,
+            slot: confirmedBlock.slot,
+            currentSlot: this.fcStore.currentSlot,
+          });
+        } else {
+          this.logger?.debug("Fast confirmation produced root not in protoArray; skipping event", {
+            slot: this.fcStore.currentSlot,
+            confirmedRoot: result.confirmedRoot,
+          });
+        }
       } catch (err) {
         this.logger?.debug(
           "Fast confirmation failed",

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1961,18 +1961,14 @@ export class ForkChoice implements IForkChoice {
         this.fcStore.confirmedRoot = result.confirmedRoot;
 
         const confirmedBlock = this.getBlockHexDefaultStatus(result.confirmedRoot);
-        if (confirmedBlock !== null) {
-          this.fcStore.notifyFastConfirmation?.({
-            block: result.confirmedRoot,
-            slot: confirmedBlock.slot,
-            currentSlot: this.fcStore.currentSlot,
-          });
-        } else {
-          this.logger?.debug("Fast confirmation produced root not in protoArray; skipping event", {
-            slot: this.fcStore.currentSlot,
-            confirmedRoot: result.confirmedRoot,
-          });
+        if (confirmedBlock === null) {
+          throw new Error(`Fast confirmation produced root not in protoArray: ${result.confirmedRoot}`);
         }
+        this.fcStore.notifyFastConfirmation?.({
+          block: result.confirmedRoot,
+          slot: confirmedBlock.slot,
+          currentSlot: this.fcStore.currentSlot,
+        });
       } catch (err) {
         this.logger?.debug(
           "Fast confirmation failed",

--- a/packages/fork-choice/src/forkChoice/store.ts
+++ b/packages/fork-choice/src/forkChoice/store.ts
@@ -45,6 +45,7 @@ export interface IForkChoiceStore extends IFastConfirmationStore {
   unrealizedFinalizedCheckpoint: CheckpointWithHex;
   justifiedBalancesGetter: JustifiedBalancesGetter;
   equivocatingIndices: Set<ValidatorIndex>;
+  notifyFastConfirmation?(data: {block: RootHex; slot: Slot; currentSlot: Slot}): void;
 }
 
 /**
@@ -83,6 +84,7 @@ export class ForkChoiceStore implements IForkChoiceStore {
     private readonly events?: {
       onJustified: (cp: CheckpointWithHex) => void;
       onFinalized: (cp: CheckpointWithHex) => void;
+      onFastConfirmation?: (data: {block: RootHex; slot: Slot; currentSlot: Slot}) => void;
     }
   ) {
     this.justifiedBalancesGetter = justifiedBalancesGetter;
@@ -130,6 +132,16 @@ export class ForkChoiceStore implements IForkChoiceStore {
     const cp = toCheckpointWithHex(checkpoint);
     this._finalizedCheckpoint = cp;
     this.events?.onFinalized(cp);
+  }
+
+  /**
+   * Notify subscribers that the Fast Confirmation Rule executed and produced
+   * `data.block` at `data.slot`. Per beacon-APIs PR #598, this fires once per
+   * FCR execution (i.e., once per slot when FCR is enabled), regardless of
+   * whether `confirmedRoot` actually changed.
+   */
+  notifyFastConfirmation(data: {block: RootHex; slot: Slot; currentSlot: Slot}): void {
+    this.events?.onFastConfirmation?.(data);
   }
 }
 

--- a/packages/fork-choice/src/forkChoice/store.ts
+++ b/packages/fork-choice/src/forkChoice/store.ts
@@ -136,9 +136,8 @@ export class ForkChoiceStore implements IForkChoiceStore {
 
   /**
    * Notify subscribers that the Fast Confirmation Rule executed and produced
-   * `data.block` at `data.slot`. Per beacon-APIs PR #598, this fires once per
-   * FCR execution (i.e., once per slot when FCR is enabled), regardless of
-   * whether `confirmedRoot` actually changed.
+   * `data.block` at `data.slot`. Fires once per FCR execution, even when
+   * `confirmedRoot` did not change from the prior slot.
    */
   notifyFastConfirmation(data: {block: RootHex; slot: Slot; currentSlot: Slot}): void {
     this.events?.onFastConfirmation?.(data);

--- a/packages/fork-choice/test/unit/forkChoice/forkChoiceStore.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoiceStore.test.ts
@@ -1,0 +1,67 @@
+import {describe, expect, it, vi} from "vitest";
+import {fromHexString} from "@chainsafe/ssz";
+import {Slot} from "@lodestar/types";
+import {ForkChoiceStore} from "../../../src/forkChoice/store.js";
+
+describe("ForkChoiceStore", () => {
+  const genesisSlot = 0 as Slot;
+  const root = "0x0000000000000000000000000000000000000000000000000000000000000000";
+  const checkpoint = {epoch: 0, root: fromHexString(root)};
+  const justifiedBalances = new Uint16Array([32]);
+  const justifiedBalancesGetter = () => justifiedBalances;
+  const stateGetter = () => null;
+
+  describe("notifyFastConfirmation", () => {
+    it("invokes onFastConfirmation when callback is provided", () => {
+      const onFastConfirmation = vi.fn();
+      const store = new ForkChoiceStore(
+        genesisSlot,
+        checkpoint,
+        checkpoint,
+        justifiedBalances,
+        justifiedBalancesGetter,
+        stateGetter,
+        {
+          onJustified: () => {},
+          onFinalized: () => {},
+          onFastConfirmation,
+        }
+      );
+
+      store.notifyFastConfirmation({block: root, slot: 42 as Slot, currentSlot: 43 as Slot});
+
+      expect(onFastConfirmation).toHaveBeenCalledTimes(1);
+      expect(onFastConfirmation).toHaveBeenCalledWith({block: root, slot: 42, currentSlot: 43});
+    });
+
+    it("is a no-op when onFastConfirmation is not provided", () => {
+      const store = new ForkChoiceStore(
+        genesisSlot,
+        checkpoint,
+        checkpoint,
+        justifiedBalances,
+        justifiedBalancesGetter,
+        stateGetter,
+        {
+          onJustified: () => {},
+          onFinalized: () => {},
+        }
+      );
+
+      expect(() => store.notifyFastConfirmation({block: root, slot: 1 as Slot, currentSlot: 2 as Slot})).not.toThrow();
+    });
+
+    it("is a no-op when events object is not provided", () => {
+      const store = new ForkChoiceStore(
+        genesisSlot,
+        checkpoint,
+        checkpoint,
+        justifiedBalances,
+        justifiedBalancesGetter,
+        stateGetter
+      );
+
+      expect(() => store.notifyFastConfirmation({block: root, slot: 1 as Slot, currentSlot: 2 as Slot})).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
- Wires the new `fast_confirmation` Server-Sent Event from beacon-APIs PR [#598](https://github.com/ethereum/beacon-APIs/pull/598). The event fires once per slot whenever the Fast Confirmation Rule executes and carries `{block, slot}`, where `slot` is the slot of the confirmed beacon block.
- Crosses the fork-choice ↔ beacon-node boundary via a new optional `onFastConfirmation` callback on `ForkChoiceStore`, mirroring the existing `onJustified` / `onFinalized` plumbing. The emit is invoked from `ForkChoice.runFastConfirmation()` after the rule succeeds.
- Removes the now-redundant Lodestar-namespace endpoint `GET /eth/v1/lodestar/fast_confirmation_info` (and its `getConfirmedBlock` helper) — the standard SSE event supersedes it, and the head/checkpoint fields it bundled are already available via standard beacon-API endpoints.

This PR is aligned with the changes proposed in https://github.com/ethereum/beacon-APIs/pull/616

### Architecture

```
Chain.onClockSlot → forkChoice.updateTime
  └── (per tick) runFastConfirmation
       └── fcStore.notifyFastConfirmation({block, slot})
            └── ChainEventEmitter.emit(EventType.fastConfirmation, {block, slot})
                 └── SSE subscribers via /eth/v1/events?topics=fast_confirmation
```

`ApiEvents` in `ChainEventEmitter` is derived from `routes.events.EventType`, so adding the new variant flows through automatically — no per-event boilerplate in the chain or events API layers.


### Edge cases

| Scenario | Behavior |
|---|---|
| `--chain.fastConfirmation` disabled (default) | No emit (FCR doesn't run) |
| FCR rule throws | No emit; existing warn-and-continue catch is unchanged |
| Confirmed root not in `protoArray` (defensive) | Warn log with `slot`+`confirmedRoot`, skip emit |
| `updateTime` advances multiple slots | One emit per tick |