### PR TITLE
fix: set gossipsub allowedTopics

### DIFF
--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -35,7 +35,7 @@ import {
   computeGossipPeerScoreParams,
   gossipScoreThresholds,
 } from "./scoringParameters.js";
-import {GossipTopicCache, getCoreTopicsAtFork, stringifyGossipTopic} from "./topic.js";
+import {GossipTopicCache, getAllowedTopics, getCoreTopicsAtFork, stringifyGossipTopic} from "./topic.js";
 
 /** As specified in https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md */
 const GOSSIPSUB_HEARTBEAT_INTERVAL = 0.7 * 1000;
@@ -140,6 +140,7 @@ export class Eth2Gossipsub {
     const gossipsubInstance = gossipsub({
       globalSignaturePolicy: StrictNoSign,
       allowPublishToZeroTopicPeers: allowPublishToZeroPeers,
+      allowedTopics: getAllowedTopics(networkConfig),
       D: gossipsubD ?? GOSSIP_D,
       Dlo: gossipsubDLow ?? GOSSIP_D_LOW,
       Dhi: gossipsubDHigh ?? GOSSIP_D_HIGH,

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -246,7 +246,7 @@ export function parseGossipTopic(forkDigestContext: ForkDigestContext, topicStr:
 export function getCoreTopicsAtFork(
   networkConfig: NetworkConfig,
   fork: ForkName,
-  opts: {subscribeAllSubnets?: boolean; disableLightClientServer?: boolean}
+  opts: {subscribeAllSubnets?: boolean; subscribeAllColumnSubnets?: boolean; disableLightClientServer?: boolean}
 ): GossipTopicTypeMap[keyof GossipTopicTypeMap][] {
   // Common topics for all forks
   const topics: GossipTopicTypeMap[keyof GossipTopicTypeMap][] = [
@@ -266,7 +266,7 @@ export function getCoreTopicsAtFork(
 
   // After fulu also track data_column_sidecar_{index}
   if (ForkSeq[fork] >= ForkSeq.fulu) {
-    topics.push(...getDataColumnSidecarTopics(networkConfig));
+    topics.push(...getDataColumnSidecarTopics(networkConfig, opts.subscribeAllColumnSubnets));
   }
 
   // After Deneb and before Fulu also track blob_sidecar_{subnet_id}
@@ -310,14 +310,38 @@ export function getCoreTopicsAtFork(
 }
 
 /**
+ * Build the complete set of valid gossip topic strings across every fork boundary.
+ */
+export function getAllowedTopics(networkConfig: NetworkConfig): Set<string> {
+  const {config} = networkConfig;
+  const allowedTopics = new Set<string>();
+
+  for (const boundary of config.forkBoundariesAscendingEpochOrder) {
+    const topics = getCoreTopicsAtFork(networkConfig, boundary.fork, {
+      subscribeAllSubnets: true,
+      subscribeAllColumnSubnets: true,
+      disableLightClientServer: false,
+    });
+    for (const topic of topics) {
+      allowedTopics.add(stringifyGossipTopic(config, {...topic, boundary}));
+    }
+  }
+
+  return allowedTopics;
+}
+
+/**
  * Pick data column subnets to subscribe to post-fulu.
  */
 export function getDataColumnSidecarTopics(
-  networkConfig: NetworkConfig
+  networkConfig: NetworkConfig,
+  subscribeAllColumnSubnets = false
 ): GossipTopicTypeMap[keyof GossipTopicTypeMap][] {
   const topics: GossipTopicTypeMap[keyof GossipTopicTypeMap][] = [];
 
-  const subnets = networkConfig.custodyConfig.sampledSubnets;
+  const subnets = subscribeAllColumnSubnets
+    ? Array.from({length: networkConfig.config.DATA_COLUMN_SIDECAR_SUBNET_COUNT}, (_, i) => i)
+    : networkConfig.custodyConfig.sampledSubnets;
   for (const subnet of subnets) {
     topics.push({type: GossipType.data_column_sidecar, subnet});
   }

--- a/packages/beacon-node/test/unit/network/gossip/topic.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/topic.test.ts
@@ -1,9 +1,18 @@
 import {describe, expect, it} from "vitest";
 import {createBeaconConfig} from "@lodestar/config";
 import {config as chainConfig} from "@lodestar/config/default";
-import {ForkName, GENESIS_EPOCH, ZERO_HASH} from "@lodestar/params";
+import {ATTESTATION_SUBNET_COUNT, ForkName, GENESIS_EPOCH, ZERO_HASH} from "@lodestar/params";
 import {GossipEncoding, GossipTopicMap, GossipType} from "../../../../src/network/gossip/index.js";
-import {parseGossipTopic, stringifyGossipTopic} from "../../../../src/network/gossip/topic.js";
+import {
+  getAllowedTopics,
+  getCoreTopicsAtFork,
+  parseGossipTopic,
+  stringifyGossipTopic,
+} from "../../../../src/network/gossip/topic.js";
+import {NetworkConfig} from "../../../../src/network/networkConfig.js";
+import {computeNodeId} from "../../../../src/network/subnets/index.js";
+import {CustodyConfig} from "../../../../src/util/dataColumns.js";
+import {getValidPeerId} from "../../../utils/peer.js";
 
 describe("network / gossip / topic", () => {
   const config = createBeaconConfig({...chainConfig, GLOAS_FORK_EPOCH: 700000}, ZERO_HASH);
@@ -216,4 +225,89 @@ describe("network / gossip / topic", () => {
       expect(() => parseGossipTopic(config, topicStr)).toThrow();
     });
   }
+
+  describe("getAllowedTopics", () => {
+    // A config with every fork scheduled so all fork boundaries (and their topics) are present
+    const allForksConfig = createBeaconConfig(
+      {
+        ...chainConfig,
+        ALTAIR_FORK_EPOCH: 1,
+        BELLATRIX_FORK_EPOCH: 2,
+        CAPELLA_FORK_EPOCH: 3,
+        DENEB_FORK_EPOCH: 4,
+        ELECTRA_FORK_EPOCH: 5,
+        FULU_FORK_EPOCH: 6,
+        GLOAS_FORK_EPOCH: 7,
+      },
+      ZERO_HASH
+    );
+    const nodeId = computeNodeId(getValidPeerId());
+    const networkConfig: NetworkConfig = {
+      nodeId,
+      config: allForksConfig,
+      custodyConfig: new CustodyConfig({nodeId, config: allForksConfig}),
+    };
+    const allowedTopics = getAllowedTopics(networkConfig);
+
+    const findBoundary = (fork: ForkName) => {
+      const boundary = allForksConfig.forkBoundariesAscendingEpochOrder.find((b) => b.fork === fork);
+      if (!boundary) throw Error(`no boundary for fork ${fork}`);
+      return boundary;
+    };
+
+    it("is a superset of every topic the node may subscribe to across all forks", () => {
+      for (const boundary of allForksConfig.forkBoundariesAscendingEpochOrder) {
+        const topics = getCoreTopicsAtFork(networkConfig, boundary.fork, {
+          subscribeAllSubnets: true,
+          disableLightClientServer: false,
+        });
+        for (const topic of topics) {
+          const topicStr = stringifyGossipTopic(allForksConfig, {...topic, boundary});
+          expect(allowedTopics.has(topicStr), `missing subscribed topic ${topicStr}`).toBe(true);
+        }
+      }
+    });
+
+    it("includes all attestation subnets", () => {
+      const boundary = findBoundary(ForkName.phase0);
+      for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
+        const topicStr = stringifyGossipTopic(allForksConfig, {type: GossipType.beacon_attestation, subnet, boundary});
+        expect(allowedTopics.has(topicStr), `missing ${topicStr}`).toBe(true);
+      }
+    });
+
+    it("includes ALL data column subnets at fulu, not just the sampled ones", () => {
+      const boundary = findBoundary(ForkName.fulu);
+      for (let subnet = 0; subnet < allForksConfig.DATA_COLUMN_SIDECAR_SUBNET_COUNT; subnet++) {
+        const topicStr = stringifyGossipTopic(allForksConfig, {
+          type: GossipType.data_column_sidecar,
+          subnet,
+          boundary,
+        });
+        expect(allowedTopics.has(topicStr), `missing ${topicStr}`).toBe(true);
+      }
+    });
+
+    it("only contains valid, parseable topic strings", () => {
+      expect(allowedTopics.size).toBeGreaterThan(0);
+      for (const topicStr of allowedTopics) {
+        expect(() => parseGossipTopic(allForksConfig, topicStr), `unparseable allowed topic ${topicStr}`).not.toThrow();
+      }
+    });
+
+    it("excludes attacker-controlled topics (out-of-range subnet, unknown digest, garbage)", () => {
+      const boundary = findBoundary(ForkName.phase0);
+      // Valid fork digest + format, but out-of-range attestation subnet
+      const outOfRangeSubnet = stringifyGossipTopic(allForksConfig, {
+        type: GossipType.beacon_attestation,
+        subnet: 9999,
+        boundary,
+      });
+      expect(allowedTopics.has(outOfRangeSubnet)).toBe(false);
+      // Unknown fork digest
+      expect(allowedTopics.has("/eth2/ffffffff/beacon_attestation_5/ssz_snappy")).toBe(false);
+      // Garbage
+      expect(allowedTopics.has("/attacker/garbage/topic")).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
**Motivation**

- client hardening

**Description**

- Add `getAllowedTopics` function which enumerates all valid topics ever accepted by this node. This includes all known forks, all attestation subnets, and all data column subnets.
- Configure gossipsub `allowedTopics` in gossipsub construction

**AI Assistance Disclosure**

- claude assistance
