### PR TITLE
perf: reuse container nodes in upgradeStateToGloas

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@chainsafe/benchmark": "^2.0.2",
     "@chainsafe/biomejs-config": "^1.0.0",
     "@chainsafe/caxa": "3.0.6",
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@lerna-lite/cli": "^4.9.4",
     "@lerna-lite/exec": "^4.9.4",
     "@lerna-lite/publish": "^4.9.4",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@chainsafe/persistent-merkle-tree": "^1.3.0",
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@lodestar/config": "workspace:^",
     "@lodestar/params": "workspace:^",
     "@lodestar/types": "workspace:^",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -117,7 +117,7 @@
     "@chainsafe/persistent-merkle-tree": "^1.3.0",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/snappy-wasm": "^0.5.0",
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@chainsafe/threads": "^1.11.3",
     "@crate-crypto/node-eth-kzg": "0.9.1",
     "@fastify/bearer-auth": "^10.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,7 +63,7 @@
     "@chainsafe/discv5": "^12.0.1",
     "@chainsafe/enr": "^6.0.1",
     "@chainsafe/persistent-merkle-tree": "^1.3.0",
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@chainsafe/threads": "^1.11.3",
     "@libp2p/crypto": "^5.1.13",
     "@libp2p/interface": "^3.1.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -66,7 +66,7 @@
   ],
   "dependencies": {
     "@chainsafe/as-sha256": "^1.2.0",
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@lodestar/params": "workspace:^",
     "@lodestar/types": "workspace:^",
     "@lodestar/utils": "workspace:^"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -43,7 +43,7 @@
     "check-readme": "pnpm exec ts-node ../../scripts/check_readme.ts"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@lodestar/config": "workspace:^",
     "@lodestar/utils": "workspace:^",
     "classic-level": "^1.4.1"

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -39,7 +39,7 @@
     "check-readme": "pnpm exec ts-node ../../scripts/check_readme.ts"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@lodestar/config": "workspace:^",
     "@lodestar/params": "workspace:^",
     "@lodestar/state-transition": "workspace:^",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -74,7 +74,7 @@
     "winston-transport": "^4.5.0"
   },
   "devDependencies": {
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@chainsafe/threads": "^1.11.3",
     "@lodestar/test-utils": "workspace:^",
     "@types/triple-beam": "^1.3.2"

--- a/packages/reqresp/package.json
+++ b/packages/reqresp/package.json
@@ -56,7 +56,7 @@
     "uint8arraylist": "^2.4.7"
   },
   "devDependencies": {
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@libp2p/crypto": "^5.1.13",
     "@libp2p/peer-id": "^6.0.4",
     "@lodestar/logger": "workspace:^",

--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -65,7 +65,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@lodestar/types": "workspace:^",
     "vitest": "catalog:"
   }

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -69,7 +69,7 @@
     "@chainsafe/blst": "^2.2.0",
     "@chainsafe/persistent-merkle-tree": "^1.3.0",
     "@chainsafe/pubkey-index-map": "^3.0.0",
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@chainsafe/swap-or-not-shuffle": "^1.2.1",
     "@lodestar/config": "workspace:^",
     "@lodestar/params": "workspace:^",

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -1,9 +1,5 @@
 import {BranchNode, LeafNode, Node} from "@chainsafe/persistent-merkle-tree";
