### PR TITLE
chore: update ssz to 1.6.2

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -74,7 +74,7 @@
     "check-readme": "pnpm exec ts-node ../../scripts/check_readme.ts"
   },
   "dependencies": {
-    "@chainsafe/persistent-merkle-tree": "^1.2.5",
+    "@chainsafe/persistent-merkle-tree": "^1.3.0",
     "@chainsafe/ssz": "^1.6.2",
     "@lodestar/config": "workspace:^",
     "@lodestar/params": "workspace:^",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@chainsafe/persistent-merkle-tree": "^1.2.5",
-    "@chainsafe/ssz": "^1.4.0",
+    "@chainsafe/ssz": "^1.6.2",
     "@lodestar/config": "workspace:^",
     "@lodestar/params": "workspace:^",
     "@lodestar/types": "workspace:^",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -108,13 +108,13 @@
     "check-readme": "pnpm exec ts-node ../../scripts/check_readme.ts"
   },
   "dependencies": {
-    "@chainsafe/as-sha256": "^1.2.0",
+    "@chainsafe/as-sha256": "^1.2.4",
     "@chainsafe/blst": "^2.2.0",
     "@chainsafe/discv5": "^12.0.1",
     "@chainsafe/enr": "^6.0.1",
     "@chainsafe/libp2p-noise": "^17.0.0",
     "@chainsafe/libp2p-quic": "^2.1.1",
-    "@chainsafe/persistent-merkle-tree": "^1.2.5",
+    "@chainsafe/persistent-merkle-tree": "^1.3.0",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/snappy-wasm": "^0.5.0",
     "@chainsafe/ssz": "^1.6.2",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -117,7 +117,7 @@
     "@chainsafe/persistent-merkle-tree": "^1.2.5",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/snappy-wasm": "^0.5.0",
-    "@chainsafe/ssz": "^1.4.0",
+    "@chainsafe/ssz": "^1.6.2",
     "@chainsafe/threads": "^1.11.3",
     "@crate-crypto/node-eth-kzg": "0.9.1",
     "@fastify/bearer-auth": "^10.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,7 +62,7 @@
     "@chainsafe/blst": "^2.2.0",
     "@chainsafe/discv5": "^12.0.1",
     "@chainsafe/enr": "^6.0.1",
-    "@chainsafe/persistent-merkle-tree": "^1.2.5",
+    "@chainsafe/persistent-merkle-tree": "^1.3.0",
     "@chainsafe/ssz": "^1.6.2",
     "@chainsafe/threads": "^1.11.3",
     "@libp2p/crypto": "^5.1.13",
@@ -91,7 +91,7 @@
     "yargs": "^17.7.1"
   },
   "devDependencies": {
-    "@chainsafe/as-sha256": "^1.2.0",
+    "@chainsafe/as-sha256": "^1.2.4",
     "@ethereumjs/rlp": "^4.0.1",
     "@lodestar/test-utils": "workspace:^",
     "@types/debug": "^4.1.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,7 +63,7 @@
     "@chainsafe/discv5": "^12.0.1",
     "@chainsafe/enr": "^6.0.1",
     "@chainsafe/persistent-merkle-tree": "^1.2.5",
-    "@chainsafe/ssz": "^1.4.0",
+    "@chainsafe/ssz": "^1.6.2",
     "@chainsafe/threads": "^1.11.3",
     "@libp2p/crypto": "^5.1.13",
     "@libp2p/interface": "^3.1.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -65,7 +65,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/as-sha256": "^1.2.0",
+    "@chainsafe/as-sha256": "^1.2.4",
     "@chainsafe/ssz": "^1.6.2",
     "@lodestar/params": "workspace:^",
     "@lodestar/types": "workspace:^",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -66,7 +66,7 @@
   ],
   "dependencies": {
     "@chainsafe/as-sha256": "^1.2.0",
-    "@chainsafe/ssz": "^1.4.0",
+    "@chainsafe/ssz": "^1.6.2",
     "@lodestar/params": "workspace:^",
     "@lodestar/types": "workspace:^",
     "@lodestar/utils": "workspace:^"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -43,7 +43,7 @@
     "check-readme": "pnpm exec ts-node ../../scripts/check_readme.ts"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^1.4.0",
+    "@chainsafe/ssz": "^1.6.2",
     "@lodestar/config": "workspace:^",
     "@lodestar/utils": "workspace:^",
     "classic-level": "^1.4.1"

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -39,7 +39,7 @@
     "check-readme": "pnpm exec ts-node ../../scripts/check_readme.ts"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^1.4.0",
+    "@chainsafe/ssz": "^1.6.2",
     "@lodestar/config": "workspace:^",
     "@lodestar/params": "workspace:^",
     "@lodestar/state-transition": "workspace:^",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -74,7 +74,7 @@
     "winston-transport": "^4.5.0"
   },
   "devDependencies": {
-    "@chainsafe/ssz": "^1.4.0",
+    "@chainsafe/ssz": "^1.6.2",
     "@chainsafe/threads": "^1.11.3",
     "@lodestar/test-utils": "workspace:^",
     "@types/triple-beam": "^1.3.2"

--- a/packages/reqresp/package.json
+++ b/packages/reqresp/package.json
@@ -56,7 +56,7 @@
     "uint8arraylist": "^2.4.7"
   },
   "devDependencies": {
-    "@chainsafe/ssz": "^1.4.0",
+    "@chainsafe/ssz": "^1.6.2",
     "@libp2p/crypto": "^5.1.13",
     "@libp2p/peer-id": "^6.0.4",
     "@lodestar/logger": "workspace:^",

--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -65,7 +65,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@chainsafe/ssz": "^1.4.0",
+    "@chainsafe/ssz": "^1.6.2",
     "@lodestar/types": "workspace:^",
     "vitest": "catalog:"
   }

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -65,9 +65,9 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/as-sha256": "^1.2.0",
+    "@chainsafe/as-sha256": "^1.2.4",
     "@chainsafe/blst": "^2.2.0",
