### PR TITLE
fix(beacon-node): restructure unknownBlock test to fix tsgo overload resolution

### DIFF
--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -963,13 +963,9 @@ describe("UnknownBlockSync", () => {
         )
         .mockResolvedValueOnce(undefined);
 
-      let emitter!: ChainEventEmitter;
-      const processBlock = vi.fn().mockImplementation(async () => {
-        knownRoots.add(blockRootHex);
-        emitter.emit(routes.events.EventType.block, {slot: 1, block: blockRootHex, executionOptimistic: false});
-      });
+      const processBlock = vi.fn();
 
-      ({emitter} = setupPayloadSyncTest({
+      const {emitter} = setupPayloadSyncTest({
         chainOverrides: {
           processBlock,
           processExecutionPayload,
@@ -1017,7 +1013,12 @@ describe("UnknownBlockSync", () => {
           sendBeaconBlocksByRoot,
         },
         peers: [{peerId: peer}],
-      }));
+      });
+
+      processBlock.mockImplementation(async () => {
+        knownRoots.add(blockRootHex);
+        emitter.emit(routes.events.EventType.block, {slot: 1, block: blockRootHex, executionOptimistic: false});
+      });
 
       emitter.emit(ChainEvent.unknownEnvelopeBlockRoot, {
         rootHex: blockRootHex,


### PR DESCRIPTION
## Summary

- Restructures the "downloads the block and retries payload import when EL reports block not in fork choice" test in `unknownBlock.test.ts` so its `processBlock` mock no longer needs a `let emitter!: ChainEventEmitter` definite-assignment assertion plus a destructuring-assignment dance.
- That pattern caused tsgo's overload resolution to widen `emitter`'s inferred type and fall back to the `EventEmitter` base overload (expecting `unique symbol` event names) for the subsequent `emitter.emit(ChainEvent.unknownEnvelopeBlockRoot, ...)` site — surfaced as the `TS2769` check-types failure on this PR's CI.

## Diagnosis

Failing job: `Type Checks (24)` → `packages/beacon-node check-types`.

```
test/unit/sync/unknownBlock.test.ts(1027,20): error TS2769: No overload matches this call.
  Argument of type 'ChainEvent.unknownEnvelopeBlockRoot' is not assignable to parameter of type 'unique symbol'.
```

The data shape is fine — `slot: 0` is already included at line 1024, and the e2e at `unknownBlockSync.test.ts:236` also includes `slot: headSlot`. The 5 other `emitter.emit(ChainEvent.unknownEnvelopeBlockRoot, ...)` sites in the same file (lines 762/836/926/1079/1129) all typecheck fine because they use plain `const {emitter} = setupPayloadSyncTest(...)` rather than `let !` + destructuring-assignment.

## Fix

Declare `processBlock = vi.fn()` upfront, destructure `emitter` as a `const`, then attach `processBlock.mockImplementation(...)` after `setupPayloadSyncTest` returns. This matches the pattern used by every other test in the file and removes the pattern that confused tsgo.

Safe because no event fires between `setupPayloadSyncTest` and the next `emitter.emit(...)` — `processBlock` is never invoked before its implementation is attached.

## Test plan

- [ ] CI: `Type Checks (24)` passes (no TS2769 on `unknownBlock.test.ts`).
- [ ] CI: the "downloads the block and retries payload import when EL reports block not in fork choice" unit test still passes (still asserts `processBlock` called once, `processExecutionPayload` called twice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
