### PR TITLE
fix: strip NUL padding from beacon API graffiti before appending client info

### DIFF
--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -87,10 +87,11 @@ export function appendClientInfoToGraffiti(
   opts: {private?: boolean} = {}
 ): string {
   // Graffiti supplied via the beacon API is decoded from a fixed 32-byte field (see
-  // fromGraffitiHex) and arrives right-padded with NUL bytes. Strip them, otherwise the
-  // padding fills the whole 32 bytes, availableBytes is 0 and no client info is ever
-  // appended. Mirrors the padding removal already done in fromGraffitiBytes.
-  const graffiti = userGraffiti.replaceAll("\u0000", "");
+  // fromGraffitiHex) and arrives right-padded with NUL bytes. Trim only trailing padding
+  // NULs; a NUL that appears in the middle of the string is data, not padding.
+  let end = userGraffiti.length;
+  while (end > 0 && userGraffiti.charCodeAt(end - 1) === 0) end--;
+  const graffiti = userGraffiti.slice(0, end);
 
   if (opts.private) {
     return truncateUtf8ToBytes(graffiti, GRAFFITI_SIZE);

--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -86,12 +86,18 @@ export function appendClientInfoToGraffiti(
   executionClientVersion: ClientVersion | null | undefined,
   opts: {private?: boolean} = {}
 ): string {
+  // Graffiti supplied via the beacon API is decoded from a fixed 32-byte field (see
+  // fromGraffitiHex) and arrives right-padded with NUL bytes. Strip them, otherwise the
+  // padding fills the whole 32 bytes, availableBytes is 0 and no client info is ever
+  // appended. Mirrors the padding removal already done in fromGraffitiBytes.
+  const graffiti = userGraffiti.replaceAll("\u0000", "");
+
   if (opts.private) {
-    return truncateUtf8ToBytes(userGraffiti, GRAFFITI_SIZE);
+    return truncateUtf8ToBytes(graffiti, GRAFFITI_SIZE);
   }
 
   const fullClientInfo = getDefaultGraffiti(consensusClientVersion, executionClientVersion, {private: false});
-  if (userGraffiti.length === 0) {
+  if (graffiti.length === 0) {
     return fullClientInfo;
   }
 
@@ -104,7 +110,7 @@ export function appendClientInfoToGraffiti(
         ]
       : [` ${fullClientInfo}`, ` ${consensusClientVersion.code}`];
 
-  return appendLongestFittingSuffix(userGraffiti, suffixes);
+  return appendLongestFittingSuffix(graffiti, suffixes);
 }
 
 export function getBlockGraffiti(

--- a/packages/beacon-node/test/unit/util/graffiti.test.ts
+++ b/packages/beacon-node/test/unit/util/graffiti.test.ts
@@ -134,6 +134,15 @@ describe("Graffiti helper", () => {
         "BU9b0eLS80c2"
       );
     });
+
+    it("should preserve mid-string NUL bytes and only trim trailing NUL padding", () => {
+      const nul = String.fromCharCode(0);
+      // Graffiti with a data NUL in the middle, followed by trailing padding
+      const graffiti = "hello" + nul + "world" + nul.repeat(GRAFFITI_SIZE - 11);
+      const result = appendClientInfoToGraffiti(graffiti, consensusClientVersion, executionClientVersion);
+      // The mid-string NUL must be preserved; only trailing NULs are stripped
+      expect(result.startsWith("hello" + nul + "world")).toBe(true);
+    });
   });
 
   describe("getBlockGraffiti", () => {

--- a/packages/beacon-node/test/unit/util/graffiti.test.ts
+++ b/packages/beacon-node/test/unit/util/graffiti.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "vitest";
+import {GRAFFITI_SIZE} from "../../../src/constants/index.js";
 import {ClientCode} from "../../../src/execution/index.js";
 import {
   appendClientInfoToGraffiti,
@@ -116,6 +117,23 @@ describe("Graffiti helper", () => {
         appendClientInfoToGraffiti("my graffiti", consensusClientVersion, executionClientVersion, {private: true})
       ).toBe("my graffiti");
     });
+
+    it("should strip trailing NUL padding before appending client info", () => {
+      // Graffiti supplied via the beacon API is decoded from a fixed 32-byte field and is
+      // right-padded with NUL bytes. Without stripping, availableBytes would be 0.
+      const nul = String.fromCharCode(0);
+      const paddedGraffiti = "my graffiti" + nul.repeat(GRAFFITI_SIZE - "my graffiti".length);
+      expect(appendClientInfoToGraffiti(paddedGraffiti, consensusClientVersion, executionClientVersion)).toBe(
+        "my graffiti BU9b0eLS80c2"
+      );
+    });
+
+    it("should use the default watermark when graffiti is entirely NUL padding", () => {
+      const paddedGraffiti = String.fromCharCode(0).repeat(GRAFFITI_SIZE);
+      expect(appendClientInfoToGraffiti(paddedGraffiti, consensusClientVersion, executionClientVersion)).toBe(
+        "BU9b0eLS80c2"
+      );
+    });
   });
 
   describe("getBlockGraffiti", () => {
@@ -137,6 +155,14 @@ describe("Graffiti helper", () => {
       expect(
         getBlockGraffiti("my graffiti", consensusClientVersion, executionClientVersion, {graffitiAppend: false})
       ).toBe("my graffiti");
+    });
+
+    it("should append client info to NUL-padded graffiti as received from the beacon API", () => {
+      const nul = String.fromCharCode(0);
+      const paddedGraffiti = "my graffiti" + nul.repeat(GRAFFITI_SIZE - "my graffiti".length);
+      expect(
+        getBlockGraffiti(paddedGraffiti, consensusClientVersion, executionClientVersion, {graffitiAppend: true})
+      ).toBe("my graffiti BU9b0eLS80c2");
     });
   });
 });