-    "@chainsafe/persistent-merkle-tree": "^1.2.5",
+    "@chainsafe/persistent-merkle-tree": "^1.3.0",
     "@chainsafe/pubkey-index-map": "^3.0.0",
     "@chainsafe/ssz": "^1.6.2",
     "@chainsafe/swap-or-not-shuffle": "^1.2.1",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -69,7 +69,7 @@
     "@chainsafe/blst": "^2.2.0",
     "@chainsafe/persistent-merkle-tree": "^1.2.5",
     "@chainsafe/pubkey-index-map": "^3.0.0",
-    "@chainsafe/ssz": "^1.4.0",
+    "@chainsafe/ssz": "^1.6.2",
     "@chainsafe/swap-or-not-shuffle": "^1.2.1",
     "@lodestar/config": "workspace:^",
     "@lodestar/params": "workspace:^",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -81,7 +81,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/ssz": "^1.4.0",
+    "@chainsafe/ssz": "^1.6.2",
     "@lodestar/params": "workspace:^",
     "ethereum-cryptography": "^2.0.0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -46,7 +46,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/as-sha256": "^1.2.0",
+    "@chainsafe/as-sha256": "^1.2.4",
     "@vekexasia/bigint-buffer2": "^1.1.1",
     "any-signal": "^4.1.1",
     "case": "^1.6.3",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@chainsafe/blst": "^2.2.0",
-    "@chainsafe/ssz": "^1.4.0",
+    "@chainsafe/ssz": "^1.6.2",
     "@lodestar/api": "workspace:^",
     "@lodestar/config": "workspace:^",
     "@lodestar/db": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
         specifier: ^1.2.5
         version: 1.2.5
       '@chainsafe/ssz':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@lodestar/config':
         specifier: workspace:^
         version: link:../config
@@ -206,8 +206,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
       '@chainsafe/ssz':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@chainsafe/threads':
         specifier: ^1.11.3
         version: 1.11.3
