### PR TITLE
fix(beacon-node): protect just-inserted entry from pruneToMaxSize eviction

### DIFF
--- a/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
@@ -124,7 +124,7 @@ export class SeenPayloadEnvelopeInput {
       root: props.blockRootHex,
       daOutOfRange,
     });
-    this.pruneToMaxSize();
+    this.pruneToMaxSize(props.blockRootHex);
     return input;
   }
 
@@ -146,7 +146,7 @@ export class SeenPayloadEnvelopeInput {
       root: props.blockRootHex,
       daOutOfRange,
     });
-    this.pruneToMaxSize();
+    this.pruneToMaxSize(props.blockRootHex);
     return input;
   }
 
@@ -177,20 +177,43 @@ export class SeenPayloadEnvelopeInput {
     }
   }
 
-  /** Evict the lowest-slot entries (oldest / furthest behind the head) once over the max size. */
-  private pruneToMaxSize(): void {
+  /**
+   * Evict the lowest-slot entries (oldest / furthest behind the head) once over the max size.
+   * `excludeRoot` protects the just-inserted entry from being evicted by its own triggering call,
+   * which matters when a reorg or out-of-order range-sync response inserts an entry whose slot is
+   * lower than every existing entry's slot.
+   */
+  private pruneToMaxSize(excludeRoot?: RootHex): void {
     let itemsToDelete = this.payloadInputs.size - MAX_PAYLOAD_ENVELOPE_INPUT_CACHE_SIZE;
     if (itemsToDelete <= 0) {
       return;
     }
 
-    const sorted = [...this.payloadInputs.values()].sort((a, b) => a.slot - b.slot);
     let deletedCount = 0;
-    for (const input of sorted) {
-      this.evictPayloadInput(input);
-      deletedCount++;
-      if (--itemsToDelete <= 0) {
-        break;
+    if (itemsToDelete === 1) {
+      // Fast path for the per-insertion call: find the lowest-slot non-excluded entry in O(N) instead of
+      // paying for an O(N log N) sort of the whole cache.
+      let minInput: PayloadEnvelopeInput | undefined;
+      for (const input of this.payloadInputs.values()) {
+        if (input.blockRootHex === excludeRoot) continue;
+        if (minInput === undefined || input.slot < minInput.slot) {
+          minInput = input;
+        }
+      }
+      if (minInput !== undefined) {
+        this.evictPayloadInput(minInput);
+        deletedCount = 1;
+      }
+    } else {
+      const sorted = [...this.payloadInputs.values()]
+        .filter((input) => input.blockRootHex !== excludeRoot)
+        .sort((a, b) => a.slot - b.slot);
+      for (const input of sorted) {
+        this.evictPayloadInput(input);
+        deletedCount++;
+        if (--itemsToDelete <= 0) {
+          break;
+        }
       }
     }
 

--- a/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
@@ -120,6 +120,30 @@ describe("SeenPayloadEnvelopeInput", () => {
     }
   });
 
+  it("pruneToMaxSize does not evict the just-inserted entry even if it has the lowest slot", () => {
+    // Fill the cache with high-slot entries (range-sync look-ahead state)
+    const maxSize = (MAX_LOOK_AHEAD_EPOCHS + 1) * SLOTS_PER_EPOCH;
+    const highSlotBase = 1000;
+    const rootHexBySlot = new Map<number, string>();
+    for (let i = 0; i < maxSize; i++) {
+      const slot = highSlotBase + i;
+      rootHexBySlot.set(slot, addPayloadInput(slot));
+    }
+    expect(cache.size()).toBe(maxSize);
+
+    // Insert an entry whose slot is lower than every existing entry's slot — out-of-order range-sync
+    // response, reorg-recovery insert, etc. The triggering prune must NOT evict the just-inserted
+    // entry; it should evict the previously-lowest existing entry instead.
+    const lowSlot = 1;
+    const lowRootHex = addPayloadInput(lowSlot);
+
+    expect(cache.size()).toBe(maxSize);
+    // just-inserted entry survives
+    expect(cache.get(lowRootHex)).toBeDefined();
+    // previously-lowest entry is the one evicted
+    expect(cache.get(rootHexBySlot.get(highSlotBase) as string)).toBeUndefined();
+  });
+
   it("add returns the existing entry on duplicate root", () => {
     const {block, rootHex} = generateBlock({forkName: ForkName.gloas, slot: 1});
     const props = {


### PR DESCRIPTION
## Summary

Addresses Gemini's two-part review on #9489 (correctness + perf) by:
- Passing `props.blockRootHex` as `excludeRoot` from each `add` / `addFromBid` call to `pruneToMaxSize`.
- Filtering `excludeRoot` out of the eviction-candidate set inside `pruneToMaxSize`.
- Adding an O(N) fast path for the common `itemsToDelete === 1` case (per-insertion call), keeping the sort-based path for multi-item evictions.

## Why

`pruneToMaxSize()` fires from inside `add()` / `addFromBid()` and evicts the lowest-slot entry when over cap. If the just-inserted entry has a lower slot than every existing entry (out-of-order range-sync response, reorg-recovery insert), the prune evicts the entry the caller just added — defeating the insertion and surfacing as a `Missing PayloadEnvelopeInput` throw downstream at `downloadByRange.ts:230`.

Same correctness gap Codex flagged in `discussion_r3380314898` for the single-add case. Gemini's review (`discussion_r3380335185`) also flagged the O(N log N) sort cost on every insertion when only one eviction is needed.

## Scope notes

This protects the **single-add** case (gossip from a non-canonical fork that happens to be at a slot lower than everything in the cache, or a reorg-driven re-insert). The **multi-add batch-seed** scenario Codex described in `discussion_r3380314898` — `cacheByRangeResponses()` seeding 32 slots back-to-back with later iterations evicting earlier same-batch entries — is **not** addressed here; that requires either a `skipPrune` flag plumbed through batch seeding or a local seed-map fallback in `cacheByRangeResponses`. Happy to follow up with that if you want it in scope here too.

## Test plan

- [ ] CI: `Type Checks (24)` passes.
- [ ] CI: `Unit Tests` — the new test `pruneToMaxSize does not evict the just-inserted entry even if it has the lowest slot` fills the cache with high-slot entries (range-sync look-ahead state), inserts a low-slot entry, and asserts the new entry survives while the previously-lowest existing entry is evicted.
- [ ] CI: existing `pruneToMaxSize bounds the cache on insertion, evicting the lowest-slot entries` test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
