### PR TITLE
fix(beacon-node): apply tsgo cast + add slot to merged-in #9479 test emit

### DIFF
--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -1024,8 +1024,11 @@ describe("UnknownBlockSync", () => {
         peers: [{peerId: peer}],
       }));
 
-      emitter.emit(ChainEvent.unknownEnvelopeBlockRoot, {
+      // tsgo overload-resolution miss when emit is reached through a closure that captures emitter
+      // first; cast re-anchors the StrictEventEmitter overload for ChainEvent keys (see #9491).
+      (emitter as ChainEventEmitter).emit(ChainEvent.unknownEnvelopeBlockRoot, {
         rootHex: blockRootHex,
+        slot: 0,
         peer,
         source: BlockInputSource.gossip,
       });


### PR DESCRIPTION
## Summary

The base-branch update brought in #9479's new test ("defers envelope validation until the block is in fork choice when payload input is seeded from the block body") which uses the same `let emitter!: ChainEventEmitter` + destructuring-assignment + sibling closure capture pattern that #9491 already mitigated in the original failing test below. Same `TS2769` fires at the new test's emit site:

```
test/unit/sync/unknownBlock.test.ts(1027,20): error TS2769: No overload matches this call.
  Argument of type 'ChainEvent.unknownEnvelopeBlockRoot' is not assignable to parameter of type 'unique symbol'.
```

Also, #9479's emit predates this PR's addition of `slot: Slot` to the `ChainEvent.unknownEnvelopeBlockRoot` event signature, so the emit data is missing the required `slot` field after the merge.

## Fix

Same minimal cast workaround as #9491 plus the required `slot: 0` field:

```diff
-      emitter.emit(ChainEvent.unknownEnvelopeBlockRoot, {
+      // tsgo overload-resolution miss when emit is reached through a closure that captures emitter
+      // first; cast re-anchors the StrictEventEmitter overload for ChainEvent keys (see #9491).
+      (emitter as ChainEventEmitter).emit(ChainEvent.unknownEnvelopeBlockRoot, {
         rootHex: blockRootHex,
+        slot: 0,
         peer,
         source: BlockInputSource.gossip,
       });
```

Single-site change. The 5 other `emitter.emit(ChainEvent.unknownEnvelopeBlockRoot, ...)` sites in the file remain unchanged because they aren't reached through a sibling closure capture; the cast at the sibling test's emit (introduced in #9491, currently at line 1126) also remains as-is and continues to typecheck cleanly with the expanded `EventType` union from #9439.

## Test plan

- [ ] CI: `Type Checks (24)` passes (no TS2769 on `unknownBlock.test.ts`).
- [ ] CI: the new `defers envelope validation until the block is in fork choice when payload input is seeded from the block body` test still passes — emit semantics unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
