### PR TITLE
feat: evict invalid payloads from cache

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -737,6 +737,8 @@ export function getBeaconBlockApi({
         source: PayloadEnvelopeInputSource.api,
         seenTimestampSec,
         peerIdStr: undefined,
+        // signature verified during API validation above
+        verified: true,
       });
 
       if (dataColumnSidecars.length > 0) {

--- a/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
+++ b/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
@@ -148,75 +148,90 @@ export async function importExecutionPayload(
     });
   }
 
-  // 4. Verify envelope fields against state first to fail fast before the EL + BLS work.
+  // 4. Verify the envelope: fields against state first to fail fast, then EL and signature in
+  // parallel. On any verification failure, detach the envelope so a retry can attach fresh
+  // bytes from a different peer instead of re-verifying the same cached bad bytes forever.
+  // Detaching is a no-op for verified (gossip/API) envelopes.
   // When validSignature is true, gossip/API has already verified both the signature and the
   // executionRequestsRoot, so we skip those checks here.
+  let execStatus: PayloadExecutionStatus;
   try {
-    verifyExecutionPayloadEnvelope(this.config, blockState, envelope, {
-      verifyExecutionRequestsRoot: !opts.validSignature,
-    });
+    try {
+      verifyExecutionPayloadEnvelope(this.config, blockState, envelope, {
+        verifyExecutionRequestsRoot: !opts.validSignature,
+      });
+    } catch (e) {
+      throw new PayloadError(
+        {
+          code: PayloadErrorCode.ENVELOPE_VERIFICATION_ERROR,
+          message: (e as Error).message,
+        },
+        `Envelope verification error: ${(e as Error).message}`
+      );
+    }
+
+    // 4a. Run EL and signature verification in parallel
+    const [execResult, signatureValid] = await Promise.all([
+      this.executionEngine.notifyNewPayload(
+        fork,
+        envelope.payload,
+        payloadInput.getVersionedHashes(),
+        envelope.parentBeaconBlockRoot,
+        envelope.executionRequests
+      ),
+
+      opts.validSignature === true
+        ? Promise.resolve(true)
+        : verifyExecutionPayloadEnvelopeSignature(
+            this.config,
+            blockState,
+            this.pubkeyCache,
+            signedEnvelope,
+            payloadInput.proposerIndex,
+            this.bls
+          ),
+    ]);
+
+    // 4b. Check signature verification result
+    if (!signatureValid) {
+      throw new PayloadError({code: PayloadErrorCode.INVALID_SIGNATURE});
+    }
+
+    // 4c. Handle EL response
+    switch (execResult.status) {
+      case ExecutionPayloadStatus.VALID:
+        break;
+
+      case ExecutionPayloadStatus.INVALID:
+        throw new PayloadError({
+          code: PayloadErrorCode.EXECUTION_ENGINE_INVALID,
+          execStatus: execResult.status,
+          errorMessage: execResult.validationError ?? "",
+        });
+
+      case ExecutionPayloadStatus.ACCEPTED:
+      case ExecutionPayloadStatus.SYNCING:
+        break;
+
+      case ExecutionPayloadStatus.INVALID_BLOCK_HASH:
+      case ExecutionPayloadStatus.ELERROR:
+      case ExecutionPayloadStatus.UNAVAILABLE:
+        throw new PayloadError({
+          code: PayloadErrorCode.EXECUTION_ENGINE_ERROR,
+          execStatus: execResult.status,
+          errorMessage: execResult.validationError ?? "",
+        });
+    }
+
+    execStatus = toForkChoiceExecutionStatus(execResult.status);
   } catch (e) {
-    throw new PayloadError(
-      {
-        code: PayloadErrorCode.ENVELOPE_VERIFICATION_ERROR,
-        message: (e as Error).message,
-      },
-      `Envelope verification error: ${(e as Error).message}`
-    );
+    this.seenPayloadEnvelopeInputCache.removeUnverifiedPayloadEnvelope(blockRootHex);
+    throw e;
   }
 
