### PR TITLE
fix: return resource_unavailable if requested range is before earliest_available_slot

### DIFF
--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -30,12 +30,20 @@ export async function* onBeaconBlocksByRange(
   const archiveMaxSlot = finalizedSlot;
 
   const forkName = chain.config.getForkName(startSlot);
-  if (isForkPostFulu(forkName) && startSlot < chain.earliestAvailableSlot) {
-    chain.logger.verbose("Peer did not respect earliestAvailableSlot for BeaconBlocksByRange", {
+  // endSlot is exclusive, so highest served slot is endSlot - 1.
+  // Throw only when the entire requested range is below earliestAvailableSlot.
+  if (isForkPostFulu(forkName) && endSlot - 1 < chain.earliestAvailableSlot) {
+    chain.logger.verbose("Peer requested range before earliestAvailableSlot for BeaconBlocksByRange", {
       peer: prettyPrintPeerId(peerId),
       client: peerClient,
+      startSlot,
+      count,
+      earliestAvailableSlot: chain.earliestAvailableSlot,
     });
-    return;
+    throw new ResponseError(
+      RespStatus.RESOURCE_UNAVAILABLE,
+      `Requested range is before earliestAvailableSlot startSlot=${startSlot} count=${count} earliestAvailableSlot=${chain.earliestAvailableSlot}`
+    );
   }
 
   // Finalized range of blocks

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -1,6 +1,6 @@
 import {PeerId} from "@libp2p/interface";
 import {BeaconConfig} from "@lodestar/config";
-import {GENESIS_SLOT, isForkPostDeneb, isForkPostFulu} from "@lodestar/params";
+import {GENESIS_SLOT, isForkPostDeneb} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {deneb, phase0} from "@lodestar/types";
@@ -29,10 +29,9 @@ export async function* onBeaconBlocksByRange(
   // starts above it to avoid duplicate yields. See archiveBlocks.ts for the migration logic.
   const archiveMaxSlot = finalizedSlot;
 
-  const forkName = chain.config.getForkName(startSlot);
   // endSlot is exclusive, so highest served slot is endSlot - 1.
   // Throw only when the entire requested range is below earliestAvailableSlot.
-  if (isForkPostFulu(forkName) && endSlot - 1 < chain.earliestAvailableSlot) {
+  if (endSlot - 1 < chain.earliestAvailableSlot) {
     chain.logger.verbose("Peer requested range before earliestAvailableSlot for BeaconBlocksByRange", {
       peer: prettyPrintPeerId(peerId),
       client: peerClient,

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
@@ -34,12 +34,20 @@ export async function* onDataColumnSidecarsByRange(
     return;
   }
 
-  if (startSlot < chain.earliestAvailableSlot) {
-    chain.logger.verbose("Peer did not respect earliestAvailableSlot for DataColumnSidecarsByRange", {
+  // endSlot is exclusive, so highest served slot is endSlot - 1.
+  // Throw only when the entire requested range is below earliestAvailableSlot.
+  if (endSlot - 1 < chain.earliestAvailableSlot) {
+    chain.logger.verbose("Peer requested range before earliestAvailableSlot for DataColumnSidecarsByRange", {
       peer: prettyPrintPeerId(peerId),
       client: peerClient,
+      startSlot,
+      count,
+      earliestAvailableSlot: chain.earliestAvailableSlot,
     });
-    return;
+    throw new ResponseError(
+      RespStatus.RESOURCE_UNAVAILABLE,
+      `Requested range is before earliestAvailableSlot startSlot=${startSlot} count=${count} earliestAvailableSlot=${chain.earliestAvailableSlot}`
+    );
   }
 
   const finalized = db.dataColumnSidecarArchive;

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
@@ -1,3 +1,4 @@
+import {PeerId} from "@libp2p/interface";
 import {ChainConfig} from "@lodestar/config";
 import {PayloadStatus} from "@lodestar/fork-choice";
 import {GENESIS_SLOT} from "@lodestar/params";
@@ -6,17 +7,32 @@ import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {gloas} from "@lodestar/types";
 import {IBeaconChain} from "../../../chain/index.js";
 import {IBeaconDb} from "../../../db/index.js";
+import {prettyPrintPeerId} from "../../util.js";
 
 export async function* onExecutionPayloadEnvelopesByRange(
   request: gloas.ExecutionPayloadEnvelopesByRangeRequest,
   chain: IBeaconChain,
-  db: IBeaconDb
+  db: IBeaconDb,
+  peerId: PeerId,
+  peerClient: string
 ): AsyncIterable<ResponseOutgoing> {
   const {startSlot, count} = validateExecutionPayloadEnvelopesByRangeRequest(chain.config, request);
   const endSlot = startSlot + count;
 
-  if (startSlot < chain.earliestAvailableSlot) {
-    return;
+  // endSlot is exclusive, so highest served slot is endSlot - 1.
+  // Throw only when the entire requested range is below earliestAvailableSlot.
+  if (endSlot - 1 < chain.earliestAvailableSlot) {
+    chain.logger.verbose("Peer requested range before earliestAvailableSlot for ExecutionPayloadEnvelopesByRange", {
+      peer: prettyPrintPeerId(peerId),
+      client: peerClient,
+      startSlot,
+      count,
+      earliestAvailableSlot: chain.earliestAvailableSlot,
+    });
+    throw new ResponseError(
+      RespStatus.RESOURCE_UNAVAILABLE,
+      `Requested range is before earliestAvailableSlot startSlot=${startSlot} count=${count} earliestAvailableSlot=${chain.earliestAvailableSlot}`
+    );
   }
 
   const finalized = db.executionPayloadEnvelopeArchive;

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -74,9 +74,9 @@ export function getReqRespHandlers({db, chain}: {db: IBeaconDb; chain: IBeaconCh
       const body = ExecutionPayloadEnvelopesByRootRequestType(chain.config).deserialize(req.data);
       return onExecutionPayloadEnvelopesByRoot(body, chain, db, peerId, peerClient);
     },
-    [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: (req) => {
+    [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: (req, peerId, peerClient) => {
       const body = ssz.gloas.ExecutionPayloadEnvelopesByRangeRequest.deserialize(req.data);
-      return onExecutionPayloadEnvelopesByRange(body, chain, db);
+      return onExecutionPayloadEnvelopesByRange(body, chain, db, peerId, peerClient);
     },
 
     [ReqRespMethod.LightClientBootstrap]: (req) => {


### PR DESCRIPTION
**Motivation**

- lodestar silently return 0-block response if requested range is before the earliest_available_slot

**Description**

- throw resource_unavailable error in that case

found when reviewing #9417

**AI Assistance Disclosure**

- created with the help of Claude