### PR TITLE
feat(cli): support nested maps in rc config file

### DIFF
--- a/packages/cli/docsgen/markdown.ts
+++ b/packages/cli/docsgen/markdown.ts
@@ -23,17 +23,15 @@ function sanitizeDescription(description: string): string {
   });
 }
 
-function renderExampleBody(example: Partial<Omit<CliExample, "title">>, lodestarCommand?: string): string {
-  const cliExample: string[] = [];
+function renderExampleBody(example: CliExample, lodestarCommand?: string): string {
+  const cliExample = [
+    `\`\`\`sh
+${lodestarCommand ? `${lodestarCommand} ` : ""}${example.command}
+\`\`\``,
+  ];
 
   if (example.description) {
-    cliExample.push(sanitizeDescription(example.description));
-  }
-
-  if (example.command) {
-    cliExample.push(`\`\`\`sh
-${lodestarCommand ? `${lodestarCommand} ` : ""}${example.command}
-\`\`\``);
+    cliExample.unshift(sanitizeDescription(example.description));
   }
 
   return cliExample.join(DEFAULT_SEPARATOR);

--- a/packages/cli/docsgen/markdown.ts
+++ b/packages/cli/docsgen/markdown.ts
@@ -23,15 +23,17 @@ function sanitizeDescription(description: string): string {
   });
 }
 
-function renderExampleBody(example: CliExample, lodestarCommand?: string): string {
-  const cliExample = [
-    `\`\`\`sh
-${lodestarCommand ? `${lodestarCommand} ` : ""}${example.command}
-\`\`\``,
-  ];
+function renderExampleBody(example: Partial<Omit<CliExample, "title">>, lodestarCommand?: string): string {
+  const cliExample: string[] = [];
 
   if (example.description) {
-    cliExample.unshift(sanitizeDescription(example.description));
+    cliExample.push(sanitizeDescription(example.description));
+  }
+
+  if (example.command) {
+    cliExample.push(`\`\`\`sh
+${lodestarCommand ? `${lodestarCommand} ` : ""}${example.command}
+\`\`\``);
   }
 
   return cliExample.join(DEFAULT_SEPARATOR);

--- a/packages/cli/docsgen/markdown.ts
+++ b/packages/cli/docsgen/markdown.ts
@@ -139,7 +139,9 @@ function renderOption(optionName: string, option: CliOptionDefinition): string |
   }
 
   if (option.example) {
-    commandOption.push(`example: ${renderExampleBody(option.example)}`);
+    // Render option examples as a standalone block (no "example:" label). rcConfig — the only
+    // option with an example — is a config-file snippet where the inline label just adds noise.
+    commandOption.push(renderExampleBody(option.example));
   }
 
   return commandOption.join(DEFAULT_SEPARATOR).concat(LINE_BREAK);

--- a/packages/cli/docsgen/markdown.ts
+++ b/packages/cli/docsgen/markdown.ts
@@ -23,17 +23,15 @@ function sanitizeDescription(description: string): string {
   });
 }
 
-function renderExampleBody(example: Partial<Omit<CliExample, "title">>, lodestarCommand?: string): string {
-  const cliExample: string[] = [];
+function renderExampleBody(example: CliExample, lodestarCommand?: string): string {
+  const cliExample = [
+    `\`\`\`sh
+${lodestarCommand ? `${lodestarCommand} ` : ""}${example.command}
+\`\`\``,
+  ];
 
   if (example.description) {
-    cliExample.push(sanitizeDescription(example.description));
-  }
-
-  if (example.command) {
-    cliExample.push(`\`\`\`sh
-${lodestarCommand ? `${lodestarCommand} ` : ""}${example.command}
-\`\`\``);
+    cliExample.unshift(sanitizeDescription(example.description));
   }
 
   return cliExample.join(DEFAULT_SEPARATOR);
@@ -141,10 +139,7 @@ function renderOption(optionName: string, option: CliOptionDefinition): string |
   }
 
   if (option.example) {
-    // Command examples get an "example:" label; config-only snippets render as a standalone block
-    commandOption.push(
-      option.example.command ? `example: ${renderExampleBody(option.example)}` : renderExampleBody(option.example)
-    );
+    commandOption.push(`example: ${renderExampleBody(option.example)}`);
   }
 
   return commandOption.join(DEFAULT_SEPARATOR).concat(LINE_BREAK);

--- a/packages/cli/docsgen/markdown.ts
+++ b/packages/cli/docsgen/markdown.ts
@@ -139,9 +139,7 @@ function renderOption(optionName: string, option: CliOptionDefinition): string |
   }
 
   if (option.example) {
-    // Render option examples as a standalone block (no "example:" label). rcConfig — the only
-    // option with an example — is a config-file snippet where the inline label just adds noise.
-    commandOption.push(renderExampleBody(option.example));
+    commandOption.push(`example: ${renderExampleBody(option.example)}`);
   }
 
   return commandOption.join(DEFAULT_SEPARATOR).concat(LINE_BREAK);

