### PR TITLE
ci: bump codecov-action to v6.0.2 for keybase migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
       #   if: ${{ failure() && steps.unit_tests.conclusion == 'failure' }}
 
       - name: Upload coverage data
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
## Summary

- `codecov-action@v6.0.1` started failing on `unstable` because Codecov lost write access to the `codecovsecurity` keybase account, bricked it, and migrated to `codecovsecops`. v6.0.1 hardcodes the old URL, so the wrapper's GPG key import 404s, signature verify fails, and the `Upload coverage data` step exits 1 (example: [Unit Tests (24) on 79c77e2e](https://github.com/ChainSafe/lodestar/actions/runs/27069917312/job/79898204341)).
- Codecov shipped `v6.0.2` as a literal copy of `v7.0.0` (same commit) so v6 consumers can adopt the fix without crossing a major. See codecov/codecov-action#1955 / codecov/codecov-action#1956.
- The only runtime change vs `v6.0.1` is the keybase URL swap (`codecovsecurity` → `codecovsecops`); GPG integrity verification of the uploader binary is preserved — no `use_pypi` / `skip_validation` workaround needed.

## Test plan

- [ ] Tests workflow runs to completion on this PR
- [ ] `Upload coverage data` step in Unit Tests (24) succeeds (no `gpg: no valid OpenPGP data found` / `Could not verify signature`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)