### PR TITLE
fix: produce payload attestation for any seen block at slot

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1110,10 +1110,10 @@ export function getValidatorApi(
       notWhileSyncing();
       await waitForSlot(slot);
 
-      const block = chain.forkChoice.getCanonicalBlockAtSlot(slot);
+      const block = chain.forkChoice.getMaxWeightBlockAtSlot(slot);
       if (!block) {
         // No block is seen at slot. Return 404 so vc can skip casting payload attestation.
-        throw new ApiError(404, `No canonical block found at slot=${slot}`);
+        throw new ApiError(404, `No block found at slot=${slot}`);
       }
 
       const payloadInput = chain.seenPayloadEnvelopeInputCache.get(block.blockRoot);

--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -62,6 +62,7 @@ vi.mock("@lodestar/fork-choice", async (importActual) => {
       iterateAncestorBlocks: vi.fn(),
       getBlockSummariesByParentRoot: vi.fn(),
       getCanonicalBlockAtSlot: vi.fn(),
+      getMaxWeightBlockAtSlot: vi.fn(),
       getCanonicalBlockClosestLteSlot: vi.fn(),
       getCanonicalBlockByRoot: vi.fn(),
       getFinalizedCheckpoint: vi.fn(),

--- a/packages/beacon-node/test/unit/api/impl/validator/produceAttestationData.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceAttestationData.test.ts
@@ -50,7 +50,7 @@ describe("api - validator - produceAttestationData", () => {
       );
     });
 
-    it("Should produce payload attestation data for the canonical block", async () => {
+    it("Should produce payload attestation data for the max-weight block at slot", async () => {
       const gloasConfig = createChainForkConfig({
         ...defaultChainConfig,
         ALTAIR_FORK_EPOCH: 0,
@@ -65,7 +65,7 @@ describe("api - validator - produceAttestationData", () => {
       modules.config = gloasConfig;
       api = getValidatorApi(defaultApiOptions, modules);
 
-      modules.forkChoice.getCanonicalBlockAtSlot.mockReturnValue({
+      modules.forkChoice.getMaxWeightBlockAtSlot.mockReturnValue({
         slot: 0,
         blockRoot: ZERO_HASH_HEX,
       } as ProtoBlock);
@@ -87,7 +87,7 @@ describe("api - validator - produceAttestationData", () => {
       expect(res.data.blobDataAvailable).toBe(true);
     });
 
-    it("Should throw 404 when no canonical block has been seen for the assigned slot", async () => {
+    it("Should throw 404 when no block (canonical or not) has been seen for the assigned slot", async () => {
       const gloasConfig = createChainForkConfig({
         ...defaultChainConfig,
         ALTAIR_FORK_EPOCH: 0,
@@ -102,9 +102,9 @@ describe("api - validator - produceAttestationData", () => {
       modules.config = gloasConfig;
       api = getValidatorApi(defaultApiOptions, modules);
 
-      modules.forkChoice.getCanonicalBlockAtSlot.mockReturnValue(null);
+      modules.forkChoice.getMaxWeightBlockAtSlot.mockReturnValue(null);
 
-      await expect(api.producePayloadAttestationData({slot: 1})).rejects.toThrow("No canonical block found at slot=1");
+      await expect(api.producePayloadAttestationData({slot: 1})).rejects.toThrow("No block found at slot=1");
     });
   });
 });

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1363,6 +1363,28 @@ export class ForkChoice implements IForkChoice {
     return blocksAtSlot;
   }
 
+  /**
+   * Returns the highest-weight block at the given slot, or `null` if no block
+   * (canonical or not) has been seen at the slot. On weight ties, the canonical
+   * block is preferred — the search is seeded with the canonical block at slot
+   * and only replaced by a node with strictly greater weight.
+   *
+   * Used by the PTC validator API to know which block's payload PTC
+   * should attest to
+   *
+   */
+  getMaxWeightBlockAtSlot(slot: Slot): ProtoBlock | null {
+    let best = this.getCanonicalBlockAtSlot(slot) as ProtoNode | null;
+    const nodes = this.protoArray.nodes;
+    for (let i = 0, len = nodes.length; i < len; i++) {
+      const node = nodes[i];
+      if (node.slot === slot && (best === null || node.weight > best.weight)) {
+        best = node;
+      }
+    }
+    return best;
+  }
+
   /** Returns the distance of common ancestor of nodes to the max of the newNode and the prevNode. */
   getCommonAncestorDepth(prevBlock: ProtoBlock, newBlock: ProtoBlock): AncestorResult {
     const prevNode = this.protoArray.getNode(prevBlock.blockRoot, prevBlock.payloadStatus);

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -335,6 +335,11 @@ export interface IForkChoice {
   forwardIterateDescendantsDefaultStatus(blockRoot: RootHex): IterableIterator<ProtoBlock>;
   getBlockSummariesByParentRoot(parentRoot: RootHex): ProtoBlock[];
   getBlockSummariesAtSlot(slot: Slot): ProtoBlock[];
+  /**
+   * Returns the highest-weight block at the given slot,
+   * or `null` if no block has been seen at that slot.
+   */
+  getMaxWeightBlockAtSlot(slot: Slot): ProtoBlock | null;
   /** Returns the distance of common ancestor of nodes to the max of the newNode and the prevNode. */
   getCommonAncestorDepth(prevBlock: ProtoBlock, newBlock: ProtoBlock): AncestorResult;
   /**

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -191,6 +191,54 @@ describe("Forkchoice", () => {
     expect(forkCombined.nonAncestors).toEqual(forkNonAncestorBlocks);
   });
 
+  describe("getMaxWeightBlockAtSlot", () => {
+    const siblingBlockRoot = toHex(Buffer.alloc(32, 0xcc));
+    const buildSibling = (slot: number): ProtoBlock => ({
+      ...getBlock(slot),
+      blockRoot: siblingBlockRoot,
+      stateRoot: toHex(Buffer.alloc(32, 0xdd)),
+    });
+
+    it("returns null when no block has been seen at slot", () => {
+      populateProtoArray(genesisSlot + 2);
+      const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
+      expect(forkchoice.getMaxWeightBlockAtSlot(genesisSlot + 100)).toBeNull();
+    });
+
+    it("returns the block with strictly greater weight among siblings", () => {
+      populateProtoArray(genesisSlot + 2);
+      const sibling = buildSibling(genesisSlot + 2);
+      protoArr.onBlock(sibling, sibling.slot, null);
+
+      const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
+      const canonical = forkchoice.getCanonicalBlockAtSlot(genesisSlot + 2);
+      if (!canonical) throw Error("expected canonical block at slot 2");
+
+      const siblingRoot = canonical.blockRoot === siblingBlockRoot ? getBlockRoot(genesisSlot + 2) : siblingBlockRoot;
+      const siblingNode = protoArr.nodes.find((n) => n.blockRoot === siblingRoot && n.slot === genesisSlot + 2);
+      if (!siblingNode) throw Error("expected sibling node");
+      siblingNode.weight = 100;
+
+      const result = forkchoice.getMaxWeightBlockAtSlot(genesisSlot + 2);
+      expect(result?.blockRoot).toBe(siblingRoot);
+    });
+
+    it("prefers the canonical block on weight tie", () => {
+      populateProtoArray(genesisSlot + 2);
+      const sibling = buildSibling(genesisSlot + 2);
+      protoArr.onBlock(sibling, sibling.slot, null);
+
+      const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
+      const canonical = forkchoice.getCanonicalBlockAtSlot(genesisSlot + 2);
+      if (!canonical) throw Error("expected canonical block at slot 2");
+
+      // Both nodes still have weight 0 — tie. Seeding with canonical means strict `>` cannot
+      // displace it, regardless of insertion order in protoArray.nodes.
+      const result = forkchoice.getMaxWeightBlockAtSlot(genesisSlot + 2);
+      expect(result?.blockRoot).toBe(canonical.blockRoot);
+    });
+  });
+
   beforeAll(() => {
     expect(SLOTS_PER_EPOCH).toBe(32);
   });


### PR DESCRIPTION
Per Gloas validator spec, the PTC attestation should be produced for any beacon block seen at the assigned slot, not only a canonical block. Only 404 when no block (canonical or not) has been observed.

Adds `getMaxWeightBlockAtSlot` to ForkChoice which seeds the search with the canonical block at the slot and replaces it only with a strictly heavier sibling — canonical is preferred on weight tie.