--- a/packages/cli/docsgen/markdown.ts
+++ b/packages/cli/docsgen/markdown.ts
@@ -23,15 +23,17 @@ function sanitizeDescription(description: string): string {
   });
 }
 
-function renderExampleBody(example: CliExample, lodestarCommand?: string): string {
-  const cliExample = [
-    `\`\`\`sh
-${lodestarCommand ? `${lodestarCommand} ` : ""}${example.command}
-\`\`\``,
-  ];
+function renderExampleBody(example: Partial<Omit<CliExample, "title">>, lodestarCommand?: string): string {
+  const cliExample: string[] = [];
 
   if (example.description) {
-    cliExample.unshift(sanitizeDescription(example.description));
+    cliExample.push(sanitizeDescription(example.description));
+  }
+
+  if (example.command) {
+    cliExample.push(`\`\`\`sh
+${lodestarCommand ? `${lodestarCommand} ` : ""}${example.command}
+\`\`\``);
   }
 
   return cliExample.join(DEFAULT_SEPARATOR);
@@ -139,7 +141,10 @@ function renderOption(optionName: string, option: CliOptionDefinition): string |
   }
 
   if (option.example) {
-    commandOption.push(`example: ${renderExampleBody(option.example)}`);
+    // Command examples get an "example:" label; config-only snippets render as a standalone block
+    commandOption.push(
+      option.example.command ? `example: ${renderExampleBody(option.example)}` : renderExampleBody(option.example)
+    );
   }
 
   return commandOption.join(DEFAULT_SEPARATOR).concat(LINE_BREAK);

--- a/packages/cli/docsgen/markdown.ts
+++ b/packages/cli/docsgen/markdown.ts
@@ -23,17 +23,15 @@ function sanitizeDescription(description: string): string {
   });
 }
 
-function renderExampleBody(example: Partial<Omit<CliExample, "title">>, lodestarCommand?: string): string {
-  const cliExample: string[] = [];
+function renderExampleBody(example: CliExample, lodestarCommand?: string): string {
+  const cliExample = [
+    `\`\`\`sh
+${lodestarCommand ? `${lodestarCommand} ` : ""}${example.command}
+\`\`\``,
+  ];
 
   if (example.description) {
-    cliExample.push(sanitizeDescription(example.description));
-  }
-
-  if (example.command) {
-    cliExample.push(`\`\`\`sh
-${lodestarCommand ? `${lodestarCommand} ` : ""}${example.command}
-\`\`\``);
+    cliExample.unshift(sanitizeDescription(example.description));
   }
 
   return cliExample.join(DEFAULT_SEPARATOR);
@@ -140,8 +138,8 @@ function renderOption(optionName: string, option: CliOptionDefinition): string |
     commandOption.push(`default: \`${defaultValue}\``);
   }
 
-  if (option.example) {
-    commandOption.push(`example: ${renderExampleBody(option.example)}`);
+  if (option.example?.description) {
+    commandOption.push(`example: ${sanitizeDescription(option.example.description)}`);
   }
 
   return commandOption.join(DEFAULT_SEPARATOR).concat(LINE_BREAK);

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -52,7 +52,9 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
     description: "RC file to supplement command line args, accepted formats: .yml, .yaml, .json",
     type: "string",
     example: {
-      description: `\`\`\`yaml
+      description: `Options can be written as nested maps or dotted keys:
+
+\`\`\`yaml
 network: hoodi
 rest:
   address: 0.0.0.0

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -63,7 +63,6 @@ metrics:
   enabled: true
   port: 8008
 \`\`\``,
-      command: "beacon --rcConfig beacon-config.yaml",
     },
   },
 

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -52,9 +52,7 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
     description: "RC file to supplement command line args, accepted formats: .yml, .yaml, .json",
     type: "string",
     example: {
-      description: `Options can be written as nested maps or dotted keys:
-
-\`\`\`yaml
+      description: `\`\`\`yaml
 network: hoodi
 rest:
   address: 0.0.0.0

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -1,7 +1,7 @@
 import {ACTIVE_PRESET} from "@lodestar/params";
 import {CliCommandOptions} from "@lodestar/utils";
 import {NetworkName, networkNames} from "../networks/index.js";
-import {readFile} from "../util/index.js";
+import {flattenObject, readFile} from "../util/index.js";
 import {IParamsArgs, paramsOptions} from "./paramsOptions.js";
 
 type GlobalSingleArgs = {
@@ -70,7 +70,7 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
 export const rcConfigOption: [string, string, (configPath: string) => Record<string, unknown>] = [
   "rcConfig",
   globalSingleOptions.rcConfig.description as string,
-  (configPath: string): Record<string, unknown> => readFile(configPath, ["json", "yml", "yaml"]),
+  (configPath: string): Record<string, unknown> => flattenObject(readFile(configPath, ["json", "yml", "yaml"])),
 ];
 
 export type GlobalArgs = GlobalSingleArgs & IParamsArgs;

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -1,7 +1,7 @@
 import {ACTIVE_PRESET} from "@lodestar/params";
 import {CliCommandOptions} from "@lodestar/utils";
 import {NetworkName, networkNames} from "../networks/index.js";
-import {flattenObject, readFile} from "../util/index.js";
+import {flattenObject, readFile, translateEnabledKeys} from "../util/index.js";
 import {IParamsArgs, paramsOptions} from "./paramsOptions.js";
 
 type GlobalSingleArgs = {
@@ -60,15 +60,12 @@ network: hoodi
 rest:
   address: 0.0.0.0
   port: 9596
+metrics:
+  enabled: true
+  port: 8008
 \`\`\`
 
-A few options are both a value/flag and a prefix for other options — e.g. \`metrics\` is an on/off flag but also has sub-options like \`metrics.port\`. YAML can't give one key both a value and nested children, so configure these with dotted keys instead of nesting:
-
-\`\`\`yaml
-# enable metrics AND set its port
-metrics: true
-metrics.port: 8008
-\`\`\``,
+For an on/off flag such as \`--metrics\`, use \`enabled\` under the nested map (\`metrics.enabled\`) or the dotted \`metrics\` key.`,
       command: "beacon --rcConfig beacon.config.yaml",
     },
   },
