### PR TITLE
chore: rename era shortHistoricalRoot to shortEraRoot

### DIFF
--- a/packages/era/src/era/reader.ts
+++ b/packages/era/src/era/reader.ts
@@ -26,34 +26,28 @@ export class EraReader {
   readonly fh: FileHandle;
   /** The era number retrieved from the file name */
   readonly eraNumber: number;
-  /** The short historical root retrieved from the file name */
-  readonly shortHistoricalRoot: string;
+  /** The short era root retrieved from the file name */
+  readonly shortEraRoot: string;
   /** An array of state and block indices, one per group */
   readonly groups: EraIndices[];
 
-  constructor(
-    config: ChainForkConfig,
-    fh: FileHandle,
-    eraNumber: number,
-    shortHistoricalRoot: string,
-    indices: EraIndices[]
-  ) {
+  constructor(config: ChainForkConfig, fh: FileHandle, eraNumber: number, shortEraRoot: string, indices: EraIndices[]) {
     this.config = config;
     this.fh = fh;
     this.eraNumber = eraNumber;
-    this.shortHistoricalRoot = shortHistoricalRoot;
+    this.shortEraRoot = shortEraRoot;
     this.groups = indices;
   }
 
   static async open(config: ChainForkConfig, path: string): Promise<EraReader> {
     const fh = await open(path, "r");
     const name = basename(path);
-    const {configName, eraNumber, shortHistoricalRoot} = parseEraName(name);
+    const {configName, eraNumber, shortEraRoot} = parseEraName(name);
     if (config.CONFIG_NAME !== configName) {
       throw new Error(`Config name mismatch: expected ${config.CONFIG_NAME}, got ${configName}`);
     }
     const indices = await readAllEraIndices(fh);
-    return new EraReader(config, fh, eraNumber, shortHistoricalRoot, indices);
+    return new EraReader(config, fh, eraNumber, shortEraRoot, indices);
   }
 
   /**

--- a/packages/era/src/era/util.ts
+++ b/packages/era/src/era/util.ts
@@ -7,7 +7,7 @@ import {readUint48} from "../util.js";
 
 /**
  * Parsed components of an .era file name.
- * Format: <config-name>-<era-number>-<short-historical-root>.era
+ * Format: <config-name>-<era-number>-<short-era-root>.era
  */
 export interface EraFileName {
   /** CONFIG_NAME field of runtime config (mainnet, sepolia, hoodi, etc.) */
@@ -15,7 +15,7 @@ export interface EraFileName {
   /** Number of the first era stored in file, 5-digit zero-padded (00000, 00001, etc.) */
   eraNumber: number;
   /** First 4 bytes of last historical root, lower-case hex-encoded (8 chars) */
-  shortHistoricalRoot: string;
+  shortEraRoot: string;
 }
 
 export interface EraIndices {
@@ -46,9 +46,9 @@ export function computeStartBlockSlotFromEraNumber(eraNumber: number): Slot {
 /**
  * Parse era filename.
  *
- * Format: `<config-name>-<era-number>-<short-historical-root>.era`
+ * Format: `<config-name>-<era-number>-<short-era-root>.era`
  */
-export function parseEraName(filename: string): {configName: string; eraNumber: number; shortHistoricalRoot: string} {
+export function parseEraName(filename: string): {configName: string; eraNumber: number; shortEraRoot: string} {
   const match = filename.match(/^(.*)-(\d{5})-([0-9a-f]{8})\.era$/);
   if (!match) {
     throw new Error(`Invalid era filename format: ${filename}`);
@@ -56,7 +56,7 @@ export function parseEraName(filename: string): {configName: string; eraNumber: 
   return {
     configName: match[1],
     eraNumber: parseInt(match[2], 10),
-    shortHistoricalRoot: match[3],
+    shortEraRoot: match[3],
   };
 }
 
@@ -118,7 +118,7 @@ export function readSlotFromBeaconStateBytes(beaconStateBytes: Uint8Array): Slot
   );
 }
 
-export function getShortHistoricalRoot(config: ChainForkConfig, state: BeaconState): string {
+export function getShortEraRoot(config: ChainForkConfig, state: BeaconState): string {
   return Buffer.from(
     state.slot === 0
       ? state.genesisValidatorsRoot

--- a/packages/era/src/era/util.ts
+++ b/packages/era/src/era/util.ts
@@ -14,7 +14,7 @@ export interface EraFileName {
   configName: string;
   /** Number of the first era stored in file, 5-digit zero-padded (00000, 00001, etc.) */
   eraNumber: number;
-  /** First 4 bytes of last historical root, lower-case hex-encoded (8 chars) */
+  /** First 4 bytes of last era root, lower-case hex-encoded (8 chars) */
   shortEraRoot: string;
 }
 

--- a/packages/era/src/era/writer.ts
+++ b/packages/era/src/era/writer.ts
@@ -5,12 +5,7 @@ import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {BeaconState, SignedBeaconBlock, Slot} from "@lodestar/types";
 import {E2STORE_HEADER_SIZE, EntryType, SlotIndex, serializeSlotIndex, writeEntry} from "../e2s.js";
 import {snappyCompress} from "../util.js";
-import {
-  computeStartBlockSlotFromEraNumber,
-  getShortHistoricalRoot,
-  isSlotInRange,
-  isValidEraStateSlot,
-} from "./util.js";
+import {computeStartBlockSlotFromEraNumber, getShortEraRoot, isSlotInRange, isValidEraStateSlot} from "./util.js";
 
 enum WriterStateType {
   InitGroup,
@@ -35,7 +30,7 @@ type WriterState =
       type: WriterStateType.FinishedGroup;
       eraNumber: number;
       currentOffset: number;
-      shortHistoricalRoot: string;
+      shortEraRoot: string;
     };
 
 /**
@@ -76,7 +71,7 @@ export class EraWriter {
     const pathParts = parse(this.path);
     const newPath = format({
       ...pathParts,
-      base: `${this.config.CONFIG_NAME}-${String(this.eraNumber).padStart(5, "0")}-${this.state.shortHistoricalRoot}.era`,
+      base: `${this.config.CONFIG_NAME}-${String(this.eraNumber).padStart(5, "0")}-${this.state.shortEraRoot}.era`,
     });
     await rename(this.path, newPath);
 
@@ -105,7 +100,7 @@ export class EraWriter {
     };
   }
 
-  async writeCompressedState(slot: Slot, shortHistoricalRoot: string, data: Uint8Array): Promise<void> {
+  async writeCompressedState(slot: Slot, shortEraRoot: string, data: Uint8Array): Promise<void> {
     if (this.state.type === WriterStateType.InitGroup) {
       await this.writeVersion();
     }
@@ -148,21 +143,21 @@ export class EraWriter {
       type: WriterStateType.FinishedGroup,
       eraNumber: this.state.eraNumber,
       currentOffset: this.state.currentOffset,
-      shortHistoricalRoot,
+      shortEraRoot,
     };
   }
 
-  async writeSerializedState(slot: Slot, shortHistoricalRoot: string, data: Uint8Array): Promise<void> {
+  async writeSerializedState(slot: Slot, shortEraRoot: string, data: Uint8Array): Promise<void> {
     const compressed = await snappyCompress(data);
-    await this.writeCompressedState(slot, shortHistoricalRoot, compressed);
+    await this.writeCompressedState(slot, shortEraRoot, compressed);
   }
 
   async writeState(state: BeaconState): Promise<void> {
     const slot = state.slot;
-    const shortHistoricalRoot = getShortHistoricalRoot(this.config, state);
+    const shortEraRoot = getShortEraRoot(this.config, state);
     const ssz = this.config.getForkTypes(slot).BeaconState.serialize(state);
 
-    await this.writeSerializedState(slot, shortHistoricalRoot, ssz);
+    await this.writeSerializedState(slot, shortEraRoot, ssz);
   }
 
   async writeCompressedBlock(slot: Slot, data: Uint8Array): Promise<void> {


### PR DESCRIPTION
**Motivation**

There has been some recent updates to the era spec in e2store-format-specs , This PR make sure the lodestar era implementation adheres to the recent changes.  Pls see https://github.com/eth-clients/e2store-format-specs/commit/247cb548e4210b4befd9f3a93c7632236f249b86 for more details.


**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

<!-- Insert any AI assistance disclosure here -->
I have not used any AI for the commit , as the commit is fairly straight forward