@@ -402,8 +402,8 @@ importers:
         specifier: ^1.2.5
         version: 1.2.5
       '@chainsafe/ssz':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@chainsafe/threads':
         specifier: ^1.11.3
         version: 1.11.3
@@ -532,8 +532,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@chainsafe/ssz':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@lodestar/params':
         specifier: workspace:^
         version: link:../params
@@ -547,8 +547,8 @@ importers:
   packages/db:
     dependencies:
       '@chainsafe/ssz':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@lodestar/config':
         specifier: workspace:^
         version: link:../config
@@ -587,8 +587,8 @@ importers:
   packages/fork-choice:
     dependencies:
       '@chainsafe/ssz':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@lodestar/config':
         specifier: workspace:^
         version: link:../config
@@ -624,8 +624,8 @@ importers:
         version: 4.6.0
     devDependencies:
       '@chainsafe/ssz':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@chainsafe/threads':
         specifier: ^1.11.3
         version: 1.11.3
@@ -682,8 +682,8 @@ importers:
         version: 2.4.8
     devDependencies:
       '@chainsafe/ssz':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@libp2p/crypto':
         specifier: ^5.1.13
         version: 5.1.19
@@ -703,8 +703,8 @@ importers:
   packages/spec-test-util:
     dependencies:
       '@chainsafe/ssz':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@lodestar/types':
         specifier: workspace:^
         version: link:../types
@@ -736,8 +736,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       '@chainsafe/ssz':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@chainsafe/swap-or-not-shuffle':
         specifier: ^1.2.1
         version: 1.2.1
@@ -795,8 +795,8 @@ importers:
   packages/types:
     dependencies:
       '@chainsafe/ssz':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@lodestar/params':
         specifier: workspace:^
         version: link:../params
@@ -838,8 +838,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@chainsafe/ssz':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.2
+        version: 1.6.2
       '@lodestar/api':
         specifier: workspace:^
         version: link:../api
@@ -1247,6 +1247,9 @@ packages:
   '@chainsafe/persistent-merkle-tree@1.2.5':
     resolution: {integrity: sha512-uyv3/nHkD8vNXjdez6q89rhXwGDUp3YX2mBbOwB7/xelgZ9E7hc3HQgOuq1EdfM9Vyh09jiwimXF/hskmymOfQ==}
 
+  '@chainsafe/persistent-merkle-tree@1.3.0':
+    resolution: {integrity: sha512-xGe95xNkYayC5BYQpo7ft5oHwyf52YtqBip+GJqZ9XgKSzraw93qUMNeqKrOVJbZM5HEOys8xxkt0h7VD1a9cw==}
+
   '@chainsafe/prometheus-gc-stats@1.0.2':
     resolution: {integrity: sha512-h3mFKduSX85XMVbOdWOYvx9jNq99jGcRVNyW5goGOqju1CsI+ZJLhu5z4zBb/G+ksL0R4uLVulu/mIMe7Y0rNg==}
     engines: {node: '>=18'}
@@ -1312,8 +1315,8 @@ packages:
   '@chainsafe/snappy-wasm@0.5.0':
     resolution: {integrity: sha512-ydXvhr9p+JjvzSSEyi6XExq8pHugFnrk70mk17T6mhDsklPvaXc+8K90G7TJF+u51lxI/fpv7MahrA5ayjFcSA==}
 
-  '@chainsafe/ssz@1.4.0':
-    resolution: {integrity: sha512-DRje073CIU0lvIdNKmW89jAo4UAidoKpgYco5wvQve8WK1DUk/YS/54c5FX/e/iiKiJ1mo44CNCg4xiKWY3/yQ==}
+  '@chainsafe/ssz@1.6.2':
+    resolution: {integrity: sha512-XJELFJBHBstcvyRuXWPmNc/WRWmV5FVV03+iPTpgtCPQaImEHjKU4bc/5me35dRrXpehC04LD4ePYayOUjxFbw==}
 
   '@chainsafe/swap-or-not-shuffle-darwin-arm64@1.2.1':
     resolution: {integrity: sha512-kTewLZe1KqMAJ1gHfagOxo0BI4kTcMOAkGJ7pRLFM5ZkL2P7sh3/4ixnjdbtMkO207vMZEZL3fxJSSs14kg9Kg==}
