### PR TITLE
fix: reject out-of-range builder_index in execution payload bid gossip validation

### DIFF
--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -122,17 +122,20 @@ async function validateExecutionPayloadBid(
     throw new Error(`Expected gloas+ state for execution payload bid validation, got fork=${state.forkName}`);
   }
 
-  // [REJECT] `bid.builder_index` is a valid/active builder index -- i.e.
-  // `is_active_builder(state, bid.builder_index)` returns `True`.
-  let builder: gloas.Builder;
-  try {
-    builder = state.getBuilder(bid.builderIndex);
-  } catch {
+  // [REJECT] `bid.builder_index` is within bounds -- i.e. `bid.builder_index < len(state.builders)`.
+  // `state.getBuilder` returns a lazy SSZ `getReadonly` view that is not bounds-checked eagerly; an
+  // out-of-range index only throws (`LeafNode has no right node`) on deferred field access (e.g. inside
+  // `isActiveBuilder`), escaping a try/catch around `getBuilder`. Check the length explicitly instead.
+  if (bid.builderIndex >= state.getBuildersLength()) {
     throw new ExecutionPayloadBidError(GossipAction.REJECT, {
       code: ExecutionPayloadBidErrorCode.BUILDER_NOT_ELIGIBLE,
       builderIndex: bid.builderIndex,
     });
   }
+
+  // [REJECT] `bid.builder_index` is a valid/active builder index -- i.e.
+  // `is_active_builder(state, bid.builder_index)` returns `True`.
+  const builder = state.getBuilder(bid.builderIndex);
   if (!isActiveBuilder(builder, state.finalizedCheckpoint.epoch)) {
     throw new ExecutionPayloadBidError(GossipAction.REJECT, {
       code: ExecutionPayloadBidErrorCode.BUILDER_NOT_ELIGIBLE,


### PR DESCRIPTION
## Problem

`validateExecutionPayloadBid` (Gloas execution payload bid gossip validation) does not implement the spec's `[REJECT] bid.builder_index < len(state.builders)` bounds check. It looks up the builder inside a `try/catch` meant to turn an out-of-range index into a `GossipReject`:

```ts
let builder: gloas.Builder;
try {
  builder = state.getBuilder(bid.builderIndex);
} catch {
  throw new ExecutionPayloadBidError(GossipAction.REJECT, {code: BUILDER_NOT_ELIGIBLE, ...});
}
if (!isActiveBuilder(builder, state.finalizedCheckpoint.epoch)) { ... }
```

But `state.getBuilder(i)` returns a **lazy** SSZ view (`builders.getReadonly(i)`) that is not bounds-checked eagerly. An out-of-range `builder_index` therefore does **not** throw at `getBuilder` — it throws `LeafNode has no right node` later, on deferred field access inside `isActiveBuilder` (`builder.depositEpoch`), which is outside the `try/catch`. The net effect is an **uncaught error** on the gossip validation path instead of a clean `REJECT`.

## Fix

Add an explicit `bid.builder_index < len(state.builders)` bounds check up front using the existing `state.getBuildersLength()`, and drop the now-ineffective `try/catch`.

## Testing

Found by running the consensus-specs [#5294](https://github.com/ethereum/consensus-specs/pull/5294) Gloas networking reference tests (spec `v1.7.0-alpha.12`). The `gossip_execution_payload_bid__reject_builder_index_out_of_range` case now returns `REJECT` (previously an uncaught throw), with no regression across the rest of the `gossip_execution_payload_bid` suite (minimal + mainnet presets).

> Note: these Gloas gossip validators currently have no unit-test coverage on `unstable`; the reftest suite (wired up in #9372) is their canonical coverage.

🤖 Generated with AI assistance
