### PR TITLE
fix: derive proposer duties dependent root from state

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1295,7 +1295,7 @@ export function getValidatorApi(
       // It should be set to the latest block applied to `self` or the genesis block root.
       const dependentRoot =
         // In v2 the dependent root is different after fulu due to deterministic proposer lookahead
-        proposerShufflingDecisionRoot(opts?.v2 ? config.getForkName(startSlot) : ForkName.phase0, state, epoch) ||
+        proposerShufflingDecisionRoot(opts?.v2 ? config.getForkName(startSlot) : ForkName.phase0, state) ||
         (await getGenesisBlockRoot(state));
 
       return {

--- a/packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -2,7 +2,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {routes} from "@lodestar/api";
 import {getConfig} from "@lodestar/config/test-utils";
 import {ForkName, MAX_EFFECTIVE_BALANCE, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {BeaconStateAllForks, BeaconStateView} from "@lodestar/state-transition";
+import {BeaconStateAllForks, BeaconStateView, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Slot} from "@lodestar/types";
 import {SYNC_TOLERANCE_EPOCHS, getValidatorApi} from "../../../../../../src/api/impl/validator/index.js";
 import {defaultApiOptions} from "../../../../../../src/api/options.js";
@@ -61,6 +61,7 @@ describe("get proposers api impl", () => {
   }
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -102,6 +103,22 @@ describe("get proposers api impl", () => {
     expect(cachedState.epochCtx.getBeaconProposers).not.toHaveBeenCalled();
     expect(cachedState.epochCtx.getBeaconProposersNextEpoch).toHaveBeenCalledOnce();
     expect(cachedState.epochCtx.getBeaconProposersPrevEpoch).not.toHaveBeenCalled();
+    expect(result.map((p) => p.slot)).toEqual(
+      Array.from({length: SLOTS_PER_EPOCH}, (_, i) => nextEpoch * SLOTS_PER_EPOCH + i)
+    );
+  });
+
+  it("should get v1 proposers for next epoch mid-epoch", async () => {
+    const nextEpoch = currentEpoch + 1;
+    const getBlockRootAtSlotSpy = vi.spyOn(BeaconStateView.prototype, "getBlockRootAtSlot");
+
+    const {data: result} = (await api.getProposerDuties({epoch: nextEpoch})) as {
+      data: routes.validator.ProposerDutyList;
+    };
+
+    expect(result.length).toBe(SLOTS_PER_EPOCH);
+    expect(getBlockRootAtSlotSpy).toHaveBeenCalledWith(currentSlot - 1);
+    expect(getBlockRootAtSlotSpy).not.toHaveBeenCalledWith(computeStartSlotAtEpoch(nextEpoch) - 1);
     expect(result.map((p) => p.slot)).toEqual(
       Array.from({length: SLOTS_PER_EPOCH}, (_, i) => nextEpoch * SLOTS_PER_EPOCH + i)
     );

--- a/packages/state-transition/src/util/shuffling.ts
+++ b/packages/state-transition/src/util/shuffling.ts
@@ -17,30 +17,24 @@ import {computeStartSlotAtEpoch} from "./epoch.js";
 import {EpochShuffling} from "./epochShuffling.js";
 
 /**
- * Block root that decided the proposer shuffling for `proposalEpoch` (keys that shuffling).
- * Computed for the requested epoch, not `state.epoch`, so it is correct when `state` is one
- * epoch off the requested epoch (e.g. serving next-epoch duties from the current state).
+ * Block root that decided the proposer shuffling for the state used to serve proposer duties.
  *
  * Returns `null` when the genesis block decides its own shuffling (caller falls back to the
  * genesis block root).
  */
-export function proposerShufflingDecisionRoot(
-  fork: ForkName,
-  state: IBeaconStateView,
-  proposalEpoch: Epoch
-): Root | null {
-  const decisionSlot = proposerShufflingDecisionSlot(fork, proposalEpoch);
+export function proposerShufflingDecisionRoot(fork: ForkName, state: IBeaconStateView): Root | null {
+  const decisionSlot = proposerShufflingDecisionSlot(fork, state);
   if (state.slot === decisionSlot) {
     return null;
   }
   return state.getBlockRootAtSlot(decisionSlot);
 }
 
-/** Slot whose block root keys the proposer shuffling for `proposalEpoch`. */
-function proposerShufflingDecisionSlot(fork: ForkName, proposalEpoch: Epoch): Slot {
+/** Slot whose block root keys the proposer shuffling for `state`. */
+function proposerShufflingDecisionSlot(fork: ForkName, state: IBeaconStateView): Slot {
   // Post-Fulu the shuffling is decided one epoch earlier (deterministic proposer lookahead,
-  // MIN_SEED_LOOKAHEAD = 1); pre-Fulu it is the last block before `proposalEpoch`.
-  const decisionEpoch = isForkPostFulu(fork) ? proposalEpoch - 1 : proposalEpoch;
+  // MIN_SEED_LOOKAHEAD = 1); pre-Fulu it is the last block before `state.epoch`.
+  const decisionEpoch = isForkPostFulu(fork) ? state.epoch - 1 : state.epoch;
   return Math.max(computeStartSlotAtEpoch(decisionEpoch) - 1, 0);
 }
 


### PR DESCRIPTION
## Motivation

`GET /eth/v1/validator/duties/proposer/{epoch}` can be called for the next epoch while the node is still mid-epoch. After #9380, `proposerShufflingDecisionRoot()` computed the dependent root from the requested proposal epoch. For a v1 next-epoch request this points at `start(nextEpoch) - 1`, which is still in the future for most of the current epoch and trips `getBlockRootAtSlot()` with:

```
Can only get block root in the past currentSlot=14518170 slot=14518175
```

This showed up from Vero polling proposer duties against a Lodestar BN. Lodestar VC uses the v2 route post-Fulu, but the BN should serve the v1 next-epoch route without a 500 too.

## Changes

- Derive proposer-duty dependent root from the state used to serve the proposer list, instead of from the requested epoch.
- Keep the post-Fulu offset behavior by applying it to `state.epoch`; near-boundary `currentEpoch + 2` v2 duties are still served from the checkpoint state advanced to `nextEpoch`.
- Add a regression test for v1 next-epoch proposer duties mid-epoch, asserting we use the current state decision slot and do not read `start(nextEpoch) - 1`.

## Spec / client audit

- Fulu `proposer_lookahead` starts from the beginning of the state current epoch and covers `MIN_SEED_LOOKAHEAD + 1` epochs.
- `process_proposer_lookahead()` computes the newly appended epoch at the epoch transition, so the state epoch is the right anchor for the dependent root of the proposer list being returned.
- Vero-style next-epoch prefetch is valid validator-client behavior; the BN response must not depend on the caller arriving in the last slot of the epoch.

## Verification

- `pnpm build`
- `pnpm vitest run --project unit packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts`
- `pnpm check-types`
- `pnpm lint`

Authored with AI assistance (OpenAI Codex / Lodekeeper).
