### PR TITLE
test: catch StreamResetError in sendData noise bench

### DIFF
--- a/packages/beacon-node/test/perf/network/noise/sendData.test.ts
+++ b/packages/beacon-node/test/perf/network/noise/sendData.test.ts
@@ -72,11 +72,7 @@ describe("network / noise / sendData", () => {
               // for-await consumer sees StreamResetError once draining ends. The expected
               // teardown reset fires only after every message has been delivered — a reset
               // before all expected bytes arrived would be a real regression and must rethrow.
-              if (
-                !(err instanceof Error) ||
-                err.name !== "StreamResetError" ||
-                bytesReceived < expectedBytes
-              ) {
+              if (!(err instanceof Error) || err.name !== "StreamResetError" || bytesReceived < expectedBytes) {
                 throw err;
               }
             }

--- a/packages/beacon-node/test/perf/network/noise/sendData.test.ts
+++ b/packages/beacon-node/test/perf/network/noise/sendData.test.ts
@@ -61,15 +61,24 @@ describe("network / noise / sendData", () => {
             await connA.close();
           })(),
           (async () => {
+            let bytesReceived = 0;
+            const expectedBytes = numberOfMessages * messageLength;
             try {
-              for await (const _chunk of connB) {
-                // Drain inbound messages
+              for await (const chunk of connB) {
+                bytesReceived += chunk.byteLength;
               }
             } catch (err) {
-              // MockMuxer routes connA.close() as a reset frame on the inbound side,
-              // so the for-await consumer sees StreamResetError once draining ends.
-              // This is teardown noise, not a benchmark failure — rethrow anything else.
-              if (!(err instanceof Error) || err.name !== "StreamResetError") throw err;
+              // MockMuxer routes connA.close() as a reset frame on the inbound side, so the
+              // for-await consumer sees StreamResetError once draining ends. The expected
+              // teardown reset fires only after every message has been delivered — a reset
+              // before all expected bytes arrived would be a real regression and must rethrow.
+              if (
+                !(err instanceof Error) ||
+                err.name !== "StreamResetError" ||
+                bytesReceived < expectedBytes
+              ) {
+                throw err;
+              }
             }
           })(),
         ]);

--- a/packages/beacon-node/test/perf/network/noise/sendData.test.ts
+++ b/packages/beacon-node/test/perf/network/noise/sendData.test.ts
@@ -61,8 +61,15 @@ describe("network / noise / sendData", () => {
             await connA.close();
           })(),
           (async () => {
-            for await (const _chunk of connB) {
-              // Drain inbound messages
+            try {
+              for await (const _chunk of connB) {
+                // Drain inbound messages
+              }
+            } catch (err) {
+              // MockMuxer routes connA.close() as a reset frame on the inbound side,
+              // so the for-await consumer sees StreamResetError once draining ends.
+              // This is teardown noise, not a benchmark failure — rethrow anything else.
+              if (!(err instanceof Error) || err.name !== "StreamResetError") throw err;
             }
           })(),
         ]);


### PR DESCRIPTION
## Motivation

`bench` runs on `unstable` have been failing with `1 benchmark(s) failed: unknown error` ([example run](https://github.com/ChainSafe/lodestar/actions/runs/27218604384/job/80367013945)). All 8 `send data - 1000 NB messages` cases throw on every iteration:

```
StreamResetError: The stream has been reset
    at EncryptedMessageStream.onRemoteReset (.../abstract-message-stream.js:260:21)
    at MockMuxedStream.noiseOnClose (.../@chainsafe/libp2p-noise@17.0.0/dist/src/utils.js:83:26)
    at MockMuxer.onMessage (.../@libp2p/utils@7.2.2/.../mock-muxer.js:155:20)
```

Reproduces locally and on multiple recent unstable runs (`27225662417` b00d95d0, `27203232811` 8d5a6a4f).

## Root cause

When `connA.close()` lands after sending all 1000 messages, `MockMuxer` routes the close as a **reset frame** to the inbound side (`mock-muxer.js:155` → `stream.onRemoteReset()`). That dispatches a `close` event the noise layer is subscribed to (`libp2p-noise/utils.js:77-89`), which calls `EncryptedMessageStream.onRemoteReset()` and puts the encrypted stream into `reset` status while the inbound `for await (const _chunk of connB)` is still draining. The async iterator then throws `StreamResetError` on its next pull. The throw propagates through `Promise.all` and `fn`'s `await`, the bench harness reports the iteration as failed, and the whole file is reported as `unknown error`.

The existing `process.on("uncaughtException", ...)` only suppresses `StreamStateError` from the **drain** race — it can't catch this one because the error is a normal async throw inside `fn`, not an uncaught exception.

## Fix

Wrap the inbound `for await` in a `try/catch` that swallows `StreamResetError` only. Rethrow anything else.

## Test plan
- [x] Reproduced the failure locally on `unstable@b00d95d0` — all 8 cases fail with the same stack.
- [x] After the fix, all 8 cases pass locally:
  ```
  ✔ send data - 1000 256B messages    250.06 ops/s  3.999 ms/op  28 runs
  ✔ send data - 1000 512B messages    236.67 ops/s  4.225 ms/op  18 runs
  ✔ send data - 1000 1024B messages   212.73 ops/s  4.701 ms/op  17 runs
  ✔ send data - 1000 1200B messages   212.85 ops/s  4.698 ms/op  17 runs
  ✔ send data - 1000 2048B messages   190.46 ops/s  5.251 ms/op  23 runs
  ✔ send data - 1000 4096B messages   172.39 ops/s  5.801 ms/op  22 runs
  ✔ send data - 1000 16384B messages   87.81 ops/s 11.389 ms/op  12 runs
  ✔ send data - 1000 65536B messages   29.22 ops/s 34.222 ms/op  10 runs
    8 passing, 0 failed
  ```
- [x] `lint` clean.
- [ ] CI bench job.

🤖 AI-assisted with Claude Code (Opus 4.7).