### PR TITLE
fix: continue past non-custody column requests in DataColumnSidecarsByRoot

### DIFF
--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRoot.ts
@@ -30,7 +30,7 @@ export async function* onDataColumnSidecarsByRoot(
     const {blockRoot, columns: requestedColumns} = dataColumnsByRootIdentifier;
     const availableColumns = validateRequestedDataColumns(chain, requestedColumns);
     if (availableColumns.length === 0) {
-      return;
+      continue;
     }
 
     const blockRootHex = toRootHex(blockRoot);


### PR DESCRIPTION
**Motivation**

`onDataColumnSidecarsByRoot` iterates over the list of `DataColumnsByRootIdentifier` in the request body. When one identifier resolves to zero in-custody columns (i.e. every requested column is outside our advertised custody) it currently `return`s out of the async generator — silently dropping the response for **every remaining identifier** in the same request.

A peer that mixes one bad request (e.g. a column we never custodied, or a stale advertised CGC) with otherwise-valid ones gets nothing back for any of them. This is hard to spot in logs because the per-identifier `verbose("Requested dataColumnSidecars not available")` only fires for the offending entry; the rest are dropped without a trace.

**Description**

Change `return` to `continue` so unrelated identifiers in the batch are still served.

```diff
     const availableColumns = validateRequestedDataColumns(chain, requestedColumns);
     if (availableColumns.length === 0) {
-      return;
+      continue;
     }
```

`onDataColumnSidecarsByRange` has the same `return` but only one set of requested columns per request, so it is correct there.

🤖 Generated with AI assistance