### PR TITLE
fix: return 503 instead of wedging when regen target is too far behind head

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -14,7 +14,8 @@ import {
 } from "@lodestar/types";
 import {byteArrayEquals, fromHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../../chain/index.js";
-import {ApiError, ValidationError} from "../../errors.js";
+import {RegenError, RegenErrorCode} from "../../../../chain/regen/errors.js";
+import {ApiError, NodeIsSyncing, ValidationError} from "../../errors.js";
 
 export function resolveStateId(
   forkChoice: IForkChoice,
@@ -55,16 +56,28 @@ export async function getStateResponseWithRegen(
 ): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean}> {
   const stateId = resolveStateId(chain.forkChoice, inStateId);
 
-  const res =
-    typeof stateId === "string"
-      ? await chain.getStateByStateRoot(stateId, {allowRegen: true})
-      : typeof stateId === "number"
-        ? stateId > chain.clock.currentSlot
-          ? null // Don't try to serve future slots
-          : stateId >= chain.forkChoice.getFinalizedBlock().slot
-            ? await chain.getStateBySlot(stateId, {allowRegen: true})
-            : await chain.getHistoricalStateBySlot(stateId)
-        : await chain.getStateOrBytesByCheckpoint(stateId);
+  let res: {state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null;
+  try {
+    res =
+      typeof stateId === "string"
+        ? await chain.getStateByStateRoot(stateId, {allowRegen: true})
+        : typeof stateId === "number"
+          ? stateId > chain.clock.currentSlot
+            ? null // Don't try to serve future slots
+            : stateId >= chain.forkChoice.getFinalizedBlock().slot
+              ? await chain.getStateBySlot(stateId, {allowRegen: true})
+              : await chain.getHistoricalStateBySlot(stateId)
+          : await chain.getStateOrBytesByCheckpoint(stateId);
+  } catch (e) {
+    // A far-behind node can't regenerate a state that is > SLOTS_PER_HISTORICAL_ROOT slots past its latest
+    // block. Surface that as 503 (node syncing) rather than a generic 500, matching the duties endpoints.
+    if (e instanceof RegenError && e.type.code === RegenErrorCode.SLOT_TOO_FAR_FROM_BLOCK) {
+      throw new NodeIsSyncing(
+        `requested state at slot ${e.type.slot} is too far ahead of head at slot ${e.type.blockSlot}`
+      );
+    }
+    throw e;
+  }
 
   if (!res) {
     throw new ApiError(404, `State not found for id '${inStateId}'`);

--- a/packages/beacon-node/src/chain/regen/errors.ts
+++ b/packages/beacon-node/src/chain/regen/errors.ts
@@ -4,6 +4,7 @@ export enum RegenErrorCode {
   BLOCK_NOT_IN_FORKCHOICE = "REGEN_ERROR_BLOCK_NOT_IN_FORKCHOICE",
   STATE_NOT_IN_FORKCHOICE = "REGEN_ERROR_STATE_NOT_IN_FORKCHOICE",
   SLOT_BEFORE_BLOCK_SLOT = "REGEN_ERROR_SLOT_BEFORE_BLOCK_SLOT",
+  SLOT_TOO_FAR_FROM_BLOCK = "REGEN_ERROR_SLOT_TOO_FAR_FROM_BLOCK",
   NO_SEED_STATE = "REGEN_ERROR_NO_SEED_STATE",
   TOO_MANY_BLOCK_PROCESSED = "REGEN_ERROR_TOO_MANY_BLOCK_PROCESSED",
   BLOCK_NOT_IN_DB = "REGEN_ERROR_BLOCK_NOT_IN_DB",
@@ -15,6 +16,7 @@ export type RegenErrorType =
   | {code: RegenErrorCode.BLOCK_NOT_IN_FORKCHOICE; blockRoot: RootHex | Root}
   | {code: RegenErrorCode.STATE_NOT_IN_FORKCHOICE; stateRoot: RootHex | Root}
   | {code: RegenErrorCode.SLOT_BEFORE_BLOCK_SLOT; slot: Slot; blockSlot: Slot}
+  | {code: RegenErrorCode.SLOT_TOO_FAR_FROM_BLOCK; slot: Slot; blockSlot: Slot}
   | {code: RegenErrorCode.NO_SEED_STATE}
   | {code: RegenErrorCode.TOO_MANY_BLOCK_PROCESSED; stateRoot: RootHex | Root}
   | {code: RegenErrorCode.BLOCK_NOT_IN_DB; blockRoot: RootHex | Root}

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -101,9 +101,12 @@ export class StateRegenerator implements IStateRegeneratorInternal {
       });
     }
 
-    // A state can't be advanced more than SLOTS_PER_HISTORICAL_ROOT slots past its block (empty-slot processing
-    // needs block roots within that window). Fail fast instead of grinding hundreds of epochs; REST maps to 503.
-    if (slot - block.slot > SLOTS_PER_HISTORICAL_ROOT) {
+    // A far-behind node polled via REST can request a state hundreds of epochs past its latest block.
+    // Regen can't advance a state more than SLOTS_PER_HISTORICAL_ROOT slots past its block (empty-slot
+    // processing needs block roots within that window), so fail fast instead of grinding hundreds of epochs
+    // and starving sync; the REST layer maps this to 503. Only the REST caller is guarded: consensus paths
+    // (block import, block production, gossip validation) must still advance through long empty-slot periods.
+    if (regenCaller === RegenCaller.restApi && slot - block.slot > SLOTS_PER_HISTORICAL_ROOT) {
       throw new RegenError({
         code: RegenErrorCode.SLOT_TOO_FAR_FROM_BLOCK,
         slot,

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -1,6 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
@@ -96,6 +96,16 @@ export class StateRegenerator implements IStateRegeneratorInternal {
     if (slot < block.slot) {
       throw new RegenError({
         code: RegenErrorCode.SLOT_BEFORE_BLOCK_SLOT,
+        slot,
+        blockSlot: block.slot,
+      });
+    }
+
+    // A state can't be advanced more than SLOTS_PER_HISTORICAL_ROOT slots past its block (empty-slot processing
+    // needs block roots within that window). Fail fast instead of grinding hundreds of epochs; REST maps to 503.
+    if (slot - block.slot > SLOTS_PER_HISTORICAL_ROOT) {
+      throw new RegenError({
+        code: RegenErrorCode.SLOT_TOO_FAR_FROM_BLOCK,
         slot,
         blockSlot: block.slot,
       });

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -91,5 +91,19 @@ describe("beacon state api utils", () => {
 
       await expect(getStateResponseWithRegen(chain, String(requestedSlot))).rejects.toBe(err);
     });
+
+    it("returns 503 (NodeIsSyncing) when regen for a state root is too far ahead of head", async () => {
+      const stateRoot = `0x${"00".repeat(32)}`;
+      const chain = {
+        clock: {currentSlot: 14_734_273},
+        forkChoice: {},
+        getStateByStateRoot: () =>
+          Promise.reject(
+            new RegenError({code: RegenErrorCode.SLOT_TOO_FAR_FROM_BLOCK, slot: 14_734_272, blockSlot: 14_719_007})
+          ),
+      } as unknown as IBeaconChain;
+
+      await expect(getStateResponseWithRegen(chain, stateRoot)).rejects.toBeInstanceOf(NodeIsSyncing);
+    });
   });
 });

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -1,7 +1,10 @@
 import {describe, expect, it} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
 import {BeaconStateView} from "@lodestar/state-transition";
-import {getStateValidatorIndex} from "../../../../../../src/api/impl/beacon/state/utils.js";
+import {getStateResponseWithRegen, getStateValidatorIndex} from "../../../../../../src/api/impl/beacon/state/utils.js";
+import {NodeIsSyncing} from "../../../../../../src/api/impl/errors.js";
+import type {IBeaconChain} from "../../../../../../src/chain/index.js";
+import {RegenError, RegenErrorCode} from "../../../../../../src/chain/regen/errors.js";
 import {generateCachedAltairState} from "../../../../../utils/state.js";
 
 describe("beacon state api utils", () => {
@@ -59,6 +62,34 @@ describe("beacon state api utils", () => {
       } else {
         expect.fail("validator index should be found - Uint8Array input");
       }
+    });
+  });
+
+  describe("getStateResponseWithRegen", () => {
+    it("returns 503 (NodeIsSyncing) when the requested slot is too far ahead of head to regenerate", async () => {
+      const requestedSlot = 14_734_272;
+      const chain = {
+        clock: {currentSlot: requestedSlot + 1},
+        forkChoice: {getFinalizedBlock: () => ({slot: 0})},
+        getStateBySlot: () =>
+          Promise.reject(
+            new RegenError({code: RegenErrorCode.SLOT_TOO_FAR_FROM_BLOCK, slot: requestedSlot, blockSlot: 14_719_007})
+          ),
+      } as unknown as IBeaconChain;
+
+      await expect(getStateResponseWithRegen(chain, String(requestedSlot))).rejects.toBeInstanceOf(NodeIsSyncing);
+    });
+
+    it("rethrows non-regen errors unchanged", async () => {
+      const requestedSlot = 14_734_272;
+      const err = new Error("boom");
+      const chain = {
+        clock: {currentSlot: requestedSlot + 1},
+        forkChoice: {getFinalizedBlock: () => ({slot: 0})},
+        getStateBySlot: () => Promise.reject(err),
+      } as unknown as IBeaconChain;
+
+      await expect(getStateResponseWithRegen(chain, String(requestedSlot))).rejects.toBe(err);
     });
   });
 });

--- a/packages/beacon-node/test/unit/chain/regen/regen.test.ts
+++ b/packages/beacon-node/test/unit/chain/regen/regen.test.ts
@@ -1,11 +1,17 @@
 import {beforeEach, describe, expect, it} from "vitest";
 import {createBeaconConfig} from "@lodestar/config";
 import {chainConfig as chainConfigDef} from "@lodestar/config/default";
+import type {ProtoBlock} from "@lodestar/fork-choice";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {BeaconStateView, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {RegenErrorCode} from "../../../../src/chain/regen/errors.js";
 import {RegenCaller} from "../../../../src/chain/regen/interface.js";
-import {processSlotsToNearestCheckpoint} from "../../../../src/chain/regen/regen.js";
+import {
+  type RegenModules,
+  StateRegenerator,
+  processSlotsToNearestCheckpoint,
+} from "../../../../src/chain/regen/regen.js";
 import {FIFOBlockStateCache} from "../../../../src/chain/stateCache/fifoBlockStateCache.js";
 import {PersistentCheckpointStateCache} from "../../../../src/chain/stateCache/persistentCheckpointsCache.js";
 import {getTestDatastore} from "../../../utils/chain/stateCache/datastore.js";
@@ -140,6 +146,34 @@ describe("regen", () => {
 
       // there are 2 epoch transitions, so the checkpoint states of epoch 20 should be pruned
       expect(fileApisBuffer.size).toEqual(1);
+    });
+  });
+
+  describe("getBlockSlotState", () => {
+    const block = {slot: 1000, blockRoot: "0x00"} as unknown as ProtoBlock;
+
+    it("throws SLOT_TOO_FAR_FROM_BLOCK when the slot is more than SLOTS_PER_HISTORICAL_ROOT past the block", async () => {
+      const regen = new StateRegenerator({} as unknown as RegenModules);
+      await expect(
+        regen.getBlockSlotState(
+          block,
+          block.slot + SLOTS_PER_HISTORICAL_ROOT + 1,
+          {dontTransferCache: true},
+          RegenCaller.restApi
+        )
+      ).rejects.toThrow(RegenErrorCode.SLOT_TOO_FAR_FROM_BLOCK);
+    });
+
+    it("does not throw SLOT_TOO_FAR_FROM_BLOCK at exactly SLOTS_PER_HISTORICAL_ROOT past the block", async () => {
+      const regen = new StateRegenerator({} as unknown as RegenModules);
+      await expect(
+        regen.getBlockSlotState(
+          block,
+          block.slot + SLOTS_PER_HISTORICAL_ROOT,
+          {dontTransferCache: true},
+          RegenCaller.restApi
+        )
+      ).rejects.not.toThrow(RegenErrorCode.SLOT_TOO_FAR_FROM_BLOCK);
     });
   });
 });