@@ -90,7 +87,8 @@ metrics.port: 8008
 export const rcConfigOption: [string, string, (configPath: string) => Record<string, unknown>] = [
   "rcConfig",
   globalSingleOptions.rcConfig.description as string,
-  (configPath: string): Record<string, unknown> => flattenObject(readFile(configPath, ["json", "yml", "yaml"])),
+  (configPath: string): Record<string, unknown> =>
+    translateEnabledKeys(flattenObject(readFile(configPath, ["json", "yml", "yaml"]))),
 ];
 
 export type GlobalArgs = GlobalSingleArgs & IParamsArgs;

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -52,7 +52,9 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
     description: "RC file to supplement command line args, accepted formats: .yml, .yaml, .json",
     type: "string",
     example: {
-      description: `\`\`\`yaml
+      description: `Options can be written as nested maps or dotted keys:
+
+\`\`\`yaml
 network: hoodi
 rest:
   address: 0.0.0.0
@@ -61,6 +63,7 @@ metrics:
   enabled: true
   port: 8008
 \`\`\``,
+      command: "beacon --rcConfig beacon.config.yaml",
     },
   },
 

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -56,9 +56,7 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
 
 \`\`\`yaml
 network: hoodi
-rest:
-  address: 0.0.0.0
-  port: 9596
+logLevel: debug
 metrics:
   enabled: true
   port: 8008

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -52,14 +52,14 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
     description: "RC file to supplement command line args, accepted formats: .yml, .yaml, .json",
     type: "string",
     example: {
-      description: `Options can be written as nested maps or dotted keys:
+      description: `Options can be written as nested maps or dotted keys
 
 \`\`\`yaml
 network: hoodi
 logLevel: debug
-metrics:
+metrics: # nested map
   enabled: true
-  port: 8008
+metrics.port: 8008 # dotted key
 \`\`\``,
     },
   },

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -52,9 +52,7 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
     description: "RC file to supplement command line args, accepted formats: .yml, .yaml, .json",
     type: "string",
     example: {
-      description: `Options can be written as nested maps or dotted keys:
-
-\`\`\`yaml
+      description: `\`\`\`yaml
 network: hoodi
 rest:
   address: 0.0.0.0
@@ -63,7 +61,6 @@ metrics:
   enabled: true
   port: 8008
 \`\`\``,
-      command: "beacon --rcConfig beacon.config.yaml",
     },
   },
 

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -49,11 +49,12 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
   },
 
   rcConfig: {
-    description:
-      "RC file to supplement command line args, accepted formats: .yml, .yaml, .json. Options can be written as nested maps or dotted keys.",
+    description: "RC file to supplement command line args, accepted formats: .yml, .yaml, .json",
     type: "string",
     example: {
-      description: `\`\`\`yaml
+      description: `Options can be written as nested maps or dotted keys:
+
+\`\`\`yaml
 network: hoodi
 rest:
   address: 0.0.0.0
@@ -62,6 +63,7 @@ metrics:
   enabled: true
   port: 8008
 \`\`\``,
+      command: "beacon --rcConfig beacon.config.yaml",
     },
   },
 

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -63,7 +63,7 @@ metrics:
   enabled: true
   port: 8008
 \`\`\``,