-  // 4a. Run EL and signature verification in parallel
-  const [execResult, signatureValid] = await Promise.all([
-    this.executionEngine.notifyNewPayload(
-      fork,
-      envelope.payload,
-      payloadInput.getVersionedHashes(),
-      envelope.parentBeaconBlockRoot,
-      envelope.executionRequests
-    ),
-
-    opts.validSignature === true
-      ? Promise.resolve(true)
-      : verifyExecutionPayloadEnvelopeSignature(
-          this.config,
-          blockState,
-          this.pubkeyCache,
-          signedEnvelope,
-          payloadInput.proposerIndex,
-          this.bls
-        ),
-  ]);
-
-  // 4b. Check signature verification result
-  if (!signatureValid) {
-    throw new PayloadError({code: PayloadErrorCode.INVALID_SIGNATURE});
-  }
-
-  // 4c. Handle EL response
-  switch (execResult.status) {
-    case ExecutionPayloadStatus.VALID:
-      break;
-
-    case ExecutionPayloadStatus.INVALID:
-      throw new PayloadError({
-        code: PayloadErrorCode.EXECUTION_ENGINE_INVALID,
-        execStatus: execResult.status,
-        errorMessage: execResult.validationError ?? "",
-      });
-
-    case ExecutionPayloadStatus.ACCEPTED:
-    case ExecutionPayloadStatus.SYNCING:
-      break;
-
-    case ExecutionPayloadStatus.INVALID_BLOCK_HASH:
-    case ExecutionPayloadStatus.ELERROR:
-    case ExecutionPayloadStatus.UNAVAILABLE:
-      throw new PayloadError({
-        code: PayloadErrorCode.EXECUTION_ENGINE_ERROR,
-        execStatus: execResult.status,
-        errorMessage: execResult.validationError ?? "",
-      });
-  }
+  // The envelope passed all verification steps — mark verified so it is never removed later.
+  // No-op for gossip/API envelopes which are verified at attach time.
+  payloadInput.markPayloadEnvelopeVerified();
 
   // 5. Persist payload envelope to hot DB. Wait for write-queue space here to apply backpressure
   // on the import pipeline during sync, then perform the write asynchronously to avoid blocking.
@@ -232,7 +247,6 @@ export async function importExecutionPayload(
   });
 
   // 6. Update fork choice, transitions the block's PENDING variant to FULL
-  const execStatus = toForkChoiceExecutionStatus(execResult.status);
   this.forkChoice.onExecutionPayload(
     blockRootHex,
     blockHashHex,

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
@@ -29,6 +29,7 @@ export type PayloadEnvelopeInputState =
       hasComputedAllData: false;
       payloadEnvelope: gloas.SignedExecutionPayloadEnvelope;
       payloadEnvelopeSource: SourceMeta;
+      payloadEnvelopeVerified: boolean;
     }
   | {
       hasPayload: true;
@@ -36,6 +37,7 @@ export type PayloadEnvelopeInputState =
       hasComputedAllData: boolean;
       payloadEnvelope: gloas.SignedExecutionPayloadEnvelope;
       payloadEnvelopeSource: SourceMeta;
+      payloadEnvelopeVerified: boolean;
       timeCompleteSec: number;
     };
 
@@ -79,7 +81,7 @@ export class PayloadEnvelopeInput {
 
   private timeCreatedSec: number;
 
-  private readonly payloadEnvelopeDataPromise: PromiseParts<gloas.SignedExecutionPayloadEnvelope>;
+  private payloadEnvelopeDataPromise: PromiseParts<gloas.SignedExecutionPayloadEnvelope>;
   private readonly allDataPromise: PromiseParts<gloas.DataColumnSidecar[]>;
   private readonly columnsDataPromise: PromiseParts<gloas.DataColumnSidecar[]>;
 
@@ -197,6 +199,7 @@ export class PayloadEnvelopeInput {
         hasComputedAllData: this.state.hasComputedAllData,
         payloadEnvelope: props.envelope,
         payloadEnvelopeSource: source,
+        payloadEnvelopeVerified: props.verified,
         timeCompleteSec: props.seenTimestampSec,
       };
       this.payloadEnvelopeDataPromise.resolve(props.envelope);
@@ -208,8 +211,56 @@ export class PayloadEnvelopeInput {
         hasComputedAllData: false,
         payloadEnvelope: props.envelope,
         payloadEnvelopeSource: source,
+        payloadEnvelopeVerified: props.verified,
       };
     }