@@ -6775,6 +6778,12 @@ snapshots:
       '@chainsafe/hashtree': 1.0.2
       '@noble/hashes': 1.8.0
 
+  '@chainsafe/persistent-merkle-tree@1.3.0':
+    dependencies:
+      '@chainsafe/as-sha256': 1.2.4
+      '@chainsafe/hashtree': 1.0.2
+      '@noble/hashes': 1.8.0
+
   '@chainsafe/prometheus-gc-stats@1.0.2(prom-client@15.1.3)':
     dependencies:
       prom-client: 15.1.3
@@ -6816,10 +6825,10 @@ snapshots:
 
   '@chainsafe/snappy-wasm@0.5.0': {}
 
-  '@chainsafe/ssz@1.4.0':
+  '@chainsafe/ssz@1.6.2':
     dependencies:
-      '@chainsafe/as-sha256': 1.2.0
-      '@chainsafe/persistent-merkle-tree': 1.2.5
+      '@chainsafe/as-sha256': 1.2.4
+      '@chainsafe/persistent-merkle-tree': 1.3.0
 
   '@chainsafe/swap-or-not-shuffle-darwin-arm64@1.2.1':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
   packages/api:
     dependencies:
       '@chainsafe/persistent-merkle-tree':
-        specifier: ^1.2.5
-        version: 1.2.5
+        specifier: ^1.3.0
+        version: 1.3.0
       '@chainsafe/ssz':
         specifier: ^1.6.2
         version: 1.6.2
@@ -179,8 +179,8 @@ importers:
   packages/beacon-node:
     dependencies:
       '@chainsafe/as-sha256':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.2.4
+        version: 1.2.4
       '@chainsafe/blst':
         specifier: ^2.2.0
         version: 2.2.0
@@ -197,8 +197,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       '@chainsafe/persistent-merkle-tree':
-        specifier: ^1.2.5
-        version: 1.2.5
+        specifier: ^1.3.0
+        version: 1.3.0
       '@chainsafe/prometheus-gc-stats':
         specifier: ^1.0.0
         version: 1.0.2(prom-client@15.1.3)
@@ -399,8 +399,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       '@chainsafe/persistent-merkle-tree':
-        specifier: ^1.2.5
-        version: 1.2.5
+        specifier: ^1.3.0
+        version: 1.3.0
       '@chainsafe/ssz':
         specifier: ^1.6.2
         version: 1.6.2
@@ -481,8 +481,8 @@ importers:
         version: 17.7.2
     devDependencies:
       '@chainsafe/as-sha256':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.2.4
+        version: 1.2.4
       '@ethereumjs/rlp':
         specifier: ^4.0.1
         version: 4.0.1
@@ -529,8 +529,8 @@ importers:
   packages/config:
     dependencies:
       '@chainsafe/as-sha256':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.2.4
+        version: 1.2.4
       '@chainsafe/ssz':
         specifier: ^1.6.2
         version: 1.6.2
@@ -724,14 +724,14 @@ importers:
   packages/state-transition:
     dependencies:
       '@chainsafe/as-sha256':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.2.4
+        version: 1.2.4
       '@chainsafe/blst':
         specifier: ^2.2.0
         version: 2.2.0
       '@chainsafe/persistent-merkle-tree':
-        specifier: ^1.2.5
-        version: 1.2.5
+        specifier: ^1.3.0
+        version: 1.3.0
       '@chainsafe/pubkey-index-map':
         specifier: ^3.0.0
         version: 3.0.0
@@ -807,8 +807,8 @@ importers:
   packages/utils:
     dependencies:
       '@chainsafe/as-sha256':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.2.4
+        version: 1.2.4
       '@vekexasia/bigint-buffer2':
         specifier: ^1.1.1
         version: 1.1.1
