### PR TITLE
fix: refresh next-epoch proposer duties before the gloas fork

### DIFF
--- a/packages/validator/src/services/blockDuties.ts
+++ b/packages/validator/src/services/blockDuties.ts
@@ -161,7 +161,9 @@ export class BlockDutiesService {
   /**
    * Slot-tick handler. Notifies block production for cached proposers in this slot, and on
    * the last slot of a pre-Gloas epoch schedules the boundary fetch for `nextEpoch` duties.
-   * Reorg detection is handled by `onNewHead`, so this task does not re-poll on every slot.
+   * Reorg detection is otherwise handled by `onNewHead`; the exception is the final pre-Gloas
+   * epoch, where `onNewHead` can't refresh the next-epoch dep_root (not exposed by the v1 head
+   * event), so we re-poll the next epoch each slot to keep pre-fork proposer preferences fresh.
    */
   private runEverySlotTask = async (slot: Slot, signal: AbortSignal): Promise<void> => {
     try {
@@ -172,13 +174,25 @@ export class BlockDutiesService {
       this.notifyProposersForSlot(slot);
 
       const nextEpoch = computeEpochAtSlot(slot) + 1;
-      const isLastSlotOfEpoch = computeStartSlotAtEpoch(nextEpoch) === slot + 1;
+      const nextEpochStartSlot = computeStartSlotAtEpoch(nextEpoch);
+      const isLastSlotOfEpoch = nextEpochStartSlot === slot + 1;
       if (isLastSlotOfEpoch && !isForkPostGloas(this.config.getForkName(slot + 1))) {
         // Pre-Gloas the VC uses v1 and does not pre-fetch the next epoch on the epoch tick, so
         // fetch it ~1s before the boundary instead. Pre-Fulu this is required (0-epoch lookahead);
         // for Fulu the lookahead exists but the v2 path is deferred to Gloas (see top of file).
         this.pollBeaconProposersBeforeBoundary(slot, nextEpoch, signal).catch((e) => {
           this.logger.error("Error on pollBeaconProposersBeforeBoundary", {nextEpoch}, e);
+        });
+      } else if (
+        !isForkPostGloas(this.config.getForkName(slot)) &&
+        isForkPostGloas(this.config.getForkName(nextEpochStartSlot))
+      ) {
+        // Final pre-Gloas epoch: `onNewHead` can't reorg-refresh the next (Gloas) epoch's duties
+        // here since the v1 head event doesn't carry their dep_root, yet validators submit proposer
+        // preferences for the first Gloas slots before the fork. Re-poll each slot so a dep_root
+        // shift is picked up and those preferences resubmit under the current root.
+        this.pollBeaconProposers(nextEpoch).catch((e) => {
+          this.logger.error("Error polling next-epoch proposers before Gloas fork", {nextEpoch}, e);
         });
       }
     } catch (e) {

--- a/packages/validator/test/unit/services/blockDuties.test.ts
+++ b/packages/validator/test/unit/services/blockDuties.test.ts
@@ -317,6 +317,54 @@ describe("BlockDutiesService", () => {
     expect(api.validator.getProposerDuties).toHaveBeenCalledTimes(1);
   });
 
+  it("Final pre-Gloas epoch re-polls next-epoch duties each slot", async () => {
+    // Gloas activates at epoch 1, so epoch 0 is the final pre-Gloas epoch and epoch 1 is Gloas.
+    const forkBoundaryConfig = getConfig(ForkName.gloas, 1);
+    const epoch1Duties: routes.validator.ProposerDutyList = [{slot: 32, validatorIndex: 0, pubkey: pubkeys[0]}];
+    const depRootEpoch1 = ZERO_HASH_HEX;
+    const depRootEpoch1Reorg = toHex(Buffer.alloc(32, 7));
+
+    let epoch1DepRoot = depRootEpoch1;
+    api.validator.getProposerDuties.mockResolvedValue(
+      mockApiResponse({data: [], meta: {dependentRoot: ZERO_HASH_HEX, executionOptimistic: false}})
+    );
+    // Epoch 1 is Gloas so it is fetched via v2.
+    api.validator.getProposerDutiesV2.mockImplementation(async ({epoch}) =>
+      mockApiResponse({
+        data: epoch === 1 ? epoch1Duties : [],
+        meta: {dependentRoot: epoch === 1 ? epoch1DepRoot : ZERO_HASH_HEX, executionOptimistic: false},
+      })
+    );
+
+    const clock = new ClockMock();
+    const dutiesService = new BlockDutiesService(
+      forkBoundaryConfig,
+      loggerVc,
+      api,
+      clock,
+      validatorStore,
+      chainHeaderTracker,
+      null
+    );
+
+    // Epoch tick pre-fetches the upcoming Gloas epoch once.
+    await clock.tickEpochFns(0, controller.signal);
+    expect(api.validator.getProposerDutiesV2).toHaveBeenCalledTimes(1);
+    expect(api.validator.getProposerDutiesV2.mock.calls[0][0]).toEqual({epoch: 1});
+
+    // Simulate the next-epoch proposer dep_root shifting (e.g. a reorg) mid-epoch. `onNewHead`
+    // can't detect it pre-Gloas since the v1 head event doesn't carry the next-epoch dep_root.
+    epoch1DepRoot = depRootEpoch1Reorg;
+
+    // Mid-epoch slot tick re-polls the Gloas epoch and picks up the shifted dep_root.
+    await clock.tickSlotFns(15, controller.signal);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(api.validator.getProposerDutiesV2).toHaveBeenCalledTimes(2);
+    expect(api.validator.getProposerDutiesV2.mock.calls[1][0]).toEqual({epoch: 1});
+    expect(dutiesService["proposers"].get(1)?.dependentRoot).toEqual(depRootEpoch1Reorg);
+  });
+
   it("Post-Gloas last slot of epoch does NOT schedule a boundary fetch", async () => {
     api.validator.getProposerDutiesV2.mockResolvedValue(
       mockApiResponse({data: [], meta: {dependentRoot: ZERO_HASH_HEX, executionOptimistic: false}})


### PR DESCRIPTION
### Motivation

Follow-up to #9571. In the final pre-Gloas epoch the validator submits proposer preferences for the first Gloas slots, which reads the next epoch's proposer duties from `BlockDutiesService`. Pre-Gloas, `onNewHead` cannot reorg-refresh those duties since the v1 head event does not expose the next-epoch proposer dep_root, and the boundary poll only fetches the next epoch when it is still pre-Gloas. A reorg in the last `SUBMIT_BEFORE_PROPOSAL_SLOTS` that shifts the Gloas epoch's dep_root therefore leaves the cached duties stale, the resubmit-on-shift check never fires, and the preferences go out under a stale dep_root which the beacon node ignores.

### Description

Re-poll the next epoch each slot during the final pre-Gloas epoch so a dep_root shift is picked up and the pre-fork preferences resubmit under the current root.