+  }
+
+  /**
+   * Detach the payload envelope so a fresh copy can be re-attached, e.g. after signature or
+   * envelope verification failure during import of an optimistically attached envelope.
+   * Verified envelopes are never removed — their signature proves the bytes are canonical, so
+   * re-downloading cannot produce different ones. Reverts only the payload dimension of state;
+   * columns and hasComputedAllData are preserved.
+   *
+   * Returns the removed envelope and its source for serialized-cache cleanup and logging, or
+   * null when there is nothing to remove (no envelope attached, or envelope is verified).
+   */
+  removeUnverifiedPayloadEnvelope(): {envelope: gloas.SignedExecutionPayloadEnvelope; sourceMeta: SourceMeta} | null {
+    if (!this.state.hasPayload || this.state.payloadEnvelopeVerified) {
+      return null;
+    }
+    const {payloadEnvelope, payloadEnvelopeSource} = this.state;
+
+    if (this.state.hasAllData) {
+      // Complete -> data-only (drops timeCompleteSec, preserves hasComputedAllData)
+      this.state = {hasPayload: false, hasAllData: true, hasComputedAllData: this.state.hasComputedAllData};
+    } else {
+      // Envelope-only -> empty
+      this.state = {hasPayload: false, hasAllData: false, hasComputedAllData: false};
+    }
+
+    // The old promise may already be resolved with the removed envelope (see addPayloadEnvelope /
+    // addColumn). Re-create so future waiters observe the replacement envelope; in-flight waiters
+    // on the old promise are bounded by withTimeout in waitForEnvelopeAndAllData.
+    this.payloadEnvelopeDataPromise = createPromise();
+
+    return {envelope: payloadEnvelope, sourceMeta: payloadEnvelopeSource};
+  }
+
+  /**
+   * Mark the attached envelope as verified after its signature has been checked during import.
+   * Verified envelopes are never removed by removeUnverifiedPayloadEnvelope(). No-op if no envelope is
+   * attached or it is already verified.
+   */
+  markPayloadEnvelopeVerified(): void {
+    if (this.state.hasPayload) {
+      this.state.payloadEnvelopeVerified = true;
+    }
+  }
+
+  isPayloadEnvelopeVerified(): boolean {
+    return this.state.hasPayload && this.state.payloadEnvelopeVerified;
   }
 
   addColumn(columnWithSource: ColumnWithSource): boolean {
@@ -255,6 +306,7 @@ export class PayloadEnvelopeInput {
         hasComputedAllData: hasComputedAllData || this.state.hasComputedAllData,
         payloadEnvelope: this.state.payloadEnvelope,
         payloadEnvelopeSource: this.state.payloadEnvelopeSource,
+        payloadEnvelopeVerified: this.state.payloadEnvelopeVerified,
         timeCompleteSec: seenTimestampSec,
       };
       this.payloadEnvelopeDataPromise.resolve(this.state.payloadEnvelope);

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/types.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/types.ts
@@ -49,4 +49,5 @@ export type CreateFromBidProps = {
 
 export type AddPayloadEnvelopeProps = SourceMeta & {
   envelope: gloas.SignedExecutionPayloadEnvelope;
+  verified: boolean;
 };

--- a/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenPayloadEnvelopeInput.ts
@@ -160,6 +160,28 @@ export class SeenPayloadEnvelopeInput {
     }
   }
 
+  /**
+   * Detach an unverified envelope from a cached entry WITHOUT evicting the entry itself —
+   * whole-entry eviction breaks payload-by-root sync (see pruneBelowParent). The next
+   * by-range/by-root download can then attach fresh bytes. No-op if the entry does not exist,
+   * has no envelope, or the envelope is verified (see PayloadEnvelopeInput.removeUnverifiedPayloadEnvelope).
+   */
+  removeUnverifiedPayloadEnvelope(blockRootHex: RootHex): void {
+    const input = this.payloadInputs.get(blockRootHex);
+    const removed = input?.removeUnverifiedPayloadEnvelope();
+    if (input === undefined || removed == null) {
+      return;
+    }
+    this.serializedCache.delete([removed.envelope]);
+    this.metrics?.seenCache.payloadEnvelopeInput.envelopesRemoved.inc({source: removed.sourceMeta.source});
+    this.logger?.verbose("SeenPayloadEnvelopeInput.removeUnverifiedPayloadEnvelope detached envelope", {
+      slot: input.slot,
+      root: blockRootHex,
+      source: removed.sourceMeta.source,
+      peer: removed.sourceMeta.peerIdStr ?? "unknown",
+    });
+  }
+
   pruneBelowParent(parentBlock: ProtoBlock): void {
     for (const block of this.forkChoice.getAllAncestorBlocks(parentBlock.blockRoot, parentBlock.payloadStatus)) {
       // Only evict once the payload is FULL (revealed/imported) — on an EMPTY/PENDING branch we may

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1593,6 +1593,11 @@ export function createLodestarMetrics(
           name: "lodestar_seen_payload_envelope_input_cache_items_created_total",
           help: "Number of PayloadEnvelopeInputs created",
         }),
+        envelopesRemoved: register.counter<{source: PayloadEnvelopeInputSource}>({
+          name: "lodestar_seen_payload_envelope_input_cache_envelopes_removed_total",
+          help: "Number of unverified payload envelopes detached from cached PayloadEnvelopeInputs after import failure",
+          labelNames: ["source"],
+        }),
       },
     },
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1170,6 +1170,8 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         source: PayloadEnvelopeInputSource.gossip,
         seenTimestampSec,
         peerIdStr,
