### PR TITLE
fix(heze): remove inclusion list bitlist from ExecutionPayloadBid (specs#5371)

### DIFF
--- a/packages/beacon-node/src/chain/opPools/inclusionListStore.ts
+++ b/packages/beacon-node/src/chain/opPools/inclusionListStore.ts
@@ -1,4 +1,3 @@
-import {BitArray} from "@chainsafe/ssz";
 import {INCLUSION_LIST_COMMITTEE_SIZE} from "@lodestar/params";
 import type {IBeaconStateViewHeze} from "@lodestar/state-transition";
 import {RootHex, Slot, ValidatorIndex, bellatrix, heze, ssz} from "@lodestar/types";
@@ -39,8 +38,6 @@ function makeKey(slot: Slot, committeeRoot: Uint8Array | RootHex): CommitteeKey 
  * Spec helpers exposed:
  * - `processInclusionList(il, isTimely)`
  * - `getInclusionListTransactions(state, slot, onlyTimely)`
- * - `getInclusionListBits(state, slot, onlyTimely)`
- * - `isInclusionListBitsInclusive(state, slot, bits, onlyTimely)`
  */
 export class InclusionListStore {
   // (slot, committee_root) -> il_root -> InclusionList
@@ -154,44 +151,6 @@ export class InclusionListStore {
       }
     }
     return out;
-  }
-
-  /**
-   * Spec heze/inclusion-list.md `get_inclusion_list_bits`.
-   * Bit i is set iff the ith committee member submitted a valid, non-equivocating IL at `slot`.
-   */
-  getInclusionListBits(state: IBeaconStateViewHeze, slot: Slot, onlyTimely = true): BitArray {
-    const committee = state.getInclusionListCommittee(slot);
-    const key = makeKey(slot, ssz.heze.InclusionListCommittee.hashTreeRoot([...committee]));
-
-    const submitted = new Set<ValidatorIndex>();
-    const stored = this.inclusionLists.get(key);
-    if (stored) {
-      const equivocators = this.equivocators.get(key);
-      for (const [ilRoot, il] of stored) {
-        if (equivocators?.has(il.validatorIndex)) continue;
-        if (onlyTimely && !this.inclusionListTimeliness.get(ilRoot)) continue;
-        submitted.add(il.validatorIndex);
-      }
-    }
-
-    const bits = BitArray.fromBitLen(INCLUSION_LIST_COMMITTEE_SIZE);
-    for (let i = 0; i < committee.length; i++) {
-      if (submitted.has(committee[i])) bits.set(i, true);
-    }
-    return bits;
-  }
-
-  /**
-   * Spec heze/inclusion-list.md `is_inclusion_list_bits_inclusive`.
-   * Returns true iff `bits` is a superset of the locally observed bits.
-   */
-  isInclusionListBitsInclusive(state: IBeaconStateViewHeze, slot: Slot, bits: BitArray, onlyTimely = true): boolean {
-    const local = this.getInclusionListBits(state, slot, onlyTimely);
-    for (let i = 0; i < INCLUSION_LIST_COMMITTEE_SIZE; i++) {
-      if (local.get(i) && !bits.get(i)) return false;
-    }
-    return true;
   }
 
   /** Drop entries older than `clockSlot - SLOTS_RETAINED`. */

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -356,28 +356,14 @@ export async function produceBlockBody<T extends BlockType>(
       blobKzgCommitments: blobsBundle.commitments,
       executionRequestsRoot: ssz.electra.ExecutionRequests.hashTreeRoot(executionRequests),
     };
