### PR TITLE
feat: chain.targetGasLimit

### DIFF
--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -35,6 +35,7 @@ export type IChainOptions = BlockProcessOpts &
     persistOrphanedBlocksDir?: string;
     skipCreateStateCacheIfAvailable?: boolean;
     suggestedFeeRecipient: string;
+    targetGasLimit?: number;
     graffitiAppend?: boolean;
     maxSkipSlots?: number;
     /** Ensure blobs returned by the execution engine are valid */

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -702,6 +702,7 @@ export async function prepareExecutionPayload(
     config: ChainForkConfig;
     forkChoice: IForkChoice;
     proposerPreferencesPool: ProposerPreferencesPool;
+    opts?: {targetGasLimit?: number};
   },
   logger: Logger,
   fork: ForkPostBellatrix,
@@ -861,6 +862,7 @@ function preparePayloadAttributes(
     config: ChainForkConfig;
     forkChoice: IForkChoice;
     proposerPreferencesPool: ProposerPreferencesPool;
+    opts?: {targetGasLimit?: number};
   },
   {
     prepareState,
@@ -944,8 +946,9 @@ function preparePayloadAttributes(
  *
  * Sourced from the `SignedProposerPreferences` the proposer's VC submitted to the pool
  * (same `(slot, dependent_root)` lookup as gossip bid validation). When no matching
- * preferences are pooled, target the parent payload's gas limit so the gas limit stays
- * unchanged (`is_gas_limit_target_compatible` then requires `gas_limit == parent_gas_limit`).
+ * preferences are pooled, fallback to `chain.targetGasLimit` and if it is not provided,
+ * target the parent payload's gas limit so the gas limit stays unchanged
+ * (`is_gas_limit_target_compatible` then requires `gas_limit == parent_gas_limit`).
  *
  * The parent payload's gas_limit is read from fork choice — the variant matching
  * `(parentBlockRoot, parentBlockHash)` carries the correct value for both FULL parents
@@ -953,7 +956,7 @@ function preparePayloadAttributes(
  * (EMPTY.executionPayloadGasLimit = inherited grandparent's gas_limit).
  */
 function getProposerTargetGasLimit(
-  chain: {forkChoice: IForkChoice; proposerPreferencesPool: ProposerPreferencesPool},
+  chain: {forkChoice: IForkChoice; proposerPreferencesPool: ProposerPreferencesPool; opts?: {targetGasLimit?: number}},
   prepareSlot: Slot,
   parentBlockRoot: Root,
   parentBlockHash: Bytes32
@@ -979,6 +982,12 @@ function getProposerTargetGasLimit(
   const pref = dependentRootHex !== null ? chain.proposerPreferencesPool.get(prepareSlot, dependentRootHex) : null;
   if (pref !== null) {
     return pref.message.targetGasLimit;
+  }
+
+  // Optional fallback for when there is no proposer preference provided.
+  const configuredTargetGasLimit = chain.opts?.targetGasLimit;
+  if (configuredTargetGasLimit !== undefined) {
+    return configuredTargetGasLimit;
   }
 
   const parentPayloadVariant = chain.forkChoice.getBlockHexAndBlockHash(parentBlockRootHex, toRootHex(parentBlockHash));

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -25,6 +25,7 @@ export type ChainArgs = {
   "chain.fastConfirmation"?: boolean;
   "chain.assertCorrectProgressiveBalances"?: boolean;
   "chain.maxSkipSlots"?: number;
+  "chain.targetGasLimit"?: number;
   emitPayloadAttributes?: boolean;
   broadcastValidationStrictness?: string;
   "chain.minSameMessageSignatureSetsToBatch"?: number;
@@ -66,6 +67,7 @@ export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
     fastConfirmation: args["chain.fastConfirmation"],
     assertCorrectProgressiveBalances: args["chain.assertCorrectProgressiveBalances"],
     maxSkipSlots: args["chain.maxSkipSlots"],
+    targetGasLimit: args["chain.targetGasLimit"],
     emitPayloadAttributes: args.emitPayloadAttributes,
     broadcastValidationStrictness: args.broadcastValidationStrictness,
     minSameMessageSignatureSetsToBatch:
@@ -235,6 +237,12 @@ Will double processing times. Use only for debugging purposes.",
     hidden: true,
     type: "number",
     description: "Refuse to skip more than this many slots when processing a block or attestation",
+    group: "chain",
+  },
+
+  "chain.targetGasLimit": {
+    type: "number",
+    description: "Fallback gas limit for when no proposer preferences are available",
     group: "chain",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -244,6 +244,12 @@ Will double processing times. Use only for debugging purposes.",
     type: "number",
     description: "Fallback gas limit for when no proposer preferences are available",
     group: "chain",
+    coerce: (value: number): number => {
+      if (value <= 0 || !Number.isInteger(value)) {
+        throw new Error("chain.targetGasLimit must be a positive integer");
+      }
+      return value;
+    },
   },
 
   "chain.assertCorrectProgressiveBalances": {


### PR DESCRIPTION
**Motivation**

Introduces optional CLI param `chain.targetGasLimit` which is a first layer of fallback when proposer preference is not provided.

**Description**

`chain.targetGasLimit` is introduced as an optional CLI param which has a similar prupose as Prysm's `DefaultBuilderGasLimit`.
Since previously a direct fallback to the parent block gas limit existed, this param introduces a layer over it, and the old fallback is not removed.
This provides better coverage of a matter than having a default constant value.

Fallback flow:

proposer preference -> `chain.targetGasLimit` -> parent gas limit
 
I made a couple of my own decisions here, and I am willing to change the approach if needed.

Closes #9385

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Used Claude to ping pong on a proper direction and audit changes.
