### PR TITLE
fix: clamp pivotSlot calculation to GENESIS_SLOT

### DIFF
--- a/packages/state-transition/src/util/epochShuffling.ts
+++ b/packages/state-transition/src/util/epochShuffling.ts
@@ -124,7 +124,7 @@ export async function computeEpochShufflingAsync(
 }
 
 export function calculateDecisionRoot(state: BeaconStateAllForks, epoch: Epoch): RootHex {
-  const pivotSlot = computeStartSlotAtEpoch(epoch - 1) - 1;
+  const pivotSlot = Math.max(GENESIS_SLOT, computeStartSlotAtEpoch(epoch - 1) - 1);
   return toRootHex(getBlockRootAtSlot(state, pivotSlot));
 }
 


### PR DESCRIPTION
calculating pivotSlot underflowed; this was inconsequential in prod since `calculateShufflingDecisionRoot` returned the genesis block root anyway since this condition `slot < GENESIS_SLOT` was true by accident.

This failed spec tests though when integrating zig native transition since we use unsigned integers there and clamp the calculation, and semantically its the right fix to clamp this subtraction anyway.

Claude was used to find this bug, comparing logs of failed tests in #9516