### PR TITLE
fix: reject expensive beacon state requests while syncing

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/index.ts
@@ -7,7 +7,7 @@ import {getBeaconRewardsApi} from "./rewards/index.js";
 import {getBeaconStateApi} from "./state/index.js";
 
 export function getBeaconApi(
-  modules: Pick<ApiModules, "chain" | "config" | "logger" | "metrics" | "network" | "db">
+  modules: Pick<ApiModules, "chain" | "config" | "logger" | "metrics" | "network" | "db" | "sync">
 ): ApplicationMethods<routes.beacon.Endpoints> {
   const block = getBeaconBlockApi(modules);
   const pool = getBeaconPoolApi(modules);

--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -26,11 +26,12 @@ import {
 export function getBeaconStateApi({
   chain,
   config,
-}: Pick<ApiModules, "chain" | "config">): ApplicationMethods<routes.beacon.state.Endpoints> {
+  sync,
+}: Pick<ApiModules, "chain" | "config" | "sync">): ApplicationMethods<routes.beacon.state.Endpoints> {
   async function getState(
     stateId: routes.beacon.StateId
   ): Promise<{state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean}> {
-    const {state, executionOptimistic, finalized} = await getStateResponseWithRegen(chain, stateId);
+    const {state, executionOptimistic, finalized} = await getStateResponseWithRegen(chain, sync, stateId);
 
     return {
       state: state instanceof Uint8Array ? chain.getHeadState().loadOtherState(state) : state,

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -14,7 +14,9 @@ import {
 } from "@lodestar/types";
 import {byteArrayEquals, fromHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../../chain/index.js";
+import {IBeaconSync} from "../../../../sync/index.js";
 import {ApiError, ValidationError} from "../../errors.js";
+import {notWhileSyncing} from "../../utils.js";
 
 export function resolveStateId(
   forkChoice: IForkChoice,
@@ -51,8 +53,13 @@ export function resolveStateId(
 
 export async function getStateResponseWithRegen(
   chain: IBeaconChain,
+  sync: IBeaconSync,
   inStateId: routes.beacon.StateId
 ): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean}> {
+  // A far-behind node must not serve state lookups: a REST-triggered regen can walk back past the
+  // block-root window (SLOTS_PER_HISTORICAL_ROOT) and wedge the node. Reject with 503 while syncing.
+  notWhileSyncing(chain, sync);
+
   const stateId = resolveStateId(chain.forkChoice, inStateId);
 
   const res =

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -61,7 +61,7 @@ export async function getStateResponseWithRegen(
   // (SLOTS_PER_HISTORICAL_ROOT) and wedge a far-behind node. Keep serving those (node observability,
   // dashboards, validator client checks) even while syncing; guard only the regen-capable lookups.
   if (inStateId !== "head" && inStateId !== "finalized" && inStateId !== "justified" && inStateId !== "genesis") {
-    notWhileSyncing(chain, sync);
+    notWhileSyncing(chain, sync.state);
   }
 
   const stateId = resolveStateId(chain.forkChoice, inStateId);

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -56,9 +56,13 @@ export async function getStateResponseWithRegen(
   sync: IBeaconSync,
   inStateId: routes.beacon.StateId
 ): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean}> {
-  // A far-behind node must not serve state lookups: a REST-triggered regen can walk back past the
-  // block-root window (SLOTS_PER_HISTORICAL_ROOT) and wedge the node. Reject with 503 while syncing.
-  notWhileSyncing(chain, sync);
+  // "head", "finalized" and "justified" resolve to already-available cached states, and "genesis" to a
+  // historical DB read - none trigger the forward regen that can walk back past the block-root window
+  // (SLOTS_PER_HISTORICAL_ROOT) and wedge a far-behind node. Keep serving those (node observability,
+  // dashboards, validator client checks) even while syncing; guard only the regen-capable lookups.
+  if (inStateId !== "head" && inStateId !== "finalized" && inStateId !== "justified" && inStateId !== "genesis") {
+    notWhileSyncing(chain, sync);
+  }
 
   const stateId = resolveStateId(chain.forkChoice, inStateId);
 

--- a/packages/beacon-node/src/api/impl/debug/index.ts
+++ b/packages/beacon-node/src/api/impl/debug/index.ts
@@ -39,7 +39,8 @@ function toPayloadStatusName(status: PayloadStatus): "pending" | "empty" | "full
 export function getDebugApi({
   chain,
   config,
-}: Pick<ApiModules, "chain" | "config" | "db">): ApplicationMethods<routes.debug.Endpoints> {
+  sync,
+}: Pick<ApiModules, "chain" | "config" | "db" | "sync">): ApplicationMethods<routes.debug.Endpoints> {
   return {
     async getDebugChainHeadsV2() {
       const heads = chain.forkChoice.getHeads();
@@ -132,7 +133,7 @@ export function getDebugApi({
     },
 
     async getStateV2({stateId}, context) {
-      const {state, executionOptimistic, finalized} = await getStateResponseWithRegen(chain, stateId);
+      const {state, executionOptimistic, finalized} = await getStateResponseWithRegen(chain, sync, stateId);
       let slot: number, data: Uint8Array | BeaconState;
       if (state instanceof Uint8Array) {
         slot = getStateSlotFromBytes(state);

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -217,7 +217,7 @@ export function getLodestarApi({
     },
 
     async getHistoricalSummaries({stateId}) {
-      const {state, executionOptimistic, finalized} = await getStateResponseWithRegen(chain, stateId);
+      const {state, executionOptimistic, finalized} = await getStateResponseWithRegen(chain, sync, stateId);
 
       const stateView = state instanceof Uint8Array ? chain.getHeadState().loadOtherState(state) : state;
 
@@ -332,7 +332,7 @@ export function getLodestarApi({
 
       for (const [epoch, attestationsPerEpoch] of attestations) {
         const slot = computeStartSlotAtEpoch(epoch);
-        const {state} = await getStateResponseWithRegen(chain, slot);
+        const {state} = await getStateResponseWithRegen(chain, sync, slot);
         const stateView = state instanceof Uint8Array ? chain.getHeadState().loadOtherState(state) : state;
         const shuffling = stateView.getShufflingAtEpoch(epoch);
         for (const attestation of attestationsPerEpoch) {

--- a/packages/beacon-node/src/api/impl/proof/index.ts
+++ b/packages/beacon-node/src/api/impl/proof/index.ts
@@ -8,7 +8,7 @@ import {ApiModules} from "../types.js";
 
 export function getProofApi(
   opts: ApiOptions,
-  {chain, config}: Pick<ApiModules, "chain" | "config" | "db">
+  {chain, config, sync}: Pick<ApiModules, "chain" | "config" | "db" | "sync">
 ): ApplicationMethods<routes.proof.Endpoints> {
   // It's currently possible to request gigantic proofs (eg: a proof of the entire beacon state)
   // We want some some sort of resistance against this DoS vector.
@@ -21,7 +21,7 @@ export function getProofApi(
         throw new Error("Requested proof is too large.");
       }
 
-      const res = await getStateResponseWithRegen(chain, stateId);
+      const res = await getStateResponseWithRegen(chain, sync, stateId);
 
       const state = res.state instanceof Uint8Array ? chain.getHeadState().loadOtherState(res.state) : res.state;
 

--- a/packages/beacon-node/src/api/impl/utils.ts
+++ b/packages/beacon-node/src/api/impl/utils.ts
@@ -1,6 +1,6 @@
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import type {IBeaconChain} from "../../chain/index.js";
-import {type IBeaconSync, SyncState} from "../../sync/index.js";
+import {SyncState} from "../../sync/index.js";
 import {ApiError, NodeIsSyncing} from "./errors.js";
 
 /**
@@ -24,13 +24,13 @@ export const SYNC_TOLERANCE_EPOCHS = 1;
  * back past the block-root window (`SLOTS_PER_HISTORICAL_ROOT`) and wedge the node. Throws
  * {@link NodeIsSyncing} (503).
  */
-export function notWhileSyncing(chain: IBeaconChain, sync: IBeaconSync): void {
+export function notWhileSyncing(chain: IBeaconChain, syncState: SyncState): void {
   // Consider node synced before or close to genesis
   if (chain.clock.currentSlot < SLOTS_PER_EPOCH) {
     return;
   }
 
-  switch (sync.state) {
+  switch (syncState) {
     case SyncState.SyncingFinalized:
     case SyncState.SyncingHead: {
       const currentSlot = chain.clock.currentSlot;

--- a/packages/beacon-node/src/api/impl/utils.ts
+++ b/packages/beacon-node/src/api/impl/utils.ts
@@ -1,4 +1,54 @@
-import {ApiError} from "./errors.js";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import type {IBeaconChain} from "../../chain/index.js";
+import {type IBeaconSync, SyncState} from "../../sync/index.js";
+import {ApiError, NodeIsSyncing} from "./errors.js";
+
+/**
+ * If the node is within this many epochs from the head, we declare it to be synced regardless of
+ * the network sync state.
+ *
+ * This helps prevent attacks where nodes can convince us that we're syncing some non-existent
+ * finalized head.
+ *
+ * TODO: Lighthouse uses 8 for the attack described above. However, 8 kills Lodestar since validators
+ * can trigger regen to fast-forward head state 8 epochs to be immediately invalidated as sync sets
+ * a new head. Then the checkpoint state cache grows unbounded with very different states (because
+ * they are 8 epochs apart) and causes an OOM. Research a proper solution once regen and the state
+ * caches are better.
+ */
+export const SYNC_TOLERANCE_EPOCHS = 1;
+
+/**
+ * Reject any request while the node is syncing. Used by endpoints that must not serve while the
+ * node is behind — validator duties, and beacon state lookups whose regen could otherwise walk
+ * back past the block-root window (`SLOTS_PER_HISTORICAL_ROOT`) and wedge the node. Throws
+ * {@link NodeIsSyncing} (503).
+ */
+export function notWhileSyncing(chain: IBeaconChain, sync: IBeaconSync): void {
+  // Consider node synced before or close to genesis
+  if (chain.clock.currentSlot < SLOTS_PER_EPOCH) {
+    return;
+  }
+
+  switch (sync.state) {
+    case SyncState.SyncingFinalized:
+    case SyncState.SyncingHead: {
+      const currentSlot = chain.clock.currentSlot;
+      const headSlot = chain.forkChoice.getHead().slot;
+      if (currentSlot - headSlot > SYNC_TOLERANCE_EPOCHS * SLOTS_PER_EPOCH) {
+        throw new NodeIsSyncing(`headSlot ${headSlot} currentSlot ${currentSlot}`);
+      }
+
+      return;
+    }
+
+    case SyncState.Synced:
+      return;
+
+    case SyncState.Stalled:
+      throw new NodeIsSyncing("waiting for peers");
+  }
+}
 
 /**
  * Ensures that the array contains unique values, and throws an ApiError

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -528,7 +528,7 @@ export function getValidatorApi(
     builderBoostFactor?: bigint,
     {feeRecipient, builderSelection, strictFeeRecipientCheck}: routes.validator.ExtraProduceBlockOpts = {}
   ): Promise<ProduceBlindedBlockOrBlockContentsRes> {
-    notWhileSyncing(chain, sync);
+    notWhileSyncing(chain, sync.state);
     await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
     const parentBlock = chain.getProposerHead(slot);
@@ -872,7 +872,7 @@ export function getValidatorApi(
         throw new ApiError(400, `produceBlockV4 not supported for pre-gloas fork=${fork}`);
       }
 
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
       await waitForSlot(slot);
 
       const parentBlock = chain.getProposerHead(slot);
@@ -990,7 +990,7 @@ export function getValidatorApi(
     },
 
     async produceAttestationData({committeeIndex, slot}) {
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
 
       await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
@@ -1071,7 +1071,7 @@ export function getValidatorApi(
         throw new ApiError(400, `producePayloadAttestationData is not supported before Gloas fork=${fork}`);
       }
 
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
       await waitForSlot(slot);
 
       const block = chain.forkChoice.getCanonicalBlockAtSlot(slot);
@@ -1156,7 +1156,7 @@ export function getValidatorApi(
     },
 
     async getProposerDuties({epoch}, _context, opts?: {v2?: boolean}) {
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
 
       const currentEpoch = currentEpochWithDisparity();
       const nextEpoch = currentEpoch + 1;
@@ -1297,7 +1297,7 @@ export function getValidatorApi(
     },
 
     async getAttesterDuties({epoch, indices}) {
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
 
       if (indices.length === 0) {
         throw new ApiError(400, "No validator to get attester duties");
@@ -1357,7 +1357,7 @@ export function getValidatorApi(
     },
 
     async getPtcDuties({epoch, indices}) {
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
 
       if (indices.length === 0) {
         throw new ApiError(400, "No validator to get PTC duties");
@@ -1419,7 +1419,7 @@ export function getValidatorApi(
      * @param validatorIndices an array of the validator indices for which to obtain the duties.
      */
     async getSyncCommitteeDuties({epoch, indices}) {
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
 
       if (indices.length === 0) {
         throw new ApiError(400, "No validator to get attester duties");
@@ -1466,7 +1466,7 @@ export function getValidatorApi(
     },
 
     async getAggregatedAttestationV2({attestationDataRoot, slot, committeeIndex}) {
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
 
       await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
@@ -1489,7 +1489,7 @@ export function getValidatorApi(
     },
 
     async publishAggregateAndProofsV2({signedAggregateAndProofs}) {
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
 
       const seenTimestampSec = Date.now() / 1000;
       const failures: FailureList = [];
@@ -1550,7 +1550,7 @@ export function getValidatorApi(
      * https://github.com/ethereum/beacon-APIs/pull/137
      */
     async publishContributionAndProofs({contributionAndProofs}) {
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
 
       const failures: FailureList = [];
 
@@ -1599,7 +1599,7 @@ export function getValidatorApi(
     },
 
     async prepareBeaconCommitteeSubnet({subscriptions}) {
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
 
       await network.prepareBeaconCommitteeSubnets(
         subscriptions.map(({validatorIndex, slot, isAggregator, committeesAtSlot, committeeIndex}) => ({
@@ -1632,7 +1632,7 @@ export function getValidatorApi(
      * https://github.com/ethereum/beacon-APIs/pull/136
      */
     async prepareSyncCommitteeSubnets({subscriptions}) {
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
 
       // A `validatorIndex` can be in multiple subnets, so compute the CommitteeSubscription with double for loop
       const subs: CommitteeSubscription[] = [];
@@ -1776,7 +1776,7 @@ export function getValidatorApi(
         throw new ApiError(400, `getExecutionPayloadEnvelope not supported for pre-gloas fork=${fork}`);
       }
 
-      notWhileSyncing(chain, sync);
+      notWhileSyncing(chain, sync.state);
       await waitForSlot(slot);
 
       const blockRootHex = toRootHex(beaconBlockRoot);

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -82,7 +82,6 @@ import {ZERO_HASH} from "../../../constants/index.js";
 import {BuilderStatus, NoBidReceived} from "../../../execution/builder/http.js";
 import {validateGossipFnRetryUnknownRoot} from "../../../network/processor/gossipHandlers.js";
 import {CommitteeSubscription} from "../../../network/subnets/index.js";
-import {SyncState} from "../../../sync/index.js";
 import {callInNextEventLoop} from "../../../util/eventLoop.js";
 import {isOptimisticBlock} from "../../../util/forkChoice.js";
 import {getBlockGraffiti, toGraffitiBytes} from "../../../util/graffiti.js";
@@ -91,22 +90,8 @@ import {ApiOptions} from "../../options.js";
 import {getStateResponseWithRegen} from "../beacon/state/utils.js";
 import {ApiError, FailureList, IndexedError, NodeIsSyncing, OnlySupportedByDVT} from "../errors.js";
 import {ApiModules} from "../types.js";
+import {notWhileSyncing} from "../utils.js";
 import {computeSubnetForCommitteesAtSlot, getPubkeysForIndices, selectBlockProductionSource} from "./utils.js";
-
-/**
- * If the node is within this many epochs from the head, we declare it to be synced regardless of
- * the network sync state.
- *
- * This helps prevent attacks where nodes can convince us that we're syncing some non-existent
- * finalized head.
- *
- * TODO: Lighthouse uses 8 for the attack described above. However, 8 kills Lodestar since validators
- * can trigger regen to fast-forward head state 8 epochs to be immediately invalidated as sync sets
- * a new head. Then the checkpoint state cache grows unbounded with very different states (because
- * they are 8 epochs apart) and causes an OOM. Research a proper solution once regen and the state
- * caches are better.
- */
-export const SYNC_TOLERANCE_EPOCHS = 1;
 
 /**
  * Cutoff time to wait from start of the slot for execution and builder block production apis to resolve.
@@ -342,36 +327,6 @@ export function getValidatorApi(
   }
 
   /**
-   * Reject any request while the node is syncing
-   */
-  function notWhileSyncing(): void {
-    // Consider node synced before or close to genesis
-    if (chain.clock.currentSlot < SLOTS_PER_EPOCH) {
-      return;
-    }
-
-    const syncState = sync.state;
-    switch (syncState) {
-      case SyncState.SyncingFinalized:
-      case SyncState.SyncingHead: {
-        const currentSlot = chain.clock.currentSlot;
-        const headSlot = chain.forkChoice.getHead().slot;
-        if (currentSlot - headSlot > SYNC_TOLERANCE_EPOCHS * SLOTS_PER_EPOCH) {
-          throw new NodeIsSyncing(`headSlot ${headSlot} currentSlot ${currentSlot}`);
-        }
-
-        return;
-      }
-
-      case SyncState.Synced:
-        return;
-
-      case SyncState.Stalled:
-        throw new NodeIsSyncing("waiting for peers");
-    }
-  }
-
-  /**
    * Post merge, the CL and EL could be out of step in the sync, and could result in
    * Syncing status of the chain head. To be precise:
    * 1. CL could be ahead of the EL, with the validity of head payload not yet verified
@@ -573,7 +528,7 @@ export function getValidatorApi(
     builderBoostFactor?: bigint,
     {feeRecipient, builderSelection, strictFeeRecipientCheck}: routes.validator.ExtraProduceBlockOpts = {}
   ): Promise<ProduceBlindedBlockOrBlockContentsRes> {
-    notWhileSyncing();
+    notWhileSyncing(chain, sync);
     await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
     const parentBlock = chain.getProposerHead(slot);
@@ -917,7 +872,7 @@ export function getValidatorApi(
         throw new ApiError(400, `produceBlockV4 not supported for pre-gloas fork=${fork}`);
       }
 
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
       await waitForSlot(slot);
 
       const parentBlock = chain.getProposerHead(slot);
@@ -1035,7 +990,7 @@ export function getValidatorApi(
     },
 
     async produceAttestationData({committeeIndex, slot}) {
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
 
       await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
@@ -1116,7 +1071,7 @@ export function getValidatorApi(
         throw new ApiError(400, `producePayloadAttestationData is not supported before Gloas fork=${fork}`);
       }
 
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
       await waitForSlot(slot);
 
       const block = chain.forkChoice.getCanonicalBlockAtSlot(slot);
@@ -1201,7 +1156,7 @@ export function getValidatorApi(
     },
 
     async getProposerDuties({epoch}, _context, opts?: {v2?: boolean}) {
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
 
       const currentEpoch = currentEpochWithDisparity();
       const nextEpoch = currentEpoch + 1;
@@ -1248,7 +1203,7 @@ export function getValidatorApi(
           // requested epoch is within that range, we can use the head state at current epoch
           state = await chain.getHeadStateAtCurrentEpoch(RegenCaller.getDuties);
         } else {
-          const res = await getStateResponseWithRegen(chain, startSlot);
+          const res = await getStateResponseWithRegen(chain, sync, startSlot);
 
           state = res.state instanceof Uint8Array ? chain.getHeadState().loadOtherState(res.state) : res.state;
 
@@ -1342,7 +1297,7 @@ export function getValidatorApi(
     },
 
     async getAttesterDuties({epoch, indices}) {
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
 
       if (indices.length === 0) {
         throw new ApiError(400, "No validator to get attester duties");
@@ -1402,7 +1357,7 @@ export function getValidatorApi(
     },
 
     async getPtcDuties({epoch, indices}) {
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
 
       if (indices.length === 0) {
         throw new ApiError(400, "No validator to get PTC duties");
@@ -1464,7 +1419,7 @@ export function getValidatorApi(
      * @param validatorIndices an array of the validator indices for which to obtain the duties.
      */
     async getSyncCommitteeDuties({epoch, indices}) {
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
 
       if (indices.length === 0) {
         throw new ApiError(400, "No validator to get attester duties");
@@ -1511,7 +1466,7 @@ export function getValidatorApi(
     },
 
     async getAggregatedAttestationV2({attestationDataRoot, slot, committeeIndex}) {
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
 
       await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
@@ -1534,7 +1489,7 @@ export function getValidatorApi(
     },
 
     async publishAggregateAndProofsV2({signedAggregateAndProofs}) {
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
 
       const seenTimestampSec = Date.now() / 1000;
       const failures: FailureList = [];
@@ -1595,7 +1550,7 @@ export function getValidatorApi(
      * https://github.com/ethereum/beacon-APIs/pull/137
      */
     async publishContributionAndProofs({contributionAndProofs}) {
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
 
       const failures: FailureList = [];
 
@@ -1644,7 +1599,7 @@ export function getValidatorApi(
     },
 
     async prepareBeaconCommitteeSubnet({subscriptions}) {
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
 
       await network.prepareBeaconCommitteeSubnets(
         subscriptions.map(({validatorIndex, slot, isAggregator, committeesAtSlot, committeeIndex}) => ({
@@ -1677,7 +1632,7 @@ export function getValidatorApi(
      * https://github.com/ethereum/beacon-APIs/pull/136
      */
     async prepareSyncCommitteeSubnets({subscriptions}) {
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
 
       // A `validatorIndex` can be in multiple subnets, so compute the CommitteeSubscription with double for loop
       const subs: CommitteeSubscription[] = [];
@@ -1821,7 +1776,7 @@ export function getValidatorApi(
         throw new ApiError(400, `getExecutionPayloadEnvelope not supported for pre-gloas fork=${fork}`);
       }
 
-      notWhileSyncing();
+      notWhileSyncing(chain, sync);
       await waitForSlot(slot);
 
       const blockRootHex = toRootHex(beaconBlockRoot);

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -1,7 +1,11 @@
 import {describe, expect, it} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {BeaconStateView} from "@lodestar/state-transition";
-import {getStateValidatorIndex} from "../../../../../../src/api/impl/beacon/state/utils.js";
+import {getStateResponseWithRegen, getStateValidatorIndex} from "../../../../../../src/api/impl/beacon/state/utils.js";
+import {NodeIsSyncing} from "../../../../../../src/api/impl/errors.js";
+import {IBeaconChain} from "../../../../../../src/chain/index.js";
+import {IBeaconSync, SyncState} from "../../../../../../src/sync/index.js";
 import {generateCachedAltairState} from "../../../../../utils/state.js";
 
 describe("beacon state api utils", () => {
@@ -59,6 +63,19 @@ describe("beacon state api utils", () => {
       } else {
         expect.fail("validator index should be found - Uint8Array input");
       }
+    });
+  });
+
+  describe("getStateResponseWithRegen", () => {
+    it("throws NodeIsSyncing while the node is behind and syncing", async () => {
+      const chain = {
+        clock: {currentSlot: 10 * SLOTS_PER_EPOCH},
+        forkChoice: {getHead: () => ({slot: 0})},
+      } as unknown as IBeaconChain;
+      const sync = {state: SyncState.SyncingFinalized} as unknown as IBeaconSync;
+
+      // notWhileSyncing runs before any regen, so a minimal clock/forkChoice/sync mock is enough
+      await expect(getStateResponseWithRegen(chain, sync, "head")).rejects.toThrow(NodeIsSyncing);
     });
   });
 });

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -67,15 +67,33 @@ describe("beacon state api utils", () => {
   });
 
   describe("getStateResponseWithRegen", () => {
-    it("throws NodeIsSyncing while the node is behind and syncing", async () => {
-      const chain = {
-        clock: {currentSlot: 10 * SLOTS_PER_EPOCH},
-        forkChoice: {getHead: () => ({slot: 0})},
-      } as unknown as IBeaconChain;
-      const sync = {state: SyncState.SyncingFinalized} as unknown as IBeaconSync;
+    // Node far behind head and syncing. Chain getters return a dummy response so the resolved
+    // "already-available" state ids don't blow up; the regen paths are never reached in these tests.
+    const servedResponse = {state: {}, executionOptimistic: false, finalized: false};
+    const syncingChain = {
+      clock: {currentSlot: 10 * SLOTS_PER_EPOCH},
+      forkChoice: {
+        getHead: () => ({slot: 0, stateRoot: "0x00"}),
+        getFinalizedCheckpoint: () => ({rootHex: "0x00", epoch: 0}),
+        getJustifiedCheckpoint: () => ({rootHex: "0x00", epoch: 0}),
+        getFinalizedBlock: () => ({slot: 0}),
+      },
+      getStateByStateRoot: () => Promise.resolve(servedResponse),
+      getStateOrBytesByCheckpoint: () => Promise.resolve(servedResponse),
+      getStateBySlot: () => Promise.resolve(servedResponse),
+      getHistoricalStateBySlot: () => Promise.resolve(servedResponse),
+    } as unknown as IBeaconChain;
+    const sync = {state: SyncState.SyncingFinalized} as unknown as IBeaconSync;
 
+    it("throws NodeIsSyncing for a regen-triggering slot while the node is behind and syncing", async () => {
       // notWhileSyncing runs before any regen, so a minimal clock/forkChoice/sync mock is enough
-      await expect(getStateResponseWithRegen(chain, sync, "head")).rejects.toThrow(NodeIsSyncing);
+      await expect(getStateResponseWithRegen(syncingChain, sync, 5 * SLOTS_PER_EPOCH)).rejects.toThrow(NodeIsSyncing);
+    });
+
+    it("serves head/finalized/justified/genesis while syncing (no regen wedge risk)", async () => {
+      for (const stateId of ["head", "finalized", "justified", "genesis"] as const) {
+        await expect(getStateResponseWithRegen(syncingChain, sync, stateId), stateId).resolves.toBeDefined();
+      }
     });
   });
 });

--- a/packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -5,7 +5,8 @@ import {ForkName, MAX_EFFECTIVE_BALANCE, SLOTS_PER_EPOCH} from "@lodestar/params
 import {BeaconStateAllForks, BeaconStateView} from "@lodestar/state-transition";
 import {Slot} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
-import {SYNC_TOLERANCE_EPOCHS, getValidatorApi} from "../../../../../../src/api/impl/validator/index.js";
+import {SYNC_TOLERANCE_EPOCHS} from "../../../../../../src/api/impl/utils.js";
+import {getValidatorApi} from "../../../../../../src/api/impl/validator/index.js";
 import {defaultApiOptions} from "../../../../../../src/api/options.js";
 import {FAR_FUTURE_EPOCH} from "../../../../../../src/constants/index.js";
 import {SyncState} from "../../../../../../src/sync/interface.js";


### PR DESCRIPTION
## Problem

A far-behind node (e.g. resumed from a stale DB, hundreds of epochs behind) that is polled for a beacon state via REST can trigger a `regen` that needs to walk back further than `SLOTS_PER_HISTORICAL_ROOT` (8192) slots. Regen can't get a block root more than 8192 slots in the past, so the node **wedges**: the request grinds on the main thread, 0 blocks get imported, and the only recovery is detaching the poller or checkpoint-syncing fresh.

## Fix

Guard the shared `getStateResponseWithRegen` entry point with the existing `notWhileSyncing` check, so REST state requests return **503 `NodeIsSyncing`** while the node is behind — before regen is ever reached. This matches how the validator duties endpoints already behave (and other clients).

- Extract `notWhileSyncing` + `SYNC_TOLERANCE_EPOCHS` from the validator API into shared `api/impl/utils.ts` and reuse them (no behavior change for validator endpoints).
- Thread `sync` into `getStateResponseWithRegen` and its callers (beacon `state`, `proof`, `debug`, `lodestar`, validator duties). It's the single choke point for all REST state-serving endpoints, so guarding it there covers all of them.
- `head`/`finalized`/`justified`/`genesis` are exempt from the guard — they resolve to already-available states (no regen), so they keep serving during sync (observability, dashboards, VC checks).
- Added unit tests: `getStateResponseWithRegen` throws `NodeIsSyncing` for a regen-capable slot while syncing, and still serves the four always-available state ids.

## Relation to #9634

This is the `notWhileSyncing` alternative to #9634, per @nflaig's review. It's simpler (drops the custom `RegenError`/`SLOT_TOO_FAR_FROM_BLOCK` machinery) and covers all REST state-serving endpoints, not just the far-slot regen case. If this is preferred, #9634 can be closed.

## Behavior note

While the node is more than `SYNC_TOLERANCE_EPOCHS` behind, this returns 503 for regen-capable state lookups (arbitrary slots / state roots). `head`/`finalized`/`justified`/`genesis` keep serving (they never trigger regen). This is broader than the far-slot-only guard in #9634 but consistent with the duties endpoints and other clients.

🤖 Generated with AI assistance