### PR TITLE
perf: memoize fast confirmation total active balance

### DIFF
--- a/packages/fork-choice/src/forkChoice/fastConfirmation/data.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/data.ts
@@ -14,6 +14,7 @@ export function createFastConfirmationCache(): FastConfirmationCache {
     committeeBySlot: new Map(),
     isDescendantByRootPair: new Map(),
     voteWeightBySource: new Map(),
+    totalActiveBalanceByKey: new Map(),
     checkpointStateByKey: new Map(),
   };
 }

--- a/packages/fork-choice/src/forkChoice/fastConfirmation/types.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/types.ts
@@ -9,6 +9,8 @@ export type FastConfirmationBalanceSource = {
   balances: EffectiveBalanceIncrements;
 };
 
+export type TotalActiveBalanceCacheKey = IBeaconStateView | EffectiveBalanceIncrements;
+
 export type ForkChoiceStateGetter = (
   opts: {stateRoot: RootHex; checkpoint?: never} | {stateRoot?: never; checkpoint: CheckpointWithHex}
 ) => IBeaconStateView | null;
@@ -92,6 +94,8 @@ export type FastConfirmationCache = {
   isDescendantByRootPair: Map<string, boolean>;
   /** voteRoot -> totalWeight, keyed by sourceKey */
   voteWeightBySource: Map<BalanceSourceKey, Map<RootHex, number>>;
+  /** total active balance, keyed by the balance source's state or balances reference */
+  totalActiveBalanceByKey: Map<TotalActiveBalanceCacheKey, number>;
   headState?: IBeaconStateView;
   pulledUpHeadState?: IBeaconStateView;
   checkpointStateByKey: Map<string, IBeaconStateView | null>;

--- a/packages/fork-choice/src/forkChoice/fastConfirmation/utils.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/utils.ts
@@ -18,6 +18,7 @@ import {
   FastConfirmationContext,
   FastConfirmationSnapshot,
   IFastConfirmationStore,
+  type TotalActiveBalanceCacheKey,
 } from "./types.ts";
 
 // Spec: adjust_committee_weight_estimate_to_ensure_safety
@@ -266,22 +267,32 @@ export function getPreviousBalanceSource(
   return getBalanceSource(store, cache, "previous");
 }
 
-export function getTotalActiveBalance(balanceSource: FastConfirmationBalanceSource): number {
-  if (balanceSource.state) {
-    return computeTotalBalance(balanceSource.state.getEffectiveBalanceIncrementsZeroInactive());
-  }
-  // Fallback balances come from the justified-balance path and already zero inactive
-  // validators, so summing them gives the active justified total for this balance source.
-  return computeTotalBalance(balanceSource.balances);
+export function getTotalActiveBalance(
+  balanceSource: FastConfirmationBalanceSource,
+  cache: FastConfirmationCache
+): number {
+  const key: TotalActiveBalanceCacheKey = balanceSource.state ?? balanceSource.balances;
+  const cached = cache.totalActiveBalanceByKey.get(key);
+  if (cached !== undefined) return cached;
+
+  const total = balanceSource.state
+    ? computeTotalBalance(balanceSource.state.getEffectiveBalanceIncrementsZeroInactive())
+    : // Fallback balances come from the justified-balance path and already zero inactive
+      // validators, so summing them gives the active justified total for this balance source.
+      computeTotalBalance(balanceSource.balances);
+
+  cache.totalActiveBalanceByKey.set(key, total);
+  return total;
 }
 
 export function estimateCommitteeWeightBetweenSlots(
   balanceSource: FastConfirmationBalanceSource,
+  cache: FastConfirmationCache,
   startSlot: Slot,
   endSlot: Slot
 ): number {
   if (startSlot > endSlot) return 0;
-  const totalActiveBalance = getTotalActiveBalance(balanceSource);
+  const totalActiveBalance = getTotalActiveBalance(balanceSource, cache);
   const startEpoch = computeEpochAtSlot(startSlot);
   const endEpoch = computeEpochAtSlot(endSlot);
 
@@ -334,9 +345,10 @@ export function isFullValidatorSetCovered(startSlot: Slot, endSlot: Slot): boole
 
 export function computeProposerScore(
   ctx: FastConfirmationContext,
-  balanceSource: FastConfirmationBalanceSource
+  balanceSource: FastConfirmationBalanceSource,
+  cache: FastConfirmationCache
 ): number {
-  const totalActiveBalance = getTotalActiveBalance(balanceSource);
+  const totalActiveBalance = getTotalActiveBalance(balanceSource, cache);
   const committeeWeight = Math.floor(totalActiveBalance / SLOTS_PER_EPOCH);
   return Math.floor((committeeWeight * ctx.config.PROPOSER_SCORE_BOOST) / 100);
 }
@@ -469,7 +481,7 @@ export function computeAdversarialWeight(
   startSlot: Slot,
   endSlot: Slot
 ): number {
-  const maximumWeight = estimateCommitteeWeightBetweenSlots(balanceSource, startSlot, endSlot);
+  const maximumWeight = estimateCommitteeWeightBetweenSlots(balanceSource, cache, startSlot, endSlot);
   // The spec uses raw Gwei and computes `maximum_weight // 100 * threshold`.
   // Lodestar carries effective-balance increments instead, so divide after multiplying to avoid
   // dropping the adversarial budget to zero for small validator sets/minimal presets.
@@ -564,9 +576,10 @@ export function computeSafetyThreshold(
   // Spec: compute_safety_threshold(store, block_root, balance_source)
   // Build the threshold from the same terms used in the paper/spec:
   // max possible committee support, proposer boost, empty-slot discount, and adversarial budget.
-  const proposerScore = computeProposerScore(ctx, balanceSource);
+  const proposerScore = computeProposerScore(ctx, balanceSource, cache);
   const maximumSupport = estimateCommitteeWeightBetweenSlots(
     balanceSource,
+    cache,
     (parentBlock.slot + 1) as Slot,
     (currentSlot - 1) as Slot
   );
@@ -711,10 +724,12 @@ export function computeHonestFfgSupportForCurrentTarget(
   const currentEpoch = computeEpochAtSlot(currentSlot);
   const targetState = getCurrentEpochState(ctx, store, cache);
   if (!targetState) return 0;
-  const totalActiveBalance = computeTotalBalance(targetState.getEffectiveBalanceIncrementsZeroInactive());
+  const targetBalanceSource = {state: targetState, balances: targetState.effectiveBalanceIncrements};
+  const totalActiveBalance = getTotalActiveBalance(targetBalanceSource, cache);
   const ffgSupport = getCurrentTargetScore(ctx, store, cache);
   const tillNowFFGWeight = estimateCommitteeWeightBetweenSlots(
-    {state: targetState, balances: targetState.effectiveBalanceIncrements},
+    targetBalanceSource,
+    cache,
     computeStartSlotAtEpoch(currentEpoch),
     (currentSlot - 1) as Slot
   );
@@ -747,7 +762,10 @@ export function willNoConflictingCheckpointBeJustified(
   }
   const targetState = getCurrentEpochState(ctx, store, cache);
   if (!targetState) return false;
-  const totalActiveBalance = computeTotalBalance(targetState.getEffectiveBalanceIncrementsZeroInactive());
+  const totalActiveBalance = getTotalActiveBalance(
+    {state: targetState, balances: targetState.effectiveBalanceIncrements},
+    cache
+  );
   const honestSupport = computeHonestFfgSupportForCurrentTarget(ctx, store, cache);
   return 3 * honestSupport > 1 * totalActiveBalance;
 }
@@ -759,7 +777,10 @@ export function willCurrentTargetBeJustified(
 ): boolean {
   const targetState = getCurrentEpochState(ctx, store, cache);
   if (!targetState) return false;
-  const totalActiveBalance = computeTotalBalance(targetState.getEffectiveBalanceIncrementsZeroInactive());
+  const totalActiveBalance = getTotalActiveBalance(
+    {state: targetState, balances: targetState.effectiveBalanceIncrements},
+    cache
+  );
   const honestSupport = computeHonestFfgSupportForCurrentTarget(ctx, store, cache);
   return 3 * honestSupport >= 2 * totalActiveBalance;
 }

--- a/packages/fork-choice/src/forkChoice/fastConfirmation/utils.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/utils.ts
@@ -271,6 +271,8 @@ export function getTotalActiveBalance(
   balanceSource: FastConfirmationBalanceSource,
   cache: FastConfirmationCache
 ): number {
+  // Invariant per balance source within a run, but read many times per is_one_confirmed evaluation
+  // across the epoch-boundary chain walk; memoize so the full validator-set scan runs once per run.
   const key: TotalActiveBalanceCacheKey = balanceSource.state ?? balanceSource.balances;
   const cached = cache.totalActiveBalanceByKey.get(key);
   if (cached !== undefined) return cached;

--- a/packages/fork-choice/test/perf/forkChoice/fastConfirmation.test.ts
+++ b/packages/fork-choice/test/perf/forkChoice/fastConfirmation.test.ts
@@ -1,6 +1,7 @@
 import {bench, describe} from "@chainsafe/benchmark";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {Slot} from "@lodestar/types";
+import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {Epoch, RootHex, Slot} from "@lodestar/types";
 import {
   buildFastConfirmationSnapshot,
   createFastConfirmationCache,
@@ -16,17 +17,22 @@ describe("forkchoice fast confirmation", () => {
     runFCRRulesBenchmark({initialValidatorCount, initialBlockCount, initialEquivocatedCount: 0});
   }
 
-  for (const initialBlockCount of [10 * SLOTS_PER_EPOCH, (4 * 60 * 60) / 12]) {
-    runFCRRulesBenchmark({initialValidatorCount: 600_000, initialBlockCount, initialEquivocatedCount: 0});
-  }
+  // Larger confirmed chain (more blocks) at a fixed validator count. initialBlockCount must be a
+  // multiple of SLOTS_PER_EPOCH so currentSlot lands on an epoch boundary and isConfirmedChainSafe() runs.
+  runFCRRulesBenchmark({
+    initialValidatorCount: 600_000,
+    initialBlockCount: 10 * SLOTS_PER_EPOCH,
+    initialEquivocatedCount: 0,
+  });
 
-  for (const initialEquivocatedCount of [1_000, 10_000, 300_000]) {
-    runFCRRulesBenchmark({
-      initialValidatorCount: 600_000,
-      initialBlockCount: 3 * SLOTS_PER_EPOCH,
-      initialEquivocatedCount,
-    });
-  }
+  // One equivocation case to keep the equivocation-scoring path covered. Kept at a smaller validator
+  // count because the test stub treats every slot's committee as the full validator set, which makes
+  // the equivocation path much heavier than mainnet — so this is path coverage, not a realistic figure.
+  runFCRRulesBenchmark({
+    initialValidatorCount: 100_000,
+    initialBlockCount: 3 * SLOTS_PER_EPOCH,
+    initialEquivocatedCount: 1_000,
+  });
 });
 
 /**
@@ -44,13 +50,21 @@ function runFCRRulesBenchmark(opts: Opts): void {
       // Vote everyone for head so the FCR vote-map paths see a populated voteNextIndices.
       everyoneVotes(head, forkChoice);
 
-      // Advance to second slot of epoch 2 (not epoch boundary)
-      const currentSlot = (opts.initialBlockCount + 1) as Slot;
-      forkChoice.updateTime(currentSlot);
+      // Measure the epoch-boundary path that walks the previous epoch's confirmed chain.
+      // Avoid calling updateTime() here: it would run FCR in setup instead of inside the benchmarked fn.
+      const currentSlot = opts.initialBlockCount as Slot;
+      const confirmedRoot = rootFromSlot(computeStartSlotAtEpoch((computeEpochAtSlot(currentSlot) - 1) as Epoch));
+      forkChoice["fcStore"].currentSlot = currentSlot;
+      forkChoice["fcStore"].confirmedRoot = confirmedRoot;
 
       // Set previousSlotHead/currentSlotHead for loop conditions
       forkChoice["fcStore"].previousSlotHead = head.blockRoot;
       forkChoice["fcStore"].currentSlotHead = head.blockRoot;
+
+      const confirmedBlock = forkChoice["getBlockHexDefaultStatus"](confirmedRoot);
+      if (!confirmedBlock || computeEpochAtSlot(confirmedBlock.slot) + 1 !== computeEpochAtSlot(currentSlot)) {
+        throw Error("fast confirmation benchmark must start at an epoch boundary with a previous-epoch confirmed root");
+      }
 
       // Extract private FCR context and store for direct calls
       const ctx = forkChoice["fastConfirmationContext"] as FastConfirmationContext;
@@ -73,6 +87,10 @@ function runFCRRulesBenchmark(opts: Opts): void {
       runFastConfirmationRules(snapshot, ctx, store, cache);
     },
   });
+}
+
+function rootFromSlot(slot: Slot): RootHex {
+  return `0x${String(slot).padStart(64, "0")}`;
 }
 
 function everyoneVotes(vote: ProtoBlock, forkChoice: ForkChoice): void {

--- a/packages/fork-choice/test/perf/forkChoice/util.ts
+++ b/packages/fork-choice/test/perf/forkChoice/util.ts
@@ -11,6 +11,7 @@ import {
   ProtoArray,
   ProtoBlock,
 } from "../../../src/index.js";
+import {makeState} from "../../unit/forkChoice/fastConfirmationTestUtils.js";
 
 const genesisSlot = 0;
 const genesisEpoch = 0;
@@ -51,6 +52,10 @@ export function initializeForkChoice(opts: Opts): ForkChoice {
   );
 
   const balances = new Uint16Array(Array.from({length: opts.initialValidatorCount}, () => 32));
+
+  // Lightweight stub state so the FCR's FFG-justification path (getCurrentEpochState ->
+  // getHeadState -> ...) has a state to read. Reuses the same stub the unit tests use.
+  const stubState = makeState(opts.initialValidatorCount, 32, []);
 
   // The first block of epoch 1 is used as the confirmed root.
   // This ensures confirmedEpoch + 1 >= currentEpoch so findLatestConfirmedDescendant runs.
@@ -109,7 +114,7 @@ export function initializeForkChoice(opts: Opts): ForkChoice {
     previousEpochGreatestUnrealizedBalances: balances,
     previousSlotHead: genesisRoot,
     currentSlotHead: genesisRoot,
-    stateGetter: () => null,
+    stateGetter: () => stubState,
   };
 
   const forkchoice = new ForkChoice(config, fcStore, protoArr, opts.initialValidatorCount, null, {

--- a/packages/fork-choice/test/unit/forkChoice/fastConfirmation.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/fastConfirmation.test.ts
@@ -15,6 +15,7 @@ import {
   getEquivocationScore,
   isConfirmedChainSafe,
   isOneConfirmed,
+  willCurrentTargetBeJustified,
 } from "../../../src/forkChoice/fastConfirmation/utils.js";
 import {ExecutionStatus} from "../../../src/index.js";
 import {
@@ -60,6 +61,83 @@ describe("fast confirmation", () => {
   it("adjustCommitteeWeightEstimateToEnsureSafety applies the spec safety bump in effective balance increments", () => {
     expect(adjustCommitteeWeightEstimateToEnsureSafety(999)).toBe(1004);
     expect(adjustCommitteeWeightEstimateToEnsureSafety(1001)).toBe(1007);
+  });
+
+  // Perf regression guard: computing the total active balance scans (and in production allocates)
+  // the full validator set. It is invariant per balance source within an FCR run but is read several
+  // times per is_one_confirmed evaluation, across every block of the epoch-boundary chain walk.
+  // The cache must memoize it so the full-set work happens once per run, not once per evaluation.
+  it("memoizes total active balance once per balance source across a chain walk", () => {
+    const blockCount = 32;
+    const blocks = [makeBlock(0, ZERO_ROOT, {blockRoot: ZERO_ROOT})];
+    for (let slot = 1; slot <= blockCount; slot++) {
+      blocks.push(makeBlock(slot, blocks[slot - 1].blockRoot));
+    }
+
+    const baseState = makeState(256, 32, [1 as Slot]);
+    let zeroInactiveCalls = 0;
+    const state = {
+      ...baseState,
+      getEffectiveBalanceIncrementsZeroInactive: () => {
+        zeroInactiveCalls++;
+        return baseState.effectiveBalanceIncrements;
+      },
+    } as typeof baseState;
+    const balanceSource = {state, balances: state.effectiveBalanceIncrements};
+
+    const head = blocks[blockCount];
+    const currentSlot = (blockCount + 1) as Slot;
+    const store = makeStore(head.blockRoot, ZERO_ROOT, ZERO_ROOT, 0, 0, head.blockRoot, head.blockRoot, state);
+    const ctx = makeContext(
+      currentSlot,
+      head.blockRoot,
+      blocks,
+      latestMessagesFor(256, head.blockRoot, 0),
+      {epoch: 0, rootHex: ZERO_ROOT},
+      state
+    );
+
+    // Evaluate every block on the chain with the same per-run cache, mirroring the per-block
+    // is_one_confirmed calls of the chain-safety walk / descendant search at an epoch boundary.
+    const cache = createFastConfirmationCache();
+    for (let slot = 1; slot <= blockCount; slot++) {
+      computeSafetyThreshold(ctx, store, cache, balanceSource, blocks[slot].blockRoot);
+    }
+
+    // Memoized: one full-set computation per balance source per run, regardless of block count.
+    // Without the fix this is ~3 per evaluation (≈ 3 * blockCount).
+    expect(zeroInactiveCalls).toBe(1);
+  });
+
+  it("memoizes total active balance across current-target justification checks", () => {
+    const block = makeBlock(1, ZERO_ROOT);
+    const blocks = [makeBlock(0, ZERO_ROOT, {blockRoot: ZERO_ROOT}), block];
+
+    const baseState = makeState(256, 32, [1 as Slot]);
+    let zeroInactiveCalls = 0;
+    const state = {
+      ...baseState,
+      getEffectiveBalanceIncrementsZeroInactive: () => {
+        zeroInactiveCalls++;
+        return baseState.effectiveBalanceIncrements;
+      },
+    } as typeof baseState;
+
+    const store = makeStore(block.blockRoot, ZERO_ROOT, ZERO_ROOT, 0, 0, ZERO_ROOT, block.blockRoot, state);
+    const ctx = makeContext(
+      2 as Slot,
+      block.blockRoot,
+      blocks,
+      latestMessagesFor(256, block.blockRoot, 0),
+      {epoch: 0, rootHex: block.blockRoot},
+      state
+    );
+    const cache = createFastConfirmationCache();
+
+    expect(willCurrentTargetBeJustified(ctx, store, cache)).toBe(true);
+    expect(willCurrentTargetBeJustified(ctx, store, cache)).toBe(true);
+
+    expect(zeroInactiveCalls).toBe(1);
   });
 
   it("isOneConfirmed returns true only when support exceeds the computed threshold", () => {


### PR DESCRIPTION
## Summary

The fast confirmation rule (FCR) recomputed the **total active balance** on every `is_one_confirmed` evaluation. That value is invariant per balance source within a single FCR run, but it was read ~3× per evaluation (proposer score, committee weight, adversarial weight) across every block of the epoch-boundary chain walk. For a state-backed balance source each call also **allocates and scans the full validator set** (`getEffectiveBalanceIncrementsZeroInactive`).

This memoizes it on the per-run cache, keyed by the balance source's state/balances reference, so the full-set work runs **once per source per run** instead of once per evaluation.

## Impact / how it was found

Observed on a mainnet node: at an epoch boundary the FCR blocked the Node.js **event loop for ~11s** (zero gossip/attestation/block processing during the window), seen in logs as ~56 serial `Fast confirmation one-confirmed evaluation` lines ~150–300ms apart. The FCR runs on the chain thread (`onClockSlot → forkChoice.updateTime → runFastConfirmationRules`), so this delayed block import and attestation processing.

Root cause: at an epoch boundary the FCR evaluates dozens of blocks (the `isConfirmedChainSafe` chain walk **plus** the descendant search), and each evaluation recomputed the full-validator-set total active balance several times.

## Perf analysis

**Deterministic call-count (the regression guard)** — number of full-set `getEffectiveBalanceIncrementsZeroInactive` computations for a 32-block chain walk:

| | computations |
|---|---|
| before | **96** (≈3 × per evaluation × 32 blocks) |
| after | **1** (memoized per balance source per run) |

A 96× reduction for a single 32-block walk; an epoch-boundary run (~56 evaluations) drops from ~168 full-set computations to 1 per source.

**Benchmark** (`runFastConfirmationRules`, epoch-boundary path; `test/perf/forkChoice/fastConfirmation.test.ts`):

| case | ms/op |
|---|---|
| vc 100k, bc 96 | 4.6 ms |
| vc 600k, bc 96 | 32 ms |
| vc 1M, bc 96 | 54 ms |
| vc 600k, bc 320 | 34 ms |
| vc 100k, bc 96, eq 1000 | 1.27 s (equivocation-path coverage) |

(The harness uses a flat-balances stub, so its absolute cost is far below production — where each `getTotalActiveBalance` call also allocates + tree-scans the validator set — but it captures the per-evaluation redundancy the fix removes.)

## Changes

- `fastConfirmation/utils.ts`: `getTotalActiveBalance` reads/writes a per-run memo; threaded `cache` through `estimateCommitteeWeightBetweenSlots` / `computeProposerScore`; routed the FFG-justification helpers (`computeHonestFfgSupportForCurrentTarget`, `willNoConflictingCheckpointBeJustified`, `willCurrentTargetBeJustified`) through it too.
- `fastConfirmation/types.ts` + `data.ts`: `totalActiveBalanceByKey` cache field + init.
- `test/unit/.../fastConfirmation.test.ts`: two deterministic memoization regression tests (chain walk + current-target justification).
- `test/perf/.../fastConfirmation.test.ts` + `util.ts`: benchmark exercises the epoch-boundary path; lightweight stub state (reusing the unit-test `makeState`) so the FFG path is reachable.

## Testing

- `check-types` ✅, biome lint ✅
- fork-choice unit suite ✅ 184/184 (incl. the 2 new memoization tests)
- perf benchmark ✅ 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
