### PR TITLE
fix: apply gossip clock disparity to execution payload bid slot validation

### DIFF
--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -37,9 +37,17 @@ async function validateExecutionPayloadBid(
   const parentBlockRootHex = toRootHex(bid.parentBlockRoot);
   const parentBlockHashHex = toRootHex(bid.parentBlockHash);
 
-  // [IGNORE] `bid.slot` is the current slot or the next slot.
-  const currentSlot = chain.clock.currentSlot;
-  if (bid.slot !== currentSlot && bid.slot !== currentSlot + 1) {
+  // [IGNORE] `bid.slot` is the current slot or the next slot, with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY`
+  // allowance on both ends. Equivalent to the spec's `is_within_slot_range(state, bid.slot, 1, ...)`:
+  // the clock must be in slot `bid.slot - 1` (bid.slot is the next slot) or `bid.slot` (the current
+  // slot), i.e. now within `[start(bid.slot - 1), start(bid.slot + 1)] ± MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
+  // Millisecond-precise on purpose: the disparity boundary is sub-slot, so slot-granular helpers
+  // (`currentSlotWithGossipDisparity` / `slotWithFutureTolerance`) cannot express it.
+  const maxGossipClockDisparityMs = chain.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY;
+  if (
+    chain.clock.msFromSlot(bid.slot - 1) < -maxGossipClockDisparityMs ||
+    chain.clock.msFromSlot(bid.slot + 1) > maxGossipClockDisparityMs
+  ) {
     throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
       code: ExecutionPayloadBidErrorCode.INVALID_SLOT,
       builderIndex: bid.builderIndex,

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -37,8 +37,7 @@ async function validateExecutionPayloadBid(
   const parentBlockRootHex = toRootHex(bid.parentBlockRoot);
   const parentBlockHashHex = toRootHex(bid.parentBlockHash);
 
-  // [IGNORE] `bid.slot` is the current or next slot (allowing for `MAXIMUM_GOSSIP_CLOCK_DISPARITY`) --
-  // i.e. `bid.slot` is the current slot, or `bid.slot - 1` is the current slot so `bid.slot` is next.
+  // [IGNORE] `bid.slot` is the current slot, or the next slot (`bid.slot - 1` is current), allowing for `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
   if (
     !chain.clock.isCurrentSlotGivenGossipDisparity(bid.slot) &&
     !chain.clock.isCurrentSlotGivenGossipDisparity(bid.slot - 1)

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -37,11 +37,11 @@ async function validateExecutionPayloadBid(
   const parentBlockRootHex = toRootHex(bid.parentBlockRoot);
   const parentBlockHashHex = toRootHex(bid.parentBlockHash);
 
-  // [IGNORE] `bid.slot` is the current or next slot, allowing for `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
-  const maxGossipClockDisparityMs = chain.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY;
+  // [IGNORE] `bid.slot` is the current or next slot (allowing for `MAXIMUM_GOSSIP_CLOCK_DISPARITY`) --
+  // i.e. `bid.slot` is the current slot, or `bid.slot - 1` is the current slot so `bid.slot` is next.
   if (
-    chain.clock.msFromSlot(bid.slot - 1) < -maxGossipClockDisparityMs ||
-    chain.clock.msFromSlot(bid.slot + 1) > maxGossipClockDisparityMs
+    !chain.clock.isCurrentSlotGivenGossipDisparity(bid.slot) &&
+    !chain.clock.isCurrentSlotGivenGossipDisparity(bid.slot - 1)
   ) {
     throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
       code: ExecutionPayloadBidErrorCode.INVALID_SLOT,

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -37,12 +37,7 @@ async function validateExecutionPayloadBid(
   const parentBlockRootHex = toRootHex(bid.parentBlockRoot);
   const parentBlockHashHex = toRootHex(bid.parentBlockHash);
 
-  // [IGNORE] `bid.slot` is the current slot or the next slot, with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY`
-  // allowance on both ends. Equivalent to the spec's `is_within_slot_range(state, bid.slot, 1, ...)`:
-  // the clock must be in slot `bid.slot - 1` (bid.slot is the next slot) or `bid.slot` (the current
-  // slot), i.e. now within `[start(bid.slot - 1), start(bid.slot + 1)] ± MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
-  // Millisecond-precise on purpose: the disparity boundary is sub-slot, so slot-granular helpers
-  // (`currentSlotWithGossipDisparity` / `slotWithFutureTolerance`) cannot express it.
+  // [IGNORE] `bid.slot` is the current or next slot, allowing for `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
   const maxGossipClockDisparityMs = chain.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY;
   if (
     chain.clock.msFromSlot(bid.slot - 1) < -maxGossipClockDisparityMs ||


### PR DESCRIPTION
## Problem

The Gloas execution payload bid gossip validation checked the slot with an exact match and **no** `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance:

```ts
const currentSlot = chain.clock.currentSlot;
if (bid.slot !== currentSlot && bid.slot !== currentSlot + 1) {
  throw new ExecutionPayloadBidError(GossipAction.IGNORE, {code: INVALID_SLOT, ...});
}
```

Every other gossip slot check in Lodestar applies the disparity allowance (see `block.ts`, `blobSidecar.ts`, `attestation.ts`). Without it, a bid that arrives within `MAXIMUM_GOSSIP_CLOCK_DISPARITY` of a slot boundary is wrongly `IGNORE`d.

## Fix

Implement the spec's `is_within_slot_range(state, bid.slot, 1, current_time_ms)` semantics: the current time must fall within `[start(bid.slot - 1), start(bid.slot + 1)]`, extended by `± MAXIMUM_GOSSIP_CLOCK_DISPARITY` on both ends — i.e. the clock is in slot `bid.slot - 1` (bid.slot is the *next* slot) or `bid.slot` (the *current* slot).

Implemented with `chain.clock.msFromSlot(...)` because the disparity boundary is **sub-slot**: the passing/failing reftests are exactly **1 ms** apart at the edge (e.g. `95500` valid vs `95499` ignore; `108500` valid vs `108501` ignore). The slot-granular helpers (`currentSlotWithGossipDisparity` / `slotWithFutureTolerance`) floor to integer slots and produce identical values on either side of that 1 ms boundary, so they cannot express this check — a millisecond-precise comparison is required.

## Testing

Found by running the consensus-specs [#5294](https://github.com/ethereum/consensus-specs/pull/5294) Gloas networking reference tests (spec `v1.7.0-alpha.12`). All five `gossip_execution_payload_bid` slot cases now pass (minimal + mainnet):

- `valid_slot_at_lower_disparity`, `valid_slot_at_upper_disparity` — now `valid` (were `ignore`)
- `ignore_slot_outside_lower_disparity`, `ignore_slot_outside_upper_disparity`, `ignore_slot_too_far_future` — still `ignore` (no regression on the 1 ms-outside boundary)

> Note: these Gloas gossip validators currently have no unit-test coverage on `unstable`; the reftest suite (wired up in #9372) is their canonical coverage.

🤖 Generated with AI assistance
