### PR TITLE
perf: use custodyColumnsIndex for O(1) custody lookup in column reqresp

### DIFF
--- a/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
+++ b/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
@@ -79,9 +79,16 @@ export function validateRequestedDataColumns(chain: IBeaconChain, requestedColum
     throw new ResponseError(RespStatus.INVALID_REQUEST, "dataColumnSidecar requested without column indices");
   }
 
-  const custodyColumns = chain.custodyConfig.custodyColumns;
-  const availableColumns = requestedColumns.filter((c) => custodyColumns.includes(c));
-  const missingColumns = requestedColumns.filter((c) => !custodyColumns.includes(c));
+  const {custodyColumns, custodyColumnsIndex} = chain.custodyConfig;
+  const availableColumns: ColumnIndex[] = [];
+  const missingColumns: ColumnIndex[] = [];
+  for (const c of requestedColumns) {
+    if (custodyColumnsIndex[c] !== 0) {
+      availableColumns.push(c);
+    } else {
+      missingColumns.push(c);
+    }
+  }
 
   if (missingColumns.length > 0) {
     chain.logger.verbose("Requested dataColumnSidecar for non-custody columns", {

--- a/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
+++ b/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
@@ -83,7 +83,10 @@ export function validateRequestedDataColumns(chain: IBeaconChain, requestedColum
   const availableColumns: ColumnIndex[] = [];
   const missingColumns: ColumnIndex[] = [];
   for (const c of requestedColumns) {
-    if (custodyColumnsIndex[c] !== 0) {
+    // `c` is peer-controlled and SSZ-deserialized as `uint64`, so it may exceed
+    // `NUMBER_OF_COLUMNS - 1`; `Uint8Array` returns `undefined` for OOB reads,
+    // and `undefined !== 0` would silently classify OOB indices as custodied.
+    if ((custodyColumnsIndex[c] ?? 0) !== 0) {
       availableColumns.push(c);
     } else {
       missingColumns.push(c);


### PR DESCRIPTION
**Motivation**

`validateRequestedDataColumns` ran `Array.includes` over `custodyConfig.custodyColumns` once per requested column to split the request into available / missing, doing two full passes:

```ts
const availableColumns = requestedColumns.filter((c) => custodyColumns.includes(c));
const missingColumns = requestedColumns.filter((c) => !custodyColumns.includes(c));
```

That's O(N*M) per request — for a CGC=128 node serving a 128-column request, ~32k operations per request. Called on every `DataColumnSidecarsByRoot` / `DataColumnSidecarsByRange` request.

**Description**

`CustodyConfig` already maintains a `custodyColumnsIndex: Uint8Array` (`0` = not custodied, non-zero = custodied) for O(1) lookups. Use it, and partition in a single pass.

No behaviour change — same `availableColumns` / `missingColumns` for any input. Existing `Requested dataColumnSidecar for non-custody columns` logging is unchanged.

🤖 Generated with AI assistance