+        // signature verified during gossip validation above
+        verified: true,
       });
 
       chain.emitter.emit(routes.events.EventType.executionPayloadGossip, {

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -526,6 +526,8 @@ export class BlockInputSync {
         envelope: queuedEnvelope,
         source: PayloadEnvelopeInputSource.byRoot,
         seenTimestampSec: Date.now() / 1000,
+        // optimistically attached, signature is only verified during import
+        verified: false,
       });
     }
 
@@ -1042,8 +1044,9 @@ export class BlockInputSync {
         case PayloadErrorCode.EXECUTION_ENGINE_INVALID:
         case PayloadErrorCode.ENVELOPE_VERIFICATION_ERROR:
         case PayloadErrorCode.INVALID_SIGNATURE:
-          // TODO GLOAS: Decide how invalid payload inputs should eventually leave memory without
-          // reintroducing envelope replacement / recreation flows.
+          // For unverified envelopes failing signature/envelope verification, the import already
+          // detached the bad envelope from the cached PayloadEnvelopeInput (see
+          // importExecutionPayload), so a later download can attach fresh bytes.
           this.logger.debug("Error processing payload from unknown sync", logCtx, res.err);
           this.removePendingPayloadAndDescendants(rootHex);
           break;

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -241,6 +241,8 @@ export function cacheByRangeResponses({
           source: PayloadEnvelopeInputSource.byRange,
           seenTimestampSec,
           peerIdStr,
+          // optimistically attached, signature is only verified during import
+          verified: false,
         });
       }
 

