### PR TITLE
chore: export builder id route type

### DIFF
--- a/packages/api/src/beacon/routes/beacon/index.ts
+++ b/packages/api/src/beacon/routes/beacon/index.ts
@@ -15,6 +15,7 @@ export type {BlockHeaderResponse, BlockId} from "./block.js";
 export {BroadcastValidation} from "./block.js";
 // TODO: Review if re-exporting all these types is necessary
 export type {
+  BuilderId,
   BuilderResponse,
   BuilderStatus,
   EpochCommitteeResponse,

--- a/packages/api/src/beacon/routes/beacon/state.ts
+++ b/packages/api/src/beacon/routes/beacon/state.ts
@@ -38,6 +38,7 @@ export type StateArgs = {
 };
 
 export type ValidatorId = string | number;
+export type BuilderId = string | number;
 
 export type {BuilderStatus, ValidatorStatus};
 
@@ -229,7 +230,7 @@ export type Endpoints = {
     "POST",
     StateArgs & {
       /** Either hex encoded public key (any bytes48 with 0x prefix) or builder index */
-      builderIds?: ValidatorId[];
+      builderIds?: BuilderId[];
       statuses?: BuilderStatus[];
     },
     {params: {state_id: string}; body: {ids?: string[]; statuses?: BuilderStatus[]}},

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -92,7 +92,7 @@ type StateBuilderIndexResponse =
   | {valid: false; code: number; reason: string};
 
 export function getStateBuilderIndex(
-  id: routes.beacon.ValidatorId | BLSPubkey,
+  id: routes.beacon.BuilderId | BLSPubkey,
   state: IBeaconStateViewGloas
 ): StateBuilderIndexResponse {
   if (typeof id === "string") {


### PR DESCRIPTION
Addresses review feedback on #9593 by exporting a dedicated BuilderId route type and using it for builder state lookups instead of ValidatorId.\n\nVerification:\n- pnpm lint\n- pnpm build\n- pnpm check-types