@@ -1054,9 +1054,6 @@ packages:
   '@chainsafe/as-chacha20poly1305@0.1.0':
     resolution: {integrity: sha512-BpNcL8/lji/GM3+vZ/bgRWqJ1q5kwvTFmGPk7pxm/QQZDbaMI98waOHjEymTjq2JmdD/INdNBFOVSyJofXg7ew==}
 
-  '@chainsafe/as-sha256@1.2.0':
-    resolution: {integrity: sha512-H2BNHQ5C3RS+H0ZvOdovK6GjFAyq5T6LClad8ivwj9Oaiy28uvdsGVS7gNJKuZmg0FGHAI+n7F0Qju6U0QkKDA==}
-
   '@chainsafe/as-sha256@1.2.4':
     resolution: {integrity: sha512-3GXDysZOKD6cTYbm48lEdXdUbS7cafjXQZfgHOspTByhoGR/JM3KBXyF3vE6bf63ImjNPyoEZwnQcpYPQ6k3bQ==}
 
@@ -1243,9 +1240,6 @@ packages:
 
   '@chainsafe/netmask@2.0.0':
     resolution: {integrity: sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==}
-
-  '@chainsafe/persistent-merkle-tree@1.2.5':
-    resolution: {integrity: sha512-uyv3/nHkD8vNXjdez6q89rhXwGDUp3YX2mBbOwB7/xelgZ9E7hc3HQgOuq1EdfM9Vyh09jiwimXF/hskmymOfQ==}
 
   '@chainsafe/persistent-merkle-tree@1.3.0':
     resolution: {integrity: sha512-xGe95xNkYayC5BYQpo7ft5oHwyf52YtqBip+GJqZ9XgKSzraw93qUMNeqKrOVJbZM5HEOys8xxkt0h7VD1a9cw==}
@@ -6570,8 +6564,6 @@ snapshots:
 
   '@chainsafe/as-chacha20poly1305@0.1.0': {}
 
-  '@chainsafe/as-sha256@1.2.0': {}
-
   '@chainsafe/as-sha256@1.2.4': {}
 
   '@chainsafe/benchmark@2.0.2(encoding@0.1.13)':
@@ -6715,7 +6707,7 @@ snapshots:
   '@chainsafe/libp2p-noise@17.0.0':
     dependencies:
       '@chainsafe/as-chacha20poly1305': 0.1.0
-      '@chainsafe/as-sha256': 1.2.0
+      '@chainsafe/as-sha256': 1.2.4
       '@libp2p/crypto': 5.1.19
       '@libp2p/interface': 3.2.3
       '@libp2p/peer-id': 6.0.10
@@ -6771,12 +6763,6 @@ snapshots:
   '@chainsafe/netmask@2.0.0':
     dependencies:
       '@chainsafe/is-ip': 2.1.0
-
-  '@chainsafe/persistent-merkle-tree@1.2.5':
-    dependencies:
-      '@chainsafe/as-sha256': 1.2.4
-      '@chainsafe/hashtree': 1.0.2
-      '@noble/hashes': 1.8.0
 
   '@chainsafe/persistent-merkle-tree@1.3.0':
     dependencies:


### PR DESCRIPTION
## Summary

- update `@chainsafe/ssz` from `^1.4.0` to `^1.6.2` across workspace dependencies and the `spec-test-util` peer dependency
- align `@chainsafe/persistent-merkle-tree` from `^1.2.5` to `^1.3.0`
- align `@chainsafe/as-sha256` from `^1.2.0` to `^1.2.4`
- refresh the pnpm lockfile and remove the duplicate older transitive versions

## Impact

Lodestar now uses the latest published SSZ release with a single version of its core merkle-tree and SHA-256 dependencies. This avoids duplicate package instances and their associated bundle-size, memory, and cross-version object compatibility risks.

This is a dependency-only update with no application code changes.

## Validation

- `pnpm lint`
- `pnpm check-types`
- `pnpm test:unit` (308 files passed, 1 skipped; 3,228 tests passed)

> This PR was written primarily by Codex.