-      command: "beacon --rcConfig beacon.config.yaml",
+      command: "beacon --rcConfig beacon-config.yaml",
     },
   },
 

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -62,7 +62,13 @@ rest:
   port: 9596
 \`\`\`
 
-Note: an option that is both a value/flag and a prefix (e.g. \`network\` with \`network.maxPeers\`, or the \`metrics\`/\`builder\` enable flags with their \`.port\` settings) can't carry both forms under one nested key — set those with dotted keys, e.g. \`metrics: true\` alongside \`metrics.port: 8008\`.`,
+A few options are both a value/flag and a prefix for other options — e.g. \`metrics\` is an on/off flag but also has sub-options like \`metrics.port\`. YAML can't give one key both a value and nested children, so configure these with dotted keys instead of nesting:
+
+\`\`\`yaml
+# enable metrics AND set its port
+metrics: true
+metrics.port: 8008
+\`\`\``,
       command: "beacon --rcConfig beacon.config.yaml",
     },
   },

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -51,6 +51,18 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
   rcConfig: {
     description: "RC file to supplement command line args, accepted formats: .yml, .yaml, .json",
     type: "string",
+    example: {
+      description: `Supply CLI options from a file. Options can be written as nested maps or dotted keys:
+
+\`\`\`yaml
+# beacon.config.yaml
+network: hoodi
+rest:
+  address: 0.0.0.0
+  port: 9596
+\`\`\``,
+      command: "beacon --rcConfig beacon.config.yaml",
+    },
   },
 
   supernode: {

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -57,9 +57,9 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
 \`\`\`yaml
 network: hoodi
 logLevel: debug
-metrics: # nested map
+metrics:
   enabled: true
-metrics.port: 8008 # dotted key
+  port: 8008
 \`\`\``,
     },
   },

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -60,7 +60,9 @@ network: hoodi
 rest:
   address: 0.0.0.0
   port: 9596
-\`\`\``,
+\`\`\`
+
+Note: an option that is both a value/flag and a prefix (e.g. \`network\` with \`network.maxPeers\`, or the \`metrics\`/\`builder\` enable flags with their \`.port\` settings) can't carry both forms under one nested key — set those with dotted keys, e.g. \`metrics: true\` alongside \`metrics.port: 8008\`.`,
       command: "beacon --rcConfig beacon.config.yaml",
     },
   },

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -49,13 +49,11 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
   },
 
   rcConfig: {
-    description: "RC file to supplement command line args, accepted formats: .yml, .yaml, .json",
+    description:
+      "RC file to supplement command line args, accepted formats: .yml, .yaml, .json. Options can be written as nested maps or dotted keys.",
     type: "string",
     example: {
-      description: `Supply CLI options from a file. Options can be written as nested maps or dotted keys:
-
-\`\`\`yaml
-# beacon.config.yaml
+      description: `\`\`\`yaml
 network: hoodi
 rest:
   address: 0.0.0.0
@@ -63,10 +61,7 @@ rest:
 metrics:
   enabled: true
   port: 8008
-\`\`\`
-
-For an on/off flag such as \`--metrics\`, use \`enabled\` under the nested map (\`metrics.enabled\`) or the dotted \`metrics\` key.`,
-      command: "beacon --rcConfig beacon.config.yaml",
+\`\`\``,
     },
   },
 

