### PR TITLE
fix(api): guard post-fulu blob reconstruction window

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -83,6 +83,15 @@ const MAX_API_CLOCK_DISPARITY_MS = 1000;
  */
 const IDENTITY_PEER_ID = ""; // TODO: Compute identity keypair
 
+function assertDataColumnsWithinAvailableWindow(chain: ApiModules["chain"], slot: number, blockRootHex: string): void {
+  if (slot < chain.earliestAvailableSlot) {
+    throw new ApiError(
+      404,
+      `Data column sidecars are not available for slot=${slot}, root=${blockRootHex}, earliestAvailableSlot=${chain.earliestAvailableSlot}`
+    );
+  }
+}
+
 export function getBeaconBlockApi({
   chain,
   config,
@@ -903,6 +912,8 @@ export function getBeaconBlockApi({
         const blobCount = blobKzgCommitments.length;
 
         if (blobCount > 0) {
+          assertDataColumnsWithinAvailableWindow(chain, block.message.slot, blockRootHex);
+
           const dataColumnSidecars = await chain.getDataColumnSidecars(block.message.slot, blockRootHex);
 
           if (dataColumnSidecars.length === 0) {
@@ -995,6 +1006,8 @@ export function getBeaconBlockApi({
         const blobCount = blobKzgCommitments.length;
 
         if (blobCount > 0) {
+          assertDataColumnsWithinAvailableWindow(chain, block.message.slot, blockRootHex);
+
           const dataColumnSidecars = await chain.getDataColumnSidecars(block.message.slot, blockRootHex);
 
           if (dataColumnSidecars.length === 0) {

--- a/packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlobs.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlobs.test.ts
@@ -1,0 +1,88 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {ForkName, NUMBER_OF_COLUMNS} from "@lodestar/params";
+import {toRootHex} from "@lodestar/utils";
+import {getBeaconBlockApi} from "../../../../../../src/api/impl/beacon/blocks/index.js";
+import {ApiTestModules, getApiTestModules} from "../../../../../utils/api.js";
+import {config, generateBlockWithColumnSidecars} from "../../../../../utils/blocksAndData.js";
+
+describe("api - beacon - blob sidecars", () => {
+  let modules: ApiTestModules;
+  let api: ReturnType<typeof getBeaconBlockApi>;
+
+  beforeEach(() => {
+    modules = getApiTestModules({config});
+    api = getBeaconBlockApi(modules);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setupPostFuluBlockBeforeAvailableWindow(): {
+    blockId: string;
+    blockRoot: string;
+    getDataColumnSidecars: ReturnType<typeof vi.fn>;
+  } {
+    const {block} = generateBlockWithColumnSidecars({forkName: ForkName.fulu});
+    const blockRoot = toRootHex(config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message));
+    const getDataColumnSidecars = vi.fn();
+
+    modules.chain.getCanonicalBlockAtSlot.mockResolvedValue({
+      block,
+      executionOptimistic: false,
+      finalized: false,
+    });
+    modules.chain.getBlockByRoot.mockResolvedValue({
+      block,
+      executionOptimistic: false,
+      finalized: false,
+    });
+
+    Object.defineProperties(modules.chain, {
+      custodyConfig: {
+        value: {targetCustodyGroupCount: NUMBER_OF_COLUMNS / 2},
+        configurable: true,
+      },
+      earliestAvailableSlot: {
+        value: block.message.slot + 1,
+        configurable: true,
+      },
+      getDataColumnSidecars: {
+        value: getDataColumnSidecars,
+        configurable: true,
+      },
+    });
+
+    return {blockId: String(block.message.slot), blockRoot, getDataColumnSidecars};
+  }
+
+  it("does not load data columns for post-fulu getBlobSidecars before the available window", async () => {
+    const {blockId, getDataColumnSidecars} = setupPostFuluBlockBeforeAvailableWindow();
+
+    await expect(api.getBlobSidecars({blockId})).rejects.toMatchObject({
+      statusCode: 404,
+      message: expect.stringContaining("Data column sidecars are not available"),
+    });
+    expect(getDataColumnSidecars).not.toHaveBeenCalled();
+  });
+
+  it("does not load data columns for post-fulu getBlobSidecars by root before the available window", async () => {
+    const {blockRoot, getDataColumnSidecars} = setupPostFuluBlockBeforeAvailableWindow();
+
+    await expect(api.getBlobSidecars({blockId: blockRoot})).rejects.toMatchObject({
+      statusCode: 404,
+      message: expect.stringContaining("Data column sidecars are not available"),
+    });
+    expect(getDataColumnSidecars).not.toHaveBeenCalled();
+  });
+
+  it("does not load data columns for post-fulu getBlobs before the available window", async () => {
+    const {blockId, getDataColumnSidecars} = setupPostFuluBlockBeforeAvailableWindow();
+
+    await expect(api.getBlobs({blockId})).rejects.toMatchObject({
+      statusCode: 404,
+      message: expect.stringContaining("Data column sidecars are not available"),
+    });
+    expect(getDataColumnSidecars).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Motivation

Public mainnet REST traffic hit old post-Fulu blob endpoints and forced Lodestar into the data-column reconstruction path for slots far older than the node's available data-column window.

Production evidence from `public-mainnet-hzax41-1` on 2026-06-16 09:00-11:00 UTC:
- ~407 `getBlobs` requests, ~89 errors
- active REST sockets up to 55
- p99 event-loop lag spike to 18.1s
- repeated `dataColumnSidecars not found in db` warnings for old slot `13916440`

## Description

- Adds a post-Fulu availability-window guard before `getBlobSidecars` and `getBlobs` call `chain.getDataColumnSidecars()` / reconstruct blobs.
- Requests for non-empty post-Fulu blob data older than `chain.earliestAvailableSlot` now return 404 immediately.
- Keeps the existing zero-blob behavior returning `[]`, since it does not enter the expensive data-column path.
- Adds focused API regression coverage for slot and root block IDs.

The nginx block should stay as an ops mitigation until this lands.

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm check-types`
- `pnpm vitest run --project unit packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlobs.test.ts`

Assisted-by: Lodekeeper (AI)