### PR TITLE
chore: remove v1 attestation endpoints

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -6,7 +6,6 @@ import {
   ForkPostGloas,
   ForkPreBellatrix,
   ForkPreDeneb,
-  ForkPreElectra,
   isForkPostBellatrix,
   isForkPostDeneb,
   isForkPostGloas,
@@ -97,18 +96,6 @@ export type Endpoints = {
     {params: {block_id: string}},
     SignedBlindedBeaconBlock | SignedBeaconBlock<ForkPreBellatrix>,
     ExecutionOptimisticFinalizedAndVersionMeta
-  >;
-
-  /**
-   * Get block attestations
-   * Retrieves attestation included in requested block.
-   */
-  getBlockAttestations: Endpoint<
-    "GET",
-    BlockArgs,
-    {params: {block_id: string}},
-    BeaconBlockBody<ForkPreElectra>["attestations"],
-    ExecutionOptimisticAndFinalizedMeta
   >;
 
   /**
@@ -316,15 +303,6 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           isForkPostBellatrix(fork) ? ssz[fork].SignedBlindedBeaconBlock : ssz[fork].SignedBeaconBlock
         ),
         meta: ExecutionOptimisticFinalizedAndVersionCodec,
-      },
-    },
-    getBlockAttestations: {
-      url: "/eth/v1/beacon/blocks/{block_id}/attestations",
-      method: "GET",
-      req: blockIdOnlyReq,
-      resp: {
-        data: ssz.phase0.BeaconBlockBody.fields.attestations,
-        meta: ExecutionOptimisticAndFinalizedCodec,
       },
     },
     getBlockAttestationsV2: {

--- a/packages/api/src/beacon/routes/beacon/pool.ts
+++ b/packages/api/src/beacon/routes/beacon/pool.ts
@@ -75,18 +75,6 @@ export type Endpoints = {
    * Get Attestations from operations pool
    * Retrieves attestations known by the node but not necessarily incorporated into any block
    */
-  getPoolAttestations: Endpoint<
-    "GET",
-    {slot?: Slot; committeeIndex?: CommitteeIndex},
-    {query: {slot?: number; committee_index?: number}},
-    AttestationListPhase0,
-    EmptyMeta
-  >;
-
-  /**
-   * Get Attestations from operations pool
-   * Retrieves attestations known by the node but not necessarily incorporated into any block
-   */
   getPoolAttestationsV2: Endpoint<
     "GET",
     {slot?: Slot; committeeIndex?: CommitteeIndex},
@@ -117,19 +105,6 @@ export type Endpoints = {
     {query: {slot?: number}},
     SignedProposerPreferencesList,
     VersionMeta
-  >;
-
-  /**
-   * Get AttesterSlashings from operations pool
-   * Retrieves attester slashings known by the node but not necessarily incorporated into any block
-   */
-  getPoolAttesterSlashings: Endpoint<
-    // ⏎
-    "GET",
-    EmptyArgs,
-    EmptyRequest,
-    AttesterSlashingListPhase0,
-    EmptyMeta
   >;
 
   /**
@@ -192,38 +167,10 @@ export type Endpoints = {
    *
    * If one or more attestations fail validation the node MUST return a 400 error with details of which attestations have failed, and why.
    */
-  submitPoolAttestations: Endpoint<
-    "POST",
-    {signedAttestations: SingleAttestation<ForkPreElectra>[]},
-    {body: unknown},
-    EmptyResponseData,
-    EmptyMeta
-  >;
-
-  /**
-   * Submit Attestation objects to node
-   * Submits Attestation objects to the node.  Each attestation in the request body is processed individually.
-   *
-   * If an attestation is validated successfully the node MUST publish that attestation on the appropriate subnet.
-   *
-   * If one or more attestations fail validation the node MUST return a 400 error with details of which attestations have failed, and why.
-   */
   submitPoolAttestationsV2: Endpoint<
     "POST",
     {signedAttestations: SingleAttestation[]},
     {body: unknown; headers: {[MetaHeader.Version]: string}},
-    EmptyResponseData,
-    EmptyMeta
-  >;
-
-  /**
-   * Submit AttesterSlashing object to node's pool
-   * Submits AttesterSlashing object to node's pool and if passes validation node MUST broadcast it to network.
-   */
-  submitPoolAttesterSlashings: Endpoint<
-    "POST",
-    {attesterSlashing: phase0.AttesterSlashing},
-    {body: unknown},
     EmptyResponseData,
     EmptyMeta
   >;
@@ -315,19 +262,6 @@ export type Endpoints = {
 
 export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoints> {
   return {
-    getPoolAttestations: {
-      url: "/eth/v1/beacon/pool/attestations",
-      method: "GET",
-      req: {
-        writeReq: ({slot, committeeIndex}) => ({query: {slot, committee_index: committeeIndex}}),
-        parseReq: ({query}) => ({slot: query.slot, committeeIndex: query.committee_index}),
-        schema: {query: {slot: Schema.Uint, committee_index: Schema.Uint}},
-      },
-      resp: {
-        data: AttestationListTypePhase0,
-        meta: EmptyMetaCodec,
-      },
-    },
     getPoolAttestationsV2: {
       url: "/eth/v2/beacon/pool/attestations",
       method: "GET",
@@ -367,15 +301,6 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         meta: VersionCodec,
       },
     },
-    getPoolAttesterSlashings: {
-      url: "/eth/v1/beacon/pool/attester_slashings",
-      method: "GET",
-      req: EmptyRequestCodec,
-      resp: {
-        data: AttesterSlashingListTypePhase0,
-        meta: EmptyMetaCodec,
-      },
-    },
     getPoolAttesterSlashingsV2: {
       url: "/eth/v2/beacon/pool/attester_slashings",
       method: "GET",
@@ -413,20 +338,6 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         data: SignedBLSToExecutionChangeListType,
         meta: EmptyMetaCodec,
       },
-    },
-    submitPoolAttestations: {
-      url: "/eth/v1/beacon/pool/attestations",
-      method: "POST",
-      req: {
-        writeReqJson: ({signedAttestations}) => ({body: SingleAttestationListTypePhase0.toJson(signedAttestations)}),
-        parseReqJson: ({body}) => ({signedAttestations: SingleAttestationListTypePhase0.fromJson(body)}),
-        writeReqSsz: ({signedAttestations}) => ({body: SingleAttestationListTypePhase0.serialize(signedAttestations)}),
-        parseReqSsz: ({body}) => ({signedAttestations: SingleAttestationListTypePhase0.deserialize(body)}),
-        schema: {
-          body: Schema.ObjectArray,
-        },
-      },
-      resp: EmptyResponseCodec,
     },
     submitPoolAttestationsV2: {
       url: "/eth/v2/beacon/pool/attestations",
@@ -469,20 +380,6 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         schema: {
           body: Schema.ObjectArray,
           headers: {[MetaHeader.Version]: Schema.String},
-        },
-      },
-      resp: EmptyResponseCodec,
-    },
-    submitPoolAttesterSlashings: {
-      url: "/eth/v1/beacon/pool/attester_slashings",
-      method: "POST",
-      req: {
-        writeReqJson: ({attesterSlashing}) => ({body: ssz.phase0.AttesterSlashing.toJson(attesterSlashing)}),
-        parseReqJson: ({body}) => ({attesterSlashing: ssz.phase0.AttesterSlashing.fromJson(body)}),
-        writeReqSsz: ({attesterSlashing}) => ({body: ssz.phase0.AttesterSlashing.serialize(attesterSlashing)}),
-        parseReqSsz: ({body}) => ({attesterSlashing: ssz.phase0.AttesterSlashing.deserialize(body)}),
-        schema: {
-          body: Schema.Object,
         },
       },
       resp: EmptyResponseCodec,

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -501,23 +501,6 @@ export type Endpoints = {
 
   /**
    * Get aggregated attestation
-   * Aggregates all attestations matching given attestation data root and slot
-   * Returns an aggregated `Attestation` object with same `AttestationData` root.
-   */
-  getAggregatedAttestation: Endpoint<
-    "GET",
-    {
-      /** HashTreeRoot of AttestationData that validator want's aggregated */
-      attestationDataRoot: Root;
-      slot: Slot;
-    },
-    {query: {attestation_data_root: string; slot: number}},
-    phase0.Attestation,
-    EmptyMeta
-  >;
-
-  /**
-   * Get aggregated attestation
    * Aggregates all attestations matching given attestation data root, slot and committee index
    * Returns an aggregated `Attestation` object with same `AttestationData` root.
    */
@@ -532,18 +515,6 @@ export type Endpoints = {
     {query: {attestation_data_root: string; slot: number; committee_index: number}},
     Attestation,
     VersionMeta
-  >;
-
-  /**
-   * Publish multiple aggregate and proofs
-   * Verifies given aggregate and proofs and publishes them on appropriate gossipsub topic.
-   */
-  publishAggregateAndProofs: Endpoint<
-    "POST",
-    {signedAggregateAndProofs: SignedAggregateAndProofListPhase0},
-    {body: unknown},
-    EmptyResponseData,
-    EmptyMeta
   >;
 
   /**
@@ -1040,29 +1011,6 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         meta: EmptyMetaCodec,
       },
     },
-    getAggregatedAttestation: {
-      url: "/eth/v1/validator/aggregate_attestation",
-      method: "GET",
-      req: {
-        writeReq: ({attestationDataRoot, slot}) => ({
-          query: {attestation_data_root: toRootHex(attestationDataRoot), slot},
-        }),
-        parseReq: ({query}) => ({
-          attestationDataRoot: fromHex(query.attestation_data_root),
-          slot: query.slot,
-        }),
-        schema: {
-          query: {
-            attestation_data_root: Schema.StringRequired,
-            slot: Schema.UintRequired,
-          },
-        },
-      },
-      resp: {
-        data: ssz.phase0.Attestation,
-        meta: EmptyMetaCodec,
-      },
-    },
     getAggregatedAttestationV2: {
       url: "/eth/v2/validator/aggregate_attestation",
       method: "GET",
@@ -1087,28 +1035,6 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         data: WithVersion((fork) => (isForkPostElectra(fork) ? ssz.electra.Attestation : ssz.phase0.Attestation)),
         meta: VersionCodec,
       },
-    },
-    publishAggregateAndProofs: {
-      url: "/eth/v1/validator/aggregate_and_proofs",
-      method: "POST",
-      req: {
-        writeReqJson: ({signedAggregateAndProofs}) => ({
-          body: SignedAggregateAndProofListPhase0Type.toJson(signedAggregateAndProofs),
-        }),
-        parseReqJson: ({body}) => ({
-          signedAggregateAndProofs: SignedAggregateAndProofListPhase0Type.fromJson(body),
-        }),
-        writeReqSsz: ({signedAggregateAndProofs}) => ({
-          body: SignedAggregateAndProofListPhase0Type.serialize(signedAggregateAndProofs),
-        }),
-        parseReqSsz: ({body}) => ({
-          signedAggregateAndProofs: SignedAggregateAndProofListPhase0Type.deserialize(body),
-        }),
-        schema: {
-          body: Schema.ObjectArray,
-        },
-      },
-      resp: EmptyResponseCodec,
     },
     publishAggregateAndProofsV2: {
       url: "/eth/v2/validator/aggregate_and_proofs",

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -46,10 +46,6 @@ export const testData: GenericServerTestCases<Endpoints> = {
       meta: {executionOptimistic: true, finalized: false, version: ForkName.electra},
     },
   },
-  getBlockAttestations: {
-    args: {blockId: "head"},
-    res: {data: [ssz.phase0.Attestation.defaultValue()], meta: {executionOptimistic: true, finalized: false}},
-  },
   getBlockAttestationsV2: {
     args: {blockId: "head"},
     res: {
@@ -123,10 +119,6 @@ export const testData: GenericServerTestCases<Endpoints> = {
 
   // pool
 
-  getPoolAttestations: {
-    args: {slot: 1, committeeIndex: 2},
-    res: {data: [ssz.phase0.Attestation.defaultValue()]},
-  },
   getPoolAttestationsV2: {
     args: {slot: 1, committeeIndex: 2},
     res: {data: [ssz.electra.Attestation.defaultValue()], meta: {version: ForkName.electra}},
@@ -138,10 +130,6 @@ export const testData: GenericServerTestCases<Endpoints> = {
   getPoolProposerPreferences: {
     args: {slot: 1},
     res: {data: [ssz.gloas.SignedProposerPreferences.defaultValue()], meta: {version: ForkName.gloas}},
-  },
-  getPoolAttesterSlashings: {
-    args: undefined,
-    res: {data: [ssz.phase0.AttesterSlashing.defaultValue()]},
   },
   getPoolAttesterSlashingsV2: {
     args: undefined,
@@ -159,16 +147,8 @@ export const testData: GenericServerTestCases<Endpoints> = {
     args: undefined,
     res: {data: [ssz.capella.SignedBLSToExecutionChange.defaultValue()]},
   },
-  submitPoolAttestations: {
-    args: {signedAttestations: [ssz.phase0.Attestation.defaultValue()]},
-    res: undefined,
-  },
   submitPoolAttestationsV2: {
     args: {signedAttestations: [ssz.electra.SingleAttestation.defaultValue()]},
-    res: undefined,
-  },
-  submitPoolAttesterSlashings: {
-    args: {attesterSlashing: ssz.phase0.AttesterSlashing.defaultValue()},
     res: undefined,
   },
   submitPoolAttesterSlashingsV2: {

--- a/packages/api/test/unit/beacon/testData/validator.ts
+++ b/packages/api/test/unit/beacon/testData/validator.ts
@@ -117,17 +117,9 @@ export const testData: GenericServerTestCases<Endpoints> = {
     args: {slot: 32000, subcommitteeIndex: 2, beaconBlockRoot: ZERO_HASH},
     res: {data: ssz.altair.SyncCommitteeContribution.defaultValue()},
   },
-  getAggregatedAttestation: {
-    args: {attestationDataRoot: ZERO_HASH, slot: 32000},
-    res: {data: ssz.phase0.Attestation.defaultValue()},
-  },
   getAggregatedAttestationV2: {
     args: {attestationDataRoot: ZERO_HASH, slot: 32000, committeeIndex: 2},
     res: {data: ssz.electra.Attestation.defaultValue(), meta: {version: ForkName.electra}},
-  },
-  publishAggregateAndProofs: {
-    args: {signedAggregateAndProofs: [ssz.phase0.SignedAggregateAndProof.defaultValue()]},
-    res: undefined,
   },
   publishAggregateAndProofsV2: {
     args: {signedAggregateAndProofs: [ssz.electra.SignedAggregateAndProof.defaultValue()]},

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -11,7 +11,6 @@ import {
   SLOTS_PER_HISTORICAL_ROOT,
   isForkPostBellatrix,
   isForkPostDeneb,
-  isForkPostElectra,
   isForkPostFulu,
   isForkPostGloas,
 } from "@lodestar/params";
@@ -595,23 +594,6 @@ export function getBeaconBlockApi({
           finalized,
           version: fork,
         },
-      };
-    },
-
-    async getBlockAttestations({blockId}) {
-      const {block, executionOptimistic, finalized} = await getBlockResponse(chain, blockId);
-      const fork = config.getForkName(block.message.slot);
-
-      if (isForkPostElectra(fork)) {
-        throw new ApiError(
-          400,
-          `Use getBlockAttestationsV2 to retrieve block attestations for post-electra fork=${fork}`
-        );
-      }
-
-      return {
-        data: block.message.body.attestations,
-        meta: {executionOptimistic, finalized},
       };
     },
 

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -9,7 +9,7 @@ import {
   isForkPostGloas,
 } from "@lodestar/params";
 import {isStatePostAltair} from "@lodestar/state-transition";
-import {Attestation, Epoch, SingleAttestation, isElectraAttestation, ssz, sszTypesFor} from "@lodestar/types";
+import {Epoch, SingleAttestation, isElectraAttestation, ssz, sszTypesFor} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {
   AttestationError,
@@ -40,25 +40,6 @@ export function getBeaconPoolApi({
   network,
 }: Pick<ApiModules, "chain" | "logger" | "metrics" | "network">): ApplicationMethods<routes.beacon.pool.Endpoints> {
   return {
-    async getPoolAttestations({slot, committeeIndex}) {
-      // Already filtered by slot
-      let attestations: Attestation[] = chain.aggregatedAttestationPool.getAll(slot);
-      const fork = chain.config.getForkName(slot ?? chain.clock.currentSlot);
-
-      if (isForkPostElectra(fork)) {
-        throw new ApiError(
-          400,
-          `Use getPoolAttestationsV2 to retrieve pool attestations for post-electra fork=${fork}`
-        );
-      }
-
-      if (committeeIndex !== undefined) {
-        attestations = attestations.filter((attestation) => committeeIndex === attestation.data.index);
-      }
-
-      return {data: attestations};
-    },
-
     async getPoolAttestationsV2({slot, committeeIndex}) {
       // Already filtered by slot
       let attestations = chain.aggregatedAttestationPool.getAll(slot);
@@ -134,19 +115,6 @@ export function getBeaconPoolApi({
       }
     },
 
-    async getPoolAttesterSlashings() {
-      const fork = chain.config.getForkName(chain.clock.currentSlot);
-
-      if (isForkPostElectra(fork)) {
-        throw new ApiError(
-          400,
-          `Use getPoolAttesterSlashingsV2 to retrieve pool attester slashings for post-electra fork=${fork}`
-        );
-      }
-
-      return {data: chain.opPool.getAllAttesterSlashings()};
-    },
-
     async getPoolAttesterSlashingsV2() {
       const fork = chain.config.getForkName(chain.clock.currentSlot);
       return {data: chain.opPool.getAllAttesterSlashings(), meta: {version: fork}};
@@ -162,10 +130,6 @@ export function getBeaconPoolApi({
 
     async getPoolBLSToExecutionChanges() {
       return {data: chain.opPool.getAllBlsToExecutionChanges().map(({data}) => data)};
-    },
-
-    async submitPoolAttestations({signedAttestations}) {
-      await this.submitPoolAttestationsV2({signedAttestations});
     },
 
     async submitPoolAttestationsV2({signedAttestations}) {
@@ -245,10 +209,6 @@ export function getBeaconPoolApi({
       if (failures.length > 0) {
         throw new IndexedError("Error processing attestations", failures);
       }
-    },
-
-    async submitPoolAttesterSlashings({attesterSlashing}) {
-      await this.submitPoolAttesterSlashingsV2({attesterSlashing});
     },
 
     async submitPoolAttesterSlashingsV2({attesterSlashing}) {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1501,33 +1501,6 @@ export function getValidatorApi(
       };
     },
 
-    async getAggregatedAttestation({attestationDataRoot, slot}) {
-      notWhileSyncing();
-
-      await waitForSlot(slot); // Must never request for a future slot > currentSlot
-
-      const dataRootHex = toRootHex(attestationDataRoot);
-      const aggregate = chain.attestationPool.getAggregate(slot, dataRootHex, null);
-      const fork = chain.config.getForkName(slot);
-
-      if (isForkPostElectra(fork)) {
-        throw new ApiError(
-          400,
-          `Use getAggregatedAttestationV2 to retrieve aggregated attestations for post-electra fork=${fork}`
-        );
-      }
-
-      if (!aggregate) {
-        throw new ApiError(404, `No aggregated attestation for slot=${slot}, dataRoot=${dataRootHex}`);
-      }
-
-      metrics?.production.producedAggregateParticipants.observe(aggregate.aggregationBits.getTrueBitIndexes().length);
-
-      return {
-        data: aggregate,
-      };
-    },
-
     async getAggregatedAttestationV2({attestationDataRoot, slot, committeeIndex}) {
       notWhileSyncing();
 
@@ -1549,10 +1522,6 @@ export function getValidatorApi(
         data: aggregate,
         meta: {version: config.getForkName(slot)},
       };
-    },
-
-    async publishAggregateAndProofs({signedAggregateAndProofs}) {
-      await this.publishAggregateAndProofsV2({signedAggregateAndProofs});
     },
 
     async publishAggregateAndProofsV2({signedAggregateAndProofs}) {


### PR DESCRIPTION
**Motivation**

V1 attestation endpoints are no longer part of the spec and should be removed.

**Description**

Removes following v1 endpoints:
- `getBlockAttestations`
- `getPoolAttestations`
- `getPoolAttesterSlashings`
- `submitPoolAttestations`
- `submitPoolAttesterSlashings`
- `getAggregatedAttestation`
- `publishAggregateAndProofs`

Closes #7412

Used Claude to audit the changes.
