### PR TITLE
docs: mention graffiti append option

### DIFF
--- a/docs/pages/run/validator-management/proposer-config.md
+++ b/docs/pages/run/validator-management/proposer-config.md
@@ -6,7 +6,7 @@ This is an alpha feature. The feature and its format are subject to change.
 
 With Lodestar's validator client, you can assign specific metadata for each proposer/public key using a proposer configuration file written in YAML file. This will allow you to set specific graffiti, fee recipients and builder settings per validator key.
 
-When graffiti is supplied by the validator client, the connected Lodestar beacon node appends CL/EL client information to the graffiti by default when there is enough space in the 32-byte field. Run the beacon node with [`--graffitiAppend false`](../beacon-management/beacon-cli.md#--graffitiappend) to publish validator-supplied graffiti without the appended client information.
+When graffiti is supplied by the validator client, the connected Lodestar beacon node appends CL/EL client information to the graffiti by default when there is enough space left. Run the beacon node with [`--graffitiAppend false`](../beacon-management/beacon-cli.md#--graffitiappend) to disable this misbehavior. (@matthewkeil fix this)
 
 ### Example proposer_config.yaml
 

--- a/docs/pages/run/validator-management/proposer-config.md
+++ b/docs/pages/run/validator-management/proposer-config.md
@@ -6,6 +6,8 @@ This is an alpha feature. The feature and its format are subject to change.
 
 With Lodestar's validator client, you can assign specific metadata for each proposer/public key using a proposer configuration file written in YAML file. This will allow you to set specific graffiti, fee recipients and builder settings per validator key.
 
+When graffiti is supplied by the validator client, the connected Lodestar beacon node appends CL/EL client information to the graffiti by default when there is enough space in the 32-byte field. Run the beacon node with [`--graffitiAppend false`](../beacon-management/beacon-cli.md#--graffitiappend) to publish validator-supplied graffiti without the appended client information.
+
 ### Example proposer_config.yaml
 
 ```yaml


### PR DESCRIPTION
## Motivation

wemeetagain noted on #9599 that the graffiti append behavior should be documented too.

## Changes

- Document that Lodestar beacon nodes append CL/EL client information to validator-supplied graffiti by default when it fits.
- Point users to `--graffitiAppend false` when they need validator-supplied graffiti without the appended client information.

## Verification

- `pnpm build`
- `pnpm --filter @chainsafe/lodestar docs:build`
- `pnpm exec prettier docs/pages/run/validator-management/proposer-config.md --check`

AI assistance: drafted with OpenAI Codex under lodekeeper supervision.