--- a/packages/beacon-node/test/unit/chain/regen/regen.test.ts
+++ b/packages/beacon-node/test/unit/chain/regen/regen.test.ts
@@ -175,5 +175,19 @@ describe("regen", () => {
         )
       ).rejects.not.toThrow(RegenErrorCode.SLOT_TOO_FAR_FROM_BLOCK);
     });
+
+    it("does not throw SLOT_TOO_FAR_FROM_BLOCK for non-REST callers (consensus paths may advance through long skips)", async () => {
+      const regen = new StateRegenerator({} as unknown as RegenModules);
+      // Block import, production and gossip validation share this path and must not be rejected by the
+      // REST-only guard, even when a block arrives more than SLOTS_PER_HISTORICAL_ROOT slots after its parent.
+      await expect(
+        regen.getBlockSlotState(
+          block,
+          block.slot + SLOTS_PER_HISTORICAL_ROOT + 1,
+          {dontTransferCache: true},
+          RegenCaller.processBlocksInEpoch
+        )
+      ).rejects.not.toThrow(RegenErrorCode.SLOT_TOO_FAR_FROM_BLOCK);
+    });
   });
 });


### PR DESCRIPTION
## Problem

A beacon node that has fallen **more than `SLOTS_PER_HISTORICAL_ROOT` (8192) slots (256 epochs) behind head** permanently wedges — it stops importing blocks entirely and cannot self-recover — when a co-located consumer keeps polling a state endpoint.

