### PR TITLE
perf: skip equivocation participant set when there are no equivocators

### DIFF
--- a/packages/fork-choice/src/forkChoice/fastConfirmation/utils.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/utils.ts
@@ -436,13 +436,20 @@ export function getEquivocationScore(
   endSlot: Slot
 ): number {
   if (startSlot > endSlot) return 0;
+
+  // Equivocators are extremely rare (none in normal operation). With none, the equivocation score is
+  // always 0, so return before building the slot-range participant set, which otherwise spans up to a
+  // full epoch of committees (~all active validators) and is rebuilt on every is_one_confirmed
+  // evaluation. This build dominates fast-confirmation cost, especially the epoch-boundary chain walk.
+  const equivocating = ctx.getEquivocatingIndices();
+  if (equivocating.size === 0) return 0;
+
   const balances = balanceSource.balances;
   const state = balanceSource.state;
   const stateEpoch = state ? computeEpochAtSlot(state.slot) : null;
   const participants = getSlotRangeParticipants(ctx, store, cache, startSlot, endSlot);
   if (participants.size === 0) return 0;
 
-  const equivocating = ctx.getEquivocatingIndices();
   let score = 0;
   for (const i of participants) {
     if (!equivocating.has(i)) continue;

--- a/packages/fork-choice/test/unit/forkChoice/fastConfirmation.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/fastConfirmation.test.ts
@@ -12,6 +12,7 @@ import {
   computeSafetyThreshold,
   findLatestConfirmedDescendant,
   getBlockSupportBetweenSlots,
+  getEquivocationScore,
   isConfirmedChainSafe,
   isOneConfirmed,
 } from "../../../src/forkChoice/fastConfirmation/utils.js";
@@ -158,6 +159,56 @@ describe("fast confirmation", () => {
     );
 
     expect(support).toBe(64);
+  });
+
+  it("getEquivocationScore returns 0 when there are no equivocators", () => {
+    const parent = makeBlock(1, ZERO_ROOT);
+    const child = makeBlock(2, parent.blockRoot);
+    const blocks = [makeBlock(0, ZERO_ROOT, {blockRoot: ZERO_ROOT}), parent, child];
+    const state = makeState(4, 32, [2 as Slot]);
+    const store = makeStore(parent.blockRoot, ZERO_ROOT, ZERO_ROOT, 0, 0, parent.blockRoot, child.blockRoot, state);
+    // No equivocating indices, even though slot 2's committee has 4 participants -> score is 0.
+    const ctx = makeContext(3 as Slot, child.blockRoot, blocks, new Map(), {epoch: 0, rootHex: ZERO_ROOT}, state);
+
+    const score = getEquivocationScore(
+      ctx,
+      store,
+      createFastConfirmationCache(),
+      {state, balances: state.effectiveBalanceIncrements},
+      2 as Slot,
+      2 as Slot
+    );
+
+    expect(score).toBe(0);
+  });
+
+  it("getEquivocationScore sums balances of equivocating validators in the slot range", () => {
+    const parent = makeBlock(1, ZERO_ROOT);
+    const child = makeBlock(2, parent.blockRoot);
+    const blocks = [makeBlock(0, ZERO_ROOT, {blockRoot: ZERO_ROOT}), parent, child];
+    const state = makeState(4, 32, [2 as Slot]);
+    const store = makeStore(parent.blockRoot, ZERO_ROOT, ZERO_ROOT, 0, 0, parent.blockRoot, child.blockRoot, state);
+    // Validators 1 and 3 equivocate and are both in slot 2's committee, so each contributes its 32 balance.
+    const ctx = makeContext(
+      3 as Slot,
+      child.blockRoot,
+      blocks,
+      new Map(),
+      {epoch: 0, rootHex: ZERO_ROOT},
+      state,
+      [1, 3]
+    );
+
+    const score = getEquivocationScore(
+      ctx,
+      store,
+      createFastConfirmationCache(),
+      {state, balances: state.effectiveBalanceIncrements},
+      2 as Slot,
+      2 as Slot
+    );
+
+    expect(score).toBe(64);
   });
 
   it("isConfirmedChainSafe fails when a block in the confirmed chain cannot be re-confirmed", () => {


### PR DESCRIPTION
## Problem

`is_one_confirmed` computes the adversarial-weight term via `getEquivocationScore`, which calls `getSlotRangeParticipants(block.slot, currentSlot - 1)`. That builds a fresh `Set` of every validator that attested across the range — up to a full epoch of committees (≈ all active validators) — on **every** evaluation.

On the epoch-boundary chain-safety walk, `is_one_confirmed` runs over the whole confirmed chain (and again on the descendant re-walk) — ~56 evaluations across ranges up to a full epoch. On a mainnet node this was observed taking **~14s of main-thread time**, which starves attestation processing during the epoch transition.

`getEquivocationScore` only uses the participant set to intersect it with the equivocating-indices set. With **no equivocators** — the normal case — the score is always `0`, so the entire build is wasted work.

## Fix

Return early from `getEquivocationScore` when there are no equivocating indices, before building the participant set. Behavior is unchanged (the score is `0` in that case); only the wasted work is removed.

## Numbers

Micro-bench of a single `getEquivocationScore` call over a one-epoch range at 600k validators, `eq=0`:

| | per call |
|---|---|
| before | ~2680 ms |
| after  | ~0.00 ms |

(The micro uses a cold per-slot committee cache, so it's an upper bound; with the cache warm the live-node per-eval was ~265 ms. Either way the `eq=0` cost goes to ~0.)

## Tests

Adds unit coverage for `getEquivocationScore`: returns `0` with no equivocators (the new fast path), and still sums equivocating participants' balances when there are equivocators.

## Context

Found while investigating fast-confirmation "resets" on a mainnet node: the ~14s main-thread cost here starves attestation processing at the epoch boundary, which transiently under-counts the newest block's support and triggers a spurious confirmed-boundary reset. This PR fixes the perf root cause; a separate change for confirmed-marker monotonicity may follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
