### PR TITLE
fix: namespace graffiti append cli option

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -4,7 +4,7 @@ import {ensure0xPrefix} from "../../util/format.js";
 
 export type ChainArgs = {
   suggestedFeeRecipient: string;
-  graffitiAppend?: boolean;
+  "chain.graffitiAppend"?: boolean;
   serveHistoricalState?: boolean;
   "chain.blacklistedBlocks"?: string[];
   "chain.blsVerifyAllMultiThread"?: boolean;
@@ -44,7 +44,7 @@ export type ChainArgs = {
 export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
   return {
     suggestedFeeRecipient: args.suggestedFeeRecipient,
-    graffitiAppend: args.graffitiAppend,
+    graffitiAppend: args["chain.graffitiAppend"],
     serveHistoricalState: args.serveHistoricalState,
     blacklistedBlocks: args["chain.blacklistedBlocks"],
     blsVerifyAllMultiThread: args["chain.blsVerifyAllMultiThread"],
@@ -100,7 +100,7 @@ export const options: CliCommandOptions<ChainArgs> = {
     group: "chain",
   },
 
-  graffitiAppend: {
+  "chain.graffitiAppend": {
     type: "boolean",
     description: "Append CL/EL client info to graffiti supplied by validator when space allows",
     default: defaultOptions.chain.graffitiAppend,

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -42,7 +42,7 @@ describe("options / beaconNodeOptions", () => {
       "chain.maxCPStateEpochsOnDisk": 1000,
       "chain.archiveMode": ArchiveMode.Frequency,
       emitPayloadAttributes: false,
-      graffitiAppend: false,
+      "chain.graffitiAppend": false,
 
       "execution.urls": ["http://localhost:8551"],
       "execution.timeout": 12000,


### PR DESCRIPTION
Fixes the remaining CLI option namespacing review item on #9599 by registering/parsing the flag as `chain.graffitiAppend` instead of the top-level `graffitiAppend`.

Verification:
- `pnpm build`
- `pnpm vitest run --project unit packages/beacon-node/test/unit/util/graffiti.test.ts packages/cli/test/unit/options/beaconNodeOptions.test.ts`
- `pnpm lint`

AI assistance: implemented with Lodekeeper/Codex.