### PR TITLE
ci: detect zapi packages via zapi.targets in native portability check

### DIFF
--- a/scripts/ci/check_native_portability.sh
+++ b/scripts/ci/check_native_portability.sh
@@ -126,6 +126,10 @@ function hasBundledPrebuild(prebuildFiles, targetName) {
   }
 }
 
+function hasZapiTarget(zapiTargets, target) {
+  return zapiTargets.some((zapiTarget) => target.aliases.includes(zapiTarget));
+}
+
 function visitManifest(manifestPath) {
   const realManifestPath = fs.realpathSync(manifestPath);
   if (visited.has(realManifestPath)) {
@@ -142,8 +146,12 @@ function visitManifest(manifestPath) {
   const hasTargetPackages = Object.keys(optionalDependencies).some((name) =>
     requiredTargets.some((target) => target.aliases.some((alias) => name.endsWith(`-${alias}`)))
   );
+  // zapi packages (e.g. @chainsafe/lodestar-z) declare their platform matrix as `zapi.targets` and
+  // build the `.node` under `zig-out/lib`, so they have neither per-target optionalDependencies nor a
+  // `prebuilds/` dir. Treat `zapi.targets` as a native-target signal so they aren't silently skipped.
+  const zapiTargets = Array.isArray(manifest.zapi?.targets) ? manifest.zapi.targets : [];
 
-  if (hasTargetPackages || prebuildFiles.length > 0) {
+  if (hasTargetPackages || prebuildFiles.length > 0 || zapiTargets.length > 0) {
     nativePackageCount++;
     const packageErrors = [];
     const knownPackageGaps = [];
@@ -154,8 +162,12 @@ function visitManifest(manifestPath) {
         if (!optionalDependencyForTarget(optionalDependencies, target)) {
           error = `missing optional dependency for ${target.name}`;
         }
-      } else if (!hasBundledPrebuild(prebuildFiles, target.name)) {
-        error = `missing bundled prebuild for ${target.name}`;
+      } else if (prebuildFiles.length > 0) {
+        if (!hasBundledPrebuild(prebuildFiles, target.name)) {
+          error = `missing bundled prebuild for ${target.name}`;
+        }
+      } else if (!hasZapiTarget(zapiTargets, target)) {
+        error = `missing zapi target for ${target.name}`;
       }
 
       if (error !== null) {


### PR DESCRIPTION
Follow-up to #9642 (against `nflaig/check-native-portability`), addressing the Codex bot P2 comment (`r3561870210`).

## Relevant? Yes

`check_native_portability.sh` detects native packages via **(a)** per-target `optionalDependencies` naming or **(b)** a `prebuilds/` dir. zapi packages (e.g. `@chainsafe/lodestar-z`) declare their platform matrix as `package.json#zapi.targets` and build the `.node` under `zig-out/lib`. A zapi package with **neither** per-target optionalDependencies **nor** a `prebuilds/` dir is `hasTargetPackages === false && prebuildFiles.length === 0` → **skipped entirely** for target coverage, so a dropped target (e.g. `aarch64-unknown-linux-musl`) passes CI — the exact regression this check exists to catch.

`lodestar-z@0.1.2` happens to also ship per-target `optionalDependencies` today, so it is detected via (a) — but that relies on the optionalDependency naming convention rather than the authoritative `zapi.targets` declaration.

## Fix

Treat `zapi.targets` as a native-target signal:
- add it to native-package **detection** (`hasTargetPackages || prebuildFiles.length > 0 || zapiTargets.length > 0`) so zapi packages are never silently skipped;
- **validate** it against the required matrix as a fallback, after optionalDependencies and prebuilds.

Precedence is optionalDeps → prebuilds → `zapi.targets`, so packages that ship both (like `lodestar-z`) keep their existing verified behavior; `zapi.targets` only kicks in for the otherwise-skipped shape.

## Verification

- **No regression on the real graph:** running the patched script against the installed `beacon-node`/`validator` dependency graph produces byte-identical output to the base branch (exit 0).
- **Catches the gap:** a synthetic pure-zapi package (only `zapi.targets`, missing `aarch64-unknown-linux-musl`, `.node` under `zig-out/lib`, no optionalDeps/prebuilds) alongside a complete native package:
  - base script → **exit 0** (silently passes; package never appears in target coverage)
  - patched script → **exit 1**, `FAIL: @chainsafe/fake-zapi@1.0.0 / missing zapi target for aarch64-unknown-linux-musl`

🤖 Generated with AI assistance
