### PR TITLE
feat: broadcast proposer preferences before the gloas fork

### DIFF
--- a/packages/validator/src/services/proposerPreferences.ts
+++ b/packages/validator/src/services/proposerPreferences.ts
@@ -29,7 +29,10 @@ type SubmittedAtEpoch = {dependentRoot: RootHex; slots: Set<Slot>};
  * dependent root for an epoch shifts (e.g. after a reorg) — detected by comparing the cached
  * `dependentRoot` reported by `BlockDutiesService` against the one we last submitted under.
  *
- * No-op pre-gloas.
+ * Proposers should broadcast their preferences before the fork so the proposer preference caches
+ * of beacon nodes and builders are warm for the first Gloas slots. We start submitting
+ * as soon as a duty's proposal slot is in Gloas, which is up to `SUBMIT_BEFORE_PROPOSAL_SLOTS`
+ * before the fork, so only the first few Gloas slots are affected by this pre-fork submission.
  */
 export class ProposerPreferencesService {
   private readonly submitted = new Map<Epoch, SubmittedAtEpoch>();
@@ -47,7 +50,10 @@ export class ProposerPreferencesService {
   }
 
   private runProposerPreferencesTask = async (slot: Slot): Promise<void> => {
-    if (!isForkPostGloas(this.config.getForkName(slot))) {
+    // Start running once the submission window (`slot + SUBMIT_BEFORE_PROPOSAL_SLOTS`) reaches
+    // Gloas, i.e. already in the epoch before the fork. This allows builders to prepare and
+    // submit bids for the first Gloas slots.
+    if (!isForkPostGloas(this.config.getForkName(slot + SUBMIT_BEFORE_PROPOSAL_SLOTS))) {
       return;
     }
 
@@ -82,6 +88,7 @@ export class ProposerPreferencesService {
       for (const duty of dutiesAtEpoch.data) {
         if (duty.slot <= slot) continue;
         if (duty.slot > slot + SUBMIT_BEFORE_PROPOSAL_SLOTS) continue;
+        if (!isForkPostGloas(this.config.getForkName(duty.slot))) continue;
         if (submission.slots.has(duty.slot)) continue;
 
         try {


### PR DESCRIPTION
As per https://github.com/ethereum/beacon-APIs/pull/608
>  Validator clients SHOULD begin submitting signed proposer preferences one epoch before the
    Gloas fork activates, so the proposer preference caches kept by both beacon nodes and
    builders are warm at the fork boundary, letting builders prepare valid bids for the first
    Gloas slots.


Also related to https://github.com/ethereum/consensus-specs/pull/4947 but we already do this since we subscribe to new gossip topics 2 epochs before the fork (`SUBSCRIPTIONS_LOOKAHEAD_EPOCHS = 2`).