--- a/packages/cli/src/util/object.ts
+++ b/packages/cli/src/util/object.ts
@@ -1,4 +1,4 @@
-import {RecursivePartial} from "@lodestar/utils";
+import {RecursivePartial, isPlainObject} from "@lodestar/utils";
 
 /**
  * Removes (mutates) all properties with a value === undefined, recursively
@@ -27,10 +27,22 @@ export function removeUndefinedRecursive<T extends {[key: string]: any}>(obj: T)
  * last in the file wins.
  */
 export function flattenObject(obj: Record<string, unknown>, parentKey?: string): Record<string, unknown> {
+  // Guard non-plain input: an empty or scalar rc config file makes `readFile` return `undefined`
+  // or a primitive, which would otherwise throw on `Object.entries`. `isPlainObject` also rejects
+  // arrays and class instances (Date, Buffer, typed arrays); those are handled as leaf values below.
+  if (!isPlainObject(obj)) {
+    return {};
+  }
   const flattened: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
+    // Skip prototype-polluting keys as defense-in-depth (config files can be semi-trusted).
+    if (key === "__proto__") {
+      continue;
+    }
     const prefixedKey = parentKey ? `${parentKey}.${key}` : key;
-    if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    // Only recurse into plain objects; arrays and class instances (e.g. Date) are kept as leaf
+    // values — recursing into them would silently drop or mis-flatten them.
+    if (isPlainObject(value)) {
       Object.assign(flattened, flattenObject(value as Record<string, unknown>, prefixedKey));
     } else {
       flattened[prefixedKey] = value;

--- a/packages/cli/src/util/object.ts
+++ b/packages/cli/src/util/object.ts
@@ -50,3 +50,37 @@ export function flattenObject(obj: Record<string, unknown>, parentKey?: string):
   }
   return flattened;
 }
+
+/**
+ * Rewrites `{prefix}.enabled` keys to the bare `{prefix}` flag.
+ *
+ * Some options are exposed as an on/off boolean flag (`--metrics`, `--rest`, `--builder`) whose
+ * internal config shape nests the toggle under `.enabled` (e.g. `{metrics: {enabled, port}}`). This
+ * lets an rc config file be written in the natural nested form:
+ *
+ * ```yaml
+ * metrics:
+ *   enabled: true
+ *   port: 8008
+ * ```
+ *
+ * which {@link flattenObject} turns into `{"metrics.enabled": true, "metrics.port": 8008}`. The CLI
+ * registers the toggle as the bare `metrics` flag (there is no `metrics.enabled` option), so rewrite
+ * `{prefix}.enabled` -> `{prefix}` to match a registered option. No CLI option is registered with an
+ * `.enabled` suffix, so this is unambiguous. If the bare `{prefix}` key is already set (e.g. mixed
+ * dotted and nested forms), the `.enabled` key is left untouched so the conflict surfaces as an
+ * "unknown argument" error rather than being silently overridden.
+ */
+export function translateEnabledKeys(flattened: Record<string, unknown>): Record<string, unknown> {
+  const suffix = ".enabled";
+  const translated: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(flattened)) {
+    const prefix = key.endsWith(suffix) ? key.slice(0, -suffix.length) : "";
+    if (prefix && !(prefix in flattened)) {
+      translated[prefix] = value;
+    } else {
+      translated[key] = value;
+    }
+  }
+  return translated;
+}

--- a/packages/cli/src/util/object.ts
+++ b/packages/cli/src/util/object.ts
@@ -13,3 +13,28 @@ export function removeUndefinedRecursive<T extends {[key: string]: any}>(obj: T)
   }
   return obj as RecursivePartial<T>;
 }
+
+/**
+ * Flattens a nested object into a single-level object with dot-notation keys.
+ *
+ * Allows the rc config file to be written with either nested maps or dotted keys, e.g.
+ * `{rest: {address: "0.0.0.0"}}` and `{"rest.address": "0.0.0.0"}` both flatten to
+ * `{"rest.address": "0.0.0.0"}`, matching how CLI options are registered (`dot-notation`
+ * is disabled in yargs). Arrays are preserved as values (not flattened by index) so
+ * array options like `rest.namespace` or `bootnodes` keep working.
+ *
+ * If the same option is provided in both nested and dotted form, the value that appears
+ * last in the file wins.
+ */
+export function flattenObject(obj: Record<string, unknown>, parentKey?: string): Record<string, unknown> {
+  const flattened: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const prefixedKey = parentKey ? `${parentKey}.${key}` : key;
+    if (value != null && typeof value === "object" && !Array.isArray(value)) {
+      Object.assign(flattened, flattenObject(value as Record<string, unknown>, prefixedKey));
+    } else {
+      flattened[prefixedKey] = value;
+    }
+  }
+  return flattened;
+}

