### PR TITLE
refactor: move slot to query param in producePayloadAttestationData

### DIFF
--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -495,7 +495,7 @@ export type Endpoints = {
       /** The slot for which payload attestation data should be created */
       slot: Slot;
     },
-    {params: {slot: Slot}},
+    {query: {slot: Slot}},
     MaybePayloadAttestationData,
     VersionMeta
   >;
@@ -999,13 +999,13 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       },
     },
     producePayloadAttestationData: {
-      url: "/eth/v1/validator/payload_attestation_data/{slot}",
+      url: "/eth/v1/validator/payload_attestation_data",
       method: "GET",
       req: {
-        writeReq: ({slot}) => ({params: {slot}}),
-        parseReq: ({params}) => ({slot: params.slot}),
+        writeReq: ({slot}) => ({query: {slot}}),
+        parseReq: ({query}) => ({slot: query.slot}),
         schema: {
-          params: {slot: Schema.UintRequired},
+          query: {slot: Schema.UintRequired},
         },
       },
       resp: {

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -54,6 +54,10 @@ const testDatas = {
 const ignoredOperations = [
   // TODO GLOAS: not yet implemented
   "getExecutionPayloadBid",
+  // TODO: remove once the pinned beacon-APIs spec version includes beacon-APIs#626
+  // (slot path param -> query param). Pinned v5.0.0-alpha.2 still defines slot as a
+  // path param, so ignore this op to avoid a false conformance mismatch until the bump.
+  "producePayloadAttestationData",
 ];
 
 const ignoredProperties: Record<string, IgnoredProperty> = {


### PR DESCRIPTION
**Motivation**

Aligns `producePayloadAttestationData` with [beacon-APIs#626](https://github.com/ethereum/beacon-APIs/pull/626) (merged): `slot` moves from a path parameter to a query parameter, consistent with the other "produce data to sign for a slot" validator endpoints — `produceAttestationData` and `produceSyncCommitteeContribution` — which all take `slot` as a required query param.

**Description**

- `GET /eth/v1/validator/payload_attestation_data/{slot}` → `GET /eth/v1/validator/payload_attestation_data?slot={slot}`
- Only the request wire encoding changes (path → query). The endpoint args, the impl handler (`{slot}`), and the response are unchanged.
- The `204`-on-no-block response already landed in #9589.

Closes #9628

**oapiSpec conformance**

The pinned beacon-APIs spec (`v5.0.0-alpha.2`) predates beacon-APIs#626 and still defines `slot` as a path param, so `producePayloadAttestationData` is temporarily added to `ignoredOperations` in `oapiSpec.test.ts` to avoid a false mismatch. **Remove that ignore once the pin is bumped to a release that includes #626.**

🤖 Generated with AI assistance