### PR TITLE
fix: skip orphaned payload columns in data columns by range

### DIFF
--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -980,6 +980,12 @@ export async function validateColumnsByRangeResponse(
           missingIndices: prettyPrintIndices(request.columns),
         })
       );
+      // Gloas: the bid commits to blobs even for payloads that get orphaned, whose columns are
+      // pruned and unservable. Skip instead of truncating + re-requesting forever; DA is enforced
+      // on envelope processing. Pre-Gloas commitments are canonical, so keep strict.
+      if (isForkPostGloas(forkName)) {
+        continue;
+      }
       break;
     }
 


### PR DESCRIPTION
The bid commits to blob KZG commitments even when its payload is orphaned, whose columns are pruned and unservable, so the batch must not be truncated and re-requested (which stalls range sync). Skip such blocks instead; data availability is enforced on envelope processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)