### PR TITLE
test: un-ignore churn related fields in gloas

### DIFF
--- a/packages/config/test/e2e/ensure-config-is-synced.test.ts
+++ b/packages/config/test/e2e/ensure-config-is-synced.test.ts
@@ -29,10 +29,6 @@ const ignoredRemoteConfigFields: (keyof ChainConfig)[] = [
   // Future spec params not yet in Lodestar
   "EPOCHS_PER_SHUFFLING_PHASE" as keyof ChainConfig,
   "PROPOSER_SELECTION_GAP" as keyof ChainConfig,
-  // Gloas churn constants - not yet in local config
-  "CHURN_LIMIT_QUOTIENT_GLOAS" as keyof ChainConfig,
-  "CONSOLIDATION_CHURN_LIMIT_QUOTIENT" as keyof ChainConfig,
-  "MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT_GLOAS" as keyof ChainConfig,
   // Future forks not yet implemented in Lodestar
   "HEZE_FORK_VERSION" as keyof ChainConfig,
   "HEZE_FORK_EPOCH" as keyof ChainConfig,


### PR DESCRIPTION
CHURN_LIMIT_QUOTIENT_GLOAS, CONSOLIDATION_CHURN_LIMIT_QUOTIENT and MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT_GLOAS are now present in local chainConfig and match the spec, so drop them from
ignoredRemoteConfigFields.