### PR TITLE
fix: remove parent_block_number from payload_attributes event post-gloas

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -840,7 +840,7 @@ export function getPayloadAttributesForSSE(
   } as SSEPayloadAttributes;
 
   if (!isForkPostGloas(fork)) {
-    // Removed in Gloas, builders can get the block number from the EL via the block hash
+    // Removed in Gloas, builders can get the block number from the EL via the block hash if required
     (ssePayloadAttributes as bellatrix.SSEPayloadAttributes).parentBlockNumber = prepareState.payloadBlockNumber;
   }
 

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -840,7 +840,7 @@ export function getPayloadAttributesForSSE(
   } as SSEPayloadAttributes;
 
   if (!isForkPostGloas(fork)) {
-    // Removed in Gloas, ELs can get the parent block number from the parent block hash
+    // Removed in Gloas, builders can get the parent block number from the EL via the parent block hash
     (ssePayloadAttributes as bellatrix.SSEPayloadAttributes).parentBlockNumber = prepareState.payloadBlockNumber;
   }
 

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -840,7 +840,7 @@ export function getPayloadAttributesForSSE(
   } as SSEPayloadAttributes;
 
   if (!isForkPostGloas(fork)) {
-    // Removed in Gloas, builders can get the parent block number from the EL via the parent block hash
+    // Removed in Gloas, builders can get the block number from the EL via the block hash
     (ssePayloadAttributes as bellatrix.SSEPayloadAttributes).parentBlockNumber = prepareState.payloadBlockNumber;
   }
 

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -43,6 +43,7 @@ import {
   ValidatorIndex,
   Wei,
   altair,
+  bellatrix,
   capella,
   deneb,
   electra,
@@ -830,28 +831,19 @@ export function getPayloadAttributesForSSE(
     feeRecipient,
   });
 
-  let parentBlockNumber: number;
-  if (isForkPostGloas(fork)) {
-    const parentBlock = chain.forkChoice.getBlockHexAndBlockHash(
-      toRootHex(parentBlockRoot),
-      toRootHex(parentBlockHash)
-    );
-    if (parentBlock?.executionPayloadBlockHash == null) {
-      throw Error(`Parent block not found in fork choice root=${toRootHex(parentBlockRoot)}`);
-    }
-    parentBlockNumber = parentBlock.executionPayloadNumber;
-  } else {
-    parentBlockNumber = prepareState.payloadBlockNumber;
-  }
-
-  const ssePayloadAttributes: SSEPayloadAttributes = {
+  const ssePayloadAttributes = {
     proposerIndex: prepareState.getBeaconProposer(prepareSlot),
     proposalSlot: prepareSlot,
-    parentBlockNumber,
     parentBlockRoot,
     parentBlockHash,
     payloadAttributes,
-  };
+  } as SSEPayloadAttributes;
+
+  if (!isForkPostGloas(fork)) {
+    // Removed in GLOAS, ELs can get the parent block number from the parent block hash
+    (ssePayloadAttributes as bellatrix.SSEPayloadAttributes).parentBlockNumber = prepareState.payloadBlockNumber;
+  }
+
   return ssePayloadAttributes;
 }
 

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -840,7 +840,7 @@ export function getPayloadAttributesForSSE(
   } as SSEPayloadAttributes;
 
   if (!isForkPostGloas(fork)) {
-    // Removed in GLOAS, ELs can get the parent block number from the parent block hash
+    // Removed in Gloas, ELs can get the parent block number from the parent block hash
     (ssePayloadAttributes as bellatrix.SSEPayloadAttributes).parentBlockNumber = prepareState.payloadBlockNumber;
   }
 

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -372,7 +372,7 @@ export const SSEPayloadAttributes = new ContainerType(
   {
     proposerIndex: UintNum64,
     proposalSlot: Slot,
-    // parentBlockNumber: UintNum64, // Removed in GLOAS
+    // parentBlockNumber: UintNum64, // Removed in GLOAS:EIP7732
     parentBlockRoot: Root,
     parentBlockHash: Root,
     payloadAttributes: PayloadAttributes,

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -22,7 +22,6 @@ import {
   SLOTS_PER_HISTORICAL_ROOT,
 } from "@lodestar/params";
 import {ssz as altairSsz} from "../altair/index.js";
-import {ssz as bellatrixSsz} from "../bellatrix/index.js";
 import {ssz as capellaSsz} from "../capella/index.js";
 import {ssz as denebSsz} from "../deneb/index.js";
 import {ssz as electraSsz} from "../electra/index.js";
@@ -371,7 +370,11 @@ export const PayloadAttributes = new ContainerType(
 
 export const SSEPayloadAttributes = new ContainerType(
   {
-    ...bellatrixSsz.SSEPayloadAttributesCommon.fields,
+    proposerIndex: UintNum64,
+    proposalSlot: Slot,
+    // parentBlockNumber: UintNum64, // Removed in GLOAS
+    parentBlockRoot: Root,
+    parentBlockHash: Root,
     payloadAttributes: PayloadAttributes,
   },
   {typeName: "SSEPayloadAttributes", jsonCase: "eth2"}


### PR DESCRIPTION
**Motivation**

Implements the spec change from https://github.com/ethereum/beacon-APIs/pull/621. Gloas blocks no longer have block number info and there are edge cases where serving the parent block number becomes unnecessarily complex. ELs can get the parent block number from the parent block hash.

**Description**

- remove `parentBlockNumber` from the gloas `SSEPayloadAttributes` type
- only set `parent_block_number` on the `payload_attributes` event pre-gloas, the event is unchanged for those forks
- removes the fork choice lookup on the gloas path which could throw if the parent block was not found

The `payload_attributes` example in the oapi spec test data is kept pre-gloas until we bump the pinned spec version to a release that includes the updated example.