### PR TITLE
fix: add pubkeyCache initialization overhead

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -7,7 +7,7 @@ import {BeaconDb, BeaconNode} from "@lodestar/beacon-node";
 import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {LoggerNode, getNodeLogger} from "@lodestar/logger/node";
-import {ACTIVE_PRESET, PresetName} from "@lodestar/params";
+import {ACTIVE_PRESET, MAX_PENDING_DEPOSITS_PER_EPOCH, PresetName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {createBeaconStateView, syncPubkeys} from "@lodestar/state-transition";
 import {ErrorAborted, bytesToInt, formatBytes} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
@@ -79,7 +79,14 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       wsCheckpoint,
     } = await initBeaconState(args, beaconPaths.dataDir, config, db, logger);
     const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
-    pubkeyCache.ensureCapacity(anchorState.validators.length);
+    // Reserve headroom so the native cache does not realloc on growth. Reallocs are unsafe
+    // while the historical state worker reads the cache, until lodestar-z adds locking.
+    // Registry growth is capped at MAX_PENDING_DEPOSITS_PER_EPOCH new validators per epoch,
+    // reserve 3 months of worst-case growth, over a year at organic rates. If exceeded,
+    // native capacity doubling kicks in.
+    const headroomEpochs = (90 * 24 * 60 * 60) / (config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH);
+    const pubkeyCacheHeadroom = MAX_PENDING_DEPOSITS_PER_EPOCH * Math.ceil(headroomEpochs);
+    pubkeyCache.ensureCapacity(anchorState.validators.length + pubkeyCacheHeadroom);
     syncPubkeys(pubkeyCache, anchorState.validators.getAllReadonlyValues());
     const anchorStateView = args["chain.nativeStateView"]
       ? createBeaconStateView({useNative: true, stateBytes: anchorStateBytes})

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -79,11 +79,9 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       wsCheckpoint,
     } = await initBeaconState(args, beaconPaths.dataDir, config, db, logger);
     const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
-    // Reserve headroom so the native cache does not realloc on growth. Reallocs are unsafe
-    // while the historical state worker reads the cache, until lodestar-z adds locking.
-    // Registry growth is capped at MAX_PENDING_DEPOSITS_PER_EPOCH new validators per epoch,
-    // reserve 3 months of worst-case growth, over a year at organic rates. If exceeded,
-    // native capacity doubling kicks in.
+    // Growing the native cache reallocs its memory which is not safe while other threads
+    // read it. Reserve 3 months of worst-case registry growth (MAX_PENDING_DEPOSITS_PER_EPOCH
+    // per epoch), over a year at organic rates. If exceeded, native capacity doubling kicks in.
     const headroomEpochs = (90 * 24 * 60 * 60) / (config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH);
     const pubkeyCacheHeadroom = MAX_PENDING_DEPOSITS_PER_EPOCH * Math.ceil(headroomEpochs);
     pubkeyCache.ensureCapacity(anchorState.validators.length + pubkeyCacheHeadroom);

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -81,7 +81,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
     const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
     // Growing the native cache reallocates its memory which is not safe while other threads
     // read it. Reserve 3 months of worst-case registry growth (MAX_PENDING_DEPOSITS_PER_EPOCH
-    // per epoch), over a year at organic rates. If exceeded, native capacity doubling kicks in.
+    // per epoch), over a year at organic rates. If exceeded, the native cache grows by the same step.
     const headroomEpochs = (90 * 24 * 60 * 60) / (config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH);
     const pubkeyCacheHeadroom = MAX_PENDING_DEPOSITS_PER_EPOCH * Math.ceil(headroomEpochs);
     pubkeyCache.ensureCapacity(anchorState.validators.length + pubkeyCacheHeadroom);

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -79,7 +79,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       wsCheckpoint,
     } = await initBeaconState(args, beaconPaths.dataDir, config, db, logger);
     const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