--- a/packages/beacon-node/test/unit/chain/blocks/payloadEnvelopeInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/payloadEnvelopeInput.test.ts
@@ -1,0 +1,184 @@
+import {describe, expect, it} from "vitest";
+import {ForkName} from "@lodestar/params";
+import {ColumnIndex, SignedBeaconBlock, gloas, ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
+import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
+
+function buildPayloadInput({blobCount, sampledColumns}: {blobCount: number; sampledColumns: ColumnIndex[]}): {
+  payloadInput: PayloadEnvelopeInput;
+  blockRoot: Uint8Array;
+} {
+  const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+  block.message.slot = 1;
+  const commitments = Array.from({length: blobCount}, () => Buffer.alloc(48, 0x77));
+  block.message.body.signedExecutionPayloadBid.message.blobKzgCommitments = commitments;
+
+  const blockRoot = ssz.gloas.BeaconBlock.hashTreeRoot(block.message);
+
+  const payloadInput = PayloadEnvelopeInput.createFromBlock({
+    blockRootHex: toRootHex(blockRoot),
+    block: block as SignedBeaconBlock<typeof ForkName.gloas>,
+    forkName: ForkName.gloas,
+    sampledColumns,
+    custodyColumns: sampledColumns,
+    timeCreatedSec: Date.now() / 1000,
+    daOutOfRange: false,
+  });
+
+  return {payloadInput, blockRoot};
+}
+
+function buildEnvelope(blockRoot: Uint8Array, builderIndex = 0): gloas.SignedExecutionPayloadEnvelope {
+  const signedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+  signedEnvelope.message.beaconBlockRoot = blockRoot;
+  signedEnvelope.message.builderIndex = builderIndex;
+  return signedEnvelope;
+}
+
+function buildColumnSidecar(index: ColumnIndex): gloas.DataColumnSidecar {
+  const columnSidecar = ssz.gloas.DataColumnSidecar.defaultValue();
+  columnSidecar.index = index;
+  return columnSidecar;
+}
+
+describe("PayloadEnvelopeInput", () => {
+  describe("removeUnverifiedPayloadEnvelope", () => {
+    it("removes an unverified envelope from the complete state", () => {
+      // no blobs -> hasAllData from creation, attaching an envelope completes the input
+      const {payloadInput, blockRoot} = buildPayloadInput({blobCount: 0, sampledColumns: []});
+      const envelope = buildEnvelope(blockRoot);
+      payloadInput.addPayloadEnvelope({
+        envelope,
+        source: PayloadEnvelopeInputSource.byRange,
+        seenTimestampSec: Date.now() / 1000,
+        peerIdStr: "peerA",
+        verified: false,
+      });
+      expect(payloadInput.isComplete()).toBe(true);
+
+      const removed = payloadInput.removeUnverifiedPayloadEnvelope();
+
+      expect(removed?.envelope).toBe(envelope);
+      expect(removed?.sourceMeta).toEqual({
+        source: PayloadEnvelopeInputSource.byRange,
+        seenTimestampSec: expect.any(Number),
+        peerIdStr: "peerA",
+      });
+      expect(payloadInput.hasPayloadEnvelope()).toBe(false);
+      expect(payloadInput.hasAllData()).toBe(true);
+      expect(payloadInput.hasComputedAllData()).toBe(true);
+      expect(payloadInput.isComplete()).toBe(false);
+      expect(payloadInput.getSerializedCacheKeys()).not.toContain(envelope);
+    });
+
+    it("removes an unverified envelope from the envelope-only state and preserves columns", () => {
+      const {payloadInput, blockRoot} = buildPayloadInput({blobCount: 1, sampledColumns: [0, 1]});
+      payloadInput.addColumn({
+        columnSidecar: buildColumnSidecar(0),
+        source: PayloadEnvelopeInputSource.byRange,
+        seenTimestampSec: Date.now() / 1000,
+      });
+      payloadInput.addPayloadEnvelope({
+        envelope: buildEnvelope(blockRoot),
+        source: PayloadEnvelopeInputSource.byRange,
+        seenTimestampSec: Date.now() / 1000,
+        verified: false,
+      });
+      expect(payloadInput.hasAllData()).toBe(false);
+
+      const removed = payloadInput.removeUnverifiedPayloadEnvelope();
+
+      expect(removed).not.toBeNull();
+      expect(payloadInput.hasPayloadEnvelope()).toBe(false);
+      expect(payloadInput.hasAllData()).toBe(false);
+      expect(payloadInput.hasComputedAllData()).toBe(false);
+      // previously added columns survive the detach
+      expect(payloadInput.hasColumn(0)).toBe(true);
+      expect(payloadInput.getMissingSampledColumnMeta().missing).toEqual([1]);
+    });
+
+    it("never removes an envelope attached as verified", () => {
+      const {payloadInput, blockRoot} = buildPayloadInput({blobCount: 0, sampledColumns: []});
+      const envelope = buildEnvelope(blockRoot);
+      payloadInput.addPayloadEnvelope({
+        envelope,
+        source: PayloadEnvelopeInputSource.gossip,
+        seenTimestampSec: Date.now() / 1000,
+        verified: true,
+      });
+
+      expect(payloadInput.removeUnverifiedPayloadEnvelope()).toBeNull();
+      expect(payloadInput.hasPayloadEnvelope()).toBe(true);
+      expect(payloadInput.getPayloadEnvelope()).toBe(envelope);
+    });
+
+    it("never removes an envelope upgraded via markPayloadEnvelopeVerified", () => {
+      const {payloadInput, blockRoot} = buildPayloadInput({blobCount: 0, sampledColumns: []});
+      payloadInput.addPayloadEnvelope({
+        envelope: buildEnvelope(blockRoot),
+        source: PayloadEnvelopeInputSource.byRange,
+        seenTimestampSec: Date.now() / 1000,
+        verified: false,
+      });
+      expect(payloadInput.isPayloadEnvelopeVerified()).toBe(false);
+
+      payloadInput.markPayloadEnvelopeVerified();
+
+      expect(payloadInput.isPayloadEnvelopeVerified()).toBe(true);
+      expect(payloadInput.removeUnverifiedPayloadEnvelope()).toBeNull();
+      expect(payloadInput.hasPayloadEnvelope()).toBe(true);
+    });
+
+    it("allows re-attaching a fresh envelope after removal", async () => {
+      const {payloadInput, blockRoot} = buildPayloadInput({blobCount: 0, sampledColumns: []});
+      payloadInput.addPayloadEnvelope({
+        envelope: buildEnvelope(blockRoot, 0),
+        source: PayloadEnvelopeInputSource.byRange,
+        seenTimestampSec: Date.now() / 1000,
+        verified: false,
+      });
+      payloadInput.removeUnverifiedPayloadEnvelope();
+
+      // the wait below must observe the replacement envelope, not the removed one
+      const waitPromise = payloadInput.waitForEnvelopeAndAllData(1_000);
+
+      const freshEnvelope = buildEnvelope(blockRoot, 1);
+      expect(() =>
+        payloadInput.addPayloadEnvelope({
+          envelope: freshEnvelope,
+          source: PayloadEnvelopeInputSource.byRange,
+          seenTimestampSec: Date.now() / 1000,
+          verified: false,
+        })
+      ).not.toThrow();
+
+      await waitPromise;
+      expect(payloadInput.getPayloadEnvelope()).toBe(freshEnvelope);
+      expect(payloadInput.isComplete()).toBe(true);
+    });
+
+    it("is a no-op when no envelope is attached or on double removal", () => {
+      const {payloadInput, blockRoot} = buildPayloadInput({blobCount: 0, sampledColumns: []});
+      expect(payloadInput.removeUnverifiedPayloadEnvelope()).toBeNull();
+
+      payloadInput.addPayloadEnvelope({
+        envelope: buildEnvelope(blockRoot),
+        source: PayloadEnvelopeInputSource.byRange,
+        seenTimestampSec: Date.now() / 1000,
+        verified: false,
+      });
+      expect(payloadInput.removeUnverifiedPayloadEnvelope()).not.toBeNull();
+      expect(payloadInput.removeUnverifiedPayloadEnvelope()).toBeNull();
+      expect(payloadInput.hasPayloadEnvelope()).toBe(false);
+    });
+  });
+
+  describe("markPayloadEnvelopeVerified", () => {
+    it("is a no-op when no envelope is attached", () => {
+      const {payloadInput} = buildPayloadInput({blobCount: 0, sampledColumns: []});
+      expect(() => payloadInput.markPayloadEnvelopeVerified()).not.toThrow();
+      expect(payloadInput.isPayloadEnvelopeVerified()).toBe(false);
+    });
+  });
+});

--- a/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
@@ -53,6 +53,7 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment with 
       source: PayloadEnvelopeInputSource.byRange,
       seenTimestampSec,
       peerIdStr: "peer",
+      verified: false,
     });
     return payloadInput;
   }

