### PR TITLE
test: skip Proxy-cost V8 microbench to stop noisy CI perf alerts

### DIFF
--- a/packages/state-transition/test/perf/misc/proxy.test.ts
+++ b/packages/state-transition/test/perf/misc/proxy.test.ts
@@ -1,5 +1,16 @@
 import {bench, describe} from "@chainsafe/benchmark";
 
+/**
+ * V8 Proxy-overhead reference microbenchmark. Kept for ad-hoc evaluation only — these are
+ * tight 100K-iteration hot loops with no per-iteration work besides the property read, so
+ * results are dominated by V8 inline-cache and engine-version effects and have very high
+ * run-to-run variance on the shared CI runner (e.g. `arrayWithProxy get 100000 times`
+ * tripped a 3.73x alert on PR #9494 with no Lodestar code change touching this path).
+ *
+ * No `src/` code uses `new Proxy(...)` so this isn't tracking a real regression surface;
+ * skip in CI to stop generating false-positive alerts on unrelated PRs. Switch to
+ * `bench(...)` locally if you want to take a measurement.
+ */
 describe("Proxy cost", () => {
   const n = 100_000;
   const array: number[] = [];
@@ -23,15 +34,15 @@ describe("Proxy cost", () => {
     },
   };
 
-  bench(`regular array get ${n} times`, () => {
+  bench.skip(`regular array get ${n} times`, () => {
     for (let i = 0; i < n; i++) array[i];
   });
 
-  bench(`wrappedArray get ${n} times`, () => {
+  bench.skip(`wrappedArray get ${n} times`, () => {
     for (let i = 0; i < n; i++) wrappedArray.get(i);
   });
 
-  bench(`arrayWithProxy get ${n} times`, () => {
+  bench.skip(`arrayWithProxy get ${n} times`, () => {
     for (let i = 0; i < n; i++) arrayWithProxy[i];
   });
 });


### PR DESCRIPTION
## Summary

`packages/state-transition/test/perf/misc/proxy.test.ts` is a tight 100K-iteration hot loop measuring V8's `Proxy.get` overhead as a baseline reference. With no per-iteration work besides the property read, results are dominated by V8 inline-cache and engine-version effects and have very high run-to-run variance on the shared CI runner.

- `arrayWithProxy get 100000 times` tripped a 3.73x alert on PR #9494 ([`issuecomment-4671463687`](https://github.com/ChainSafe/lodestar/pull/9494#issuecomment-4671463687)) with no Lodestar code change touching this path.
- `proposeBlockBody type=full, size=empty` and `Full columns - reconstruct half of the blobs out of 20` have fired similarly on #9481, #9484, #9489 — same pattern of unrelated benchmarks tripping.

No `src/` code uses `new Proxy(...)`, so this benchmark isn't tracking a real regression surface. This PR switches the three Proxy-cost benches to `bench.skip(...)` so CI stops generating false-positive alerts on unrelated PRs. The source code stays in place so it can be flipped back to `bench(...)` locally for ad-hoc measurements (see the new docstring on the `describe` block).

## Test plan

- [ ] CI: `Benchmark` job no longer emits alerts on the Proxy-cost suite.
- [ ] CI: `Type Checks` / `Unit Tests` unaffected (skip doesn't touch the test discovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
