### PR TITLE
fix(utils): reject non-finite byte counts in formatBytes

### DIFF
--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -119,8 +119,8 @@ export function prettyPrintIndices(indices: number[]): string {
 }
 
 export function formatBytes(bytes: number): string {
-  if (bytes < 0) {
-    throw new Error("bytes must be a positive number, got " + bytes);
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    throw new Error("bytes must be a finite non-negative number, got " + bytes);
   }
 
   if (bytes === 0) {

--- a/packages/utils/test/unit/bytes.test.ts
+++ b/packages/utils/test/unit/bytes.test.ts
@@ -183,4 +183,11 @@ describe("formatBytes", () => {
       expect(formatBytes(input)).toBe(output);
     });
   }
+
+  const invalidTestCases = [-1, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
+  for (const input of invalidTestCases) {
+    it(`should reject invalid byte count ${input}`, () => {
+      expect(() => formatBytes(input)).toThrow("bytes must be a finite non-negative number");
+    });
+  }
 });


### PR DESCRIPTION
**Motivation**

<!-- Why does this PR exist? What are the goals of the pull request? -->

`formatBytes()` rejected negative values, but it still accepted non-finite numbers. This could produce misleading output such as `NaN undefined` for `NaN` or `Infinity GB` for `Infinity`.




**Description**

<!-- A clear and concise general description of the changes of this pull request. -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Update `formatBytes()` to reject values that are not finite non-negative numbers.

This keeps existing valid formatting behavior unchanged and adds regression coverage for invalid byte counts.




**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

<!-- Insert any AI assistance disclosure here -->

I used Codex to assist with testing.