-    // Spec heze/builder.md: bid.inclusion_list_bits = get_inclusion_list_bits(store, state, slot-1, only_timely=False)
-    let bid: gloas.ExecutionPayloadBid | heze.ExecutionPayloadBid = baseBid;
-    if (isStatePostHeze(currentState)) {
-      const inclusionListBits = this.inclusionListStore.getInclusionListBits(currentState, blockSlot - 1, false);
-      // Spec heze/validator.md: bid.inclusion_list_bits MUST satisfy is_inclusion_list_bits_inclusive.
-      // For self-build the bits are derived from our own view so this holds by construction; assert
-      // defensively to catch any future divergence (e.g. external builder-bid path).
-      if (
-        !this.inclusionListStore.isInclusionListBitsInclusive(currentState, blockSlot - 1, inclusionListBits, false)
-      ) {
-        throw Error("bid.inclusion_list_bits does not satisfy is_inclusion_list_bits_inclusive");
-      }
-      bid = {...baseBid, inclusionListBits};
-    }
-    const signedBid: gloas.SignedExecutionPayloadBid | heze.SignedExecutionPayloadBid = {
-      message: bid,
+    const signedBid: gloas.SignedExecutionPayloadBid = {
+      message: baseBid,
       signature: G2_POINT_AT_INFINITY,
     };
 
     const commonBlockBody = await commonBlockBodyPromise;
     const gloasBody = Object.assign({}, commonBlockBody) as gloas.BeaconBlockBody;
-    gloasBody.signedExecutionPayloadBid = signedBid as gloas.SignedExecutionPayloadBid;
+    gloasBody.signedExecutionPayloadBid = signedBid;
     gloasBody.payloadAttestations = this.payloadAttestationPool.getPayloadAttestationsForBlock(
       parentBlock.blockRoot,
       blockSlot - 1

--- a/packages/state-transition/src/slot/upgradeStateToHeze.ts
+++ b/packages/state-transition/src/slot/upgradeStateToHeze.ts
@@ -62,22 +62,8 @@ export function upgradeStateToHeze(stateGloas: CachedBeaconStateGloas): CachedBe
   stateHezeView.builderPendingPayments = stateHezeCloned.builderPendingPayments;
   stateHezeView.builderPendingWithdrawals = stateHezeCloned.builderPendingWithdrawals;
 
-  // [Modified in Heze:EIP7805] inclusion_list_bits = Bitvector[INCLUSION_LIST_COMMITTEE_SIZE]() (default zero)
-  const oldBid = stateHezeCloned.latestExecutionPayloadBid;
-  const newBid = ssz.heze.ExecutionPayloadBid.defaultViewDU();
-  newBid.parentBlockHash = oldBid.parentBlockHash;
-  newBid.parentBlockRoot = oldBid.parentBlockRoot;
-  newBid.blockHash = oldBid.blockHash;
-  newBid.prevRandao = oldBid.prevRandao;
-  newBid.feeRecipient = oldBid.feeRecipient;
-  newBid.gasLimit = oldBid.gasLimit;
-  newBid.builderIndex = oldBid.builderIndex;
-  newBid.slot = oldBid.slot;
-  newBid.value = oldBid.value;
-  newBid.executionPayment = oldBid.executionPayment;
-  newBid.blobKzgCommitments = oldBid.blobKzgCommitments;
-  newBid.executionRequestsRoot = oldBid.executionRequestsRoot;
-  stateHezeView.latestExecutionPayloadBid = newBid;
+  // [EIP7805] consensus-specs#5371: Heze `ExecutionPayloadBid` == Gloas; copy it over unchanged.
+  stateHezeView.latestExecutionPayloadBid = stateHezeCloned.latestExecutionPayloadBid;
 
   stateHezeView.payloadExpectedWithdrawals = stateHezeCloned.payloadExpectedWithdrawals;
   stateHezeView.ptcWindow = stateHezeCloned.ptcWindow;

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -370,11 +370,9 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
     }
 
     if (this._latestExecutionPayloadBid === null) {
-      // For pre-heze gloas states the bid has no `inclusion_list_bits`; the heze field defaults
-      // to an unset bitvector at runtime, so the wider heze type is a safe upper bound.
       this._latestExecutionPayloadBid = (
         this.cachedState as CachedBeaconStateGloas
-      ).latestExecutionPayloadBid.toValue() as heze.ExecutionPayloadBid;
+      ).latestExecutionPayloadBid.toValue();
     }
     return this._latestExecutionPayloadBid;
   }

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -273,7 +273,6 @@ export interface IBeaconStateViewGloas extends IBeaconStateViewFulu {
 /** Heze+ state fields — use isStatePostHeze() guard */
 export interface IBeaconStateViewHeze extends IBeaconStateViewGloas {
   forkName: ForkPostHeze;
-  /** Modified in heze: ExecutionPayloadBid carries `inclusion_list_bits`. */
   latestExecutionPayloadBid: heze.ExecutionPayloadBid;
   /**
    * Spec heze/beacon-chain.md `get_inclusion_list_committee`. Returns the IL committee for `slot`,

--- a/packages/types/src/heze/sszTypes.ts
+++ b/packages/types/src/heze/sszTypes.ts
@@ -54,19 +54,12 @@ export const SignedExecutionPayloadBid = gloasSsz.SignedExecutionPayloadBid;
 export const DataColumnSidecar = gloasSsz.DataColumnSidecar;
 export const DataColumnSidecars = gloasSsz.DataColumnSidecars;
 
-export const BeaconState = new ContainerType(
-  {
-    ...gloasSsz.BeaconState.fields,
-  },
-  {typeName: "BeaconState", jsonCase: "eth2"}
-);
+// [EIP7805] consensus-specs#5371 removed `inclusion_list_bits` from the bid (the only Heze
+// delta in these containers), so Heze `BeaconState` / `BeaconBlockBody` are now identical to
+// Gloas — reuse the Gloas containers directly (same convention as fulu's `BeaconBlock`).
+export const BeaconState = gloasSsz.BeaconState;
 
-export const BeaconBlockBody = new ContainerType(
-  {
-    ...gloasSsz.BeaconBlockBody.fields,
-  },
-  {typeName: "BeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
-);
+export const BeaconBlockBody = gloasSsz.BeaconBlockBody;
 
 export const BeaconBlock = new ContainerType(
   {

--- a/packages/types/src/heze/sszTypes.ts
+++ b/packages/types/src/heze/sszTypes.ts
@@ -45,21 +45,11 @@ export const InclusionListByCommitteeIndicesRequest = new ContainerType(
   {typeName: "InclusionListByCommitteeIndicesRequest", jsonCase: "eth2"}
 );
 
-export const ExecutionPayloadBid = new ContainerType(
-  {
-    ...gloasSsz.ExecutionPayloadBid.fields,
-    inclusionListBits: new BitVectorType(INCLUSION_LIST_COMMITTEE_SIZE), // [New in Heze:EIP7805]
-  },
-  {typeName: "ExecutionPayloadBid", jsonCase: "eth2"}
-);
+// [EIP7805] consensus-specs#5371 removed `inclusion_list_bits` from the bid, so Heze no longer
+// modifies `ExecutionPayloadBid` / `SignedExecutionPayloadBid`; they are identical to Gloas.
+export const ExecutionPayloadBid = gloasSsz.ExecutionPayloadBid;
 
-export const SignedExecutionPayloadBid = new ContainerType(
-  {
-    message: ExecutionPayloadBid,
-    signature: BLSSignature,
-  },
-  {typeName: "SignedExecutionPayloadBid", jsonCase: "eth2"}
-);
+export const SignedExecutionPayloadBid = gloasSsz.SignedExecutionPayloadBid;
 
 export const DataColumnSidecar = gloasSsz.DataColumnSidecar;
 export const DataColumnSidecars = gloasSsz.DataColumnSidecars;
@@ -67,7 +57,6 @@ export const DataColumnSidecars = gloasSsz.DataColumnSidecars;
 export const BeaconState = new ContainerType(
   {
     ...gloasSsz.BeaconState.fields,
-    latestExecutionPayloadBid: ExecutionPayloadBid, // [Modified in Heze:EIP7805]
   },
   {typeName: "BeaconState", jsonCase: "eth2"}
 );
@@ -75,7 +64,6 @@ export const BeaconState = new ContainerType(
 export const BeaconBlockBody = new ContainerType(
   {
     ...gloasSsz.BeaconBlockBody.fields,
-    signedExecutionPayloadBid: SignedExecutionPayloadBid, // [Modified in Heze:EIP7805]
   },
   {typeName: "BeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
 );

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -408,9 +408,11 @@ exceptions:
     # heze (not implemented)
     - compute_fork_version#heze
     - get_forkchoice_store#heze
+    - get_inclusion_list_bits#heze
     - get_inclusion_list_committee_assignment#heze
     - get_inclusion_list_signature#heze
     - get_inclusion_list_store#heze
+    - is_inclusion_list_bits_inclusive#heze
     - is_valid_inclusion_list_signature#heze
     - on_inclusion_list#heze
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -4352,38 +4352,6 @@
         return rewards, penalties
     </spec>
 
-- name: get_inclusion_list_bits#heze
-  sources:
-    - file: packages/beacon-node/src/chain/opPools/inclusionListStore.ts
-      search: "getInclusionListBits(state: IBeaconStateViewHeze"
-  spec: |
-    <spec fn="get_inclusion_list_bits" fork="heze" hash="e7a02248">
-    def get_inclusion_list_bits(
-        store: InclusionListStore, state: BeaconState, slot: Slot, only_timely: bool = True
-    ) -> Bitvector[INCLUSION_LIST_COMMITTEE_SIZE]:
-        """
-        Return a ``Bitvector`` over inclusion list committee indices with bits set
-        for valid and non-equivocating inclusion list submissions for the given ``slot``.
-        """
-        committee = get_inclusion_list_committee(state, slot)
-        key = hash_tree_root(committee)
-
-        inclusion_lists = store.inclusion_lists[key]
-        equivocators = store.equivocators[key]
-        timeliness = store.inclusion_list_timeliness
-
-        validator_indices = [
-            inclusion_lists[inclusion_list_root].validator_index
-            for inclusion_list_root in inclusion_lists
-            if inclusion_lists[inclusion_list_root].validator_index not in equivocators
-            if not only_timely or timeliness[inclusion_list_root]
-        ]
-
-        return Bitvector[INCLUSION_LIST_COMMITTEE_SIZE](
-            validator_index in validator_indices for validator_index in committee
-        )
-    </spec>
-
 - name: get_inclusion_list_committee#heze
   sources:
     - file: packages/state-transition/src/util/shuffling.ts
@@ -6872,33 +6840,6 @@
     <spec fn="is_in_inactivity_leak" fork="phase0" hash="e95b1146">
     def is_in_inactivity_leak(state: BeaconState) -> bool:
         return get_finality_delay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY
-    </spec>
-
-- name: is_inclusion_list_bits_inclusive#heze
-  sources:
-    - file: packages/beacon-node/src/chain/opPools/inclusionListStore.ts
-      search: "isInclusionListBitsInclusive(state: IBeaconStateViewHeze"
-  spec: |
-    <spec fn="is_inclusion_list_bits_inclusive" fork="heze" hash="5ea16f62">
-    def is_inclusion_list_bits_inclusive(
-        store: InclusionListStore,
-        state: BeaconState,
-        slot: Slot,
-        inclusion_list_bits: Bitvector[INCLUSION_LIST_COMMITTEE_SIZE],
-        only_timely: bool = True,
-    ) -> bool:
-        """
-        Return ``True`` if and only if ``inclusion_list_bits`` is a superset of
-        the locally observed inclusion list bits for the given ``slot``.
-        """
-        local_inclusion_list_bits = get_inclusion_list_bits(store, state, slot, only_timely)
-
-        return all(
-            inclusion_bit or not local_inclusion_bit
-            for inclusion_bit, local_inclusion_bit in zip(
-                inclusion_list_bits, local_inclusion_list_bits, strict=True
-            )
-        )
     </spec>
 
 - name: is_merge_transition_block#bellatrix


### PR DESCRIPTION
## Summary

Mirrors [consensus-specs#5371](https://github.com/ethereum/consensus-specs/pull/5371) ("Remove the IL bitlist from bid", merged 2026-06-18), which removes `inclusion_list_bits: Bitvector[INCLUSION_LIST_COMMITTEE_SIZE]` from the Heze `ExecutionPayloadBid`.

After the spec change Heze no longer modifies `ExecutionPayloadBid` / `SignedExecutionPayloadBid` / `BeaconState` — the bid is identical to Gloas.

## Changes

- **types** (`heze/sszTypes.ts`): `ExecutionPayloadBid` / `SignedExecutionPayloadBid` reuse the Gloas containers; drop the `latestExecutionPayloadBid` / `signedExecutionPayloadBid` overrides on `BeaconState` / `BeaconBlockBody` (they inherit the Gloas fields unchanged).
- **state-transition**: `upgrade_to_heze` copies `latest_execution_payload_bid` over unchanged (no bid reconstruction); drop the now-stale heze bid handling in `beaconStateView` / `interface`.
- **beacon-node**: remove `getInclusionListBits` / `isInclusionListBitsInclusive` from `InclusionListStore`, and the IL-bits set/inclusiveness branch in block production (`produceBlockBody`).
- **specrefs**: drop the two removed helper-function refs (`get_inclusion_list_bits#heze`, `is_inclusion_list_bits_inclusive#heze`) and add them as not-implemented exceptions.

## ⚠️ Blocked on spec-tests version bump

`spec-tests-version.json` and `specrefs/.ethspecify.yml` are pinned to **`v1.7.0-alpha.10`** (2026-06-03), which **predates #5371**. No released consensus-specs version includes the removal yet (alpha.10 is the latest; #5371 merged 2026-06-18 and is only on `master` / the `nightly` ethspecify snapshot).

While pinned at alpha.10:
- The alpha.10 heze spec-test vectors still encode `inclusion_list_bits`, so removing the field changes the heze `ExecutionPayloadBid` / `BeaconState` / block hashTreeRoots. **`heze/ssz_static/*` and heze state/block spec tests will fail** until the pin bumps to a release containing #5371.
- The `ExecutionPayloadBid#heze` / `SignedExecutionPayloadBid#heze` container specrefs and the `upgrade_to_heze` ref are left as-is (still valid against alpha.10); they auto-reconcile on the next `ethspecify process` after the pin bump.

**Recommendation:** hold as draft until consensus-specs cuts a release containing #5371, then bump `spec-tests-version.json` + `.ethspecify.yml` to it (regenerating specrefs) in this PR. Alternatively I can temporarily skip the affected heze spec suites to land sooner — whichever you prefer.

## Verification

- `pnpm build` ✅
- `pnpm check-types` ✅ (incl. test files)
- `pnpm lint` ✅
- `ethspecify process` + `ethspecify check` ✅ — specrefs idempotent, `check-specrefs` stays green
- Heze spec tests: ❌ expected red until the spec-tests pin includes #5371 (see above)

🤖 Generated with AI assistance
