### PR TITLE
chore: alias builder id serdes helpers

### DIFF
--- a/packages/api/src/beacon/routes/beacon/state.ts
+++ b/packages/api/src/beacon/routes/beacon/state.ts
@@ -23,7 +23,7 @@ import {
   ExecutionOptimisticFinalizedAndVersionCodec,
   ExecutionOptimisticFinalizedAndVersionMeta,
 } from "../../../utils/metadata.js";
-import {fromValidatorIdsStr, toValidatorIdsStr} from "../../../utils/serdes.js";
+import {fromBuilderIdsStr, fromValidatorIdsStr, toBuilderIdsStr, toValidatorIdsStr} from "../../../utils/serdes.js";
 import {WireFormat} from "../../../utils/wireFormat.js";
 import {RootResponse, RootResponseType} from "./block.js";
 
@@ -530,13 +530,13 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         writeReqJson: ({stateId, builderIds, statuses}) => ({
           params: {state_id: stateId.toString()},
           body: {
-            ids: toValidatorIdsStr(builderIds),
+            ids: toBuilderIdsStr(builderIds),
             statuses,
           },
         }),
         parseReqJson: ({params, body = {}}) => ({
           stateId: params.state_id,
-          builderIds: fromValidatorIdsStr(body.ids),
+          builderIds: fromBuilderIdsStr(body.ids),
           statuses: body.statuses ?? undefined,
         }),
         schema: {

--- a/packages/api/src/utils/serdes.ts
+++ b/packages/api/src/utils/serdes.ts
@@ -75,6 +75,9 @@ export function fromValidatorIdsStr(ids?: string[]): (string | number)[] | undef
   return ids?.map((id) => (typeof id === "string" && id.startsWith("0x") ? id : fromU64Str(id)));
 }
 
+export const toBuilderIdsStr = toValidatorIdsStr;
+export const fromBuilderIdsStr = fromValidatorIdsStr;
+
 const GRAFFITI_HEX_LENGTH = 66;
 
 export function toGraffitiHex(utf8?: string): string | undefined {


### PR DESCRIPTION
Addresses review feedback on #9593 by adding explicit builder ID serdes aliases while preserving existing validator helper names for validator call sites.

Changes:
- Add `toBuilderIdsStr` / `fromBuilderIdsStr` aliases in API serdes
- Use the builder aliases for `getStateBuilders` request serialization/parsing

Verification:
- `pnpm lint`
- `pnpm build`
- `pnpm check-types`