--- a/packages/cli/test/unit/util/object.test.ts
+++ b/packages/cli/test/unit/util/object.test.ts
@@ -1,0 +1,69 @@
+import {describe, expect, it} from "vitest";
+import {flattenObject} from "../../../src/util/object.js";
+
+describe("util / flattenObject", () => {
+  it("flattens nested maps into dot-notation keys", () => {
+    expect(flattenObject({rest: {address: "0.0.0.0", port: 9596}})).toEqual({
+      "rest.address": "0.0.0.0",
+      "rest.port": 9596,
+    });
+  });
+
+  it("leaves already-dotted keys unchanged (backwards compatible)", () => {
+    expect(flattenObject({"rest.address": "0.0.0.0", "rest.port": 9596})).toEqual({
+      "rest.address": "0.0.0.0",
+      "rest.port": 9596,
+    });
+  });
+
+  it("preserves arrays as values instead of flattening them by index", () => {
+    expect(flattenObject({rest: {namespace: ["beacon", "config"]}, bootnodes: ["enr:-a", "enr:-b"]})).toEqual({
+      "rest.namespace": ["beacon", "config"],
+      bootnodes: ["enr:-a", "enr:-b"],
+    });
+  });
+
+  it("preserves primitive value types (boolean, number, null)", () => {
+    expect(flattenObject({metrics: {enabled: true, port: 8008, host: null}})).toEqual({
+      "metrics.enabled": true,
+      "metrics.port": 8008,
+      "metrics.host": null,
+    });
+  });
+
+  it("supports nested and dotted keys mixed in the same object", () => {
+    expect(flattenObject({rest: {address: "0.0.0.0"}, "rest.port": 9596, network: "hoodi"})).toEqual({
+      "rest.address": "0.0.0.0",
+      "rest.port": 9596,
+      network: "hoodi",
+    });
+  });
+
+  it("flattens arbitrarily deep nesting", () => {
+    expect(flattenObject({a: {b: {c: 1}}})).toEqual({"a.b.c": 1});
+  });
+
+  it("returns top-level scalars untouched", () => {
+    expect(flattenObject({network: "hoodi", port: 9000, rest: true})).toEqual({
+      network: "hoodi",
+      port: 9000,
+      rest: true,
+    });
+  });
+
+  it("last definition wins when a key is given in both nested and dotted form", () => {
+    expect(flattenObject({"rest.address": "first", rest: {address: "second"}})).toEqual({
+      "rest.address": "second",
+    });
+  });
+
+  it("keeps arrays of objects intact as a single value", () => {
+    expect(flattenObject({chain: {trustedSetup: [{index: 0}, {index: 1}]}})).toEqual({
+      "chain.trustedSetup": [{index: 0}, {index: 1}],
+    });
+  });
+
+  it("drops empty nested maps and keeps sibling keys", () => {
+    expect(flattenObject({rest: {}, network: "hoodi"})).toEqual({network: "hoodi"});
+  });
+});

