### PR TITLE
chore: remove resolved todo about queuing payload envelopes

### DIFF
--- a/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
@@ -35,8 +35,6 @@ async function validateExecutionPayloadEnvelope(
   // [IGNORE] The envelope's block root `envelope.beacon_block_root` has been seen (via
   // gossip or non-gossip sources) (a client MAY queue payload for processing once
   // the block is retrieved).
-  // TODO GLOAS: Need to review this, we should queue the envelope for later
-  // processing if the block is not yet known, otherwise we would ignore it here
   const block = chain.forkChoice.getBlockDefaultStatus(envelope.beaconBlockRoot);
   if (block === null) {
     throw new ExecutionPayloadEnvelopeError(GossipAction.IGNORE, {


### PR DESCRIPTION
We are queuing payload envelopes in the network processor already, this **TODO** has been resolved