### PR TITLE
fix(network): init transports before bootnode force-dial in PeerDiscovery

### DIFF
--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -140,6 +140,16 @@ export class PeerDiscovery {
     this.discv5StartMs = Date.now();
     this.discv5FirstQueryDelayMs = opts.discv5FirstQueryDelayMs;
     this.connectToDiscv5BootnodesOnStart = opts.connectToDiscv5Bootnodes;
+    // Transport tags vary by library: @libp2p/tcp uses '@libp2p/tcp', @chainsafe/libp2p-quic uses 'quic'
+    // Normalize to simple 'tcp' / 'quic' strings for matching
+    this.transports = libp2p.services.components.transportManager
+      .getTransports()
+      .map((t) => t[Symbol.toStringTag])
+      .map((tag) => {
+        if (tag?.includes("tcp")) return "tcp";
+        if (tag?.includes("quic")) return "quic";
+        return tag;
+      });
 
     this.libp2p.addEventListener("peer:discovery", this.onDiscoveredPeer);
     this.discv5.on("discovered", this.onDiscoveredENR);
@@ -183,17 +193,6 @@ export class PeerDiscovery {
         }
       });
     }
-
-    // Transport tags vary by library: @libp2p/tcp uses '@libp2p/tcp', @chainsafe/libp2p-quic uses 'quic'
-    // Normalize to simple 'tcp' / 'quic' strings for matching
-    this.transports = libp2p.services.components.transportManager
-      .getTransports()
-      .map((t) => t[Symbol.toStringTag])
-      .map((tag) => {
-        if (tag?.includes("tcp")) return "tcp";
-        if (tag?.includes("quic")) return "quic";
-        return tag;
-      });
   }
 
   static async init(modules: PeerDiscoveryModules, opts: PeerDiscoveryOpts): Promise<PeerDiscovery> {


### PR DESCRIPTION
**Motivation**

On `glamsterdam-devnet-6`, a node started with `--network.connectToDiscv5Bootnodes` throws at startup for every bootnode ENR:

```
[network] error: Error onDiscovered - Cannot read properties of undefined (reading 'includes')
TypeError: Cannot read properties of undefined (reading 'includes')
    at PeerDiscovery.handleDiscoveredPeer (.../network/peers/discover.js:360:49)   // this.transports.includes("tcp")
    at PeerDiscovery.onDiscoveredENR (.../network/peers/discover.js)
    at new PeerDiscovery (.../network/peers/discover.js)
    at PeerDiscovery.init (...)
```

**Description**

The `PeerDiscovery` constructor registers the discovery handlers and runs the `connectToDiscv5Bootnodes` force-dial loop **before** `this.transports` is assigned (it was assigned at the very end of the constructor).

When `network.connectToDiscv5Bootnodes` is enabled, each bootnode ENR is handled synchronously inside the constructor:

```
new PeerDiscovery
  -> for (const bootENR of opts.discv5.bootEnrs) this.onDiscoveredENR(...)
       -> handleDiscoveredPeer(...)
            -> this.transports.includes("tcp")   // this.transports === undefined  -> throws
```

Consequence: the bootnodes explicitly provided via `--network.connectToDiscv5Bootnodes` are **never force-dialed** at startup (the error is swallowed by `handleDiscoveredPeer`'s try/catch, returning `DiscoveredPeerStatus.error`).

The fix moves the `this.transports` initialization up so it is assigned right after the basic field setup — before the discovery handler registration and the bootENR loop — guaranteeing it is defined before any discovered peer can be handled. Pure statement reorder, no behavior change beyond fixing the init ordering.

**Steps to test**

Start a node with `--network.connectToDiscv5Bootnodes` and at least one boot ENR; before this change the `Error onDiscovered ... reading 'includes'` is logged once per boot ENR at startup, after it the bootnodes are dialed cleanly.

A focused unit regression test would require standing up mocks for the full `libp2p` (incl. `services.components.transportManager`), `Discv5Worker`, `peerRpcScores`, `clock`, and `config` constructor dependencies, which `discover.test.ts` does not currently have. Happy to add one if preferred.

---
🤖 Generated with AI assistance