--- a/packages/cli/test/unit/util/object.test.ts
+++ b/packages/cli/test/unit/util/object.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest";
-import {flattenObject} from "../../../src/util/object.js";
+import {flattenObject, translateEnabledKeys} from "../../../src/util/object.js";
 
 describe("util / flattenObject", () => {
   it("flattens nested maps into dot-notation keys", () => {
@@ -84,5 +84,53 @@ describe("util / flattenObject", () => {
   it("keeps non-plain object values (e.g. Date) as leaves instead of dropping them", () => {
     const genesisTime = new Date("2024-01-01T00:00:00Z");
     expect(flattenObject({chain: {genesisTime}})).toEqual({"chain.genesisTime": genesisTime});
+  });
+});
+
+describe("util / translateEnabledKeys", () => {
+  it("rewrites `{prefix}.enabled` to the bare `{prefix}` flag", () => {
+    expect(translateEnabledKeys({"metrics.enabled": true, "metrics.port": 8008})).toEqual({
+      metrics: true,
+      "metrics.port": 8008,
+    });
+  });
+
+  it("translates the nested form produced by flattenObject (metrics: {enabled, port})", () => {
+    expect(translateEnabledKeys(flattenObject({metrics: {enabled: true, port: 8008}}))).toEqual({
+      metrics: true,
+      "metrics.port": 8008,
+    });
+  });
+
+  it("handles multiple prefixes independently", () => {
+    expect(
+      translateEnabledKeys({"metrics.enabled": true, "builder.enabled": false, "builder.url": "http://localhost"})
+    ).toEqual({
+      metrics: true,
+      builder: false,
+      "builder.url": "http://localhost",
+    });
+  });
+
+  it("leaves `{prefix}.enabled` untouched when the bare `{prefix}` is already set (conflict surfaces later)", () => {
+    expect(translateEnabledKeys({metrics: false, "metrics.enabled": true})).toEqual({
+      metrics: false,
+      "metrics.enabled": true,
+    });
+  });
+
+  it("is a no-op when there are no `.enabled` keys", () => {
+    expect(translateEnabledKeys({"rest.port": 9596, network: "hoodi"})).toEqual({
+      "rest.port": 9596,
+      network: "hoodi",
+    });
+  });
+
+  it("does not translate a top-level key literally named `enabled`", () => {
+    expect(translateEnabledKeys({enabled: true})).toEqual({enabled: true});
+  });
+
+  it("strips `.enabled` from a deeply-prefixed key", () => {
+    expect(translateEnabledKeys({"a.b.enabled": true})).toEqual({"a.b": true});
   });
 });

--- a/packages/cli/test/unit/util/object.test.ts
+++ b/packages/cli/test/unit/util/object.test.ts
@@ -66,4 +66,23 @@ describe("util / flattenObject", () => {
   it("drops empty nested maps and keeps sibling keys", () => {
     expect(flattenObject({rest: {}, network: "hoodi"})).toEqual({network: "hoodi"});
   });
+
+  it("returns an empty object for non-plain input instead of throwing", () => {
+    // e.g. an empty or scalar rc config file makes readFile return undefined / a primitive
+    expect(flattenObject(undefined as unknown as Record<string, unknown>)).toEqual({});
+    expect(flattenObject(null as unknown as Record<string, unknown>)).toEqual({});
+    expect(flattenObject("network: hoodi" as unknown as Record<string, unknown>)).toEqual({});
+    expect(flattenObject(42 as unknown as Record<string, unknown>)).toEqual({});
+  });
+
+  it("skips the __proto__ key and does not pollute Object.prototype", () => {
+    const malicious = JSON.parse('{"__proto__": {"polluted": true}, "network": "hoodi"}');
+    expect(flattenObject(malicious)).toEqual({network: "hoodi"});
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("keeps non-plain object values (e.g. Date) as leaves instead of dropping them", () => {
+    const genesisTime = new Date("2024-01-01T00:00:00Z");
+    expect(flattenObject({chain: {genesisTime}})).toEqual({"chain.genesisTime": genesisTime});
+  });
 });

--- a/packages/utils/src/command.ts
+++ b/packages/utils/src/command.ts
@@ -8,7 +8,8 @@ export interface CliExample {
 
 // biome-ignore lint/suspicious/noExplicitAny: We need to use `any` type here
 export interface CliOptionDefinition<T = any> extends Options {
-  example?: Omit<CliExample, "title">;
+  // `command` is optional: some option examples are config snippets shown on their own
+  example?: Partial<Omit<CliExample, "title">>;
   // Ensure `type` property matches type of `T`
   type: T extends string
     ? "string"

--- a/packages/utils/src/command.ts
+++ b/packages/utils/src/command.ts
@@ -8,8 +8,7 @@ export interface CliExample {
 
 // biome-ignore lint/suspicious/noExplicitAny: We need to use `any` type here
 export interface CliOptionDefinition<T = any> extends Options {
-  // `command` is optional: some option examples are config snippets shown on their own
-  example?: Partial<Omit<CliExample, "title">>;
+  example?: Omit<CliExample, "title">;
   // Ensure `type` property matches type of `T`
   type: T extends string
     ? "string"

--- a/packages/utils/src/command.ts
+++ b/packages/utils/src/command.ts
@@ -8,7 +8,9 @@ export interface CliExample {
 
 // biome-ignore lint/suspicious/noExplicitAny: We need to use `any` type here
 export interface CliOptionDefinition<T = any> extends Options {
-  example?: Omit<CliExample, "title">;
+  // `command` is optional for option examples: some options are illustrated by config alone
+  // (e.g. an rc config file snippet) with no accompanying command line to show.
+  example?: Partial<Omit<CliExample, "title">>;
   // Ensure `type` property matches type of `T`
   type: T extends string
     ? "string"

--- a/packages/utils/src/command.ts
+++ b/packages/utils/src/command.ts
@@ -8,9 +8,7 @@ export interface CliExample {
 
 // biome-ignore lint/suspicious/noExplicitAny: We need to use `any` type here
 export interface CliOptionDefinition<T = any> extends Options {
-  // `command` is optional for option examples: some options are illustrated by config alone
-  // (e.g. an rc config file snippet) with no accompanying command line to show.
-  example?: Partial<Omit<CliExample, "title">>;
+  example?: Omit<CliExample, "title">;
   // Ensure `type` property matches type of `T`
   type: T extends string
     ? "string"

--- a/packages/utils/src/command.ts
+++ b/packages/utils/src/command.ts
@@ -8,8 +8,8 @@ export interface CliExample {
 
 // biome-ignore lint/suspicious/noExplicitAny: We need to use `any` type here
 export interface CliOptionDefinition<T = any> extends Options {
-  // `command` is optional: some option examples are config snippets shown on their own
-  example?: Partial<Omit<CliExample, "title">>;
+  // Option examples are a description block only (e.g. an rc config snippet); no command line
+  example?: Omit<CliExample, "title" | "command">;
   // Ensure `type` property matches type of `T`
   type: T extends string
     ? "string"


### PR DESCRIPTION
## Motivation

Lodestar's `--rcConfig` file currently requires nested options to be written as **dotted keys**:

```yaml
rest.address: "0.0.0.0"
rest.port: 9596
```

This surprised a user who expected the idiomatic nested YAML form (`rest:` → `address:`). The nested form is nicer, but we don't want to break existing dotted configs — so this PR supports **both**.

## Description

### Nested maps → dotted keys

Nested maps in the config file are flattened to dotted keys before being handed to yargs, so both of these produce identical results:

```yaml
# dotted (still works)
rest.address: "0.0.0.0"
rest.port: 9596

# nested (now works too)
rest:
  address: "0.0.0.0"
  port: 9596
```

**Why flattening:** `cli.ts` sets `parserConfiguration({"dot-notation": false})` (needed so `.strict()` keeps working with dotted option names), so options are registered as literal dotted keys (`"rest.address"`) and yargs `.config()` only matches literal dotted keys from the file — nested maps are silently ignored today. Flattening the parsed file in the `rcConfig` read callback bridges the gap without touching parser config or the strictness guarantees.

- **Arrays are preserved** as values (not flattened by index) so array options (`rest.namespace`, `bootnodes`, …) keep working.
- **Already-dotted keys pass through unchanged** → fully backward compatible.
- **Prototype-pollution safe:** `__proto__` is skipped and non-plain input returns `{}`.
- If an option is given in both nested and dotted form, the value appearing last in the file wins.
- Applies to every command that shares the global `--rcConfig` option (beacon / validator / bootnode).

### `.enabled` → bare on/off flag

On/off options are registered as a bare boolean flag (e.g. `--metrics`), which reads awkwardly as a nested map. After flattening, `{prefix}.enabled` is rewritten to the bare `{prefix}` flag so the natural nested form works:

```yaml
metrics:
  enabled: true   # → the --metrics flag
  port: 8008
```

`metrics.enabled: true` → `metrics: true`. If both `{prefix}` and `{prefix}.enabled` are present, `.enabled` is left as-is so the conflict surfaces at yargs' strict check instead of being silently swallowed.

## Testing

- **`flattenObject`** — 13 unit tests: nested → dotted, dotted pass-through, mixed nested+dotted, array preservation, arrays-of-objects, primitive/null values, deep nesting, top-level scalars, empty-map elision, nested/dotted collision precedence, `__proto__` guard, non-plain input, and non-plain object leaves (`Date`).
- **`translateEnabledKeys`** — 7 unit tests: `.enabled` → bare flag, the nested `metrics: {enabled, port}` form, multiple prefixes, the already-set conflict case, no-op when absent, a top-level `enabled` is not translated, and deeply-prefixed keys.
- `check-types`, `biome lint`, full build, and the existing cli `util` / `options` / `beacon` unit suites pass — no regressions.

## Docs

Adds a compact example to the `--rcConfig` option showing both forms (a nested map and a dotted key), so it renders in the generated CLI reference ([beacon-cli#--rcconfig](https://chainsafe.github.io/lodestar/run/beacon-management/beacon-cli#--rcconfig)). Because `--rcConfig` is a **global** option, its example renders in every command's docs, so it uses options common to all of them (`network` / `logLevel` / `metrics`) rather than a beacon-only option.

Rendering an option `example` that's a config snippet (no shell command) needed a small docsgen change: `renderOption` renders the `example` description directly, and `CliOptionDefinition.example` becomes description-only (`Omit<CliExample, "title" | "command">`). The `example` is docs-only (yargs ignores it, so `--help` is unchanged) and the generated `*-cli.md` files are gitignored.

This supersedes the dedicated docs page in #9574 (now closed) — a whole page was overkill; an inline example is enough.

---
🤖 Generated with AI assistance
