### PR TITLE
fix: pass vote.slot (not nextEpoch) to addLatestMessage in everyoneVotes

### DIFF
--- a/packages/fork-choice/test/perf/forkChoice/fastConfirmation.test.ts
+++ b/packages/fork-choice/test/perf/forkChoice/fastConfirmation.test.ts
@@ -1,6 +1,5 @@
 import {bench, describe} from "@chainsafe/benchmark";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Slot} from "@lodestar/types";
 import {
   buildFastConfirmationSnapshot,
@@ -77,9 +76,11 @@ function runFCRRulesBenchmark(opts: Opts): void {
 }
 
 function everyoneVotes(vote: ProtoBlock, forkChoice: ForkChoice): void {
-  const nextEpoch = computeEpochAtSlot(vote.slot);
   const nextRoot = vote.blockRoot;
   for (let i = 0; i < forkChoice["balances"].length; i++) {
-    forkChoice["addLatestMessage"](i, nextEpoch, nextRoot, PayloadStatus.FULL);
+    // addLatestMessage's second arg is `nextSlot: Slot`, not an epoch — pass vote.slot directly so
+    // the internal computeEpochAtSlot(nextSlot) lands on the correct vote epoch instead of
+    // computeEpochAtSlot(epoch)=0 making every vote look 3 epochs stale.
+    forkChoice["addLatestMessage"](i, vote.slot, nextRoot, PayloadStatus.FULL);
   }
 }


### PR DESCRIPTION
## Summary

Applies the `everyoneVotes` fix Gemini flagged at `discussion_r3382054138` (confirmed in `discussion_r3382950784`): `addLatestMessage`'s second arg is `nextSlot: Slot`, not an epoch. The helper passed `computeEpochAtSlot(vote.slot)` (= `3` for the `bc:96` snapshot), so `voteNextSlots[i] = 3` got stored. On the next `updateTime(97)` tick, `computeEpochAtSlot(3) = 0` then made every vote look 3 epochs stale, and `runFastConfirmationRules` measured the empty-vote path instead of the intended fully-voted path.

Pass `vote.slot` directly so `computeEpochAtSlot(nextSlot)` inside `addLatestMessage` lands on the right epoch (= 3 for the snapshot). `computeEpochAtSlot` was the only reason for the `@lodestar/state-transition` import in this file; drop it too.

## Why it matters

The original PR (`#9494`) already fixed the GC-pressure flakiness, but the benchmark numbers weren't measuring what the bench id (`runFastConfirmationRules vc:600000 bc:96 ...`) claims they're measuring. With this fix, the bench actually exercises the FCR vote-map paths with a populated `voteNextIndices`.

## Test plan

- [ ] CI: `Benchmarks` job runs cleanly on the merged commit, with `runFastConfirmationRules` cases reflecting populated-vote-map cost.
- [ ] CI: `Type Checks` passes (the import drop doesn't break anything else).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
