### PR TITLE
fix: bound network worker termination to prevent shutdown hang

### DIFF
--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -171,13 +171,21 @@ export class WorkerNetworkCore implements INetworkCore {
     this.modules.logger.debug("closing network core running in network worker");
     await this.getApi().close();
     this.modules.logger.debug("terminating network worker");
-    await terminateWorkerThread({
+    const terminated = await terminateWorkerThread({
       worker: this.getApi(),
       retryCount: NETWORK_WORKER_EXIT_RETRY_COUNT,
       retryMs: NETWORK_WORKER_EXIT_TIMEOUT_MS,
       logger: this.modules.logger,
     });
-    this.modules.logger.debug("terminated network worker");
+    if (terminated) {
+      this.modules.logger.debug("terminated network worker");
+    } else {
+      // A forced terminate() can not preempt a worker blocked in a native call, so the worker may
+      // still be running. Unref it so it can not keep the main process alive, otherwise graceful
+      // shutdown would hang until the process is force-killed (see #5775, #6053).
+      (this.modules.worker as unknown as workerThreads.Worker).unref();
+      this.modules.logger.warn("Network worker did not terminate in time, unref-ed it to allow process exit");
+    }
   }
 
   async test(): Promise<void> {

--- a/packages/beacon-node/src/util/workerEvents.ts
+++ b/packages/beacon-node/src/util/workerEvents.ts
@@ -131,8 +131,16 @@ export async function terminateWorkerThread({
   });
 
   for (let i = 0; i < retryCount; i++) {
-    await Thread.terminate(worker);
-    const result = await Promise.race([terminated, sleep(retryMs).then(() => false)]);
+    // `Thread.terminate()` resolves to `Worker.terminate()`, which cannot preempt a worker that is
+    // stuck inside a synchronous native (napi) call (V8 can only tear down the isolate at a JS
+    // safepoint). If that happens the terminate call itself never resolves, so it must be raced
+    // against the timeout too - otherwise the intended `retryCount * retryMs` budget is unreachable
+    // and shutdown hangs indefinitely instead of failing bounded. See #5775 / the network-worker
+    // shutdown hang.
+    const result = await Promise.race([
+      Thread.terminate(worker).then(() => terminated),
+      sleep(retryMs).then(() => false),
+    ]);
 
     if (result) return;
 

--- a/packages/beacon-node/src/util/workerEvents.ts
+++ b/packages/beacon-node/src/util/workerEvents.ts
@@ -111,6 +111,14 @@ export function wireEventsOnMainThread<EventData>(
   }
 }
 
+/**
+ * Terminate a worker thread, bounded to `retryCount * retryMs`.
+ *
+ * @returns `true` if the worker terminated in time. Returns `false` if it could not be terminated
+ * (it may be blocked in a native call that a forced `terminate()` can not preempt); in that case the
+ * worker is still running and the caller must ensure it can not keep the process alive (e.g. by
+ * `unref`-ing it). See #5775, #6053.
+ */
 export async function terminateWorkerThread({
   worker,
   retryMs,
@@ -121,7 +129,7 @@ export async function terminateWorkerThread({
   retryMs: number;
   retryCount: number;
   logger?: Logger;
-}): Promise<void> {
+}): Promise<boolean> {
   const terminated = new Promise((resolve) => {
     Thread.events(worker).subscribe((event) => {
       if (event.type === "termination") {
@@ -142,10 +150,11 @@ export async function terminateWorkerThread({
       sleep(retryMs).then(() => false),
     ]);
 
-    if (result) return;
+    if (result) return true;
 
     logger?.warn("Worker thread failed to terminate, retrying...");
   }
 
-  throw new Error(`Worker thread failed to terminate in ${retryCount * retryMs}ms.`);
+  logger?.error(`Worker thread failed to terminate in ${retryCount * retryMs}ms`);
+  return false;
 }

--- a/packages/beacon-node/test/unit/util/workerEvents.test.ts
+++ b/packages/beacon-node/test/unit/util/workerEvents.test.ts
@@ -1,0 +1,59 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {Thread} from "@chainsafe/threads";
+import {terminateWorkerThread} from "../../../src/util/workerEvents.js";
+
+vi.mock("@chainsafe/threads", () => ({
+  Thread: {
+    terminate: vi.fn(),
+    events: vi.fn(),
+  },
+}));
+
+describe("util / workerEvents / terminateWorkerThread", () => {
+  const retryMs = 20;
+  const retryCount = 3;
+  // A fake Thread handle - the mocked Thread.* statics ignore it.
+  const worker = {} as Thread;
+
+  /** Build a Thread.events observable stub that emits the given events on subscribe. */
+  function mockEvents(events: Array<{type: string}>): void {
+    vi.mocked(Thread.events).mockReturnValue({
+      subscribe: (cb: (event: {type: string}) => void) => {
+        for (const event of events) cb(event);
+        return {unsubscribe: () => {}};
+      },
+    } as unknown as ReturnType<typeof Thread.events>);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves when the worker terminates and emits a termination event", async () => {
+    mockEvents([{type: "termination"}]);
+    vi.mocked(Thread.terminate).mockResolvedValue(undefined as never);
+
+    await expect(terminateWorkerThread({worker, retryMs, retryCount})).resolves.toBeUndefined();
+    expect(Thread.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws bounded instead of hanging when Thread.terminate() never resolves", async () => {
+    // Simulate a worker stuck in a blocking native call: terminate() never resolves and no
+    // termination event is ever emitted. The old implementation awaited terminate() outside the
+    // race and would hang forever; the fix must fall through to the throw within the retry budget.
+    mockEvents([]);
+    vi.mocked(Thread.terminate).mockReturnValue(new Promise<void>(() => {}) as never);
+
+    const start = Date.now();
+    await expect(terminateWorkerThread({worker, retryMs, retryCount})).rejects.toThrow(
+      `Worker thread failed to terminate in ${retryCount * retryMs}ms.`
+    );
+    // Must have retried the terminate call each iteration and stayed bounded (allow generous slack).
+    expect(Thread.terminate).toHaveBeenCalledTimes(retryCount);
+    expect(Date.now() - start).toBeLessThan(retryMs * retryCount * 20);
+  });
+});

--- a/packages/beacon-node/test/unit/util/workerEvents.test.ts
+++ b/packages/beacon-node/test/unit/util/workerEvents.test.ts
@@ -33,25 +33,24 @@ describe("util / workerEvents / terminateWorkerThread", () => {
     vi.useRealTimers();
   });
 
-  it("resolves when the worker terminates and emits a termination event", async () => {
+  it("returns true when the worker terminates and emits a termination event", async () => {
     mockEvents([{type: "termination"}]);
     vi.mocked(Thread.terminate).mockResolvedValue(undefined as never);
 
-    await expect(terminateWorkerThread({worker, retryMs, retryCount})).resolves.toBeUndefined();
+    await expect(terminateWorkerThread({worker, retryMs, retryCount})).resolves.toBe(true);
     expect(Thread.terminate).toHaveBeenCalledTimes(1);
   });
 
-  it("throws bounded instead of hanging when Thread.terminate() never resolves", async () => {
+  it("returns false in bounded time when Thread.terminate() never resolves (does not hang)", async () => {
     // Simulate a worker stuck in a blocking native call: terminate() never resolves and no
     // termination event is ever emitted. The old implementation awaited terminate() outside the
-    // race and would hang forever; the fix must fall through to the throw within the retry budget.
+    // race and would hang forever; the fix falls through within the retry budget and returns false
+    // (rather than throwing, which would abort the rest of graceful shutdown).
     mockEvents([]);
     vi.mocked(Thread.terminate).mockReturnValue(new Promise<void>(() => {}) as never);
 
     const start = Date.now();
-    await expect(terminateWorkerThread({worker, retryMs, retryCount})).rejects.toThrow(
-      `Worker thread failed to terminate in ${retryCount * retryMs}ms.`
-    );
+    await expect(terminateWorkerThread({worker, retryMs, retryCount})).resolves.toBe(false);
     // Must have retried the terminate call each iteration and stayed bounded (allow generous slack).
     expect(Thread.terminate).toHaveBeenCalledTimes(retryCount);
     expect(Date.now() - start).toBeLessThan(retryMs * retryCount * 20);

--- a/packages/beacon-node/test/unit/util/workerEvents.test.ts
+++ b/packages/beacon-node/test/unit/util/workerEvents.test.ts
@@ -27,6 +27,7 @@ describe("util / workerEvents / terminateWorkerThread", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
@@ -49,10 +50,13 @@ describe("util / workerEvents / terminateWorkerThread", () => {
     mockEvents([]);
     vi.mocked(Thread.terminate).mockReturnValue(new Promise<void>(() => {}) as never);
 
-    const start = Date.now();
-    await expect(terminateWorkerThread({worker, retryMs, retryCount})).resolves.toBe(false);
-    // Must have retried the terminate call each iteration and stayed bounded (allow generous slack).
+    const promise = terminateWorkerThread({worker, retryMs, retryCount});
+    // Drive the per-retry `sleep(retryMs)` timeouts deterministically instead of waiting real time,
+    // so the bound is enforced by controlled timer advancement rather than a wall-clock assertion.
+    await vi.advanceTimersByTimeAsync(retryMs * retryCount);
+
+    await expect(promise).resolves.toBe(false);
+    // Must have retried the terminate call each iteration (bounded to retryCount attempts).
     expect(Thread.terminate).toHaveBeenCalledTimes(retryCount);
-    expect(Date.now() - start).toBeLessThan(retryMs * retryCount * 20);
   });
 });


### PR DESCRIPTION
## Motivation

Lodestar can hang on graceful shutdown: `terminating network worker` is logged but `terminated network worker` never is, the node keeps ticking `Synced (slot -N)`, and it only exits when force-killed (~5 min via docker SIGKILL). On ethpandaops devnets (glamsterdam-devnet-6, lodestar-geth nodes) this reproduces on every shutdown. Recurrence of #5775 / #6053, reintroduced by the libp2p v3 + QUIC upgrades.

## Root cause

`terminateWorkerThread` awaited `Thread.terminate(worker)` **outside** the timeout race. `Thread.terminate()` delegates to Node's `worker.terminate()`, which forcibly stops the worker at the next JS safepoint but **cannot preempt a worker blocked inside a synchronous native (napi) call**. The network worker's only native transport is `@chainsafe/libp2p-quic` (Rust/quinn), so when a QUIC native call is in flight at terminate time the promise never resolves — and with the `await` outside the race the `retryCount * retryMs` budget is unreachable → unbounded hang.

A `getActiveResourcesInfo()` / `_getActiveHandles()` probe in the worker at shutdown showed **no** leftover UDP/TCP libuv handle — so it isn't a lingering handle keeping the loop alive, it's `worker.terminate()` being unable to preempt native code. The hang did not reproduce locally on `unstable` (6 SIGTERMs mid-QUIC-download, all terminated in 6–14 ms), so it's timing/condition-specific to the affected build; QUIC is implicated by elimination (`@libp2p/tcp` is pure-JS and can't block a forced terminate; discv5 is a separate worker, already closed earlier).

## Fix

1. **Bound the terminate** — race `Thread.terminate()` *inside* the timeout so a stuck `worker.terminate()` fails within `retryCount * retryMs` (~3 s) instead of hanging.
2. **Return a boolean instead of throwing.** On the throw path `BeaconNode.close()` rejects at `await this.network.close()`, so `chain.persistToDisk()` etc. are skipped and the shutdown handler falls to its `catch` → `db.close()` + `process.exit(1)`. Returning `false` lets `node.close()` run to completion (state persisted, everything closed) → `process.exit(0)`. For a node that hangs on every shutdown, that's the difference between a clean exit-0 and an error exit-1 (skipping the state persist) on every restart.
3. **`unref()` the worker** when it can't be terminated so a still-running (native-blocked) worker can't keep the event loop alive. Harmless given the handler's explicit `process.exit`, but makes `BeaconNode.close()` self-sufficient and is a step toward removing that explicit-exit workaround (#5642).

## Testing

- Unit test (`workerEvents.test.ts`): a worker that never terminates returns `false` in bounded time (~`retryCount * retryMs`) instead of hanging; the normal path returns `true`.
- Verified the `unref` semantics directly (a live worker keeps the process alive; `unref` lets it exit).
- `biome` + `tsgo` clean for the changed files.

## Follow-up (not blocking)

Pinning the exact `@chainsafe/libp2p-quic` / quinn native frame (a worker-thread stack on a box during a live hang) for an upstream report. The bound here fixes the hang regardless of which native call it is.