-    // Growing the native cache reallocs its memory which is not safe while other threads
+    // Growing the native cache reallocates its memory which is not safe while other threads
     // read it. Reserve 3 months of worst-case registry growth (MAX_PENDING_DEPOSITS_PER_EPOCH
     // per epoch), over a year at organic rates. If exceeded, native capacity doubling kicks in.
     const headroomEpochs = (90 * 24 * 60 * 60) / (config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH);

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -898,12 +898,6 @@ export class EpochCache {
   }
 
   addPubkey(index: ValidatorIndex, pubkey: Uint8Array): void {
-    // Skip no-op rewrites so replaying already-known deposits, e.g. during historical
-    // state regen in the worker thread, never writes to the shared native cache
-    const existing = this.pubkeyCache.get(index);
-    if (existing !== undefined && byteArrayEquals(existing.toBytes(), pubkey)) {
-      return;
-    }
     this.pubkeyCache.set(index, pubkey);
   }
 

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -25,7 +25,7 @@ import {
   ValidatorIndex,
   gloas,
 } from "@lodestar/types";
-import {LodestarError, byteArrayEquals} from "@lodestar/utils";
+import {LodestarError} from "@lodestar/utils";
 import {getTotalSlashingsByIncrement} from "../epoch/processSlashings.js";
 import {
   EpochShuffling,

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -25,7 +25,7 @@ import {
   ValidatorIndex,
   gloas,
 } from "@lodestar/types";
-import {LodestarError} from "@lodestar/utils";
+import {LodestarError, byteArrayEquals} from "@lodestar/utils";
 import {getTotalSlashingsByIncrement} from "../epoch/processSlashings.js";
 import {
   EpochShuffling,
@@ -898,6 +898,12 @@ export class EpochCache {
   }
 
   addPubkey(index: ValidatorIndex, pubkey: Uint8Array): void {
+    // Skip no-op rewrites so replaying already-known deposits, e.g. during historical
+    // state regen in the worker thread, never writes to the shared native cache
+    const existing = this.pubkeyCache.get(index);
+    if (existing !== undefined && byteArrayEquals(existing.toBytes(), pubkey)) {
+      return;
+    }
     this.pubkeyCache.set(index, pubkey);
   }
 


### PR DESCRIPTION
## Motivation

The lodestar-z pubkey cache introduced in #8900 is a process-global singleton shared across threads without locking. The historical state regen worker reads it (`getIndex` during sync committee cache computation) and writes it (`addPubkey` when replaying deposit blocks) while the main thread does the same. A main-thread `set()` that outgrows the reserved capacity reallocates both native structures and frees the old buffers, so a concurrent read from the worker thread is a use-after-free. The previous `ensureCapacity(validators.length)` left zero headroom, meaning the first deposit after startup triggered exactly this realloc.

## Description

- Reserve headroom when populating the cache at startup so it does not realloc during a realistic process lifetime. Sized as 3 months of worst-case registry growth (`MAX_PENDING_DEPOSITS_PER_EPOCH` new validators per epoch), which is over a year at organic rates and beyond the update cadence of any Lodestar node observed on mainnet. On mainnet this is ~324k slots, ~31MB of virtual memory and ~0 resident. ChainSafe/lodestar-z#481 aligns the native growth policy to the same step, so if the reservation is ever exceeded the cache extends by another 3-month window instead of doubling.
- Skip no-op rewrites in `EpochCache.addPubkey` when the identical pubkey is already cached at that index. Replayed deposits during historical state regen always hit this path, so the worker thread no longer writes to the shared cache at all. A different pubkey at an existing index still overwrites, preserving existing behavior on forks with conflicting deposits.

This is a mitigation, not a fix. The remaining race (a genuinely new main-thread insert concurrent with a worker hashmap probe) can at worst fail a single historical state query. The proper fix is locking around the pubkeys binding in lodestar-z, at which point the headroom becomes a realloc-avoidance nicety.
