### PR TITLE
feat: queue execution payload envelope until its block is imported

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -680,7 +680,7 @@ export function getBeaconBlockApi({
           block = chain.forkChoice.getBlockHex(blockRootHex, PayloadStatus.EMPTY);
         }
         if (block === null) {
-          throw new ApiError(404, `Block not found for beacon block root ${blockRootHex} at slot ${slot}`);
+          throw new ApiError(404, `Block not found for beacon block root ${blockRootHex}`);
         }
       }
       if (block.slot !== slot) {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -688,12 +688,13 @@ export function getBeaconBlockApi({
       // TODO GLOAS: review checks, do we want to implement `broadcast_validation`?
       let block = chain.forkChoice.getBlockHex(blockRootHex, PayloadStatus.EMPTY);
       if (block === null) {
+        const msToSlotEnd = Math.max(0, config.SLOT_DURATION_MS - chain.clock.msFromSlot(slot));
         chain.logger.debug("Execution payload envelope received before block, waiting for block to be imported", {
           blockRoot: blockRootHex,
           slot,
+          msToSlotEnd,
         });
         // Wait until the end of the slot for the block to arrive (via API or gossip)
-        const msToSlotEnd = Math.max(0, config.SLOT_DURATION_MS - chain.clock.msFromSlot(slot));
         await waitForBlockImported(chain, blockRootHex, msToSlotEnd);
         block = chain.forkChoice.getBlockHex(blockRootHex, PayloadStatus.EMPTY);
         if (block === null) {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -69,7 +69,7 @@ import {kzg} from "../../../../util/kzg.js";
 import {promiseAllMaybeAsync} from "../../../../util/promises.js";
 import {ApiModules} from "../../types.js";
 import {assertUniqueItems} from "../../utils.js";
-import {getBlockResponse, toBeaconHeaderResponse} from "./utils.js";
+import {getBlockResponse, toBeaconHeaderResponse, waitForBlockImported} from "./utils.js";
 
 type PublishBlockOpts = ImportBlockOpts;
 
@@ -686,9 +686,19 @@ export function getBeaconBlockApi({
       }
 
       // TODO GLOAS: review checks, do we want to implement `broadcast_validation`?
-      const block = chain.forkChoice.getBlockHex(blockRootHex, PayloadStatus.EMPTY);
+      let block = chain.forkChoice.getBlockHex(blockRootHex, PayloadStatus.EMPTY);
       if (block === null) {
-        throw new ApiError(404, `Block not found for beacon block root ${blockRootHex}`);
+        chain.logger.debug("Execution payload envelope received before block, waiting for block to be imported", {
+          blockRoot: blockRootHex,
+          slot,
+        });
+        // Wait until the end of the slot for the block to arrive (via API or gossip)
+        const msToSlotEnd = Math.max(0, config.SLOT_DURATION_MS - chain.clock.msFromSlot(slot));
+        await waitForBlockImported(chain, blockRootHex, msToSlotEnd);
+        block = chain.forkChoice.getBlockHex(blockRootHex, PayloadStatus.EMPTY);
+        if (block === null) {
+          throw new ApiError(404, `Block not found for beacon block root ${blockRootHex}`);
+        }
       }
       if (block.slot !== slot) {
         throw new ApiError(400, `Envelope slot ${slot} does not match block slot ${block.slot}`);
@@ -735,10 +745,11 @@ export function getBeaconBlockApi({
         await sleep(msToBlockSlot);
       }
 
-      // TODO GLOAS: if block and payload are submitted in parallel, payloadInput may not yet exist.
-      // A queuing mechanism is needed to handle this case. See https://github.com/ChainSafe/lodestar/issues/8915
       const payloadInput = chain.seenPayloadEnvelopeInputCache.get(blockRootHex);
       if (!payloadInput) {
+        // The block is awaited above (queuing if the envelope arrived first), and both the API and
+        // gossip import paths seed the PayloadEnvelopeInput before importing the block, so the input
+        // should exist here.
         throw new ApiError(404, `PayloadEnvelopeInput not found for block root ${blockRootHex}`);
       }
 

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -68,7 +68,7 @@ import {kzg} from "../../../../util/kzg.js";
 import {promiseAllMaybeAsync} from "../../../../util/promises.js";
 import {ApiModules} from "../../types.js";
 import {assertUniqueItems} from "../../utils.js";
-import {getBlockResponse, toBeaconHeaderResponse, waitForBlockImported} from "./utils.js";
+import {getBlockResponse, toBeaconHeaderResponse} from "./utils.js";
 
 type PublishBlockOpts = ImportBlockOpts;
 
@@ -672,18 +672,15 @@ export function getBeaconBlockApi({
       if (block === null) {
         // Only wait if the envelope is for the current slot
         if (chain.clock.isCurrentSlotGivenGossipDisparity(slot)) {
-          // Wait until the end of the slot for the block to arrive (via API or gossip)
-          const msToSlotEnd = Math.max(0, config.SLOT_DURATION_MS - chain.clock.msFromSlot(slot));
           chain.logger.debug("Execution payload envelope received before block, waiting for block to be imported", {
             blockRoot: blockRootHex,
             slot,
-            msToSlotEnd,
           });
-          await waitForBlockImported(chain, blockRootHex, msToSlotEnd);
+          await chain.waitForBlock(slot, blockRootHex);
           block = chain.forkChoice.getBlockHex(blockRootHex, PayloadStatus.EMPTY);
         }
         if (block === null) {
-          throw new ApiError(404, `Block not found for beacon block root ${blockRootHex}`);
+          throw new ApiError(404, `Block not found for beacon block root ${blockRootHex} at slot ${slot}`);
         }
       }
       if (block.slot !== slot) {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -688,15 +688,18 @@ export function getBeaconBlockApi({
       // TODO GLOAS: review checks, do we want to implement `broadcast_validation`?
       let block = chain.forkChoice.getBlockHex(blockRootHex, PayloadStatus.EMPTY);
       if (block === null) {
-        const msToSlotEnd = Math.max(0, config.SLOT_DURATION_MS - chain.clock.msFromSlot(slot));
-        chain.logger.debug("Execution payload envelope received before block, waiting for block to be imported", {
-          blockRoot: blockRootHex,
-          slot,
-          msToSlotEnd,
-        });
-        // Wait until the end of the slot for the block to arrive (via API or gossip)
-        await waitForBlockImported(chain, blockRootHex, msToSlotEnd);
-        block = chain.forkChoice.getBlockHex(blockRootHex, PayloadStatus.EMPTY);
+        // Only wait if the envelope is for the current slot
+        if (chain.clock.isCurrentSlotGivenGossipDisparity(slot)) {
+          // Wait until the end of the slot for the block to arrive (via API or gossip)
+          const msToSlotEnd = Math.max(0, config.SLOT_DURATION_MS - chain.clock.msFromSlot(slot));
+          chain.logger.debug("Execution payload envelope received before block, waiting for block to be imported", {
+            blockRoot: blockRootHex,
+            slot,
+            msToSlotEnd,
+          });
+          await waitForBlockImported(chain, blockRootHex, msToSlotEnd);
+          block = chain.forkChoice.getBlockHex(blockRootHex, PayloadStatus.EMPTY);
+        }
         if (block === null) {
           throw new ApiError(404, `Block not found for beacon block root ${blockRootHex}`);
         }

--- a/packages/beacon-node/src/api/impl/beacon/blocks/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/utils.ts
@@ -73,3 +73,33 @@ export async function getBlockResponse(
 
   return res;
 }
+
+/**
+ * Resolves when the beacon block `blockRootHex` is imported (seen via the API or gossip) or after
+ * `timeoutMs`, whichever comes first. The caller needs to re-check fork choice to tell them apart.
+ */
+export function waitForBlockImported(chain: IBeaconChain, blockRootHex: RootHex, timeoutMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const onBlock = (data: routes.events.EventData[routes.events.EventType.block]): void => {
+      if (data.block === blockRootHex) {
+        finish();
+      }
+    };
+
+    const finish = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      chain.emitter.off(routes.events.EventType.block, onBlock);
+      resolve();
+    };
+
+    timer = setTimeout(finish, timeoutMs);
+    chain.emitter.on(routes.events.EventType.block, onBlock);
+  });
+}

--- a/packages/beacon-node/src/api/impl/beacon/blocks/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/utils.ts
@@ -73,33 +73,3 @@ export async function getBlockResponse(
 
   return res;
 }
-
-/**
- * Resolves when the beacon block `blockRootHex` is imported (seen via the API or gossip) or after
- * `timeoutMs`, whichever comes first. The caller needs to re-check fork choice to tell them apart.
- */
-export function waitForBlockImported(chain: IBeaconChain, blockRootHex: RootHex, timeoutMs: number): Promise<void> {
-  return new Promise((resolve) => {
-    let settled = false;
-    let timer: ReturnType<typeof setTimeout>;
-
-    const onBlock = (data: routes.events.EventData[routes.events.EventType.block]): void => {
-      if (data.block === blockRootHex) {
-        finish();
-      }
-    };
-
-    const finish = (): void => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timer);
-      chain.emitter.off(routes.events.EventType.block, onBlock);
-      resolve();
-    };
-
-    timer = setTimeout(finish, timeoutMs);
-    chain.emitter.on(routes.events.EventType.block, onBlock);
-  });
-}

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -212,9 +212,10 @@ export class BlockProposingService {
     const signedBlock = await this.validatorStore.signBlock(pubkey, block, slot, this.logger);
 
     const {broadcastValidation} = this.opts;
-    // TODO GLOAS: we should be able to publish block and execution payload in parallel
-    // however for devnet-0 it's unclear if all clients have implemented queuing of the
-    // execution payload on gossip and might ignore it if the receive it before the block
+
+    // Publish the block first so it propagates as soon as possible. This reduces the chance other nodes
+    // see the payload envelope before the block over gossip and have to queue it. There's also plenty of
+    // time left in the slot to propagate the payload, so publishing it in parallel is unnecessary.
     (
       await this.api.beacon
         .publishBlockV2({


### PR DESCRIPTION
This will mostly be relevant once we support the stateless flow in case a validator client submits the block to a different node in a multi-node setup. Previously we would just return 404 right away but with this change we will wait until the end of the slot before returning an error. This also handles the 1:1 validator client setup in case some vcs publish the block and payload in parallel.

Closes https://github.com/ChainSafe/lodestar/issues/8915