### PR TITLE
fix: init transports before processing bootENRs in PeerDiscovery

### DIFF
--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -141,6 +141,22 @@ export class PeerDiscovery {
     this.discv5FirstQueryDelayMs = opts.discv5FirstQueryDelayMs;
     this.connectToDiscv5BootnodesOnStart = opts.connectToDiscv5Bootnodes;
 
+    // Transport tags vary by library: @libp2p/tcp uses '@libp2p/tcp', @chainsafe/libp2p-quic uses 'quic'
+    // Normalize to simple 'tcp' / 'quic' strings for matching.
+    // Must be initialized before the discovery listeners are registered and the bootENRs are processed
+    // below, since handleDiscoveredPeer() reads this.transports. Previously this was assigned at the end
+    // of the constructor, so when network.connectToDiscv5Bootnodes is enabled every bootENR was processed
+    // while this.transports was still undefined, throwing "Cannot read properties of undefined (reading
+    // 'includes')" and preventing the node from dialing its bootnodes on startup.
+    this.transports = libp2p.services.components.transportManager
+      .getTransports()
+      .map((t) => t[Symbol.toStringTag])
+      .map((tag) => {
+        if (tag?.includes("tcp")) return "tcp";
+        if (tag?.includes("quic")) return "quic";
+        return tag;
+      });
+
     this.libp2p.addEventListener("peer:discovery", this.onDiscoveredPeer);
     this.discv5.on("discovered", this.onDiscoveredENR);
 
@@ -183,17 +199,6 @@ export class PeerDiscovery {
         }
       });
     }
-
-    // Transport tags vary by library: @libp2p/tcp uses '@libp2p/tcp', @chainsafe/libp2p-quic uses 'quic'
-    // Normalize to simple 'tcp' / 'quic' strings for matching
-    this.transports = libp2p.services.components.transportManager
-      .getTransports()
-      .map((t) => t[Symbol.toStringTag])
-      .map((tag) => {
-        if (tag?.includes("tcp")) return "tcp";
-        if (tag?.includes("quic")) return "quic";
-        return tag;
-      });
   }
 
   static async init(modules: PeerDiscoveryModules, opts: PeerDiscoveryOpts): Promise<PeerDiscovery> {

--- a/packages/beacon-node/test/unit/network/peers/discover.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/discover.test.ts
@@ -1,5 +1,12 @@
+import {generateKeyPair} from "@libp2p/crypto/keys";
+import {multiaddr} from "@multiformats/multiaddr";
 import {describe, expect, it} from "vitest";
+import {SignableENR} from "@chainsafe/enr";
+import {config} from "@lodestar/config/default";
+import {PeerDiscovery} from "../../../../src/network/peers/discover.js";
+import {ScoreState} from "../../../../src/network/peers/score/interface.js";
 import {peerIdFromString} from "../../../../src/util/peerId.js";
+import {getMockedLogger} from "../../../mocks/loggerMock.js";
 import {getValidPeerId} from "../../../utils/peer.js";
 
 describe("network / peers / discover", () => {
@@ -8,5 +15,47 @@ describe("network / peers / discover", () => {
     const peerIdStr = peerId.toString();
     const peerFromHex = peerIdFromString(peerIdStr);
     expect(peerFromHex.toString()).toBe(peerIdStr);
+  });
+
+  // Regression test for https://github.com/ChainSafe/lodestar/pull/9560
+  // When network.connectToDiscv5Bootnodes is enabled, the constructor synchronously processes the
+  // bootENRs (onDiscoveredENR -> handleDiscoveredPeer), which reads this.transports. Previously
+  // this.transports was assigned at the END of the constructor, so it was still undefined during
+  // bootENR processing and handleDiscoveredPeer threw
+  // "Cannot read properties of undefined (reading 'includes')" (caught + logged as "Error onDiscovered"),
+  // meaning the node never dialed its bootnodes on startup.
+  it("processes bootENRs at construction without throwing on undefined transports", async () => {
+    const logger = getMockedLogger();
+
+    const privateKey = await generateKeyPair("secp256k1");
+    const enr = SignableENR.createFromPrivateKey(privateKey);
+    enr.setLocationMultiaddr(multiaddr("/ip4/127.0.0.1/tcp/9000"));
+    const bootEnr = enr.encodeTxt();
+
+    const libp2p = {
+      addEventListener: () => {},
+      services: {
+        components: {
+          transportManager: {getTransports: () => [{[Symbol.toStringTag]: "@libp2p/tcp"}]},
+          connectionManager: {getConnectionsMap: () => ({map: new Map()}), getDialQueue: () => []},
+        },
+      },
+    } as any;
+
+    const discv5 = {on: () => {}, off: () => {}} as any;
+    const peerRpcScores = {getScoreState: () => ScoreState.Healthy, isCoolingDown: () => false} as any;
+    const clock = {currentSlot: 0, genesisTime: 0} as any;
+
+    new PeerDiscovery(
+      {libp2p, clock, peerRpcScores, metrics: null, logger, networkConfig: {config} as any},
+      {discv5FirstQueryDelayMs: 0, discv5: {bootEnrs: [bootEnr]} as any, connectToDiscv5Bootnodes: true},
+      discv5
+    );
+
+    // Allow the fire-and-forget onDiscoveredENR promise(s) to settle
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const errorMessages = logger.error.mock.calls.map((args) => String(args[0]));
+    expect(errorMessages).not.toContain("Error onDiscovered");
   });
 });

--- a/packages/beacon-node/test/unit/network/peers/discover.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/discover.test.ts
@@ -3,8 +3,18 @@ import {multiaddr} from "@multiformats/multiaddr";
 import {describe, expect, it} from "vitest";
 import {SignableENR} from "@chainsafe/enr";
 import {config} from "@lodestar/config/default";
-import {PeerDiscovery} from "../../../../src/network/peers/discover.js";
-import {ScoreState} from "../../../../src/network/peers/score/interface.js";
+import type {LoggerNode} from "@lodestar/logger/node";
+import type {Discv5Worker} from "../../../../src/network/discv5/index.js";
+import type {LodestarDiscv5Opts} from "../../../../src/network/discv5/types.js";
+import type {Libp2p} from "../../../../src/network/interface.js";
+import type {NetworkConfig} from "../../../../src/network/networkConfig.js";
+import {
+  PeerDiscovery,
+  type PeerDiscoveryModules,
+  type PeerDiscoveryOpts,
+} from "../../../../src/network/peers/discover.js";
+import {type IPeerRpcScoreStore, ScoreState} from "../../../../src/network/peers/score/index.js";
+import type {IClock} from "../../../../src/util/clock.js";
 import {peerIdFromString} from "../../../../src/util/peerId.js";
 import {getMockedLogger} from "../../../mocks/loggerMock.js";
 import {getValidPeerId} from "../../../utils/peer.js";
@@ -40,17 +50,28 @@ describe("network / peers / discover", () => {
           connectionManager: {getConnectionsMap: () => ({map: new Map()}), getDialQueue: () => []},
         },
       },
-    } as any;
+    } as unknown as Libp2p;
 
