### PR TITLE
fix: get attestation block head

### DIFF
--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -194,6 +194,7 @@ async function validateAggregateAndProof(
     attTarget.root,
     attSlot,
     attEpoch,
+    attData.index,
     RegenCaller.validateGossipAggregateAndProof,
     chain.opts.maxSkipSlots
   );

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -416,6 +416,7 @@ async function validateAttestationNoSignatureCheck(
       attestationOrCache.attestation.data.target.root,
       attSlot,
       attEpoch,
+      attData.index,
       RegenCaller.validateGossipAttestation,
       chain.opts.maxSkipSlots
     );
@@ -675,10 +676,11 @@ export function verifyHeadBlockAndTargetRoot(
   targetRoot: Root,
   attestationSlot: Slot,
   attestationEpoch: Epoch,
+  attestationIndex: number,
   caller: RegenCaller,
   maxSkipSlots?: number
 ): ProtoBlock {
-  const headBlock = verifyHeadBlockIsKnown(chain, beaconBlockRoot);
+  const headBlock = verifyHeadBlockIsKnown(chain, beaconBlockRoot, attestationSlot, attestationIndex);
   // Lighthouse rejects the attestation, however Lodestar only ignores considering it's not against the spec
   // it's more about a DOS protection to us
   // With verifyPropagationSlotRange() and maxSkipSlots = 32, it's unlikely we have to regenerate states in queue
@@ -770,10 +772,23 @@ export function getAttestationDataSigningRoot(config: BeaconConfig, data: phase0
  * it's still fine to ignore here because there's no need for us to handle attestations that are
  * already finalized.
  */
-function verifyHeadBlockIsKnown(chain: IBeaconChain, beaconBlockRoot: Root): ProtoBlock {
+function verifyHeadBlockIsKnown(
+  chain: IBeaconChain,
+  beaconBlockRoot: Root,
+  attestationSlot: Slot,
+  index: number
+): ProtoBlock {
   // TODO (LH): Enforce a maximum skip distance for unaggregated attestations.
 
-  const headBlock = chain.forkChoice.getBlockDefaultStatus(beaconBlockRoot);
+  let headBlock: ProtoBlock | null;
+  try {
+    headBlock = chain.forkChoice.getAttestationHeadBlock(toRootHex(beaconBlockRoot), attestationSlot, index);
+  } catch (_e) {
+    throw new AttestationError(GossipAction.REJECT, {
+      code: AttestationErrorCode.INVALID_PAYLOAD_STATUS_VALUE,
+      attDataIndex: index,
+    });
+  }
   if (headBlock === null) {
     throw new AttestationError(GossipAction.IGNORE, {
       code: AttestationErrorCode.UNKNOWN_OR_PREFINALIZED_BEACON_BLOCK_ROOT,

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -121,6 +121,10 @@ export function getAttestationValidData(opts: AttestationValidDataOpts): {
       if (rootHex !== toHexString(beaconBlockRoot)) return null;
       return headBlock;
     },
+    getAttestationHeadBlock: (rootHex) => {
+      if (rootHex !== toHexString(beaconBlockRoot)) return null;
+      return headBlock;
+    },
     getDependentRoot: () => state.epochCtx.currentDecisionRoot,
   } as Partial<IForkChoice> as IForkChoice;
 

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -900,36 +900,21 @@ export class ForkChoice implements IForkChoice {
     // Post-gloas:
     // - always add weight to PENDING
     // - if message.slot > block.slot, it also add weights to FULL or EMPTY
-    let payloadStatus: PayloadStatus;
-
     // We need to retrieve block to check if it's Gloas and to compare slot
     // https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/fork-choice.md#new-is_supporting_vote
     const block = this.getBlockHexDefaultStatus(blockRootHex);
-
-    if (block && isGloasBlock(block)) {
-      // Post-Gloas block: determine FULL/EMPTY/PENDING based on slot and committee index
-      // If slot > block.slot, we can determine FULL or EMPTY. Else always PENDING
-      if (slot > block.slot) {
-        if (attestationData.index === 1) {
-          payloadStatus = PayloadStatus.FULL;
-        } else if (attestationData.index === 0) {
-          payloadStatus = PayloadStatus.EMPTY;
-        } else {
-          throw new ForkChoiceError({
-            code: ForkChoiceErrorCode.INVALID_ATTESTATION,
-            err: {
-              code: InvalidAttestationCode.INVALID_DATA_INDEX,
-              index: attestationData.index,
-            },
-          });
-        }
-      } else {
-        payloadStatus = PayloadStatus.PENDING;
-      }
-    } else {
-      // Pre-Gloas block or block not found: always FULL
-      payloadStatus = PayloadStatus.FULL;
+    if (block === null) {
+      // validateOnAttestation() above rejects attestations whose beacon block root is unknown
+      // (UNKNOWN_HEAD_BLOCK), so the block is always known here.
+      throw new ForkChoiceError({
+        code: ForkChoiceErrorCode.INVALID_ATTESTATION,
+        err: {
+          code: InvalidAttestationCode.UNKNOWN_HEAD_BLOCK,
+          beaconBlockRoot: blockRootHex,
+        },
+      });
     }
+    const payloadStatus = this.getAttestationPayloadStatus(block, slot, attestationData.index);
 
     if (slot < this.fcStore.currentSlot) {
       for (const validatorIndex of attestation.attestingIndices) {
@@ -1152,6 +1137,83 @@ export class ForkChoice implements IForkChoice {
     }
 
     return this.getBlockHex(blockRoot, defaultStatus);
+  }
+
+  /**
+   * Derive the payload-status variant an attestation votes for, per is_supporting_vote
+   * (gloas/fork-choice.md). `block` must be the default-status block already resolved.
+   * - pre-gloas block: always FULL
+   * - gloas, attSlot === block.slot (same slot): PENDING, and index must be 0 (payload not
+   *   yet revealed, so a same-slot attester cannot indicate payload present)
+   * - gloas, attSlot > block.slot: index === 1 -> FULL, index === 0 -> EMPTY
+   * Throws ForkChoiceError(ATTESTS_TO_FUTURE_BLOCK) when attSlot < block.slot (an attestation
+   * cannot vote for a block in a future slot), or INVALID_DATA_INDEX for a non-zero same-slot
+   * index or an index >= 2.
+   */
+  private getAttestationPayloadStatus(block: ProtoBlock, attSlot: Slot, index: number): PayloadStatus {
+    if (!isGloasBlock(block)) {
+      return PayloadStatus.FULL;
+    }
+    if (attSlot < block.slot) {
+      throw new ForkChoiceError({
+        code: ForkChoiceErrorCode.INVALID_ATTESTATION,
+        err: {
+          code: InvalidAttestationCode.ATTESTS_TO_FUTURE_BLOCK,
+          block: block.slot,
+          attestation: attSlot,
+        },
+      });
+    }
+
+    if (attSlot === block.slot) {
+      // Same-slot attestation: payload is not revealed yet, index must be 0
+      if (index !== 0) {
+        throw new ForkChoiceError({
+          code: ForkChoiceErrorCode.INVALID_ATTESTATION,
+          err: {
+            code: InvalidAttestationCode.INVALID_DATA_INDEX,
+            index,
+          },
+        });
+      }
+      return PayloadStatus.PENDING;
+    }
+
+    // attSlot > block.slot
+    if (index === 1) {
+      return PayloadStatus.FULL;
+    }
+    if (index === 0) {
+      return PayloadStatus.EMPTY;
+    }
+    throw new ForkChoiceError({
+      code: ForkChoiceErrorCode.INVALID_ATTESTATION,
+      err: {
+        code: InvalidAttestationCode.INVALID_DATA_INDEX,
+        index,
+      },
+    });
+  }
+
+  /**
+   * Resolve the ProtoBlock variant an attestation votes for, per is_supporting_vote
+   * (gloas/fork-choice.md). Uses the same index -> payloadStatus derivation as onAttestation.
+   * Returns null if the block root is unknown OR the derived variant node is absent
+   * (e.g. FULL requested before the execution payload has been imported via onExecutionPayload).
+   * Throws ForkChoiceError(INVALID_DATA_INDEX) for index >= 2 on a past gloas block.
+   */
+  getAttestationHeadBlock(beaconBlockRootHex: RootHex, attSlot: Slot, index: number): ProtoBlock | null {
+    const block = this.getBlockHexDefaultStatus(beaconBlockRootHex);
+    if (block === null) {
+      return null;
+    }
+    const payloadStatus = this.getAttestationPayloadStatus(block, attSlot, index);
+    // block is the default variant, so block.payloadStatus is the default variant status:
+    // same-slot (PENDING) and pre-gloas (FULL) reuse it without a second lookup
+    if (payloadStatus === block.payloadStatus) {
+      return block;
+    }
+    return this.getBlockHex(beaconBlockRootHex, payloadStatus);
   }
 
   /**

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -269,6 +269,12 @@ export interface IForkChoice {
   getBlockHex(blockRoot: RootHex, payloadStatus: PayloadStatus): ProtoBlock | null;
   getBlockDefaultStatus(blockRoot: Root): ProtoBlock | null;
   getBlockHexDefaultStatus(blockRoot: RootHex): ProtoBlock | null;
+  /**
+   * Resolve the ProtoBlock variant an attestation votes for from its payload-status
+   * vote (`data.index`) and slot. Returns null if the block root or the derived variant
+   * node is unknown. See ForkChoice.getAttestationHeadBlock.
+   */
+  getAttestationHeadBlock(beaconBlockRootHex: RootHex, attSlot: Slot, index: number): ProtoBlock | null;
   getBlockHexAndBlockHash(blockRoot: RootHex, blockHash: RootHex): ProtoBlock | null;
   shouldExtendPayload(blockRoot: RootHex): boolean;
   /** Spec: should_build_on_full(store, head) */

--- a/packages/fork-choice/test/unit/forkChoice/getAttestationHeadBlock.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getAttestationHeadBlock.test.ts
@@ -1,0 +1,169 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {fromHexString} from "@chainsafe/ssz";
+import {config} from "@lodestar/config/default";
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
+import {toHex} from "@lodestar/utils";
+import {
+  ExecutionStatus,
+  ForkChoice,
+  IForkChoiceStore,
+  PayloadStatus,
+  ProtoArray,
+  ProtoBlock,
+} from "../../../src/index.js";
+
+/**
+ * Tests for ForkChoice.getAttestationHeadBlock: resolving the payload-status variant
+ * (PENDING/EMPTY/FULL) an attestation votes for from `data.index` and the attestation slot.
+ */
+describe("ForkChoice.getAttestationHeadBlock", () => {
+  const genesisSlot = 0;
+  const genesisEpoch = 0;
+  const genesisRoot = "0x0000000000000000000000000000000000000000000000000000000000000000";
+  const finalizedRoot = "0x1100000000000000000000000000000000000000000000000000000000000000";
+  const gloasRoot = "0x2200000000000000000000000000000000000000000000000000000000000000";
+  const gloasSlot = 1;
+  const validatorCount = 8;
+
+  const checkpoint = {epoch: genesisEpoch, root: fromHexString(finalizedRoot), rootHex: finalizedRoot};
+  const fcStore: IForkChoiceStore = {
+    currentSlot: gloasSlot + 1,
+    justified: {checkpoint, balances: new Uint16Array([32]), totalBalance: 32},
+    unrealizedJustified: {checkpoint, balances: new Uint16Array([32])},
+    finalizedCheckpoint: checkpoint,
+    unrealizedFinalizedCheckpoint: checkpoint,
+    justifiedBalancesGetter: () => new Uint16Array([32]),
+    equivocatingIndices: new Set(),
+    confirmedRoot: finalizedRoot,
+    previousEpochObservedJustifiedCheckpoint: checkpoint,
+    currentEpochObservedJustifiedCheckpoint: checkpoint,
+    previousEpochGreatestUnrealizedCheckpoint: checkpoint,
+    previousEpochObservedJustifiedBalances: new Uint16Array([32]),
+    currentEpochObservedJustifiedBalances: new Uint16Array([32]),
+    previousEpochGreatestUnrealizedBalances: new Uint16Array([32]),
+    previousSlotHead: finalizedRoot,
+    currentSlotHead: finalizedRoot,
+    stateGetter: () => null,
+  };
+
+  // Pre-Gloas finalized genesis block (parentBlockHash === null -> not gloas)
+  function createGenesisBlock(): Omit<ProtoBlock, "targetRoot"> {
+    return {
+      slot: genesisSlot,
+      blockRoot: finalizedRoot,
+      parentRoot: toHex(Buffer.alloc(32, 0xff)),
+      stateRoot: genesisRoot,
+      justifiedEpoch: genesisEpoch,
+      justifiedRoot: genesisRoot,
+      finalizedEpoch: genesisEpoch,
+      finalizedRoot: genesisRoot,
+      unrealizedJustifiedEpoch: genesisEpoch,
+      unrealizedJustifiedRoot: genesisRoot,
+      unrealizedFinalizedEpoch: genesisEpoch,
+      unrealizedFinalizedRoot: genesisRoot,
+      executionPayloadBlockHash: null,
+      executionStatus: ExecutionStatus.PreMerge,
+      dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+      timeliness: false,
+      parentBlockHash: null,
+      payloadStatus: PayloadStatus.FULL,
+    };
+  }
+
+  // Gloas block (parentBlockHash !== null -> gloas). onBlock creates PENDING + EMPTY variants.
+  function createGloasBlock(): ProtoBlock {
+    return {
+      slot: gloasSlot,
+      blockRoot: gloasRoot,
+      parentRoot: finalizedRoot,
+      stateRoot: genesisRoot,
+      targetRoot: finalizedRoot,
+      justifiedEpoch: genesisEpoch,
+      justifiedRoot: genesisRoot,
+      finalizedEpoch: genesisEpoch,
+      finalizedRoot: genesisRoot,
+      unrealizedJustifiedEpoch: genesisEpoch,
+      unrealizedJustifiedRoot: genesisRoot,
+      unrealizedFinalizedEpoch: genesisEpoch,
+      unrealizedFinalizedRoot: genesisRoot,
+      executionPayloadBlockHash: gloasRoot,
+      executionPayloadNumber: gloasSlot,
+      executionPayloadGasLimit: 30000000,
+      executionStatus: ExecutionStatus.Valid,
+      dataAvailabilityStatus: DataAvailabilityStatus.Available,
+      timeliness: true,
+      parentBlockHash: finalizedRoot, // non-null -> gloas; parent is pre-gloas so fork-transition path
+      payloadStatus: PayloadStatus.FULL,
+    };
+  }
+
+  let protoArr: ProtoArray;
+  let forkChoice: ForkChoice;
+
+  beforeEach(() => {
+    protoArr = ProtoArray.initialize(createGenesisBlock(), genesisSlot);
+    protoArr.onBlock(createGloasBlock(), gloasSlot, null);
+    forkChoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
+  });
+
+  const importFullPayload = (): void =>
+    protoArr.onExecutionPayload(
+      gloasRoot,
+      gloasSlot,
+      gloasRoot,
+      gloasSlot,
+      30000000,
+      null,
+      ExecutionStatus.Valid,
+      DataAvailabilityStatus.Available
+    );
+
+  it("unknown root -> null", () => {
+    expect(forkChoice.getAttestationHeadBlock("0xdead", gloasSlot, 0)).toBeNull();
+  });
+
+  it("pre-gloas block -> FULL variant regardless of index", () => {
+    for (const index of [0, 1]) {
+      const block = forkChoice.getAttestationHeadBlock(finalizedRoot, genesisSlot, index);
+      expect(block?.payloadStatus).toBe(PayloadStatus.FULL);
+    }
+  });
+
+  it("gloas same-slot attestation -> PENDING, reusing the default block (single lookup)", () => {
+    // getBlockHex is called once internally via getBlockHexDefaultStatus; the derived PENDING
+    // equals the default variant so no second getBlockHex call is made.
+    const getBlockHexSpy = vi.spyOn(forkChoice, "getBlockHex");
+    const block = forkChoice.getAttestationHeadBlock(gloasRoot, gloasSlot, 0);
+    expect(block?.blockRoot).toBe(gloasRoot);
+    expect(block?.payloadStatus).toBe(PayloadStatus.PENDING);
+    expect(getBlockHexSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("gloas past-slot index=0 -> EMPTY (second lookup for non-default variant)", () => {
+    const getBlockHexSpy = vi.spyOn(forkChoice, "getBlockHex");
+    const block = forkChoice.getAttestationHeadBlock(gloasRoot, gloasSlot + 1, 0);
+    expect(block?.blockRoot).toBe(gloasRoot);
+    expect(block?.payloadStatus).toBe(PayloadStatus.EMPTY);
+    // one call for the default-status lookup + one for the explicit EMPTY variant
+    expect(getBlockHexSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("gloas past-slot index=1 -> null when FULL not imported, FULL after onExecutionPayload", () => {
+    expect(forkChoice.getAttestationHeadBlock(gloasRoot, gloasSlot + 1, 1)).toBeNull();
+    importFullPayload();
+    const block = forkChoice.getAttestationHeadBlock(gloasRoot, gloasSlot + 1, 1);
+    expect(block?.payloadStatus).toBe(PayloadStatus.FULL);
+  });
+
+  it("gloas past-slot index>=2 -> throws", () => {
+    expect(() => forkChoice.getAttestationHeadBlock(gloasRoot, gloasSlot + 1, 2)).toThrow();
+  });
+
+  it("gloas attestation slot < block slot -> throws (attests to future block)", () => {
+    expect(() => forkChoice.getAttestationHeadBlock(gloasRoot, gloasSlot - 1, 0)).toThrow();
+  });
+
+  it("gloas same-slot attestation with index != 0 -> throws (payload not yet revealed)", () => {
+    expect(() => forkChoice.getAttestationHeadBlock(gloasRoot, gloasSlot, 1)).toThrow();
+  });
+});


### PR DESCRIPTION
**Motivation**

- the head block from `verifyHeadBlockIsKnown()` is always with default status

**Description**

- pass attestation index to get the correct variant
- new `forkchoice. getAttestationHeadBlock()`
- extract duplicate logic to `getAttestationPayloadStatus()`


**AI Assistance Disclosure**

- created with the help of Claude