### PR DESCRIPTION
Targets your `nflaig/graffiti-append` branch (#9599) per your request to open a PR if I found anything. Fixes the real issue flagged by the Codex bot ([r3526217405](https://github.com/ChainSafe/lodestar/pull/9599#discussion_r3526217405)): the client watermark is never appended to graffiti supplied via the beacon API.

## Problem

Graffiti supplied via the beacon API is a `Bytes32`. On the server it is decoded with `fromGraffitiHex`, which does **not** strip the right-padding, so a short graffiti such as `"my graffiti"` arrives as the full 32-byte string right-padded with NUL bytes.

`appendClientInfoToGraffiti` then measures the available space against that padded string:

```ts
const availableBytes = GRAFFITI_SIZE - Buffer.byteLength(truncatedGraffiti, "utf8"); // 32 - 32 = 0
```

`availableBytes` is therefore always `0` and no suffix ever fits — so `graffitiAppend` (default `true`) is silently a no-op for standard graffiti. This includes the **Lodestar validator client**, whose API client pads graffiti to 32 bytes via `toGraffitiHex`.

## Fix

Strip the NUL padding before computing available space, mirroring the padding removal already done in `fromGraffitiBytes`. Added regression tests (NUL-padded graffiti and all-NUL graffiti) at both `appendClientInfoToGraffiti` and `getBlockGraffiti` level.

## Review vs #8865

Compared against my earlier closed #8865 as requested — it shared the same gap (it built `` `${userGraffiti} ${clientInfo}` `` then truncated to 32 bytes, so a padded 32-byte input truncated the watermark away as well). So this is not a regression in #9599, but neither implementation handled the REST padding; worth fixing before merge.

Local `pnpm --filter @lodestar/beacon-node` unit test + biome pass; the graffiti change is type-clean (`replaceAll` is already used in the same file).

🤖 Generated with AI assistance