--- a/packages/beacon-node/test/unit/chain/blocks/verifyPayloadsDataAvailability.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyPayloadsDataAvailability.test.ts
@@ -47,6 +47,7 @@ function buildPayloadEnvelopeInput({
     envelope: signedEnvelope,
     source: PayloadEnvelopeInputSource.gossip,
     seenTimestampSec: Date.now() / 1000,
+    verified: true,
   });
 
   return {payloadInput, signedEnvelope};
@@ -223,6 +224,7 @@ describe("PayloadEnvelopeInput.waitForEnvelopeAndAllData", () => {
       envelope: signedEnvelope,
       source: PayloadEnvelopeInputSource.gossip,
       seenTimestampSec: Date.now() / 1000,
+      verified: true,
     });
     for (const idx of sampled) {
       payloadInput.addColumn({
@@ -260,6 +262,7 @@ describe("PayloadEnvelopeInput.waitForEnvelopeAndAllData", () => {
       envelope: signedEnvelope,
       source: PayloadEnvelopeInputSource.gossip,
       seenTimestampSec: Date.now() / 1000,
+      verified: true,
     });
     expect(payloadInput.hasAllData()).toBe(false);
     expect(payloadInput.isComplete()).toBe(false);

--- a/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
@@ -3,7 +3,9 @@ import {ExecutionStatus, IForkChoice, PayloadStatus, ProtoBlock} from "@lodestar
 import {testLogger} from "@lodestar/logger/test-utils";
 import {ForkName} from "@lodestar/params";
 import {DataAvailabilityStatus} from "@lodestar/state-transition";
-import {RootHex} from "@lodestar/types";
+import {RootHex, gloas, ssz} from "@lodestar/types";
+import {fromHex} from "@lodestar/utils";
+import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
 import {ChainEventEmitter} from "../../../../src/chain/emitter.js";
 import {SeenPayloadEnvelopeInput} from "../../../../src/chain/seenCache/seenPayloadEnvelopeInput.js";
 import {SerializedCache} from "../../../../src/util/serializedCache.js";
@@ -171,5 +173,51 @@ describe("SeenPayloadEnvelopeInput", () => {
     expect(() => cache.prune(`0x${"ab".repeat(32)}`)).not.toThrow();
     expect(cache.get(rootHex)).toBeDefined();
     expect(cache.size()).toBe(1);
+  });
+
+  function attachEnvelope(rootHex: RootHex, verified: boolean): gloas.SignedExecutionPayloadEnvelope {
+    const envelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    envelope.message.beaconBlockRoot = fromHex(rootHex);
+    const input = cache.get(rootHex);
+    if (!input) throw new Error("input not found");
+    input.addPayloadEnvelope({
+      envelope,
+      source: PayloadEnvelopeInputSource.byRange,
+      seenTimestampSec: Date.now() / 1000,
+      peerIdStr: "peer",
+      verified,
+    });
+    return envelope;
+  }
+
+  it("removeUnverifiedPayloadEnvelope detaches an unverified envelope but keeps the entry", () => {
+    const rootHex = addPayloadInput(1);
+    const envelope = attachEnvelope(rootHex, false);
+    serializedCache.set(envelope, new Uint8Array([1, 2, 3]));
+
+    cache.removeUnverifiedPayloadEnvelope(rootHex);
+
+    expect(cache.get(rootHex)).toBeDefined();
+    expect(cache.hasPayload(rootHex)).toBe(false);
+    expect(serializedCache.get(envelope)).toBeUndefined();
+  });
+
+  it("removeUnverifiedPayloadEnvelope is a no-op for a verified envelope", () => {
+    const rootHex = addPayloadInput(1);
+    const envelope = attachEnvelope(rootHex, true);
+    serializedCache.set(envelope, new Uint8Array([1, 2, 3]));
+
+    cache.removeUnverifiedPayloadEnvelope(rootHex);
+
+    expect(cache.hasPayload(rootHex)).toBe(true);
+    expect(serializedCache.get(envelope)).toBeDefined();
+  });
+
+  it("removeUnverifiedPayloadEnvelope is a no-op for an unknown root or envelope-less entry", () => {
+    const rootHex = addPayloadInput(1);
+
+    expect(() => cache.removeUnverifiedPayloadEnvelope(`0x${"ab".repeat(32)}`)).not.toThrow();
+    expect(() => cache.removeUnverifiedPayloadEnvelope(rootHex)).not.toThrow();
+    expect(cache.get(rootHex)).toBeDefined();
   });
 });

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -322,6 +322,7 @@ describe("sync / range / batch", async () => {
             source: PayloadEnvelopeInputSource.byRange,
             seenTimestampSec,
             peerIdStr: peer,
+            verified: false,
           });
         }
         if (addAllColumns && sampledColumns.length > 0) {

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -1255,6 +1255,7 @@ describe("UnknownBlockSync", () => {
         envelope,
         source: PayloadEnvelopeInputSource.gossip,
         seenTimestampSec: Date.now() / 1000,
+        verified: true,
       });
 
       const processExecutionPayload = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
**Motivation**

- we optimistically add payload to cache in `downloadByRange`, it turned out the payload could be invalid, see #9660
- this invalid payload stay in cache forever, sync stalled

**Description**

- track `verified: boolean` in the cache when populating it, right now only `gossipHandler` has this as `true`, otherwise it's `false`
- if later on we fail to verify payload envelope, we remove it
- otherwise, we mark it as "verified" and we don't have to remove it again

Closes #9660

**AI Assistance Disclosure**

- created with the help of Claude