### PR TITLE
docs: prefer targeted pre-push tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 ## Critical rules
 
 - **Target branch:** `unstable` (never `stable`)
-- **Pre-push:** run `pnpm lint`, `pnpm check-types`, `pnpm test:unit` before every push
+- **Pre-push:** run only checks relevant to the change; prefer targeted tests and do not run the full
+  `pnpm test:unit` suite by default
 - **Relative imports:** use `.js` extension in TypeScript ESM imports
 - **No `any`:** avoid `any` / `as any`; use proper types or justified `biome-ignore`
 - **No `lib/` edits:** never edit `packages/*/lib/` — these are build outputs
@@ -346,12 +347,15 @@ refactor(reqresp)!: support byte based handlers
 
 ## Pre-push checklist
 
-Before pushing any commit, verify:
+Before pushing any commit, run only the checks relevant to the changed files and behavior:
 
-1. `pnpm lint` — Biome enforces formatting; CI catches failures but wastes a round-trip
-2. `pnpm check-types` — catch type errors before CI
-3. `pnpm docs:lint` — if you edited any `.md` files, check Prettier formatting
-4. No edits in `packages/*/lib/` — these are build outputs; edit `src/` instead
+1. `pnpm lint` — when changing files covered by Biome
+2. `pnpm check-types` — when changing TypeScript, public APIs, or types
+3. Targeted tests for the changed behavior, when applicable. Do not run the full `pnpm test:unit` suite
+   by default; reserve it for broad changes that cannot be covered adequately by targeted tests or when
+   explicitly requested
+4. `pnpm docs:lint` — if you edited any `.md` files, check Prettier formatting
+5. No edits in `packages/*/lib/` — these are build outputs; edit `src/` instead
 
 ## Common tasks
 
@@ -359,8 +363,8 @@ Before pushing any commit, verify:
 
 1. Create a feature branch from `unstable`
 2. Implement the feature with tests
-3. Run `pnpm lint` and `pnpm check-types`
-4. Run `pnpm test:unit` to verify tests pass
+3. Run `pnpm lint` and `pnpm check-types` when applicable
+4. Run the targeted tests for the feature
 5. Open PR with clear description and any AI disclosure
 
 ### Fixing a bug
@@ -368,7 +372,7 @@ Before pushing any commit, verify:
 1. Write a failing test that reproduces the bug
 2. Fix the bug
 3. Verify the test passes
-4. Run checks: `pnpm lint`, `pnpm check-types`, `pnpm test:unit`
+4. Run `pnpm lint` and `pnpm check-types` when applicable
 
 ### Adding a new SSZ type
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,7 +372,7 @@ Before pushing any commit, run only the checks relevant to the changed files and
 1. Write a failing test that reproduces the bug
 2. Fix the bug
 3. Verify the test passes
-4. Run `pnpm lint` and `pnpm check-types` when applicable
+4. Run targeted tests for the affected area, plus `pnpm lint` and `pnpm check-types` when applicable
 
 ### Adding a new SSZ type
 


### PR DESCRIPTION
## What changed

- make change-relevant checks the pre-push default
- prefer targeted tests for changed behavior
- reserve the full `pnpm test:unit` suite for broad changes that cannot be covered adequately by targeted tests or when explicitly requested
- align the feature and bug-fix workflows with the same guidance

## Why

Running the complete unit suite for narrow script, documentation, or isolated code changes adds significant local feedback time without improving validation over an applicable targeted test.

## Validation

- `pnpm docs:lint`

> This PR was written with assistance from Codex.
