### PR TITLE
fix: publish only subscribed columns from reconstruction

### DIFF
--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -470,15 +470,17 @@ export async function recoverDataColumnSidecars(
     return DataColumnReconstructionCode.SuccessLate;
   }
 
-  // Once the node obtains a column through reconstruction,
-  // the node MUST expose the new column as if it had received it over the network.
-  // If the node is subscribed to the subnet corresponding to the column,
-  // it MUST send the reconstructed DataColumnSidecar to its topic mesh neighbors.
-  // If instead the node is not subscribed to the corresponding subnet,
-  // it SHOULD still expose the availability of the DataColumnSidecar as part of the gossip emission process.
-  // After exposing the reconstructed DataColumnSidecar to the network,
-  // the node MAY delete the DataColumnSidecar if it is not part of the node's custody requirement.
-  const sidecarsToPublish = [];
+  // Per consensus-specs PR #4657, only publish reconstructed columns the node is
+  // subscribed to (custody + sampling). Eagerly cross-seeding non-subscribed
+  // columns floods the network with duplicates because the sender has no
+  // visibility into which peers already saw the message via the topic mesh.
+  // This matches the getBlobsV2 path in `getDataColumnSidecarsFromExecution` and
+  // aligns with Lighthouse/Prysm. Capture missing sampled indices before adding
+  // any reconstructed columns so they are not filtered out by the subsequent
+  // `addColumn` calls.
+  const missingSampledColumns = new Set(input.getMissingSampledColumnMeta().missing);
+  const sidecarsReconstructed: DataColumnSidecar[] = [];
+  const sidecarsToPublish: DataColumnSidecar[] = [];
   for (const columnSidecar of fullSidecars) {
     if (!input.hasColumn(columnSidecar.index)) {
       if (input instanceof PayloadEnvelopeInput) {
@@ -501,11 +503,14 @@ export async function recoverDataColumnSidecars(
           source: BlockInputSource.recovery,
         });
       }
-      sidecarsToPublish.push(columnSidecar);
+      sidecarsReconstructed.push(columnSidecar);
+      if (missingSampledColumns.has(columnSidecar.index)) {
+        sidecarsToPublish.push(columnSidecar);
+      }
     }
   }
-  metrics?.peerDas.reconstructedColumns.inc(sidecarsToPublish.length);
-  metrics?.dataColumns.bySource.inc({source: BlockInputSource.recovery}, sidecarsToPublish.length);
+  metrics?.peerDas.reconstructedColumns.inc(sidecarsReconstructed.length);
+  metrics?.dataColumns.bySource.inc({source: BlockInputSource.recovery}, sidecarsReconstructed.length);
   emitter.emit(ChainEvent.publishDataColumns, sidecarsToPublish);
   // TODO: Can we record dataColumns.sentPeersPerSubnet metric somehow
   return DataColumnReconstructionCode.SuccessResolved;


### PR DESCRIPTION
## Summary

Mirror the getBlobsV2 path in `getDataColumnSidecarsFromExecution` and align with Lighthouse/Prysm by publishing only the sampled (custody + sampling) columns after matrix recovery, instead of cross-seeding every recovered column to non-subscribed subnets.

Per consensus-specs [PR #4657](https://github.com/ethereum/consensus-specs/pull/4657) ("Only require nodes to publish custody columns from reconstruction"), eager fanout for non-custody columns floods the network with duplicates because the sender lacks visibility into which peers already saw the message via the topic mesh.

> Lighthouse (and probably Prysm too) currently just publishes its own sampling/custody columns for that reason. — [@jimmygchen on the spec PR](https://github.com/ethereum/consensus-specs/pull/4657#issuecomment-4599160096)

A node custodying 65 columns ends up publishing at least 64 (63 non-custody + 1 missing custody) columns every reconstruction, which is more outbound bandwidth than a supernode. This change brings Lodestar in line with the other clients.

## Change

`packages/beacon-node/src/util/dataColumns.ts` — `recoverDataColumnSidecars`:

- Capture `input.getMissingSampledColumnMeta().missing` before adding reconstructed columns (otherwise the indices are no longer "missing" after `addColumn`).
- Still add every recovered sidecar to the input so DA accounting is unchanged.
- Only push to `sidecarsToPublish` when the index is in the captured missing-sampled set.
- Split metric reporting: `peerDas.reconstructedColumns` and `dataColumns.bySource{source=recovery}` now correctly count reconstructed columns (`sidecarsReconstructed.length`) instead of accidentally tracking only published ones — they happened to be equal under the old behavior, but diverge now.

The existing getBlobsV2 path in `util/execution.ts:198-203` already follows this "publish iff subscribed" pattern using the same `getMissingSampledColumnMeta()` API; matrix recovery now matches.

## Spec note

Spec PR #4657 also tightens the reconstruction trigger ("custodies more than 50%") and softens the cross-seed clause (SHOULD → MAY). This PR only implements the publish-side change, which is what Lighthouse/Prysm already do in practice. The trigger-side wording change does not require a Lodestar code change (we already only attempt reconstruction when we have ≥50%, gated by sampling).

## Test plan

- [ ] tsgo / biome clean on touched file (verified locally)
- [ ] Sim / devnet observation: confirm reduced outbound column traffic from non-supernodes after reconstruction
- [ ] No existing unit tests for `recoverDataColumnSidecars` or the equivalent execution.ts publish path; covered by integration/sim. Happy to add a dedicated unit test if reviewers want it — it would need real KZG + a mocked `BlockInputColumns`.

🤖 Generated with AI assistance