### PR TITLE
fix: keep persistedKey when re-adding a reloaded checkpoint state

### DIFF
--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -331,8 +331,9 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     const key = toCacheKey(cpHex);
     const cacheItem = this.cache.get(key);
     this.metrics?.cpStateCache.adds.inc();
-    if (cacheItem !== undefined && isPersistedCacheItem(cacheItem)) {
-      const persistedKey = cacheItem.value;
+    // keep an existing persistedKey (persisted or reloaded-in-memory); dropping it orphans the on-disk file
+    const persistedKey = cacheItem && (isPersistedCacheItem(cacheItem) ? cacheItem.value : cacheItem.persistedKey);
+    if (persistedKey !== undefined) {
       // was persisted to disk, set back to memory
       this.cache.set(key, {type: CacheItemType.inMemory, state, persistedKey});
       this.logger.verbose("Added checkpoint state to memory but a persisted key existed", {

--- a/packages/beacon-node/test/unit-minimal/chain/stateCache/persistentCheckpointsCache.test.ts
+++ b/packages/beacon-node/test/unit-minimal/chain/stateCache/persistentCheckpointsCache.test.ts
@@ -185,6 +185,28 @@ describe("PersistentCheckpointStateCache", () => {
     expect(cache.get(cp2Hex)).not.toBeNull();
   });
 
+  // regression: re-add()ing a checkpoint that is already in memory with a persistedKey (e.g. one that
+  // was reloaded from disk) must keep that persistedKey. Otherwise its on-disk copy is orphaned, since
+  // prune/finalize removes files by the stored persistedKey.
+  it("re-adding a reloaded checkpoint keeps its persistedKey (no orphan on disk)", async () => {
+    cache.add(cp2, states["cp2"]);
+    // persist cp0b to disk
+    expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
+    expect(Array.from(fileApisBuffer.keys())).toEqual([persistent0bKey]);
+
+    // reload cp0b back into memory -> {inMemory, state, persistedKey}
+    expect((await cache.getOrReload(cp0bHex))?.serialize()).toEqual(stateBytes["cp0b"]);
+
+    // re-add the same checkpoint while it is in memory with a persistedKey
+    cache.add(cp0b, states["cp0b"]);
+
+    // finalize epoch 21 -> epoch 20 (cp0b) is pruned; its on-disk copy must be removed, not orphaned
+    expect(await cache.processState(toHexString(cp2.root), stateWithFinalizedEpoch(21))).toEqual(0);
+    expect(fileApisBuffer.has(persistent0bKey)).toBe(false);
+    expect(fileApisBuffer.size).toEqual(0);
+    expect(await cache.getStateOrBytes(cp0bHex)).toBeNull();
+  });
+
   describe("findSeedStateToReload", () => {
     beforeEach(() => {
       fileApisBuffer = new Map();


### PR DESCRIPTION
**Motivation**

`PersistentCheckpointStateCache.add()` can orphan a persisted checkpoint-state file on disk.

**Description**

`add()` only carried `persistedKey` forward when the existing cache item was *persisted*. But an in-memory item can also hold a `persistedKey` — `getStateOrReload()` sets `{type: inMemory, state, persistedKey}` when it faults a persisted state back into memory. When `add()` was then called for that same checkpoint, it fell into the `else` branch and dropped the `persistedKey`.

Since persisted files are deleted by the *stored* key only (`isPersistedCacheItem(cacheItem) ? cacheItem.value : cacheItem.persistedKey`), dropping it leaves the on-disk copy untracked — so a later prune/finalize never removes it and it stays orphaned on disk until the next restart (`init()` wipes all on-disk keys).

Trigger sequence:

1. A checkpoint state is persisted → `{persisted, value: key}`, file written.
2. `getStateOrReload()` reloads it → `{inMemory, state, persistedKey}`.
3. `add()` is called for the same checkpoint → `else` branch → `{inMemory, state}` (key dropped).
4. The epoch is pruned/finalized → cleanup finds no `persistedKey` → the file is left behind.

The fix preserves an existing in-memory item's `persistedKey` too:

```ts
const persistedKey = cacheItem && (isPersistedCacheItem(cacheItem) ? cacheItem.value : cacheItem.persistedKey);
```

**Testing**

Added a regression test in `persistentCheckpointsCache.test.ts` (`persist → reload → re-add → finalize` asserts the on-disk file is removed, not orphaned). Confirmed it **fails on the pre-fix code** (`expected true to be false` — file orphaned) and **passes with the fix**. Full `PersistentCheckpointStateCache` suite (24 tests) green; `biome check` and `tsgo` type-check clean.

**AI Assistance Disclosure**

- [x] I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

The root-cause analysis, the fix, and the regression test were developed with AI assistance (Claude Code), then reviewed and verified by me — red→green confirmed, full suite green, lint + type-check clean.