-    const discv5 = {on: () => {}, off: () => {}} as any;
-    const peerRpcScores = {getScoreState: () => ScoreState.Healthy, isCoolingDown: () => false} as any;
-    const clock = {currentSlot: 0, genesisTime: 0} as any;
+    const modules: PeerDiscoveryModules = {
+      privateKey,
+      networkConfig: {config} as unknown as NetworkConfig,
+      libp2p,
+      clock: {currentSlot: 0, genesisTime: 0} as unknown as IClock,
+      peerRpcScores: {
+        getScoreState: () => ScoreState.Healthy,
+        isCoolingDown: () => false,
+      } as unknown as IPeerRpcScoreStore,
+      metrics: null,
+      logger: logger as unknown as LoggerNode,
+    };
+    const opts: PeerDiscoveryOpts = {
+      discv5FirstQueryDelayMs: 0,
+      discv5: {bootEnrs: [bootEnr]} as unknown as LodestarDiscv5Opts,
+      connectToDiscv5Bootnodes: true,
+    };
+    const discv5 = {on: () => {}, off: () => {}} as unknown as Discv5Worker;
 
-    new PeerDiscovery(
-      {libp2p, clock, peerRpcScores, metrics: null, logger, networkConfig: {config} as any},
-      {discv5FirstQueryDelayMs: 0, discv5: {bootEnrs: [bootEnr]} as any, connectToDiscv5Bootnodes: true},
-      discv5
-    );
+    new PeerDiscovery(modules, opts, discv5);
 
     // Allow the fire-and-forget onDiscoveredENR promise(s) to settle
     await new Promise((resolve) => setTimeout(resolve, 50));


### PR DESCRIPTION
## Motivation

`PeerDiscovery` reads `this.transports` inside `handleDiscoveredPeer()` (to check transport compatibility), but the constructor assigns `this.transports` only at the **end** — after it registers the discovery listeners and, when `network.connectToDiscv5Bootnodes` is enabled, synchronously processes every bootENR via `onDiscoveredENR()` → `handleDiscoveredPeer()`.

So with `--network.connectToDiscv5Bootnodes` set, each bootENR is handled while `this.transports` is still `undefined`, throwing:

```
error: Error onDiscovered - Cannot read properties of undefined (reading 'includes')
    at PeerDiscovery.onDiscoveredENR (.../network/peers/discover.js)
```

(from `this.transports.includes("tcp")`). The error is caught and returns `DiscoveredPeerStatus.error`, so it is **not fatal** — but it means **none of the bootnodes are dialed at startup**, which hurts peer bootstrapping exactly when a freshly (re)started node needs peers most.

### Observed in the wild
On ethpandaops `glamsterdam-devnet-6`, restarted Lodestar supernodes (run with `--network.connectToDiscv5Bootnodes`) repeatedly failed to re-establish peers after a restart (stuck at 0–2 peers), and the log spammed this TypeError on every startup.

## Description
Move the `this.transports` initialization above the listener registration and the bootENR loop, with a comment documenting the ordering requirement to avoid regression. Pure reordering — no other behavior change.

## Testing
`discover.test.ts` has no constructor harness today (a regression test would need to mock `libp2p.services.components.transportManager`, the discv5 worker, etc.) — happy to add one if preferred. Verified the fix removes the startup TypeError and restores bootnode dialing on the affected devnet nodes.
