### PR TITLE
chore: stabilize fastConfirmation perf bench

### DIFF
--- a/packages/fork-choice/test/perf/forkChoice/fastConfirmation.test.ts
+++ b/packages/fork-choice/test/perf/forkChoice/fastConfirmation.test.ts
@@ -1,6 +1,5 @@
 import {bench, describe} from "@chainsafe/benchmark";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Slot} from "@lodestar/types";
 import {
   buildFastConfirmationSnapshot,
@@ -77,9 +76,11 @@ function runFCRRulesBenchmark(opts: Opts): void {
 }
 
 function everyoneVotes(vote: ProtoBlock, forkChoice: ForkChoice): void {
-  const nextEpoch = computeEpochAtSlot(vote.slot);
   const nextRoot = vote.blockRoot;
   for (let i = 0; i < forkChoice["balances"].length; i++) {
-    forkChoice["addLatestMessage"](i, nextEpoch, nextRoot, PayloadStatus.FULL);
+    // addLatestMessage's second arg is `nextSlot: Slot`, not an epoch — pass vote.slot directly so
+    // the internal computeEpochAtSlot(nextSlot) lands on the correct vote epoch instead of
+    // computeEpochAtSlot(epoch)=0 making every vote look 3 epochs stale.
+    forkChoice["addLatestMessage"](i, vote.slot, nextRoot, PayloadStatus.FULL);
   }
 }

--- a/packages/fork-choice/test/perf/forkChoice/fastConfirmation.test.ts
+++ b/packages/fork-choice/test/perf/forkChoice/fastConfirmation.test.ts
@@ -41,10 +41,8 @@ function runFCRRulesBenchmark(opts: Opts): void {
       const forkChoice = initializeForkChoice({...opts, fastConfirmation: true});
 
       const head = forkChoice.updateHead();
-      const prevBlock = forkChoice.getBlockHexDefaultStatus(head.parentRoot);
-      if (!prevBlock) throw Error("no prevBlock");
 
-      // Vote everyone for head
+      // Vote everyone for head so the FCR vote-map paths see a populated voteNextIndices.
       everyoneVotes(head, forkChoice);
 
       // Advance to second slot of epoch 2 (not epoch boundary)
@@ -60,25 +58,17 @@ function runFCRRulesBenchmark(opts: Opts): void {
       const store = forkChoice["fcStore"] as unknown as IFastConfirmationStore;
       if (!ctx) throw Error("fastConfirmationContext not initialized");
 
-      return {forkChoice, ctx, store, head, prevBlock, currentVoteIs1: true, currentSlot};
+      return {ctx, store};
     },
-    beforeEach: (data) => {
-      // Flip votes to force fresh vote map computation each iteration
-      const target = data.currentVoteIs1 ? data.prevBlock : data.head;
-      everyoneVotes(target, data.forkChoice);
-      data.currentVoteIs1 = !data.currentVoteIs1;
-      data.currentSlot = (data.currentSlot + 1) as Slot;
-
-      // Advance the slot (this calls updateHead + processAttestationQueue but NOT the FCR)
-      // We need to advance the slot so getCurrentSlot() returns the right value
-      data.forkChoice["fcStore"].currentSlot = data.currentSlot;
-      // Apply votes to proto array so getHead/isDescendant work correctly
-      data.forkChoice.updateHead();
-
-      return data;
-    },
+    // Pass-through: the bench harness invokes fn(beforeEach(inputAll)), so without a
+    // beforeEach fn would receive undefined. store is not mutated by the rule runner so
+    // no per-iteration reset is required.
+    beforeEach: (data) => data,
     fn: ({ctx, store}) => {
-      // Measure ONLY the FCR rules — build cache + snapshot + run rules
+      // Measure ONLY the FCR rules — build cache + snapshot + run rules.
+      // store is not mutated by runFastConfirmationRules (only the rule runner's caller
+      // would assign store.confirmedRoot), so each iteration replays the same work and
+      // no beforeEach reset is needed.
       const cache = createFastConfirmationCache();
       const snapshot = buildFastConfirmationSnapshot(ctx, store, cache);
       runFastConfirmationRules(snapshot, ctx, store, cache);


### PR DESCRIPTION
## Motivation
`fastConfirmation.test.ts` perf bench was flaky on CI.

## Summary
The per-iteration `everyoneVotes(...)` (100K–1M validator loop) and `updateHead()` in `beforeEach` created GC pressure inside the µs-scale measurement window. The "flip votes" logic was also a silent no-op — `addLatestMessage` rejects same-epoch votes. Since `runFastConfirmationRules` doesn't mutate `store`, `beforeEach` is now a pass-through.

Locally: ~80K–160K samples/config (was 25–424), ~0.3–5s wall time/config (was 2–17s).

## Follow-ups (separate PR)
- Rename to `runFastConfirmationRules.test.ts` to match the bench `id`.
- Add a state-backed bench that exercises `findLatestConfirmedDescendant` end-to-end using `generatePerfTestCachedStateElectra` from `@lodestar/state-transition/test-utils`.

## Test plan
- [x] `pnpm benchmark:files 'packages/fork-choice/test/perf/forkChoice/fastConfirmation.test.ts'` — stable across 3 consecutive runs.
- [x] `check-types` + `lint` clean.
- [ ] CI bench job.

🤖 AI-assisted with Claude Code (Opus 4.7).