Observed on mainnet (both v1.44.0 and v1.43.0) with an Obol charon / VC stack polling `POST /eth/v1/beacon/states/{state_id}/validators` for a near-clock slot:

- 0 blocks imported over many minutes; head frozen; `is_syncing: true`; ~486 epochs behind.
- Main thread saturated by state regen (`caller=restApi`), tens of thousands of `Processed past epoch` log lines per minute.
- Every regen attempt fails with `Cannot get block root more than 8192 in the past`.

### Why

`getStateBySlot(..., {allowRegen: true})` resolves the base block to the head (for a slot ahead of head) and calls `regen.getBlockSlotState(head, slot)`, which replays empty slots forward. As the state advances past `block.slot + SLOTS_PER_HISTORICAL_ROOT`, the checkpoint-state cache pruning (`processPastEpoch` → `getBlockRootAtSlot`) can no longer read the historical block roots it needs and throws. The throw is caught and logged at `debug`, so the empty-slot loop — which has **no distance cap** (only block replay has `MAX_EPOCH_TO_PROCESS`) — keeps grinding ~256 epochs on every request and never succeeds, starving range-sync block import on the shared main thread. Because the node stays >8192 behind, the next poll fails identically → death spiral.

This is a **long-standing gap**, not a recent regression — the `allowRegen` REST state path predates v1.43, the relevant files are unchanged between v1.43.0 and v1.44.0, and it only manifests once a node falls >256 epochs behind while something polls a state endpoint. The duties endpoints (`getProposerDuties`, …) and `PrepareNextSlotScheduler` already guard against being far behind; the state-serving path did not.

