### PR TITLE
refactor: use number representation for Gloas `ExecutionPayloadBid`'s `gasLimit`

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyExecutionPayloadEnvelope.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyExecutionPayloadEnvelope.ts
@@ -62,9 +62,7 @@ export function verifyExecutionPayloadEnvelope(
     );
   }
   if (bid.gasLimit !== payload.gasLimit) {
-    throw new Error(
-      `Gas limit mismatch between payload and bid payload=${payload.gasLimit} bid=${bid.gasLimit}`
-    );
+    throw new Error(`Gas limit mismatch between payload and bid payload=${payload.gasLimit} bid=${bid.gasLimit}`);
   }
   if (!byteArrayEquals(bid.blockHash, payload.blockHash)) {
     throw new Error(

--- a/packages/beacon-node/src/chain/blocks/verifyExecutionPayloadEnvelope.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyExecutionPayloadEnvelope.ts
@@ -61,9 +61,9 @@ export function verifyExecutionPayloadEnvelope(
       `Prev randao mismatch between bid and payload bid=${toHex(bid.prevRandao)} payload=${toHex(payload.prevRandao)}`
     );
   }
-  if (Number(bid.gasLimit) !== payload.gasLimit) {
+  if (bid.gasLimit !== payload.gasLimit) {
     throw new Error(
-      `Gas limit mismatch between payload and bid payload=${payload.gasLimit} bid=${Number(bid.gasLimit)}`
+      `Gas limit mismatch between payload and bid payload=${payload.gasLimit} bid=${bid.gasLimit}`
     );
   }
   if (!byteArrayEquals(bid.blockHash, payload.blockHash)) {

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -344,7 +344,7 @@ export async function produceBlockBody<T extends BlockType>(
       blockHash: executionPayload.blockHash,
       prevRandao: currentState.getRandaoMix(currentState.epoch),
       feeRecipient: executionPayload.feeRecipient,
-      gasLimit: BigInt(executionPayload.gasLimit),
+      gasLimit: executionPayload.gasLimit,
       builderIndex: BUILDER_INDEX_SELF_BUILD,
       slot: blockSlot,
       value: 0,

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -175,7 +175,7 @@ async function validateExecutionPayloadBid(
   // [IGNORE] `is_gas_limit_target_compatible(parent_gas_limit, bid.gas_limit, target_gas_limit)`,
   // where `parent_gas_limit` is the `gas_limit` of the parent execution payload and
   // `target_gas_limit` is `proposer_preferences.target_gas_limit`.
-  const bidGasLimit = Number(bid.gasLimit);
+  const bidGasLimit = bid.gasLimit;
   const parentGasLimit = parentPayloadVariant.executionPayloadGasLimit;
   const targetGasLimit = proposerPreferences.message.targetGasLimit;
   if (!isGasLimitTargetCompatible(parentGasLimit, bidGasLimit, targetGasLimit)) {

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -706,7 +706,7 @@ export function getBlockRootFromPayloadAttestationMessageSerialized(data: Uint8A
  *   blockHash: Bytes32            (32 bytes)
  *   prevRandao: Bytes32           (32 bytes)
  *   feeRecipient: ExecutionAddress(20 bytes)
- *   gasLimit: UintBn64            (8 bytes)
+ *   gasLimit: UintNum64           (8 bytes)
  *   builderIndex: BuilderIndex    (8 bytes)
  *   slot: Slot                    (8 bytes)  ← absolute offset 264
  */

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -48,7 +48,7 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
   stateGloasView.currentSyncCommittee = stateGloasCloned.currentSyncCommittee;
   stateGloasView.nextSyncCommittee = stateGloasCloned.nextSyncCommittee;
   stateGloasView.latestExecutionPayloadBid.blockHash = stateFulu.latestExecutionPayloadHeader.blockHash;
-  stateGloasView.latestExecutionPayloadBid.gasLimit = BigInt(stateFulu.latestExecutionPayloadHeader.gasLimit);
+  stateGloasView.latestExecutionPayloadBid.gasLimit = stateFulu.latestExecutionPayloadHeader.gasLimit;
   stateGloasView.latestExecutionPayloadBid.executionRequestsRoot = ssz.electra.ExecutionRequests.hashTreeRoot(
     ssz.electra.ExecutionRequests.defaultValue()
   );

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -146,7 +146,7 @@ export const ExecutionPayloadBid = new ContainerType(
     blockHash: Bytes32,
     prevRandao: Bytes32,
     feeRecipient: ExecutionAddress,
-    gasLimit: UintBn64,
+    gasLimit: UintNum64,
     builderIndex: BuilderIndex,
     slot: Slot,
     value: UintNum64,


### PR DESCRIPTION
**Motivation**

Find and apply proper type alignment for the `gasLimit`.
`gloas.ExecutionPayloadBid.gasLimit` is the only `gasLimit` in the codebase typed as `UintBn64`. Every other instance including gloas's `ProposerPreferences.targetGasLimit` is `UintNum64`. Since number is used from the start in all places it can be considered safe.

**Description**

Apply the `gloas.ExecutionPayloadBid.gasLimit` type change from `UintBn64` to `UintNum64` throughout the codebase.

Closes #9389

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Used Claude to track relevant places in code and audit the changes, all changes authored manually.
