### PR TITLE
fix: apply gossip clock disparity to proposer_preferences slot check

### DIFF
--- a/packages/beacon-node/src/chain/validation/proposerPreferences.ts
+++ b/packages/beacon-node/src/chain/validation/proposerPreferences.ts
@@ -32,8 +32,9 @@ export async function validateGossipProposerPreferences(
     });
   }
 
-  // [IGNORE] `preferences.proposal_slot` has not already passed.
-  const currentSlot = chain.clock.currentSlot;
+  // [IGNORE] `preferences.proposal_slot` has not already passed, i.e. `proposal_slot > current_slot`,
+  // allowing for `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
+  const currentSlot = chain.clock.slotWithFutureTolerance(chain.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY / 1000);
   if (proposalSlot <= currentSlot) {
     throw new ProposerPreferencesError(GossipAction.IGNORE, {
       code: ProposerPreferencesErrorCode.PROPOSAL_SLOT_PASSED,

--- a/packages/beacon-node/src/chain/validation/proposerPreferences.ts
+++ b/packages/beacon-node/src/chain/validation/proposerPreferences.ts
@@ -34,7 +34,7 @@ export async function validateGossipProposerPreferences(
 
   // [IGNORE] `preferences.proposal_slot` has not already passed, i.e. `proposal_slot > current_slot`,
   // allowing for `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
-  const currentSlot = chain.clock.slotWithFutureTolerance(chain.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY / 1000);
+  const currentSlot = chain.clock.currentSlotWithGossipDisparity;
   if (proposalSlot <= currentSlot) {
     throw new ProposerPreferencesError(GossipAction.IGNORE, {
       code: ProposerPreferencesErrorCode.PROPOSAL_SLOT_PASSED,


### PR DESCRIPTION
**Motivation**

The Gloas `proposer_preferences` gossip validation `[IGNORE] preferences.proposal_slot has not already passed` compares `proposal_slot` against the exact `current_slot`. A preference whose `proposal_slot` falls within `MAXIMUM_GOSSIP_CLOCK_DISPARITY` of the next-slot boundary is accepted as `valid` when it should be `ignore`d. The boundary is sub-slot (a 1&nbsp;ms shift flips the outcome), so the integer `current_slot` comparison cannot express it.

This is the same class of gap fixed for the `execution_payload_bid` slot check in #9627.

**Description**

Use `slotWithFutureTolerance(MAXIMUM_GOSSIP_CLOCK_DISPARITY / 1000)` as the `current_slot` reference, matching the existing convention in `verifyPropagationSlotRange` (`attestation.ts`).

`MAXIMUM_GOSSIP_CLOCK_DISPARITY` is a global gossip allowance that applies even where the [spec](https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md) states the check as a plain `preferences.proposal_slot > current_slot` (as confirmed for the analogous bid check).

**Verification**

Ran the Gloas networking gossip reference tests from [consensus-specs PR #5294](https://github.com/ethereum/consensus-specs/pull/5294):
- `gossip_proposer_preferences__ignore_slot_outside_disparity` → now `ignore` (was `valid`)
- `gossip_proposer_preferences__valid_slot_at_disparity_edge` → still `valid`
- `gossip_proposer_preferences__valid_at_lookahead_upper_edge` → still `valid`

Full `gossip_proposer_preferences`: **13/13 minimal + 13/13 mainnet**, no regressions in the rest of the Gloas networking suite.

🤖 Generated with AI assistance