## Fix

1. **Fail fast in regen** (`getBlockSlotState`): throw a typed `RegenError` (`SLOT_TOO_FAR_FROM_BLOCK`) when `slot - block.slot > SLOTS_PER_HISTORICAL_ROOT`, before any replay — **scoped to the REST caller** (`regenCaller === RegenCaller.restApi`) so only REST-triggered regen is bounded.
2. **Return 503 at the REST layer** (`getStateResponseWithRegen`): map that error to `NodeIsSyncing` (503), so the state endpoints behave like the duties endpoints (the beacon-APIs spec allows 503 here) instead of a generic 500.

Net effect: a far-behind node returns `503 Node is syncing` immediately for these requests and keeps syncing, instead of wedging.

## Steps to test

- `regen.test.ts`: `getBlockSlotState` throws `SLOT_TOO_FAR_FROM_BLOCK` beyond the window (REST caller), not at exactly the boundary, and **not for non-REST callers** (consensus paths may advance through long skips).
- `beacon/state/utils.test.ts`: `getStateResponseWithRegen` returns 503 on that error for both the slot and state-root paths, and rethrows other errors unchanged.
- `pnpm check-types`, `biome check`, and both unit files pass locally.

## Notes for reviewers

- **Scoped to REST (per review feedback):** `getBlockSlotState` is shared by block import (`getPreState` → `processBlocksInEpoch`, `importExecutionPayload`), block production (`prepareNextSlot`), and gossip validation (block/blob/dataColumn/bid/payloadAttestation). Those must still advance through long empty-slot periods, so the fast-fail is gated to `RegenCaller.restApi`; a valid block arriving after a `>SLOTS_PER_HISTORICAL_ROOT` skip is never rejected on a consensus path. The 503 mapping only changes the REST state endpoints.
- **Threshold choice:** I used `SLOTS_PER_HISTORICAL_ROOT` (the hard structural limit past which regen *cannot* succeed) rather than the duties' `SYNC_TOLERANCE_EPOCHS` (1 epoch). This rejects only genuinely-impossible regens; it does **not** guard the "possible but expensive" case of a node <256 epochs behind (which can still burn up to ~256 epochs of CPU per request). Happy to add a tighter cap if that's preferred.

🤖 Generated with AI assistance