-// TODO: @chainsafe/ssz should publish progressiveSubtreeFillToContents as a public export, then
-// drop this deep import. It is not re-exported from ssz's public entrypoint; resolvable because
-// ssz 1.6.0 has no package.json "exports" map. Fragile across ssz bumps.
-// biome-ignore lint/style/noRestrictedImports: no public export yet; see TODO above
-import {progressiveSubtreeFillToContents} from "@chainsafe/ssz/lib/type/progressive.js";
+import {progressiveSubtreeFillToContents} from "@chainsafe/ssz";
 import {PAYLOAD_BUILDER_VERSION, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {toPubkeyHex} from "@lodestar/utils";

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -1,3 +1,9 @@
+import {BranchNode, LeafNode, Node} from "@chainsafe/persistent-merkle-tree";
+// TODO: @chainsafe/ssz should publish progressiveSubtreeFillToContents as a public export, then
+// drop this deep import. It is not re-exported from ssz's public entrypoint; resolvable because
+// ssz 1.6.0 has no package.json "exports" map. Fragile across ssz bumps.
+// biome-ignore lint/style/noRestrictedImports: no public export yet; see TODO above
+import {progressiveSubtreeFillToContents} from "@chainsafe/ssz/lib/type/progressive.js";
 import {PAYLOAD_BUILDER_VERSION, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {toPubkeyHex} from "@lodestar/utils";
@@ -34,7 +40,7 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
   stateGloasView.eth1Data = stateGloasCloned.eth1Data;
   stateGloasView.eth1DataVotes = stateGloasCloned.eth1DataVotes;
   stateGloasView.eth1DepositIndex = stateGloasCloned.eth1DepositIndex;
-  stateGloasView.validators = ssz.gloas.Validators.toViewDU(stateGloasCloned.validators.getAllReadonlyValues());
+  stateGloasView.validators = migrateCompositeListToGloas(stateGloasCloned.validators, ssz.gloas.Validators);
   stateGloasView.balances = ssz.gloas.Balances.toViewDU(stateGloasCloned.balances.getAll());
   stateGloasView.randaoMixes = stateGloasCloned.randaoMixes;
   stateGloasView.slashings = stateGloasCloned.slashings;
@@ -65,14 +71,17 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
   stateGloasView.earliestExitEpoch = stateGloasCloned.earliestExitEpoch;
   stateGloasView.consolidationBalanceToConsume = stateGloasCloned.consolidationBalanceToConsume;
   stateGloasView.earliestConsolidationEpoch = stateGloasCloned.earliestConsolidationEpoch;
-  stateGloasView.pendingDeposits = ssz.gloas.PendingDeposits.toViewDU(
-    stateGloasCloned.pendingDeposits.getAllReadonlyValues()
+  stateGloasView.pendingDeposits = migrateCompositeListToGloas(
+    stateGloasCloned.pendingDeposits,
+    ssz.gloas.PendingDeposits
   );
-  stateGloasView.pendingPartialWithdrawals = ssz.gloas.PendingPartialWithdrawals.toViewDU(
-    stateGloasCloned.pendingPartialWithdrawals.getAllReadonlyValues()
+  stateGloasView.pendingPartialWithdrawals = migrateCompositeListToGloas(
+    stateGloasCloned.pendingPartialWithdrawals,
+    ssz.gloas.PendingPartialWithdrawals
   );
-  stateGloasView.pendingConsolidations = ssz.gloas.PendingConsolidations.toViewDU(
-    stateGloasCloned.pendingConsolidations.getAllReadonlyValues()
+  stateGloasView.pendingConsolidations = migrateCompositeListToGloas(
+    stateGloasCloned.pendingConsolidations,
+    ssz.gloas.PendingConsolidations
   );
   stateGloasView.proposerLookahead = stateGloasCloned.proposerLookahead;
   stateGloasView.ptcWindow = ssz.gloas.PtcWindow.toViewDU(initializePtcWindow(stateFulu));
@@ -93,6 +102,27 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
   stateGloas["clearCache"]();
 
   return stateGloas;
+}
+
+/**
+ * Migrate a composite list from fulu to its gloas progressive-list equivalent by reusing the fulu
+ * list's cached element nodes.
+ *
+ * Works whenever the element type is identical across the fork (e.g. validators use ValidatorNodeStruct,
+ * the pending* queues use the same electra element types). Each element's cached subtree root is then
+ * valid under gloas, so only the progressive list superstructure is rebuilt and a subsequent
+ * hashTreeRoot() skips re-hashing every element — the dominant cost for large lists like validators.
+ * Much cheaper than `gloasType.toViewDU(fuluList.getAllReadonlyValues())`, which decodes every element
+ * to a value and forces a full re-hash.
+ */
+function migrateCompositeListToGloas<V>(
+  fuluList: {getAllReadonly(): {node: Node}[]},
+  gloasType: {getViewDU(node: Node): V}
+): V {
+  const elementNodes = fuluList.getAllReadonly().map((v) => v.node);
+  const chunksNode = progressiveSubtreeFillToContents(elementNodes);
+  const rootNode = new BranchNode(chunksNode, LeafNode.fromUint32(elementNodes.length));
+  return gloasType.getViewDU(rootNode);
 }
 
 /**

--- a/packages/state-transition/test/unit/upgradeState.test.ts
+++ b/packages/state-transition/test/unit/upgradeState.test.ts
@@ -1,12 +1,13 @@
 import {describe, expect, it} from "vitest";
 import {ChainForkConfig, createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {config as chainConfig} from "@lodestar/config/default";
-import {ForkName} from "@lodestar/params";
+import {FAR_FUTURE_EPOCH, ForkName} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {createPubkeyCache} from "../../src/cache/pubkeyCache.js";
-import {createCachedBeaconState} from "../../src/cache/stateCache.js";
+import {CachedBeaconStateFulu, createCachedBeaconState} from "../../src/cache/stateCache.js";
 import {upgradeStateToDeneb} from "../../src/slot/upgradeStateToDeneb.js";
 import {upgradeStateToElectra} from "../../src/slot/upgradeStateToElectra.js";
+import {upgradeStateToGloas} from "../../src/slot/upgradeStateToGloas.js";
 
 describe("upgradeState", () => {
   it("upgradeStateToDeneb", () => {
@@ -36,6 +37,82 @@ describe("upgradeState", () => {
     );
     const newState = upgradeStateToElectra(stateView);
     expect(() => newState.toValue()).not.toThrow();
+  });
+
+  it("upgradeStateToGloas reuses composite-list nodes with identical merkle roots", () => {
+    // Enough validators to span multiple progressive subtrees (capacities 1, 4, 16, 64, ...) and to
+    // populate every slot's committee for the gloas PTC window computed during the upgrade.
+    const numValidators = 128;
+    const fuluStateView = ssz.fulu.BeaconState.defaultViewDU();
+    for (let i = 0; i < numValidators; i++) {
+      const validator = ssz.phase0.Validator.defaultValue();
+      // Distinct pubkey/withdrawalCredentials so each validator has a distinct subtree root
+      validator.pubkey = Buffer.alloc(48, i + 1);
+      validator.withdrawalCredentials = Buffer.alloc(32, i + 1);
+      validator.effectiveBalance = 32e9;
+      // Active at epoch 0 so shuffling / PTC committee selection has a non-empty validator set
+      validator.activationEligibilityEpoch = 0;
+      validator.activationEpoch = 0;
+      validator.exitEpoch = FAR_FUTURE_EPOCH;
+      validator.withdrawableEpoch = FAR_FUTURE_EPOCH;
+      fuluStateView.validators.push(ssz.phase0.Validator.toViewDU(validator));
+      fuluStateView.balances.push(32e9);
+      fuluStateView.previousEpochParticipation.push(0);
+      fuluStateView.currentEpochParticipation.push(0);
+      fuluStateView.inactivityScores.push(0);
+    }
+
+    // Populate the pending* composite queues so the node-reuse path is exercised for them too.
+    // Non-builder withdrawal credentials (default zeros) keep the deposits pending in-order.
+    for (let i = 0; i < 5; i++) {
+      const pendingDeposit = ssz.electra.PendingDeposit.defaultValue();
+      pendingDeposit.amount = 1000 + i;
+      fuluStateView.pendingDeposits.push(ssz.electra.PendingDeposit.toViewDU(pendingDeposit));
+      const pendingPartialWithdrawal = ssz.electra.PendingPartialWithdrawal.defaultValue();
+      pendingPartialWithdrawal.amount = BigInt(2000 + i);
+      fuluStateView.pendingPartialWithdrawals.push(
+        ssz.electra.PendingPartialWithdrawal.toViewDU(pendingPartialWithdrawal)
+      );
+      const pendingConsolidation = ssz.electra.PendingConsolidation.defaultValue();
+      pendingConsolidation.sourceIndex = i;
+      fuluStateView.pendingConsolidations.push(ssz.electra.PendingConsolidation.toViewDU(pendingConsolidation));
+    }
+    fuluStateView.commit();
+
+    const config = getConfig(ForkName.fulu);
+    const fuluState = createCachedBeaconState(
+      fuluStateView,
+      {
+        config: createBeaconConfig(config, fuluStateView.genesisValidatorsRoot),
+        pubkeyCache: createPubkeyCache(),
+      },
+      // dummy pubkeys aren't valid BLS keys; skip syncing (no builder deposits need the cache)
+      {skipSyncCommitteeCache: true, skipSyncPubkeys: true}
+    ) as CachedBeaconStateFulu;
+
+    // Reference gloas roots via the value-based path (what the node-reuse replaces)
+    const expectedValidatorsRoot = ssz.gloas.Validators.hashTreeRoot(fuluState.validators.getAllReadonlyValues());
+    const expectedPendingDepositsRoot = ssz.gloas.PendingDeposits.hashTreeRoot(
+      fuluState.pendingDeposits.getAllReadonlyValues()
+    );
+    const expectedPendingPartialWithdrawalsRoot = ssz.gloas.PendingPartialWithdrawals.hashTreeRoot(
+      fuluState.pendingPartialWithdrawals.getAllReadonlyValues()
+    );
+    const expectedPendingConsolidationsRoot = ssz.gloas.PendingConsolidations.hashTreeRoot(
+      fuluState.pendingConsolidations.getAllReadonlyValues()
+    );
+
+    const gloasState = upgradeStateToGloas(fuluState);
+
+    // Node-reuse must produce byte-identical merkle roots for every migrated composite list
+    expect(gloasState.validators.hashTreeRoot()).toEqual(expectedValidatorsRoot);
+    expect(gloasState.validators.length).toEqual(numValidators);
+    expect(gloasState.pendingDeposits.hashTreeRoot()).toEqual(expectedPendingDepositsRoot);
+    expect(gloasState.pendingPartialWithdrawals.hashTreeRoot()).toEqual(expectedPendingPartialWithdrawalsRoot);
+    expect(gloasState.pendingConsolidations.hashTreeRoot()).toEqual(expectedPendingConsolidationsRoot);
+    // Full state still merkleizes and round-trips
+    expect(() => gloasState.hashTreeRoot()).not.toThrow();
+    expect(() => gloasState.toValue()).not.toThrow();
   });
 });
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -81,7 +81,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@lodestar/params": "workspace:^",
     "ethereum-cryptography": "^2.0.0"
   },

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@chainsafe/blst": "^2.2.0",
-    "@chainsafe/ssz": "^1.6.0",
+    "@chainsafe/ssz": "^1.6.1",
     "@lodestar/api": "workspace:^",
     "@lodestar/config": "workspace:^",
     "@lodestar/db": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: 3.0.6
         version: 3.0.6
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@lerna-lite/cli':
         specifier: ^4.9.4
         version: 4.9.4(@lerna-lite/exec@4.10.3)(@lerna-lite/publish@4.9.4)(@lerna-lite/run@4.9.4)(@lerna-lite/version@4.9.4)(@types/node@24.10.1)
@@ -145,8 +145,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@lodestar/config':
         specifier: workspace:^
         version: link:../config
@@ -209,8 +209,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@chainsafe/threads':
         specifier: ^1.11.3
         version: 1.11.3
@@ -405,8 +405,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@chainsafe/threads':
         specifier: ^1.11.3
         version: 1.11.3
@@ -535,8 +535,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@lodestar/params':
         specifier: workspace:^
         version: link:../params
@@ -550,8 +550,8 @@ importers:
   packages/db:
     dependencies:
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@lodestar/config':
         specifier: workspace:^
         version: link:../config
@@ -590,8 +590,8 @@ importers:
   packages/fork-choice:
     dependencies:
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@lodestar/config':
         specifier: workspace:^
         version: link:../config
@@ -627,8 +627,8 @@ importers:
         version: 4.6.0
     devDependencies:
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@chainsafe/threads':
         specifier: ^1.11.3
         version: 1.11.3
@@ -685,8 +685,8 @@ importers:
         version: 2.4.8
     devDependencies:
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@libp2p/crypto':
         specifier: ^5.1.13
         version: 5.1.19
@@ -706,8 +706,8 @@ importers:
   packages/spec-test-util:
     dependencies:
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@lodestar/types':
         specifier: workspace:^
         version: link:../types
@@ -739,8 +739,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@chainsafe/swap-or-not-shuffle':
         specifier: ^1.2.1
         version: 1.2.1
@@ -798,8 +798,8 @@ importers:
   packages/types:
     dependencies:
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@lodestar/params':
         specifier: workspace:^
         version: link:../params
@@ -841,8 +841,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@chainsafe/ssz':
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.6.1
+        version: 1.6.1
       '@lodestar/api':
         specifier: workspace:^
         version: link:../api
@@ -1315,8 +1315,8 @@ packages:
   '@chainsafe/snappy-wasm@0.5.0':
     resolution: {integrity: sha512-ydXvhr9p+JjvzSSEyi6XExq8pHugFnrk70mk17T6mhDsklPvaXc+8K90G7TJF+u51lxI/fpv7MahrA5ayjFcSA==}
 
-  '@chainsafe/ssz@1.6.0':
-    resolution: {integrity: sha512-pcvxGRIGpuDaaNEbR0VIJJ89xUstPjh6dDcaOHoIcgZkNyb4xEeMm75vaKBn4XFVgUnWgz9fEbLbMXjasILRdA==}
+  '@chainsafe/ssz@1.6.1':
+    resolution: {integrity: sha512-c89Mqcn0ulBOqrIq/eFTNqvlxSLKTPAa4+YDlo3CdYqDzGtzzzVDITo9Icr25rWdbGBkEWYr0LA8cuA9IE3DSw==}
 
   '@chainsafe/swap-or-not-shuffle-darwin-arm64@1.2.1':
     resolution: {integrity: sha512-kTewLZe1KqMAJ1gHfagOxo0BI4kTcMOAkGJ7pRLFM5ZkL2P7sh3/4ixnjdbtMkO207vMZEZL3fxJSSs14kg9Kg==}
@@ -6819,7 +6819,7 @@ snapshots:
 
   '@chainsafe/snappy-wasm@0.5.0': {}
 
-  '@chainsafe/ssz@1.6.0':
+  '@chainsafe/ssz@1.6.1':
     dependencies:
       '@chainsafe/as-sha256': 1.2.4
       '@chainsafe/persistent-merkle-tree': 1.3.0


### PR DESCRIPTION
**Motivation**

- improve upgradeStateToGloas() by reusing nodes of pre-gloas BeaconState
- bump `@chainsafe/ssz` version to v1.6.1

**Description**

with mainnet state 14707840

- before
```
[bench] upgradeStateToGloas: 3205.5ms
[bench] gloas hashTreeRoot: 32196.4ms
```

- this PR
```
[bench] upgradeStateToGloas: 1178.3ms
[bench] gloas hashTreeRoot: 4899.3ms
```



**AI Assistance Disclosure**
- created with the help of Claude