### PR TITLE
fix(beacon-node): cast emitter at the failing emit site to fix tsgo overload

### DIFF
--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -1020,7 +1020,9 @@ describe("UnknownBlockSync", () => {
         emitter.emit(routes.events.EventType.block, {slot: 1, block: blockRootHex, executionOptimistic: false});
       });
 
-      emitter.emit(ChainEvent.unknownEnvelopeBlockRoot, {
+      // tsgo overload-resolution miss when emit is reached through a closure that captures emitter
+      // first; cast re-anchors the StrictEventEmitter overload for ChainEvent keys.
+      (emitter as ChainEventEmitter).emit(ChainEvent.unknownEnvelopeBlockRoot, {
         rootHex: blockRootHex,
         slot: 0,
         peer,


### PR DESCRIPTION
## Summary

Follow-up to #9488 — the restructure removed the `let !` + destructuring pattern but tsgo's overload-resolution miss persists at the same emit site because `emitter` is also captured by a sibling closure (the `processBlock` mock body that emits `routes.events.EventType.block`). Same `TS2769` error reproduces on the current head:

```
test/unit/sync/unknownBlock.test.ts(1027,20): error TS2769: No overload matches this call.
  Argument of type 'ChainEvent.unknownEnvelopeBlockRoot' is not assignable to parameter of type 'unique symbol'.
```

## Fix

Cast `emitter` at the failing site to `ChainEventEmitter` to re-anchor the `StrictEventEmitter` overload for `ChainEvent.X` keys. Minimal change — single line cast at line 1023, with a comment explaining why. The 5 other `emitter.emit(ChainEvent.unknownEnvelopeBlockRoot, ...)` sites in the file remain untouched because they aren't reached through a sibling closure capture.

The previous restructure (now in the base branch) is still worth keeping — it removed an unnecessary indirection — but it wasn't sufficient on its own.

## Test plan

- [ ] CI: `Type Checks (24)` passes (no TS2769 on `unknownBlock.test.ts`).
- [ ] CI: unit tests for the "downloads the block and retries payload import when EL reports block not in fork choice" test still pass — emit semantics unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
