### PR TITLE
fix: bound `SeenPayloadEnvelopeInput` cache size to prevent OOM

### DIFF
--- a/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
@@ -26,10 +26,11 @@ export type SeenPayloadEnvelopeInputModules = {
   logger?: Logger;
 };
 
-// Upper bound on the cache, enforced on insertion. pruneFinalized / pruneBelowParent only run on
-// finality or chain progression, so without this the cache grows unbounded during non-finality and
-// can OOM the node (see https://github.com/ChainSafe/lodestar/issues/9073). Sized to match
-// SeenBlockInput's MAX_BLOCK_INPUT_CACHE_SIZE so the range-sync look-ahead window stays resident.
+// Upper bound on the cache, enforced on every insertion. pruneFinalized / pruneBelowParent are both
+// dormant during catch-up (no finality; prepareNextSlot bails once the head is far behind the clock),
+// so without an insert-time cap the cache grows unbounded and OOMs the node
+// (see https://github.com/ChainSafe/lodestar/issues/9073). Same size as SeenBlockInput's
+// MAX_BLOCK_INPUT_CACHE_SIZE.
 const MAX_PAYLOAD_ENVELOPE_INPUT_CACHE_SIZE = (MAX_LOOK_AHEAD_EPOCHS + 1) * SLOTS_PER_EPOCH;
 
 /**
@@ -124,7 +125,7 @@ export class SeenPayloadEnvelopeInput {
       root: props.blockRootHex,
       daOutOfRange,
     });
-    this.pruneToMaxSize();
+    this.pruneToMaxSize(props.blockRootHex);
     return input;
   }
 
@@ -146,7 +147,7 @@ export class SeenPayloadEnvelopeInput {
       root: props.blockRootHex,
       daOutOfRange,
     });
-    this.pruneToMaxSize();
+    this.pruneToMaxSize(props.blockRootHex);
     return input;
   }
 
@@ -177,27 +178,26 @@ export class SeenPayloadEnvelopeInput {
     }
   }
 
-  /** Evict the lowest-slot entries (oldest / furthest behind the head) once over the max size. */
-  private pruneToMaxSize(): void {
-    let itemsToDelete = this.payloadInputs.size - MAX_PAYLOAD_ENVELOPE_INPUT_CACHE_SIZE;
-    if (itemsToDelete <= 0) {
-      return;
-    }
-
-    const sorted = [...this.payloadInputs.values()].sort((a, b) => a.slot - b.slot);
-    let deletedCount = 0;
-    for (const input of sorted) {
-      this.evictPayloadInput(input);
-      deletedCount++;
-      if (--itemsToDelete <= 0) {
-        break;
+  /**
+   * Enforce the size cap by evicting the lowest-slot entry (oldest / furthest behind the head).
+   * Called on every insertion so the cache is at most one over the cap. `excludeRoot` is never
+   * evicted, so an add can't remove itself when it is the lowest slot (e.g. an older block in a reorg).
+   */
+  private pruneToMaxSize(excludeRoot?: RootHex): void {
+    while (this.payloadInputs.size > MAX_PAYLOAD_ENVELOPE_INPUT_CACHE_SIZE) {
+      let lowest: PayloadEnvelopeInput | undefined;
+      for (const input of this.payloadInputs.values()) {
+        if (input.blockRootHex === excludeRoot) continue;
+        if (lowest === undefined || input.slot < lowest.slot) lowest = input;
       }
+      if (lowest === undefined) break;
+      this.evictPayloadInput(lowest);
+      this.logger?.debug("SeenPayloadEnvelopeInput.pruneToMaxSize evicted entry", {
+        slot: lowest.slot,
+        root: lowest.blockRootHex,
+        maxSize: MAX_PAYLOAD_ENVELOPE_INPUT_CACHE_SIZE,
+      });
     }
-
-    this.logger?.debug("SeenPayloadEnvelopeInput.pruneToMaxSize evicted entries", {
-      deletedCount,
-      maxSize: MAX_PAYLOAD_ENVELOPE_INPUT_CACHE_SIZE,
-    });
   }
 
   private evictPayloadInput(payloadInput: PayloadEnvelopeInput): void {

--- a/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
@@ -1,9 +1,11 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {CheckpointWithHex, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {RootHex} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
+import {MAX_LOOK_AHEAD_EPOCHS} from "../../sync/constants.js";
 import {IClock} from "../../util/clock.js";
 import {SerializedCache} from "../../util/serializedCache.js";
 import {isDaOutOfRange} from "../blocks/blockInput/index.js";
@@ -23,6 +25,12 @@ export type SeenPayloadEnvelopeInputModules = {
   metrics: Metrics | null;
   logger?: Logger;
 };
+
+// Upper bound on the cache, enforced on insertion. pruneFinalized / pruneBelowParent only run on
+// finality or chain progression, so without this the cache grows unbounded during non-finality and
+// can OOM the node (see https://github.com/ChainSafe/lodestar/issues/9073). Sized to match
+// SeenBlockInput's MAX_BLOCK_INPUT_CACHE_SIZE so the range-sync look-ahead window stays resident.
+const MAX_PAYLOAD_ENVELOPE_INPUT_CACHE_SIZE = (MAX_LOOK_AHEAD_EPOCHS + 1) * SLOTS_PER_EPOCH;
 
 /**
  * Cache for tracking PayloadEnvelopeInput instances, keyed by beacon block root.
@@ -116,6 +124,7 @@ export class SeenPayloadEnvelopeInput {
       root: props.blockRootHex,
       daOutOfRange,
     });
+    this.pruneToMaxSize();
     return input;
   }
 
@@ -137,6 +146,7 @@ export class SeenPayloadEnvelopeInput {
       root: props.blockRootHex,
       daOutOfRange,
     });
+    this.pruneToMaxSize();
     return input;
   }
 
@@ -165,6 +175,29 @@ export class SeenPayloadEnvelopeInput {
         }
       }
     }
+  }
+
+  /** Evict the lowest-slot entries (oldest / furthest behind the head) once over the max size. */
+  private pruneToMaxSize(): void {
+    let itemsToDelete = this.payloadInputs.size - MAX_PAYLOAD_ENVELOPE_INPUT_CACHE_SIZE;
+    if (itemsToDelete <= 0) {
+      return;
+    }
+
+    const sorted = [...this.payloadInputs.values()].sort((a, b) => a.slot - b.slot);
+    let deletedCount = 0;
+    for (const input of sorted) {
+      this.evictPayloadInput(input);
+      deletedCount++;
+      if (--itemsToDelete <= 0) {
+        break;
+      }
+    }
+
+    this.logger?.debug("SeenPayloadEnvelopeInput.pruneToMaxSize evicted entries", {
+      deletedCount,
+      maxSize: MAX_PAYLOAD_ENVELOPE_INPUT_CACHE_SIZE,
+    });
   }
 
   private evictPayloadInput(payloadInput: PayloadEnvelopeInput): void {

--- a/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
@@ -120,6 +120,20 @@ describe("SeenPayloadEnvelopeInput", () => {
     }
   });
 
+  it("excludes the just-inserted entry from pruning even when it is the lowest slot", () => {
+    const maxSize = (MAX_LOOK_AHEAD_EPOCHS + 1) * SLOTS_PER_EPOCH;
+    const prevLowest = addPayloadInput(101);
+    for (let slot = 102; slot < 101 + maxSize; slot++) addPayloadInput(slot);
+    expect(cache.size()).toBe(maxSize);
+
+    // adding an older block (lowest slot) while at cap must not evict itself; the previous lowest
+    // (slot 101) is evicted instead. Guards the reorg / older-fork case.
+    const older = addPayloadInput(1);
+    expect(cache.size()).toBe(maxSize);
+    expect(cache.get(older)).toBeDefined();
+    expect(cache.get(prevLowest)).toBeUndefined();
+  });
+
   it("add returns the existing entry on duplicate root", () => {
     const {block, rootHex} = generateBlock({forkName: ForkName.gloas, slot: 1});
     const props = {

--- a/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
@@ -1,11 +1,12 @@
 import {beforeEach, describe, expect, it, vi} from "vitest";
 import {ExecutionStatus, IForkChoice, PayloadStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {testLogger} from "@lodestar/logger/test-utils";
-import {ForkName} from "@lodestar/params";
+import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {DataAvailabilityStatus} from "@lodestar/state-transition";
 import {RootHex} from "@lodestar/types";
 import {ChainEventEmitter} from "../../../../src/chain/emitter.js";
 import {SeenPayloadEnvelopeInput} from "../../../../src/chain/seenCache/seenPayloadEnvelopeInput.js";
+import {MAX_LOOK_AHEAD_EPOCHS} from "../../../../src/sync/constants.js";
 import {SerializedCache} from "../../../../src/util/serializedCache.js";
 import {getMockedClock} from "../../../mocks/clock.js";
 import {config, generateBlock} from "../../../utils/blocksAndData.js";
@@ -94,6 +95,29 @@ describe("SeenPayloadEnvelopeInput", () => {
     cache.pruneBelowParent(parentBlock);
 
     expect(cache.get(rootHex)).toBeDefined();
+  });
+
+  it("pruneToMaxSize bounds the cache on insertion, evicting the lowest-slot entries", () => {
+    // pruneFinalized / pruneBelowParent never run here, so the insertion-time cap is the only bound
+    const maxSize = (MAX_LOOK_AHEAD_EPOCHS + 1) * SLOTS_PER_EPOCH;
+    const overflow = 5;
+
+    const rootHexBySlot = new Map<number, string>();
+    for (let slot = 1; slot <= maxSize + overflow; slot++) {
+      rootHexBySlot.set(slot, addPayloadInput(slot));
+    }
+
+    // never grows past the cap despite no finality-based pruning
+    expect(cache.size()).toBe(maxSize);
+
+    // the oldest (lowest-slot) entries are evicted ...
+    for (let slot = 1; slot <= overflow; slot++) {
+      expect(cache.get(rootHexBySlot.get(slot) as string)).toBeUndefined();
+    }
+    // ... and the most recent window is retained
+    for (let slot = overflow + 1; slot <= maxSize + overflow; slot++) {
+      expect(cache.get(rootHexBySlot.get(slot) as string)).toBeDefined();
+    }
   });
 
   it("add returns the existing entry on duplicate root", () => {


### PR DESCRIPTION
**Motivation**

`SeenPayloadEnvelopeInput` (added in #8962) has no max-size cap. Its only eviction paths are `pruneFinalized` (on finalization) and `pruneBelowParent` (on chain progression), so during extended non-finality — or a catch-up where no blocks import — neither fires and the cache grows unbounded. Each entry holds a payload envelope plus up to `NUMBER_OF_COLUMNS` data-column sidecars, so this can OOM the node.

This was hit on a Gloas devnet: a node restarting ~250 slots behind caught up via unknown-block-by-root sync that never connected to fork choice (`parentInForkChoice=false`, 0 imports, same roots re-downloaded), and the payload-envelope cache grew until the JS heap hit its `--max-old-space-size` limit and the process OOM-crashed in a loop.

This is concern #1 of #9073 (`pruneToMaxSize()` cap missing — unbounded growth during non-finality).

**Description**

- Add `MAX_PAYLOAD_ENVELOPE_INPUT_CACHE_SIZE = (MAX_LOOK_AHEAD_EPOCHS + 1) * SLOTS_PER_EPOCH`, mirroring `SeenBlockInput`'s `MAX_BLOCK_INPUT_CACHE_SIZE` so the range-sync look-ahead window stays resident.
- Add `pruneToMaxSize()` that evicts the lowest-slot entries first (oldest / furthest behind the head).
- Call it on **insertion** (`add` / `addFromBid`) rather than only after finalization. Insertion is the only event guaranteed to fire while the cache is growing, so the cap holds even when finality is stalled — the exact OOM condition. An `onFinalized`-only trigger would not have prevented it.
- Add a unit test asserting the cache stays bounded and evicts oldest-by-slot when `pruneFinalized` / `pruneBelowParent` never run.

Concerns #2 (prune on `processExecutionPayload` failure) and #4 (prune on gossip rejection) from #9073 are not addressed here.

Relates to #9073

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Root cause was diagnosed from a node's debug logs and the fix drafted with assistance from Claude; reviewed and verified by me (biome, unit tests, type-check).
