### PR TITLE
fix(api): guard post-fulu blob reconstruction window

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -83,6 +83,15 @@ const MAX_API_CLOCK_DISPARITY_MS = 1000;
  */
 const IDENTITY_PEER_ID = ""; // TODO: Compute identity keypair
 
+function assertDataColumnsWithinAvailableWindow(chain: ApiModules["chain"], slot: number, blockRootHex: string): void {
+  if (slot < chain.earliestAvailableSlot) {
+    throw new ApiError(
+      404,
+      `Data column sidecars are not available for slot=${slot}, root=${blockRootHex}, earliestAvailableSlot=${chain.earliestAvailableSlot}`
+    );
+  }
+}
+
 export function getBeaconBlockApi({
   chain,
   config,
@@ -903,6 +912,8 @@ export function getBeaconBlockApi({
         const blobCount = blobKzgCommitments.length;
 
         if (blobCount > 0) {
+          assertDataColumnsWithinAvailableWindow(chain, block.message.slot, blockRootHex);
+
           const dataColumnSidecars = await chain.getDataColumnSidecars(block.message.slot, blockRootHex);
 
           if (dataColumnSidecars.length === 0) {
@@ -995,6 +1006,8 @@ export function getBeaconBlockApi({
         const blobCount = blobKzgCommitments.length;
 
         if (blobCount > 0) {
+          assertDataColumnsWithinAvailableWindow(chain, block.message.slot, blockRootHex);
+
           const dataColumnSidecars = await chain.getDataColumnSidecars(block.message.slot, blockRootHex);
 
           if (dataColumnSidecars.length === 0) {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -34,6 +34,7 @@ import {
   sszTypesFor,
 } from "@lodestar/types";
 import {fromHex, sleep, toHex, toRootHex} from "@lodestar/utils";
+import {computeDataColumnSidecarsAvailabilityStartSlot} from "../../../../chain/archiveStore/utils/dataColumnSidecarsAvailability.js";
 import {BlockInputSource, isBlockInputBlobs, isBlockInputColumns} from "../../../../chain/blocks/blockInput/index.js";
 import {PayloadEnvelopeInputSource} from "../../../../chain/blocks/payloadEnvelopeInput/index.js";
 import {ImportBlockOpts} from "../../../../chain/blocks/types.js";
@@ -84,10 +85,19 @@ const MAX_API_CLOCK_DISPARITY_MS = 1000;
 const IDENTITY_PEER_ID = ""; // TODO: Compute identity keypair
 
 function assertDataColumnsWithinAvailableWindow(chain: ApiModules["chain"], slot: number, blockRootHex: string): void {
-  if (slot < chain.earliestAvailableSlot) {
+  const earliestDataColumnSlot = Math.max(
+    chain.earliestAvailableSlot,
+    computeDataColumnSidecarsAvailabilityStartSlot(
+      chain.config,
+      chain.clock.currentEpoch,
+      chain.archiveStore.archiveDataEpochs
+    )
+  );
+
+  if (slot < earliestDataColumnSlot) {
     throw new ApiError(
       404,
-      `Data column sidecars are not available for slot=${slot}, root=${blockRootHex}, earliestAvailableSlot=${chain.earliestAvailableSlot}`
+      `Data column sidecars are not available for slot=${slot}, root=${blockRootHex}, earliestAvailableSlot=${earliestDataColumnSlot}`
     );
   }
 }

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -85,19 +85,20 @@ const MAX_API_CLOCK_DISPARITY_MS = 1000;
 const IDENTITY_PEER_ID = ""; // TODO: Compute identity keypair
 
 function assertDataColumnsWithinAvailableWindow(chain: ApiModules["chain"], slot: number, blockRootHex: string): void {
-  const earliestDataColumnSlot = Math.max(
-    chain.earliestAvailableSlot,
-    computeDataColumnSidecarsAvailabilityStartSlot(
-      chain.config,
-      chain.clock.currentEpoch,
-      chain.archiveStore.archiveDataEpochs
-    )
+  // Guard only against the data column retention window. `chain.earliestAvailableSlot` is the anchor
+  // state slot (on restart the latest finalized slot), which is more recent than the columns we still
+  // retain — using it as a floor would hide retained columns and limit serving for no reason. Once
+  // backfill tracks true availability we can revisit incorporating it here.
+  const earliestAvailableDataColumnSlot = computeDataColumnSidecarsAvailabilityStartSlot(
+    chain.config,
+    chain.clock.currentEpoch,
+    chain.archiveStore.archiveDataEpochs
   );
 
-  if (slot < earliestDataColumnSlot) {
+  if (slot < earliestAvailableDataColumnSlot) {
     throw new ApiError(
       404,
-      `Data column sidecars are not available for slot=${slot}, root=${blockRootHex}, earliestAvailableSlot=${earliestDataColumnSlot}`
+      `Data column sidecars are not available for slot=${slot}, root=${blockRootHex}, earliestAvailableSlot=${earliestAvailableDataColumnSlot}`
     );
   }
 }

--- a/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
+++ b/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
@@ -42,7 +42,7 @@ export class ArchiveStore {
   private archiveMode: ArchiveMode;
   private jobQueue: JobItemQueue<[CheckpointWithHex], void>;
 
-  private archiveDataEpochs?: number;
+  private _archiveDataEpochs?: number;
   private readonly statesArchiverStrategy: StateArchiveStrategy;
   private readonly chain: IBeaconChain;
   private readonly db: IBeaconDb;
@@ -61,7 +61,7 @@ export class ArchiveStore {
     this.opts = opts;
     this.signal = signal;
     this.archiveMode = opts.archiveMode;
-    this.archiveDataEpochs = opts.archiveDataEpochs;
+    this._archiveDataEpochs = opts.archiveDataEpochs;
 
     this.jobQueue = new JobItemQueue<[CheckpointWithHex], void>(this.processFinalizedCheckpoint, {
       maxLength: PROCESS_FINALIZED_CHECKPOINT_QUEUE_LENGTH,
@@ -93,6 +93,10 @@ export class ArchiveStore {
         {once: true}
       );
     }
+  }
+
+  get archiveDataEpochs(): number | undefined {
+    return this._archiveDataEpochs;
   }
 
   async init(): Promise<void> {
@@ -200,7 +204,7 @@ export class ArchiveStore {
         this.logger,
         finalized,
         this.chain.clock.currentEpoch,
-        this.archiveDataEpochs,
+        this._archiveDataEpochs,
         this.chain.opts.persistOrphanedBlocks,
         this.chain.opts.persistOrphanedBlocksDir
       );

--- a/packages/beacon-node/src/chain/archiveStore/interface.ts
+++ b/packages/beacon-node/src/chain/archiveStore/interface.ts
@@ -51,6 +51,8 @@ export interface StateArchiveStrategy {
 }
 
 export interface IArchiveStore {
+  readonly archiveDataEpochs?: number;
+
   /**
    * Initialize archive store and load any worker required
    */

--- a/packages/beacon-node/src/chain/archiveStore/utils/dataColumnSidecarsAvailability.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/dataColumnSidecarsAvailability.ts
@@ -1,0 +1,21 @@
+import {BeaconConfig} from "@lodestar/config";
+import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {Epoch, Slot} from "@lodestar/types";
+
+export function computeDataColumnSidecarsAvailabilityStartSlot(
+  config: BeaconConfig,
+  currentEpoch: Epoch,
+  archiveDataEpochs?: number
+): Slot {
+  if (archiveDataEpochs === Infinity) {
+    return computeStartSlotAtEpoch(config.FULU_FORK_EPOCH);
+  }
+
+  const dataColumnSidecarsArchiveWindow = Math.max(
+    config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS,
+    archiveDataEpochs ?? 0
+  );
+  const dataColumnSidecarsMinEpoch = Math.max(currentEpoch - dataColumnSidecarsArchiveWindow, config.FULU_FORK_EPOCH);
+
+  return computeStartSlotAtEpoch(dataColumnSidecarsMinEpoch);
+}

--- a/packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlobs.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlobs.test.ts
@@ -1,5 +1,6 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {ForkName, NUMBER_OF_COLUMNS} from "@lodestar/params";
+import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {toRootHex} from "@lodestar/utils";
 import {getBeaconBlockApi} from "../../../../../../src/api/impl/beacon/blocks/index.js";
 import {ApiTestModules, getApiTestModules} from "../../../../../utils/api.js";
@@ -23,7 +24,9 @@ describe("api - beacon - blob sidecars", () => {
     blockRoot: string;
     getDataColumnSidecars: ReturnType<typeof vi.fn>;
   } {
-    const {block} = generateBlockWithColumnSidecars({forkName: ForkName.fulu});
+    const blockSlot = computeStartSlotAtEpoch(config.FULU_FORK_EPOCH);
+    const currentEpoch = config.FULU_FORK_EPOCH + config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS + 1;
+    const {block} = generateBlockWithColumnSidecars({forkName: ForkName.fulu, slot: blockSlot});
     const blockRoot = toRootHex(config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message));
     const getDataColumnSidecars = vi.fn();
 
@@ -44,13 +47,21 @@ describe("api - beacon - blob sidecars", () => {
         configurable: true,
       },
       earliestAvailableSlot: {
-        value: block.message.slot + 1,
+        value: block.message.slot - 1,
+        configurable: true,
+      },
+      archiveStore: {
+        value: {archiveDataEpochs: undefined},
         configurable: true,
       },
       getDataColumnSidecars: {
         value: getDataColumnSidecars,
         configurable: true,
       },
+    });
+    Object.defineProperty(modules.chain.clock, "currentEpoch", {
+      value: currentEpoch,
+      configurable: true,
     });
 
     return {blockId: String(block.message.slot), blockRoot, getDataColumnSidecars};

--- a/packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlobs.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlobs.test.ts
@@ -46,10 +46,6 @@ describe("api - beacon - blob sidecars", () => {
         value: {targetCustodyGroupCount: NUMBER_OF_COLUMNS / 2},
         configurable: true,
       },
-      earliestAvailableSlot: {
-        value: block.message.slot - 1,
-        configurable: true,
-      },
       archiveStore: {
         value: {archiveDataEpochs: undefined},
         configurable: true,
@@ -95,5 +91,34 @@ describe("api - beacon - blob sidecars", () => {
       message: expect.stringContaining("Data column sidecars are not available"),
     });
     expect(getDataColumnSidecars).not.toHaveBeenCalled();
+  });
+
+  it("serves data columns within the retention window even when earliestAvailableSlot is more recent", async () => {
+    // Regression for the over-restriction: the guard keys off the data column retention window, NOT
+    // chain.earliestAvailableSlot (the anchor-state slot, which after a restart is more recent than
+    // the columns we still retain). A within-window block must reach getDataColumnSidecars.
+    // currentEpoch - MIN_EPOCHS == FULU, so the retention window starts at FULU and this fulu block is within it.
+    const currentEpoch = config.FULU_FORK_EPOCH + config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS;
+    const blockSlot = computeStartSlotAtEpoch(config.FULU_FORK_EPOCH);
+    const {block} = generateBlockWithColumnSidecars({forkName: ForkName.fulu, slot: blockSlot});
+    const getDataColumnSidecars = vi.fn().mockResolvedValue([]);
+
+    modules.chain.getCanonicalBlockAtSlot.mockResolvedValue({block, executionOptimistic: false, finalized: false});
+    Object.defineProperties(modules.chain, {
+      custodyConfig: {value: {targetCustodyGroupCount: NUMBER_OF_COLUMNS / 2}, configurable: true},
+      // Anchor slot more recent than the retained block — must NOT restrict serving.
+      earliestAvailableSlot: {value: computeStartSlotAtEpoch(config.FULU_FORK_EPOCH + 1), configurable: true},
+      archiveStore: {value: {archiveDataEpochs: undefined}, configurable: true},
+      getDataColumnSidecars: {value: getDataColumnSidecars, configurable: true},
+    });
+    Object.defineProperty(modules.chain.clock, "currentEpoch", {value: currentEpoch, configurable: true});
+
+    // Guard passes (within window); falls through to the "not found in db" 404, so getDataColumnSidecars
+    // is called — with the old `Math.max(earliestAvailableSlot, ...)` this slot would have been blocked.
+    await expect(api.getBlobSidecars({blockId: String(blockSlot)})).rejects.toMatchObject({
+      statusCode: 404,
+      message: expect.stringContaining("dataColumnSidecars not found in db"),
+    });
+    expect(getDataColumnSidecars).toHaveBeenCalled();
   });
 });

--- a/packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlobs.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlobs.test.ts
@@ -1,0 +1,88 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {ForkName, NUMBER_OF_COLUMNS} from "@lodestar/params";
+import {toRootHex} from "@lodestar/utils";
+import {getBeaconBlockApi} from "../../../../../../src/api/impl/beacon/blocks/index.js";
+import {ApiTestModules, getApiTestModules} from "../../../../../utils/api.js";
+import {config, generateBlockWithColumnSidecars} from "../../../../../utils/blocksAndData.js";
+
+describe("api - beacon - blob sidecars", () => {
+  let modules: ApiTestModules;
+  let api: ReturnType<typeof getBeaconBlockApi>;
+
+  beforeEach(() => {
+    modules = getApiTestModules({config});
+    api = getBeaconBlockApi(modules);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setupPostFuluBlockBeforeAvailableWindow(): {
+    blockId: string;
+    blockRoot: string;
+    getDataColumnSidecars: ReturnType<typeof vi.fn>;
+  } {
+    const {block} = generateBlockWithColumnSidecars({forkName: ForkName.fulu});
+    const blockRoot = toRootHex(config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message));
+    const getDataColumnSidecars = vi.fn();
+
+    modules.chain.getCanonicalBlockAtSlot.mockResolvedValue({
+      block,
+      executionOptimistic: false,
+      finalized: false,
+    });
+    modules.chain.getBlockByRoot.mockResolvedValue({
+      block,
+      executionOptimistic: false,
+      finalized: false,
+    });
+
+    Object.defineProperties(modules.chain, {
+      custodyConfig: {
+        value: {targetCustodyGroupCount: NUMBER_OF_COLUMNS / 2},
+        configurable: true,
+      },
+      earliestAvailableSlot: {
+        value: block.message.slot + 1,
+        configurable: true,
+      },
+      getDataColumnSidecars: {
+        value: getDataColumnSidecars,
+        configurable: true,
+      },
+    });
+
+    return {blockId: String(block.message.slot), blockRoot, getDataColumnSidecars};
+  }
+
+  it("does not load data columns for post-fulu getBlobSidecars before the available window", async () => {
+    const {blockId, getDataColumnSidecars} = setupPostFuluBlockBeforeAvailableWindow();
+
+    await expect(api.getBlobSidecars({blockId})).rejects.toMatchObject({
+      statusCode: 404,
+      message: expect.stringContaining("Data column sidecars are not available"),
+    });
+    expect(getDataColumnSidecars).not.toHaveBeenCalled();
+  });
+
+  it("does not load data columns for post-fulu getBlobSidecars by root before the available window", async () => {
+    const {blockRoot, getDataColumnSidecars} = setupPostFuluBlockBeforeAvailableWindow();
+
+    await expect(api.getBlobSidecars({blockId: blockRoot})).rejects.toMatchObject({
+      statusCode: 404,
+      message: expect.stringContaining("Data column sidecars are not available"),
+    });
+    expect(getDataColumnSidecars).not.toHaveBeenCalled();
+  });
+
+  it("does not load data columns for post-fulu getBlobs before the available window", async () => {
+    const {blockId, getDataColumnSidecars} = setupPostFuluBlockBeforeAvailableWindow();
+
+    await expect(api.getBlobs({blockId})).rejects.toMatchObject({
+      statusCode: 404,
+      message: expect.stringContaining("Data column sidecars are not available"),
+    });
+    expect(getDataColumnSidecars).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Motivation

Public mainnet REST traffic hit old post-Fulu blob endpoints and forced Lodestar into the data-column reconstruction path for slots far older than the node's available data-column window.

Production evidence from `public-mainnet-hzax41-1` on 2026-06-16 09:00-11:00 UTC:
- ~407 `getBlobs` requests, ~89 errors
- active REST sockets up to 55
- p99 event-loop lag spike to 18.1s
- repeated `dataColumnSidecars not found in db` warnings for old slot `13916440`

## Description

- Adds a post-Fulu availability-window guard before `getBlobSidecars` and `getBlobs` call `chain.getDataColumnSidecars()` / reconstruct blobs.
- Computes the data-column availability start as the max of `chain.earliestAvailableSlot` and the archive pruning retention floor (`current_epoch - max(MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS, archiveDataEpochs)`, clamped to Fulu).
- Requests for non-empty post-Fulu blob data older than that computed window now return 404 immediately.
- Keeps the existing zero-blob behavior returning `[]`, since it does not enter the expensive data-column path.
- Adds focused API regression coverage for slot and root block IDs, including the long-running-node case where `earliestAvailableSlot` is older than the retention floor.

The nginx block should stay as an ops mitigation until this lands.

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm check-types`
- `pnpm vitest run --project unit packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlobs.test.ts`

Assisted-by: Lodekeeper (AI)