### PR TITLE
feat(shuffling-cache): add 'has' api to shuffling cache

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -9,7 +9,14 @@ import {
   NotReorgedReason,
   getSafeExecutionBlockHash,
 } from "@lodestar/fork-choice";
-import {ForkPostAltair, ForkPostElectra, ForkSeq, MAX_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {
+  ForkPostAltair,
+  ForkPostElectra,
+  ForkSeq,
+  GENESIS_EPOCH,
+  MAX_SEED_LOOKAHEAD,
+  SLOTS_PER_EPOCH,
+} from "@lodestar/params";
 import {
   IBeaconStateView,
   RootCache,
@@ -483,8 +490,15 @@ export async function importBlock(
   // Cache shufflings when crossing an epoch boundary
   const parentEpoch = computeEpochAtSlot(parentBlockSlot);
   if (parentEpoch < blockEpoch) {
-    this.shufflingCache.processState(postState);
-    this.logger.verbose("Processed shuffling for next epoch", {parentEpoch, blockEpoch, slot: blockSlot});
+    const previousEpoch = blockEpoch === GENESIS_EPOCH ? GENESIS_EPOCH : blockEpoch - 1;
+    if (
+      !this.shufflingCache.has(previousEpoch, postState.previousDecisionRoot) ||
+      !this.shufflingCache.has(blockEpoch, postState.currentDecisionRoot) ||
+      !this.shufflingCache.has(blockEpoch + 1, postState.nextDecisionRoot)
+    ) {
+      this.shufflingCache.processState(postState);
+      this.logger.verbose("Processed shuffling for next epoch", {parentEpoch, blockEpoch, slot: blockSlot});
+    }
   }
 
   if (blockSlot % SLOTS_PER_EPOCH === 0) {

--- a/packages/beacon-node/src/chain/shufflingCache.ts
+++ b/packages/beacon-node/src/chain/shufflingCache.ts
@@ -1,4 +1,4 @@
-import {ForkSeq} from "@lodestar/params";
+import {ForkSeq, GENESIS_EPOCH} from "@lodestar/params";
 import {
   EpochShuffling,
   IBeaconStateView,
@@ -156,18 +156,34 @@ export class ShufflingCache {
   }
 
   /**
+   * Check if a shuffling is cached by (epoch, decisionRoot).
+   * For native bindings, this avoids having to memoize heavy epoch shufflings within
+   * `NativeBeaconStateView`.
+   */
+  has(epoch: Epoch, decisionRoot: RootHex): boolean {
+    const cacheItem = this.itemsByDecisionRootByEpoch.getOrDefault(epoch).get(decisionRoot);
+    return cacheItem !== undefined && isShufflingCacheItem(cacheItem);
+  }
+
+  /**
    * Process a state to extract and cache all shufflings (previous, current, next).
    * Uses the stored decision roots from epochCtx.
    */
   processState(state: IBeaconStateView): void {
-    // Cache previous shuffling
-    this.set(state.getPreviousShuffling(), state.previousDecisionRoot);
+    const currentEpoch = state.epoch;
+    const previousEpoch = currentEpoch === GENESIS_EPOCH ? GENESIS_EPOCH : currentEpoch - 1;
 
-    // Cache current shuffling
-    this.set(state.getCurrentShuffling(), state.currentDecisionRoot);
+    if (!this.has(previousEpoch, state.previousDecisionRoot)) {
+      this.set(state.getPreviousShuffling(), state.previousDecisionRoot);
+    }
 
-    // Cache next shuffling
-    this.set(state.getNextShuffling(), state.nextDecisionRoot);
+    if (!this.has(currentEpoch, state.currentDecisionRoot)) {
+      this.set(state.getCurrentShuffling(), state.currentDecisionRoot);
+    }
+
+    if (!this.has(currentEpoch + 1, state.nextDecisionRoot)) {
+      this.set(state.getNextShuffling(), state.nextDecisionRoot);
+    }
   }
 
   getIndexedAttestation(

--- a/packages/beacon-node/test/unit/chain/shufflingCache.test.ts
+++ b/packages/beacon-node/test/unit/chain/shufflingCache.test.ts
@@ -24,17 +24,6 @@ describe("ShufflingCache", () => {
     expect(await shufflingCache.get(currentEpoch, currentDecisionRoot)).toEqual(state.epochCtx.currentShuffling);
   });
 
-  it("should report whether a shuffling is already cached", () => {
-    expect(shufflingCache.has(currentEpoch, currentDecisionRoot)).toBe(true);
-
-    const previousEpoch = state.epochCtx.epoch - 1;
-    const previousDecisionRoot = state.epochCtx.previousDecisionRoot;
-    expect(shufflingCache.has(previousEpoch, previousDecisionRoot)).toBe(false);
-
-    shufflingCache.insertPromise(previousEpoch, previousDecisionRoot);
-    expect(shufflingCache.has(previousEpoch, previousDecisionRoot)).toBe(false);
-  });
-
   it("processState should not materialize already cached shufflings", () => {
     const stateView = new BeaconStateView(state);
     shufflingCache = new ShufflingCache(null, null, {maxShufflingCacheEpochs: 4}, [

--- a/packages/beacon-node/test/unit/chain/shufflingCache.test.ts
+++ b/packages/beacon-node/test/unit/chain/shufflingCache.test.ts
@@ -1,4 +1,5 @@
-import {beforeEach, describe, expect, it} from "vitest";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {BeaconStateView} from "@lodestar/state-transition";
 import {generateTestCachedBeaconStateOnlyValidators} from "@lodestar/state-transition/test-utils";
 import {ShufflingCache} from "../../../src/chain/shufflingCache.js";
 
@@ -21,6 +22,45 @@ describe("ShufflingCache", () => {
 
   it("should get shuffling from cache", async () => {
     expect(await shufflingCache.get(currentEpoch, currentDecisionRoot)).toEqual(state.epochCtx.currentShuffling);
+  });
+
+  it("should report whether a shuffling is already cached", () => {
+    expect(shufflingCache.has(currentEpoch, currentDecisionRoot)).toBe(true);
+
+    const previousEpoch = state.epochCtx.epoch - 1;
+    const previousDecisionRoot = state.epochCtx.previousDecisionRoot;
+    expect(shufflingCache.has(previousEpoch, previousDecisionRoot)).toBe(false);
+
+    shufflingCache.insertPromise(previousEpoch, previousDecisionRoot);
+    expect(shufflingCache.has(previousEpoch, previousDecisionRoot)).toBe(false);
+  });
+
+  it("processState should not materialize already cached shufflings", () => {
+    const stateView = new BeaconStateView(state);
+    shufflingCache = new ShufflingCache(null, null, {maxShufflingCacheEpochs: 4}, [
+      {
+        shuffling: state.epochCtx.previousShuffling,
+        decisionRoot: state.epochCtx.previousDecisionRoot,
+      },
+      {
+        shuffling: state.epochCtx.currentShuffling,
+        decisionRoot: state.epochCtx.currentDecisionRoot,
+      },
+      {
+        shuffling: state.epochCtx.nextShuffling,
+        decisionRoot: state.epochCtx.nextDecisionRoot,
+      },
+    ]);
+
+    const previousSpy = vi.spyOn(stateView, "getPreviousShuffling");
+    const currentSpy = vi.spyOn(stateView, "getCurrentShuffling");
+    const nextSpy = vi.spyOn(stateView, "getNextShuffling");
+
+    shufflingCache.processState(stateView);
+
+    expect(previousSpy).not.toHaveBeenCalled();
+    expect(currentSpy).not.toHaveBeenCalled();
+    expect(nextSpy).not.toHaveBeenCalled();
   });
 
   it("should bound by maxSize(=1)", async () => {


### PR DESCRIPTION
This avoids having to memoize expensive shufflings across bindings

See:
chainsafe/lodestar#9516 and chainsafe/lodestar#9569 for usage/motivation

