### PR TITLE
feat: append CL/EL client info to graffiti

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -171,7 +171,6 @@ fsSL
 getNetworkIdentity
 gnosis
 gpg
-graffitiAppend
 heapdump
 heaptrack
 holesky

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -171,6 +171,7 @@ fsSL
 getNetworkIdentity
 gnosis
 gpg
+graffitiAppend
 heapdump
 heaptrack
 holesky

--- a/docs/pages/run/validator-management/proposer-config.md
+++ b/docs/pages/run/validator-management/proposer-config.md
@@ -6,6 +6,8 @@ This is an alpha feature. The feature and its format are subject to change.
 
 With Lodestar's validator client, you can assign specific metadata for each proposer/public key using a proposer configuration file written in YAML file. This will allow you to set specific graffiti, fee recipients and builder settings per validator key.
 
+When graffiti is supplied by the validator client, the connected Lodestar beacon node appends CL/EL client information to the graffiti by default when there is enough space left. Run the beacon node with [`--graffitiAppend false`](../beacon-management/beacon-cli.md#--graffitiappend) to disable this misbehavior. (@matthewkeil fix this)
+
 ### Example proposer_config.yaml
 
 ```yaml

--- a/docs/pages/run/validator-management/proposer-config.md
+++ b/docs/pages/run/validator-management/proposer-config.md
@@ -6,7 +6,7 @@ This is an alpha feature. The feature and its format are subject to change.
 
 With Lodestar's validator client, you can assign specific metadata for each proposer/public key using a proposer configuration file written in YAML file. This will allow you to set specific graffiti, fee recipients and builder settings per validator key.
 
-When graffiti is supplied by the validator client, the connected Lodestar beacon node appends CL/EL client information to the graffiti by default when there is enough space left. Run the beacon node with [`--graffitiAppend false`](../beacon-management/beacon-cli.md#--graffitiappend) to disable this misbehavior. (@matthewkeil fix this)
+When graffiti is supplied by the validator client, the connected Lodestar beacon node appends CL/EL client information to the graffiti by default if there is enough space left. If you do not want to have the beacon node announce the client its running use the [`--graffitiAppend false`](../beacon-management/beacon-cli.md#--graffitiappend) flag to disable this behavior.
 
 ### Example proposer_config.yaml
 

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -612,7 +612,7 @@ export function getValidatorApi(
 
     const graffitiBytes = toGraffitiBytes(
       getBlockGraffiti(graffiti, getLodestarClientVersion(opts), chain.executionEngine.clientVersion, {
-        ...opts,
+        private: opts.private,
         graffitiAppend: chain.opts.graffitiAppend,
       })
     );
@@ -925,7 +925,7 @@ export function getValidatorApi(
 
       const graffitiBytes = toGraffitiBytes(
         getBlockGraffiti(graffiti, getLodestarClientVersion(opts), chain.executionEngine.clientVersion, {
-          ...opts,
+          private: opts.private,
           graffitiAppend: chain.opts.graffitiAppend,
         })
       );

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -82,7 +82,7 @@ import {CommitteeSubscription} from "../../../network/subnets/index.js";
 import {SyncState} from "../../../sync/index.js";
 import {callInNextEventLoop} from "../../../util/eventLoop.js";
 import {isOptimisticBlock} from "../../../util/forkChoice.js";
-import {getDefaultGraffiti, toGraffitiBytes} from "../../../util/graffiti.js";
+import {getBlockGraffiti, toGraffitiBytes} from "../../../util/graffiti.js";
 import {getLodestarClientVersion} from "../../../util/metadata.js";
 import {ApiOptions} from "../../options.js";
 import {getStateResponseWithRegen} from "../beacon/state/utils.js";
@@ -611,7 +611,10 @@ export function getValidatorApi(
     }
 
     const graffitiBytes = toGraffitiBytes(
-      graffiti ?? getDefaultGraffiti(getLodestarClientVersion(opts), chain.executionEngine.clientVersion, opts)
+      getBlockGraffiti(graffiti, getLodestarClientVersion(opts), chain.executionEngine.clientVersion, {
+        ...opts,
+        graffitiAppend: chain.opts.graffitiAppend,
+      })
     );
 
     const loggerContext = {
@@ -921,7 +924,10 @@ export function getValidatorApi(
       metrics?.blockProductionSlotDelta.set(slot - parentSlot);
 
       const graffitiBytes = toGraffitiBytes(
-        graffiti ?? getDefaultGraffiti(getLodestarClientVersion(opts), chain.executionEngine.clientVersion, opts)
+        getBlockGraffiti(graffiti, getLodestarClientVersion(opts), chain.executionEngine.clientVersion, {
+          ...opts,
+          graffitiAppend: chain.opts.graffitiAppend,
+        })
       );
 
       // TODO GLOAS: respect builderSelection (MaxProfit, BuilderAlways, ExecutionAlways, etc.) to let

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -35,10 +35,6 @@ export type IChainOptions = BlockProcessOpts &
     persistOrphanedBlocksDir?: string;
     skipCreateStateCacheIfAvailable?: boolean;
     suggestedFeeRecipient: string;
-    /**
-     * Append CL/EL client info to validator supplied graffiti.
-     * Enabled by default; set to false to preserve user graffiti unchanged.
-     */
     graffitiAppend?: boolean;
     maxSkipSlots?: number;
     /** Ensure blobs returned by the execution engine are valid */

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -35,6 +35,11 @@ export type IChainOptions = BlockProcessOpts &
     persistOrphanedBlocksDir?: string;
     skipCreateStateCacheIfAvailable?: boolean;
     suggestedFeeRecipient: string;
+    /**
+     * Append CL/EL client info to validator supplied graffiti.
+     * Enabled by default; set to false to preserve user graffiti unchanged.
+     */
+    graffitiAppend?: boolean;
     maxSkipSlots?: number;
     /** Ensure blobs returned by the execution engine are valid */
     sanityCheckExecutionEngineBlobs?: boolean;
@@ -107,6 +112,7 @@ export const defaultChainOptions: IChainOptions = {
   computeUnrealized: true,
   fastConfirmation: false,
   suggestedFeeRecipient: defaultValidatorOptions.suggestedFeeRecipient,
+  graffitiAppend: true,
   serveHistoricalState: false,
   assertCorrectProgressiveBalances: false,
   archiveStateEpochFrequency: 1024,

--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -40,7 +40,7 @@ export function getDefaultGraffiti(
 
 function appendLongestFittingSuffix(userGraffiti: string, suffixes: string[]): string {
   const userGraffitiBytes = Buffer.byteLength(userGraffiti, "utf8");
-  if (userGraffitiBytes > GRAFFITI_SIZE) {
+  if (userGraffitiBytes >= GRAFFITI_SIZE) {
     return userGraffiti;
   }
 

--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -86,12 +86,19 @@ export function appendClientInfoToGraffiti(
   executionClientVersion: ClientVersion | null | undefined,
   opts: {private?: boolean} = {}
 ): string {
+  // Graffiti supplied via the beacon API is decoded from a fixed 32-byte field (see
+  // fromGraffitiHex) and arrives right-padded with NUL bytes. Trim only trailing padding
+  // NULs; a NUL that appears in the middle of the string is data, not padding.
+  let end = userGraffiti.length;
+  while (end > 0 && userGraffiti.charCodeAt(end - 1) === 0) end--;
+  const graffiti = userGraffiti.slice(0, end);
+
   if (opts.private) {
-    return truncateUtf8ToBytes(userGraffiti, GRAFFITI_SIZE);
+    return truncateUtf8ToBytes(graffiti, GRAFFITI_SIZE);
   }
 
   const fullClientInfo = getDefaultGraffiti(consensusClientVersion, executionClientVersion, {private: false});
-  if (userGraffiti.length === 0) {
+  if (graffiti.length === 0) {
     return fullClientInfo;
   }
 
@@ -104,7 +111,7 @@ export function appendClientInfoToGraffiti(
         ]
       : [` ${fullClientInfo}`, ` ${consensusClientVersion.code}`];
 
-  return appendLongestFittingSuffix(userGraffiti, suffixes);
+  return appendLongestFittingSuffix(graffiti, suffixes);
 }
 
 export function getBlockGraffiti(

--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -37,3 +37,89 @@ export function getDefaultGraffiti(
   // No EL client info available. We still want to include CL info albeit not spec compliant
   return `${consensusClientVersion.code}${consensusClientVersion.commit.slice(0, 4)}`;
 }
+
+/**
+ * Truncates a UTF-8 string without splitting multi-byte characters.
+ */
+export function truncateUtf8ToBytes(str: string, maxBytes: number): string {
+  if (maxBytes <= 0) {
+    return "";
+  }
+
+  const bytes = Buffer.from(str, "utf8");
+  if (bytes.length <= maxBytes) {
+    return str;
+  }
+
+  let length = maxBytes;
+  while (length > 0 && (bytes[length] & 0xc0) === 0x80) {
+    length--;
+  }
+
+  return bytes.subarray(0, length).toString("utf8");
+}
+
+function appendLongestFittingSuffix(userGraffiti: string, suffixes: string[]): string {
+  const truncatedGraffiti = truncateUtf8ToBytes(userGraffiti, GRAFFITI_SIZE);
+  const availableBytes = GRAFFITI_SIZE - Buffer.byteLength(truncatedGraffiti, "utf8");
+
+  for (const suffix of suffixes) {
+    if (Buffer.byteLength(suffix, "utf8") <= availableBytes) {
+      return `${truncatedGraffiti}${suffix}`;
+    }
+  }
+
+  return truncatedGraffiti;
+}
+
+/**
+ * Appends the richest available client watermark that fits after user graffiti.
+ *
+ * Tiers are:
+ * - full EL/CL watermark, e.g. " BU9b0eLS80c2"
+ * - EL/CL client codes, e.g. " BULS"
+ * - CL client code, e.g. " LS"
+ */
+export function appendClientInfoToGraffiti(
+  userGraffiti: string,
+  consensusClientVersion: ClientVersion,
+  executionClientVersion: ClientVersion | null | undefined,
+  opts: {private?: boolean} = {}
+): string {
+  if (opts.private) {
+    return truncateUtf8ToBytes(userGraffiti, GRAFFITI_SIZE);
+  }
+
+  const fullClientInfo = getDefaultGraffiti(consensusClientVersion, executionClientVersion, {private: false});
+  if (userGraffiti.length === 0) {
+    return fullClientInfo;
+  }
+
+  const suffixes =
+    executionClientVersion != null
+      ? [
+          ` ${fullClientInfo}`,
+          ` ${executionClientVersion.code}${consensusClientVersion.code}`,
+          ` ${consensusClientVersion.code}`,
+        ]
+      : [` ${fullClientInfo}`, ` ${consensusClientVersion.code}`];
+
+  return appendLongestFittingSuffix(userGraffiti, suffixes);
+}
+
+export function getBlockGraffiti(
+  userGraffiti: string | undefined,
+  consensusClientVersion: ClientVersion,
+  executionClientVersion: ClientVersion | null | undefined,
+  opts: {private?: boolean; graffitiAppend?: boolean}
+): string {
+  if (userGraffiti === undefined) {
+    return getDefaultGraffiti(consensusClientVersion, executionClientVersion, opts);
+  }
+
+  if (opts.graffitiAppend === false) {
+    return userGraffiti;
+  }
+
+  return appendClientInfoToGraffiti(userGraffiti, consensusClientVersion, executionClientVersion, opts);
+}

--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -38,38 +38,21 @@ export function getDefaultGraffiti(
   return `${consensusClientVersion.code}${consensusClientVersion.commit.slice(0, 4)}`;
 }
 
-/**
- * Truncates a UTF-8 string without splitting multi-byte characters.
- */
-export function truncateUtf8ToBytes(str: string, maxBytes: number): string {
-  if (maxBytes <= 0) {
-    return "";
-  }
-
-  const bytes = Buffer.from(str, "utf8");
-  if (bytes.length <= maxBytes) {
-    return str;
-  }
-
-  let length = maxBytes;
-  while (length > 0 && (bytes[length] & 0xc0) === 0x80) {
-    length--;
-  }
-
-  return bytes.subarray(0, length).toString("utf8");
-}
-
 function appendLongestFittingSuffix(userGraffiti: string, suffixes: string[]): string {
-  const truncatedGraffiti = truncateUtf8ToBytes(userGraffiti, GRAFFITI_SIZE);
-  const availableBytes = GRAFFITI_SIZE - Buffer.byteLength(truncatedGraffiti, "utf8");
+  const userGraffitiBytes = Buffer.byteLength(userGraffiti, "utf8");
+  if (userGraffitiBytes > GRAFFITI_SIZE) {
+    return userGraffiti;
+  }
+
+  const availableBytes = GRAFFITI_SIZE - userGraffitiBytes;
 
   for (const suffix of suffixes) {
     if (Buffer.byteLength(suffix, "utf8") <= availableBytes) {
-      return `${truncatedGraffiti}${suffix}`;
+      return `${userGraffiti}${suffix}`;
     }
   }
 
-  return truncatedGraffiti;
+  return userGraffiti;
 }
 
 /**
@@ -86,16 +69,18 @@ export function appendClientInfoToGraffiti(
   executionClientVersion: ClientVersion | null | undefined,
   opts: {private?: boolean} = {}
 ): string {
+  if (opts.private) {
+    return userGraffiti;
+  }
+
   // Graffiti supplied via the beacon API is decoded from a fixed 32-byte field (see
   // fromGraffitiHex) and arrives right-padded with NUL bytes. Trim only trailing padding
   // NULs; a NUL that appears in the middle of the string is data, not padding.
   let end = userGraffiti.length;
-  while (end > 0 && userGraffiti.charCodeAt(end - 1) === 0) end--;
-  const graffiti = userGraffiti.slice(0, end);
-
-  if (opts.private) {
-    return truncateUtf8ToBytes(graffiti, GRAFFITI_SIZE);
+  while (end > 0 && userGraffiti.charCodeAt(end - 1) === 0) {
+    end--;
   }
+  const graffiti = userGraffiti.slice(0, end);
 
   const fullClientInfo = getDefaultGraffiti(consensusClientVersion, executionClientVersion, {private: false});
   if (graffiti.length === 0) {

--- a/packages/beacon-node/test/unit/util/graffiti.test.ts
+++ b/packages/beacon-node/test/unit/util/graffiti.test.ts
@@ -164,6 +164,21 @@ describe("Graffiti helper", () => {
       );
     });
 
+    it("should return empty default graffiti in private mode when no user graffiti is provided", () => {
+      expect(
+        getBlockGraffiti(undefined, consensusClientVersion, executionClientVersion, {
+          private: true,
+          graffitiAppend: true,
+        })
+      ).toBe("");
+    });
+
+    it("should append client info by default when append option is omitted", () => {
+      expect(getBlockGraffiti("my graffiti", consensusClientVersion, executionClientVersion, {})).toBe(
+        "my graffiti BU9b0eLS80c2"
+      );
+    });
+
     it("should preserve user graffiti when append is disabled", () => {
       expect(
         getBlockGraffiti("my graffiti", consensusClientVersion, executionClientVersion, {graffitiAppend: false})
@@ -177,6 +192,17 @@ describe("Graffiti helper", () => {
           graffitiAppend: true,
         })
       ).toBe("my graffiti");
+    });
+
+    it("should preserve NUL-padded graffiti when private mode is enabled", () => {
+      const nul = String.fromCharCode(0);
+      const paddedGraffiti = "my graffiti" + nul.repeat(GRAFFITI_SIZE - "my graffiti".length);
+      expect(
+        getBlockGraffiti(paddedGraffiti, consensusClientVersion, executionClientVersion, {
+          private: true,
+          graffitiAppend: true,
+        })
+      ).toBe(paddedGraffiti);
     });
 
     it("should preserve NUL-padded graffiti when append is disabled", () => {

--- a/packages/beacon-node/test/unit/util/graffiti.test.ts
+++ b/packages/beacon-node/test/unit/util/graffiti.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "vitest";
+import {GRAFFITI_SIZE} from "../../../src/constants/index.js";
 import {ClientCode} from "../../../src/execution/index.js";
 import {
   appendClientInfoToGraffiti,
@@ -116,6 +117,32 @@ describe("Graffiti helper", () => {
         appendClientInfoToGraffiti("my graffiti", consensusClientVersion, executionClientVersion, {private: true})
       ).toBe("my graffiti");
     });
+
+    it("should strip trailing NUL padding before appending client info", () => {
+      // Graffiti supplied via the beacon API is decoded from a fixed 32-byte field and is
+      // right-padded with NUL bytes. Without stripping, availableBytes would be 0.
+      const nul = String.fromCharCode(0);
+      const paddedGraffiti = "my graffiti" + nul.repeat(GRAFFITI_SIZE - "my graffiti".length);
+      expect(appendClientInfoToGraffiti(paddedGraffiti, consensusClientVersion, executionClientVersion)).toBe(
+        "my graffiti BU9b0eLS80c2"
+      );
+    });
+
+    it("should use the default watermark when graffiti is entirely NUL padding", () => {
+      const paddedGraffiti = String.fromCharCode(0).repeat(GRAFFITI_SIZE);
+      expect(appendClientInfoToGraffiti(paddedGraffiti, consensusClientVersion, executionClientVersion)).toBe(
+        "BU9b0eLS80c2"
+      );
+    });
+
+    it("should preserve mid-string NUL bytes and only trim trailing NUL padding", () => {
+      const nul = String.fromCharCode(0);
+      // Graffiti with a data NUL in the middle, followed by trailing padding
+      const graffiti = "hello" + nul + "world" + nul.repeat(GRAFFITI_SIZE - 11);
+      const result = appendClientInfoToGraffiti(graffiti, consensusClientVersion, executionClientVersion);
+      // The mid-string NUL must be preserved; only trailing NULs are stripped
+      expect(result.startsWith("hello" + nul + "world")).toBe(true);
+    });
   });
 
   describe("getBlockGraffiti", () => {
@@ -137,6 +164,14 @@ describe("Graffiti helper", () => {
       expect(
         getBlockGraffiti("my graffiti", consensusClientVersion, executionClientVersion, {graffitiAppend: false})
       ).toBe("my graffiti");
+    });
+
+    it("should append client info to NUL-padded graffiti as received from the beacon API", () => {
+      const nul = String.fromCharCode(0);
+      const paddedGraffiti = "my graffiti" + nul.repeat(GRAFFITI_SIZE - "my graffiti".length);
+      expect(
+        getBlockGraffiti(paddedGraffiti, consensusClientVersion, executionClientVersion, {graffitiAppend: true})
+      ).toBe("my graffiti BU9b0eLS80c2");
     });
   });
 });

--- a/packages/beacon-node/test/unit/util/graffiti.test.ts
+++ b/packages/beacon-node/test/unit/util/graffiti.test.ts
@@ -1,6 +1,12 @@
 import {describe, expect, it} from "vitest";
 import {ClientCode} from "../../../src/execution/index.js";
-import {getDefaultGraffiti, toGraffitiBytes} from "../../../src/util/graffiti.js";
+import {
+  appendClientInfoToGraffiti,
+  getBlockGraffiti,
+  getDefaultGraffiti,
+  toGraffitiBytes,
+  truncateUtf8ToBytes,
+} from "../../../src/util/graffiti.js";
 
 describe("Graffiti helper", () => {
   describe("toGraffitiBuffer", () => {
@@ -50,6 +56,87 @@ describe("Graffiti helper", () => {
     it("should return combined version codes and commits if executionClientVersion is provided", () => {
       const result = getDefaultGraffiti(consensusClientVersion, executionClientVersion, {private: false});
       expect(result).toBe("BU9b0eLS80c2");
+    });
+  });
+
+  describe("truncateUtf8ToBytes", () => {
+    it("should truncate ASCII strings", () => {
+      expect(truncateUtf8ToBytes("hello", 3)).toBe("hel");
+    });
+
+    it("should not split multi-byte characters", () => {
+      expect(truncateUtf8ToBytes("\u00e9", 1)).toBe("");
+      expect(truncateUtf8ToBytes("a\u00e9", 2)).toBe("a");
+      expect(truncateUtf8ToBytes("\u{1f600}", 3)).toBe("");
+    });
+  });
+
+  describe("appendClientInfoToGraffiti", () => {
+    const executionClientVersion = {code: ClientCode.BU, name: "Besu", version: "24.1.1", commit: "9b0e38fa"};
+    const consensusClientVersion = {
+      code: ClientCode.LS,
+      name: "Lodestar",
+      version: "v0.36.0/80c248b",
+      commit: "80c248bb",
+    };
+
+    it("should append the full EL and CL watermark when it fits", () => {
+      expect(appendClientInfoToGraffiti("my graffiti", consensusClientVersion, executionClientVersion)).toBe(
+        "my graffiti BU9b0eLS80c2"
+      );
+    });
+
+    it("should append only EL and CL codes when the full watermark does not fit", () => {
+      expect(appendClientInfoToGraffiti("a".repeat(20), consensusClientVersion, executionClientVersion)).toBe(
+        `${"a".repeat(20)} BULS`
+      );
+    });
+
+    it("should append only the CL code when only 3 bytes are available", () => {
+      expect(appendClientInfoToGraffiti("a".repeat(29), consensusClientVersion, executionClientVersion)).toBe(
+        `${"a".repeat(29)} LS`
+      );
+    });
+
+    it("should leave user graffiti unchanged when no suffix fits", () => {
+      expect(appendClientInfoToGraffiti("a".repeat(30), consensusClientVersion, executionClientVersion)).toBe(
+        "a".repeat(30)
+      );
+      expect(appendClientInfoToGraffiti("a".repeat(32), consensusClientVersion, executionClientVersion)).toBe(
+        "a".repeat(32)
+      );
+    });
+
+    it("should append CL-only watermark when EL info is unavailable", () => {
+      expect(appendClientInfoToGraffiti("my graffiti", consensusClientVersion, undefined)).toBe("my graffiti LS80c2");
+    });
+
+    it("should respect private mode", () => {
+      expect(
+        appendClientInfoToGraffiti("my graffiti", consensusClientVersion, executionClientVersion, {private: true})
+      ).toBe("my graffiti");
+    });
+  });
+
+  describe("getBlockGraffiti", () => {
+    const executionClientVersion = {code: ClientCode.BU, name: "Besu", version: "24.1.1", commit: "9b0e38fa"};
+    const consensusClientVersion = {
+      code: ClientCode.LS,
+      name: "Lodestar",
+      version: "v0.36.0/80c248b",
+      commit: "80c248bb",
+    };
+
+    it("should use the default watermark when no user graffiti is provided", () => {
+      expect(getBlockGraffiti(undefined, consensusClientVersion, executionClientVersion, {graffitiAppend: true})).toBe(
+        "BU9b0eLS80c2"
+      );
+    });
+
+    it("should preserve user graffiti when append is disabled", () => {
+      expect(
+        getBlockGraffiti("my graffiti", consensusClientVersion, executionClientVersion, {graffitiAppend: false})
+      ).toBe("my graffiti");
     });
   });
 });

--- a/packages/beacon-node/test/unit/util/graffiti.test.ts
+++ b/packages/beacon-node/test/unit/util/graffiti.test.ts
@@ -49,7 +49,7 @@ describe("Graffiti helper", () => {
     });
 
     it("should return CL only info if EL client version is missing", () => {
-      const result = getDefaultGraffiti(consensusClientVersion, undefined, {private: false});
+      const result = getDefaultGraffiti(consensusClientVersion, null, {private: false});
       expect(result).toBe("LS80c2");
     });
 
@@ -110,7 +110,7 @@ describe("Graffiti helper", () => {
     });
 
     it("should append CL-only watermark when EL info is unavailable", () => {
-      expect(appendClientInfoToGraffiti("my graffiti", consensusClientVersion, undefined)).toBe("my graffiti LS80c2");
+      expect(appendClientInfoToGraffiti("my graffiti", consensusClientVersion, null)).toBe("my graffiti LS80c2");
     });
 
     it("should respect private mode", () => {

--- a/packages/beacon-node/test/unit/util/graffiti.test.ts
+++ b/packages/beacon-node/test/unit/util/graffiti.test.ts
@@ -6,7 +6,6 @@ import {
   getBlockGraffiti,
   getDefaultGraffiti,
   toGraffitiBytes,
-  truncateUtf8ToBytes,
 } from "../../../src/util/graffiti.js";
 
 describe("Graffiti helper", () => {
@@ -60,18 +59,6 @@ describe("Graffiti helper", () => {
     });
   });
 
-  describe("truncateUtf8ToBytes", () => {
-    it("should truncate ASCII strings", () => {
-      expect(truncateUtf8ToBytes("hello", 3)).toBe("hel");
-    });
-
-    it("should not split multi-byte characters", () => {
-      expect(truncateUtf8ToBytes("\u00e9", 1)).toBe("");
-      expect(truncateUtf8ToBytes("a\u00e9", 2)).toBe("a");
-      expect(truncateUtf8ToBytes("\u{1f600}", 3)).toBe("");
-    });
-  });
-
   describe("appendClientInfoToGraffiti", () => {
     const executionClientVersion = {code: ClientCode.BU, name: "Besu", version: "24.1.1", commit: "9b0e38fa"};
     const consensusClientVersion = {
@@ -99,12 +86,26 @@ describe("Graffiti helper", () => {
       );
     });
 
+    it("should preserve user graffiti exactly when appending a suffix", () => {
+      for (const userGraffiti of ["my graffiti", "\u{1f600}".repeat(4), "a".repeat(29)]) {
+        const result = appendClientInfoToGraffiti(userGraffiti, consensusClientVersion, executionClientVersion);
+        expect(result.slice(0, userGraffiti.length)).toBe(userGraffiti);
+        expect(result.length).toBeGreaterThan(userGraffiti.length);
+      }
+    });
+
     it("should leave user graffiti unchanged when no suffix fits", () => {
       expect(appendClientInfoToGraffiti("a".repeat(30), consensusClientVersion, executionClientVersion)).toBe(
         "a".repeat(30)
       );
       expect(appendClientInfoToGraffiti("a".repeat(32), consensusClientVersion, executionClientVersion)).toBe(
         "a".repeat(32)
+      );
+      expect(appendClientInfoToGraffiti("a".repeat(40), consensusClientVersion, executionClientVersion)).toBe(
+        "a".repeat(40)
+      );
+      expect(appendClientInfoToGraffiti("\u{1f600}".repeat(9), consensusClientVersion, executionClientVersion)).toBe(
+        "\u{1f600}".repeat(9)
       );
     });
 
@@ -116,6 +117,9 @@ describe("Graffiti helper", () => {
       expect(
         appendClientInfoToGraffiti("my graffiti", consensusClientVersion, executionClientVersion, {private: true})
       ).toBe("my graffiti");
+      expect(
+        appendClientInfoToGraffiti("a".repeat(40), consensusClientVersion, executionClientVersion, {private: true})
+      ).toBe("a".repeat(40));
     });
 
     it("should strip trailing NUL padding before appending client info", () => {
@@ -141,7 +145,7 @@ describe("Graffiti helper", () => {
       const graffiti = "hello" + nul + "world" + nul.repeat(GRAFFITI_SIZE - 11);
       const result = appendClientInfoToGraffiti(graffiti, consensusClientVersion, executionClientVersion);
       // The mid-string NUL must be preserved; only trailing NULs are stripped
-      expect(result.startsWith("hello" + nul + "world")).toBe(true);
+      expect(result).toBe("hello" + nul + "world BU9b0eLS80c2");
     });
   });
 
@@ -164,6 +168,23 @@ describe("Graffiti helper", () => {
       expect(
         getBlockGraffiti("my graffiti", consensusClientVersion, executionClientVersion, {graffitiAppend: false})
       ).toBe("my graffiti");
+    });
+
+    it("should preserve user graffiti when private mode is enabled", () => {
+      expect(
+        getBlockGraffiti("my graffiti", consensusClientVersion, executionClientVersion, {
+          private: true,
+          graffitiAppend: true,
+        })
+      ).toBe("my graffiti");
+    });
+
+    it("should preserve NUL-padded graffiti when append is disabled", () => {
+      const nul = String.fromCharCode(0);
+      const paddedGraffiti = "my graffiti" + nul.repeat(GRAFFITI_SIZE - "my graffiti".length);
+      expect(
+        getBlockGraffiti(paddedGraffiti, consensusClientVersion, executionClientVersion, {graffitiAppend: false})
+      ).toBe(paddedGraffiti);
     });
 
     it("should append client info to NUL-padded graffiti as received from the beacon API", () => {

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -106,7 +106,7 @@ export const options: CliCommandOptions<ChainArgs> = {
 
   graffitiAppend: {
     type: "boolean",
-    description: "Append CL/EL client info to validator-supplied graffiti when space allows.",
+    description: "Append CL/EL client info to graffiti supplied by validator when space allows",
     default: true,
     group: "chain",
   },

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -2,8 +2,11 @@ import {ArchiveMode, DEFAULT_ARCHIVE_MODE, IBeaconNodeOptions, defaultOptions} f
 import {CliCommandOptions} from "@lodestar/utils";
 import {ensure0xPrefix} from "../../util/format.js";
 
+const defaultGraffitiAppend = true;
+
 export type ChainArgs = {
   suggestedFeeRecipient: string;
+  graffitiAppend?: boolean;
   serveHistoricalState?: boolean;
   "chain.blacklistedBlocks"?: string[];
   "chain.blsVerifyAllMultiThread"?: boolean;
@@ -40,9 +43,14 @@ export type ChainArgs = {
   "chain.pruneHistory"?: boolean;
 };
 
-export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
+type ChainOptions = IBeaconNodeOptions["chain"] & {
+  graffitiAppend?: boolean;
+};
+
+export function parseArgs(args: ChainArgs): ChainOptions {
   return {
     suggestedFeeRecipient: args.suggestedFeeRecipient,
+    graffitiAppend: args.graffitiAppend,
     serveHistoricalState: args.serveHistoricalState,
     blacklistedBlocks: args["chain.blacklistedBlocks"],
     blsVerifyAllMultiThread: args["chain.blsVerifyAllMultiThread"],
@@ -95,6 +103,15 @@ export const options: CliCommandOptions<ChainArgs> = {
     type: "boolean",
     defaultDescription: String(defaultOptions.chain.emitPayloadAttributes),
     description: "Flag to SSE emit execution `payloadAttributes` before every slot",
+    group: "chain",
+  },
+
+  graffitiAppend: {
+    type: "boolean",
+    description:
+      "Append CL/EL client info to validator-supplied graffiti when space allows. " +
+      "Use --no-graffitiAppend to preserve user graffiti unchanged.",
+    default: defaultGraffitiAppend,
     group: "chain",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -2,8 +2,6 @@ import {ArchiveMode, DEFAULT_ARCHIVE_MODE, IBeaconNodeOptions, defaultOptions} f
 import {CliCommandOptions} from "@lodestar/utils";
 import {ensure0xPrefix} from "../../util/format.js";
 
-const defaultGraffitiAppend = true;
-
 export type ChainArgs = {
   suggestedFeeRecipient: string;
   graffitiAppend?: boolean;
@@ -108,10 +106,8 @@ export const options: CliCommandOptions<ChainArgs> = {
 
   graffitiAppend: {
     type: "boolean",
-    description:
-      "Append CL/EL client info to validator-supplied graffiti when space allows. " +
-      "Use --no-graffitiAppend to preserve user graffiti unchanged.",
-    default: defaultGraffitiAppend,
+    description: "Append CL/EL client info to validator-supplied graffiti when space allows.",
+    default: true,
     group: "chain",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -41,11 +41,7 @@ export type ChainArgs = {
   "chain.pruneHistory"?: boolean;
 };
 
-type ChainOptions = IBeaconNodeOptions["chain"] & {
-  graffitiAppend?: boolean;
-};
-
-export function parseArgs(args: ChainArgs): ChainOptions {
+export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
   return {
     suggestedFeeRecipient: args.suggestedFeeRecipient,
     graffitiAppend: args.graffitiAppend,
@@ -107,7 +103,7 @@ export const options: CliCommandOptions<ChainArgs> = {
   graffitiAppend: {
     type: "boolean",
     description: "Append CL/EL client info to graffiti supplied by validator when space allows",
-    default: true,
+    default: defaultOptions.chain.graffitiAppend,
     group: "chain",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -102,7 +102,7 @@ export const options: CliCommandOptions<ChainArgs> = {
 
   graffitiAppend: {
     type: "boolean",
-    description: "Append CL/EL client info to graffiti supplied by validator when space allows",
+    description: "Append CL/EL client info to graffiti supplied by validator client when space allows",
     default: defaultOptions.chain.graffitiAppend,
     group: "chain",
   },

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -42,6 +42,7 @@ describe("options / beaconNodeOptions", () => {
       "chain.maxCPStateEpochsOnDisk": 1000,
       "chain.archiveMode": ArchiveMode.Frequency,
       emitPayloadAttributes: false,
+      graffitiAppend: false,
 
       "execution.urls": ["http://localhost:8551"],
       "execution.timeout": 12000,
@@ -138,6 +139,7 @@ describe("options / beaconNodeOptions", () => {
         maxShufflingCacheEpochs: 100,
         archiveDataEpochs: 10000,
         archiveMode: ArchiveMode.Frequency,
+        graffitiAppend: false,
         nHistoricalStatesFileDataStore: true,
         nativeStateView: false,
         maxBlockStates: 100,


### PR DESCRIPTION
**Motivation**

We want produced blocks to carry Lodestar / EL client info when validators leave enough room in graffiti, without taking over user supplied graffiti. This keeps the default useful for client diversity/debugging while still allowing node operators to opt out.

**Description**

When a validator supplies graffiti, the beacon node appends the richest client info suffix that fits, always separated by a space:

- full EL+CL watermark, e.g. ` BU9b0eLS80c2`
- EL+CL client codes, e.g. ` BULS`
- CL client code, e.g. ` LS`

If none of these fit, the user graffiti is kept unchanged. The feature is enabled by default, use `--graffitiAppend false` to disable it. `--private` suppresses client info as before.