### PR TITLE
fix: bound network worker termination to prevent shutdown hang

### DIFF
--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -171,13 +171,21 @@ export class WorkerNetworkCore implements INetworkCore {
     this.modules.logger.debug("closing network core running in network worker");
     await this.getApi().close();
     this.modules.logger.debug("terminating network worker");
-    await terminateWorkerThread({
+    const terminated = await terminateWorkerThread({
       worker: this.getApi(),
       retryCount: NETWORK_WORKER_EXIT_RETRY_COUNT,
       retryMs: NETWORK_WORKER_EXIT_TIMEOUT_MS,
       logger: this.modules.logger,
     });
-    this.modules.logger.debug("terminated network worker");
+    if (terminated) {
+      this.modules.logger.debug("terminated network worker");
+    } else {
+      // A forced terminate() can not preempt a worker blocked in a native call, so the worker may
+      // still be running. Unref it so it can not keep the main process alive, otherwise graceful
+      // shutdown would hang until the process is force-killed (see #5775, #6053).
+      (this.modules.worker as unknown as workerThreads.Worker).unref();
+      this.modules.logger.warn("Network worker did not terminate in time, unref-ed it to allow process exit");
+    }
   }
 
   async test(): Promise<void> {

--- a/packages/beacon-node/src/util/workerEvents.ts
+++ b/packages/beacon-node/src/util/workerEvents.ts
@@ -111,6 +111,14 @@ export function wireEventsOnMainThread<EventData>(
   }
 }
 
+/**
+ * Terminate a worker thread, bounded to `retryCount * retryMs`.
+ *
+ * @returns `true` if the worker terminated in time. Returns `false` if it could not be terminated
+ * (it may be blocked in a native call that a forced `terminate()` can not preempt); in that case the
+ * worker is still running and the caller must ensure it can not keep the process alive (e.g. by
+ * `unref`-ing it). See #5775, #6053.
+ */
 export async function terminateWorkerThread({
   worker,
   retryMs,
@@ -121,7 +129,7 @@ export async function terminateWorkerThread({
   retryMs: number;
   retryCount: number;
   logger?: Logger;
-}): Promise<void> {
+}): Promise<boolean> {
   const terminated = new Promise((resolve) => {
     Thread.events(worker).subscribe((event) => {
       if (event.type === "termination") {
@@ -131,13 +139,21 @@ export async function terminateWorkerThread({
   });
 
   for (let i = 0; i < retryCount; i++) {
-    await Thread.terminate(worker);
-    const result = await Promise.race([terminated, sleep(retryMs).then(() => false)]);
+    // `Thread.terminate` is part of the race (rather than awaited before it) because it delegates to
+    // Node's `worker.terminate()`, which can hang forever when the worker is blocked inside a
+    // synchronous native (napi) call it can not preempt (V8 only tears down at a JS safepoint). If it
+    // is awaited directly, the `retryCount * retryMs` budget is unreachable and shutdown hangs.
+    const result = await Promise.race([
+      terminated,
+      Thread.terminate(worker).then(() => true),
+      sleep(retryMs).then(() => false),
+    ]);
 
-    if (result) return;
+    if (result) return true;
 
     logger?.warn("Worker thread failed to terminate, retrying...");
   }
 
-  throw new Error(`Worker thread failed to terminate in ${retryCount * retryMs}ms.`);
+  logger?.error(`Worker thread failed to terminate in ${retryCount * retryMs}ms`);
+  return false;
 }

--- a/packages/beacon-node/test/unit/util/workerEvents.test.ts
+++ b/packages/beacon-node/test/unit/util/workerEvents.test.ts
@@ -1,0 +1,58 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+const {terminateMock, subscribeMock} = vi.hoisted(() => ({
+  terminateMock: vi.fn(),
+  subscribeMock: vi.fn(),
+}));
+
+vi.mock("@chainsafe/threads", async (importActual) => {
+  const mod = await importActual<typeof import("@chainsafe/threads")>();
+  return {
+    ...mod,
+    Thread: {
+      ...mod.Thread,
+      terminate: (worker: unknown) => terminateMock(worker),
+      events: () => ({subscribe: (cb: (event: {type: string}) => void) => subscribeMock(cb)}),
+    },
+  };
+});
+
+import {terminateWorkerThread} from "../../../src/util/workerEvents.js";
+
+describe("util / workerEvents / terminateWorkerThread", () => {
+  beforeEach(() => {
+    terminateMock.mockReset();
+    subscribeMock.mockReset();
+  });
+
+  it("returns true when the worker terminates", async () => {
+    let emitTermination: (() => void) | undefined;
+    subscribeMock.mockImplementation((cb: (event: {type: string}) => void) => {
+      emitTermination = () => cb({type: "termination"});
+    });
+    terminateMock.mockImplementation(async () => {
+      emitTermination?.();
+    });
+
+    const result = await terminateWorkerThread({worker: {} as never, retryMs: 50, retryCount: 3});
+    expect(result).toBe(true);
+  });
+
+  it("returns false in bounded time when the worker never terminates (does not hang)", async () => {
+    // Simulate a worker blocked in a native call: terminate() never resolves and no termination
+    // event is ever emitted. Before the fix this hung forever on the un-raced terminate().
+    subscribeMock.mockImplementation(() => {});
+    terminateMock.mockImplementation(() => new Promise(() => {}));
+
+    const retryMs = 20;
+    const retryCount = 3;
+    const start = Date.now();
+    const result = await terminateWorkerThread({worker: {} as never, retryMs, retryCount});
+    const elapsed = Date.now() - start;
+
+    expect(result).toBe(false);
+    // Bounded by ~retryCount * retryMs; must not hang indefinitely
+    expect(elapsed).toBeGreaterThanOrEqual(retryMs);
+    expect(elapsed).toBeLessThan(retryMs * retryCount + 2000);
+  });
+});


### PR DESCRIPTION
## Motivation

Lodestar can hang on graceful shutdown: `terminating network worker` is logged but `terminated network worker` never is, the node keeps ticking `Synced (slot -N)`, and it only exits when force-killed. On ethpandaops devnets (glamsterdam-devnet-6, lodestar-geth nodes) this reproduces on **every** shutdown, dangling ~5 min until docker's stop-grace `SIGKILL`. ethpandaops reported it recurring across the last few devnets.

This is a recurrence of the network-worker shutdown hang previously tracked in #5775 and #6053, reintroduced by the libp2p v3 + QUIC upgrades.

## Root cause

`terminateWorkerThread` awaited `Thread.terminate(worker)` **outside** the timeout race:

```ts
for (let i = 0; i < retryCount; i++) {
  await Thread.terminate(worker);                 // can hang forever
  const result = await Promise.race([terminated, sleep(retryMs).then(() => false)]);
  ...
}
```

`Thread.terminate()` delegates to Node's `worker.terminate()`, which forcibly stops the worker at the next JS safepoint but **cannot preempt a worker blocked inside a synchronous native (napi) call**. The network worker's only native transport is `@chainsafe/libp2p-quic` (Rust/quinn), so when a QUIC native call is in flight at terminate time the promise never resolves — and because the `await` is outside the race, the intended `retryCount * retryMs` budget is unreachable and shutdown hangs indefinitely instead of failing bounded.

Two follow-on problems made it worse:
- The function `throw`s on failure, which would abort the rest of `BeaconNode.close()` (the `AbortController` that stops the clock/chain timers, and `db.close()`), since `node.close()` does not catch it.
- Even if `terminate()` is abandoned, a still-running worker is *ref'd* and keeps the **main** event loop alive, so the process can't exit on its own.

## Fix

1. Race `Thread.terminate()` **inside** the timeout so the `retryCount * retryMs` budget is enforced.
2. Return a `boolean` instead of throwing, so a failed termination doesn't abort the rest of graceful shutdown.
3. `unref()` the network worker when it can't be terminated, so a worker stuck in a native call can't keep the process alive — the process exits cleanly once the rest of `close()` runs.

## Testing

- New unit test (`workerEvents.test.ts`): a worker that never terminates now returns `false` in bounded time (~`retryCount * retryMs`) instead of hanging.
- Verified the `unref` mechanism directly: a live, un-terminable worker keeps the process alive without `unref` and lets it exit cleanly with `unref`.
- `biome check` and `tsgo` clean for the changed files.

## Notes

The robustness fix is independent of the exact native call — it bounds shutdown regardless. Pinning the precise `@chainsafe/libp2p-quic`/quinn call (to report upstream) is a separate follow-up; QUIC is the prime suspect by elimination (`@libp2p/tcp` is pure-JS and can't block a forced `terminate()`, and discv5 runs in its own worker that is already closed earlier in the sequence).

🤖 Generated with AI assistance
