### PR TITLE
feat: return 204 when producing payload attestation if there is no block

### DIFF
--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -483,7 +483,7 @@ export type Endpoints = {
       slot: Slot;
     },
     {params: {slot: Slot}},
-    gloas.PayloadAttestationData,
+    gloas.PayloadAttestationData | undefined,
     VersionMeta
   >;
 
@@ -982,7 +982,10 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         },
       },
       resp: {
-        data: ssz.gloas.PayloadAttestationData,
+        // `undefined` when there is no canonical block at the slot
+        data: WithVersion<gloas.PayloadAttestationData | undefined, VersionMeta>(
+          () => ssz.gloas.PayloadAttestationData
+        ),
         meta: VersionCodec,
       },
     },

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -274,6 +274,12 @@ export type LivenessResponseData = ValueOf<typeof LivenessResponseDataType>;
 export type LivenessResponseDataList = ValueOf<typeof LivenessResponseDataListType>;
 export type SignedValidatorRegistrationV1List = ValueOf<typeof SignedValidatorRegistrationV1ListType>;
 
+// The beacon node does not return any data if there is no canonical block at the requested slot (missed slot).
+// In this case, we receive a success response (204) which is not handled as an error. The generic response
+// handler already checks the status code and will not attempt to parse the body, but it will return no value.
+// It is important that this type indicates that there might be no value to ensure it is properly handled downstream.
+export type MaybePayloadAttestationData = gloas.PayloadAttestationData | undefined;
+
 export type Endpoints = {
   /**
    * Get attester duties
@@ -483,7 +489,7 @@ export type Endpoints = {
       slot: Slot;
     },
     {params: {slot: Slot}},
-    gloas.PayloadAttestationData | undefined,
+    MaybePayloadAttestationData,
     VersionMeta
   >;
 
@@ -982,10 +988,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         },
       },
       resp: {
-        // `undefined` when there is no canonical block at the slot
-        data: WithVersion<gloas.PayloadAttestationData | undefined, VersionMeta>(
-          () => ssz.gloas.PayloadAttestationData
-        ),
+        data: WithVersion<MaybePayloadAttestationData, VersionMeta>(() => ssz.gloas.PayloadAttestationData),
         meta: VersionCodec,
       },
     },

--- a/packages/api/src/utils/server/handler.ts
+++ b/packages/api/src/utils/server/handler.ts
@@ -111,6 +111,11 @@ export function createFastifyHandler<E extends Endpoint>(
       resp.statusCode = response.status;
     }
 
+    // A 204 No Content response has no body
+    if (resp.statusCode === 204) {
+      return;
+    }
+
     switch (responseWireFormat) {
       case WireFormat.json: {
         const metaHeaders = definition.resp.meta.toHeadersObject(response?.meta);

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1112,8 +1112,8 @@ export function getValidatorApi(
 
       const block = chain.forkChoice.getCanonicalBlockAtSlot(slot);
       if (!block) {
-        // No block is seen at slot. Return 404 so vc can skip casting payload attestation.
-        throw new ApiError(404, `No canonical block found at slot=${slot}`);
+        // No canonical block is seen at slot. Return 204 so vc can skip casting payload attestation.
+        return {data: undefined, meta: {version: fork}, status: 204};
       }
 
       const payloadInput = chain.seenPayloadEnvelopeInputCache.get(block.blockRoot);

--- a/packages/beacon-node/test/unit/api/impl/validator/produceAttestationData.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceAttestationData.test.ts
@@ -77,7 +77,7 @@ describe("api - validator - produceAttestationData", () => {
       } as PayloadEnvelopeInput);
 
       const res = await api.producePayloadAttestationData({slot: 0});
-      if (res.data instanceof Uint8Array) {
+      if (res.data === undefined || res.data instanceof Uint8Array) {
         throw Error("Expected payload attestation data object");
       }
 
@@ -87,7 +87,7 @@ describe("api - validator - produceAttestationData", () => {
       expect(res.data.blobDataAvailable).toBe(true);
     });
 
-    it("Should throw 404 when no canonical block has been seen for the assigned slot", async () => {
+    it("Should return no data when no canonical block has been seen for the assigned slot", async () => {
       const gloasConfig = createChainForkConfig({
         ...defaultChainConfig,
         ALTAIR_FORK_EPOCH: 0,
@@ -104,7 +104,8 @@ describe("api - validator - produceAttestationData", () => {
 
       modules.forkChoice.getCanonicalBlockAtSlot.mockReturnValue(null);
 
-      await expect(api.producePayloadAttestationData({slot: 1})).rejects.toThrow("No canonical block found at slot=1");
+      const res = await api.producePayloadAttestationData({slot: 1});
+      expect(res.data).toBeUndefined();
     });
   });
 });

--- a/packages/validator/src/services/ptc.ts
+++ b/packages/validator/src/services/ptc.ts
@@ -1,4 +1,4 @@
-import {ApiClient, HttpStatusCode, routes} from "@lodestar/api";
+import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {isForkPostGloas} from "@lodestar/params";
 import {Slot, gloas} from "@lodestar/types";
@@ -69,9 +69,10 @@ export class PtcService {
     );
 
     try {
-      const payloadAttestationData = await this.producePayloadAttestationData(slot);
+      // No canonical block at slot resolves to `undefined`
+      const payloadAttestationData = (await this.api.validator.producePayloadAttestationData({slot})).value();
       // If no beacon block was seen for the assigned slot, do not submit a payload attestation
-      if (payloadAttestationData === null) {
+      if (!payloadAttestationData) {
         this.logger.debug("Skipping payload attestation, no beacon block seen for slot", {slot});
         return;
       }
@@ -80,14 +81,6 @@ export class PtcService {
       this.logger.error("Error on PTC routine", {slot}, e as Error);
     }
   };
-
-  private async producePayloadAttestationData(slot: Slot): Promise<gloas.PayloadAttestationData | null> {
-    const res = await this.api.validator.producePayloadAttestationData({slot});
-    if (!res.ok && res.status === HttpStatusCode.NOT_FOUND) {
-      return null;
-    }
-    return res.value();
-  }
 
   private async signAndPublishPayloadAttestations(
     slot: Slot,

--- a/packages/validator/test/unit/services/ptc.test.ts
+++ b/packages/validator/test/unit/services/ptc.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {SecretKey} from "@chainsafe/blst";
 import {toHexString} from "@chainsafe/ssz";
-import {HttpStatusCode, routes} from "@lodestar/api";
+import {routes} from "@lodestar/api";
 import {createChainForkConfig} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
 import {gloas, ssz} from "@lodestar/types";
@@ -11,7 +11,7 @@ import {PtcService} from "../../../src/services/ptc.js";
 import {PtcDutiesService} from "../../../src/services/ptcDuties.js";
 import {SyncingStatusTracker} from "../../../src/services/syncingStatusTracker.js";
 import {ValidatorStore} from "../../../src/services/validatorStore.js";
-import {getApiClientStub, mockApiErrorResponse, mockApiResponse} from "../../utils/apiStub.js";
+import {getApiClientStub, mockApiResponse} from "../../utils/apiStub.js";
 import {ClockMock} from "../../utils/clock.js";
 import {loggerVc} from "../../utils/logger.js";
 import {ZERO_HASH, ZERO_HASH_HEX} from "../../utils/types.js";
@@ -135,7 +135,10 @@ describe("PtcService", () => {
     };
 
     vi.spyOn(ptcService["dutiesService"], "getDutiesAtSlot").mockReturnValue([duty]);
-    api.validator.producePayloadAttestationData.mockResolvedValue(mockApiErrorResponse(HttpStatusCode.NOT_FOUND));
+    // No canonical block at slot
+    api.validator.producePayloadAttestationData.mockResolvedValue(
+      mockApiResponse({data: undefined, meta: {version: config.getForkName(slot)}})
+    );
 
     await clock.tickSlotFns(slot, controller.signal);
 


### PR DESCRIPTION
As per https://github.com/ethereum/beacon-APIs/pull/612#discussion_r3486524957
> I am beginning to feel more strongly about using 204 here, on glamsterdam-devnet-6, there are a lot of missed blocks right now and lodestar is emitting this as warnings (our standard request handler), I don't wanna special case this api, and this is quite a frequent error/warning being emitted. Today, this was flagged incorrectly by AI as a potential CL issue to me but it's perfectly normal behavior, so let's use a status code that indicates that, 404 does not.

the spec has not settled yet but to avoid noise in the logs we should use 204 for now. Can always revert back to 404 if that's what we decide to go with on the spec side.