### PR TITLE
perf: improve process_attestation() for gloas

### DIFF
--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -355,7 +355,7 @@ export class AggregatedAttestationPool {
         // after all committees are processed, we have a list of sameAttDataCons
         for (const consolidation of sameAttDataCons) {
           // Score attestations by profitability to maximize proposer reward
-          const flags = getAttestationParticipationStatus(
+          const {flags} = getAttestationParticipationStatus(
             ForkSeq[fork],
             consolidation.attData,
             inclusionDistance,

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -20,7 +20,7 @@ import {BeaconStateTransitionMetrics} from "../metrics.js";
 import {getAttestationWithIndicesSignatureSet} from "../signatureSets/indexedAttestation.js";
 import {BeaconStateView} from "../stateView/beaconStateView.js";
 import {CachedBeaconStateAltair, CachedBeaconStateGloas} from "../types.js";
-import {isAttestationSameSlot, isAttestationSameSlotRootCache} from "../util/gloas.js";
+import {isAttestationSameSlotRootCache} from "../util/gloas.js";
 import {increaseBalance, verifySignatureSet} from "../util/index.js";
 import {RootCache} from "../util/rootCache.js";
 import {checkpointToStr, isTimelyTarget, validateAttestation} from "./processAttestationPhase0.js";
@@ -76,7 +76,7 @@ export function processAttestationsAltair(
     // Count how much additional weight added to current or previous epoch's builder pending payment (in ETH increment)
     let paymentWeightToAdd = 0;
 
-    const flagsAttestation = getAttestationParticipationStatus(
+    const {flags: flagsAttestation, isSameSlotAttestation} = getAttestationParticipationStatus(
       fork,
       data,
       stateSlot - data.slot,
@@ -132,7 +132,7 @@ export function processAttestationsAltair(
         }
       }
 
-      if (fork >= ForkSeq.gloas && flagsNewSet !== 0 && isAttestationSameSlot(state as CachedBeaconStateGloas, data)) {
+      if (isSameSlotAttestation && flagsNewSet !== 0) {
         paymentWeightToAdd += effectiveBalanceIncrements[validatorIndex];
       }
     }
@@ -180,7 +180,7 @@ export function getAttestationParticipationStatus(
   currentEpoch: Epoch,
   rootCache: RootCache,
   executionPayloadAvailability: BitArray | null
-): number {
+): {flags: number; isSameSlotAttestation: boolean} {
   const justifiedCheckpoint =
     data.target.epoch === currentEpoch ? rootCache.currentJustifiedCheckpoint : rootCache.previousJustifiedCheckpoint;
 
@@ -206,10 +206,13 @@ export function getAttestationParticipationStatus(
   let isMatchingHead =
     isMatchingTarget && byteArrayEquals(data.beaconBlockRoot, rootCache.getBlockRootAtSlot(data.slot));
 
+  let isSameSlotAttestation = false;
+
   if (fork >= ForkSeq.gloas) {
     let isMatchingPayload = false;
+    isSameSlotAttestation = isAttestationSameSlotRootCache(rootCache, data);
 
-    if (isAttestationSameSlotRootCache(rootCache, data)) {
+    if (isSameSlotAttestation) {
       if (data.index !== 0) {
         throw new Error("Attesting same slot must indicate empty payload");
       }
@@ -235,7 +238,7 @@ export function getAttestationParticipationStatus(
   if (isMatchingTarget && isTimelyTarget(fork, inclusionDelay)) flags |= TIMELY_TARGET;
   if (isMatchingHead && inclusionDelay === MIN_ATTESTATION_INCLUSION_DELAY) flags |= TIMELY_HEAD;
 
-  return flags;
+  return {flags, isSameSlotAttestation};
 }
 
 export function checkpointValueEquals(cp1: phase0.Checkpoint, cp2: phase0.Checkpoint): boolean {

--- a/packages/state-transition/src/slot/upgradeStateToAltair.ts
+++ b/packages/state-transition/src/slot/upgradeStateToAltair.ts
@@ -131,7 +131,7 @@ function translateParticipation(
 
   for (const attestation of pendingAttesations.getAllReadonly()) {
     const data = attestation.data;
-    const attestationFlags = getAttestationParticipationStatus(
+    const {flags: attestationFlags} = getAttestationParticipationStatus(
       ForkSeq.altair,
       data,
       attestation.inclusionDelay,

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -18,7 +18,6 @@ import {AttestationData} from "@lodestar/types/phase0";
 import {byteArrayEquals} from "@lodestar/utils";
 import {ZERO_HASH} from "../constants/index.js";
 import {CachedBeaconStateFulu, CachedBeaconStateGloas} from "../types.js";
-import {getBlockRootAtSlot} from "./blockRoot.js";
 import {computeDomain} from "./domain.js";
 import {computeEpochAtSlot} from "./epoch.js";
 import {computeEpochShuffling} from "./epochShuffling.js";
@@ -188,15 +187,9 @@ export function findBuilderIndexByPubkey(state: CachedBeaconStateGloas, pubkey: 
   return null;
 }
 
-export function isAttestationSameSlot(state: CachedBeaconStateGloas, data: AttestationData): boolean {
-  if (data.slot === 0) return true;
-
-  const isMatchingBlockRoot = byteArrayEquals(data.beaconBlockRoot, getBlockRootAtSlot(state, data.slot));
-  const isCurrentBlockRoot = !byteArrayEquals(data.beaconBlockRoot, getBlockRootAtSlot(state, data.slot - 1));
-
-  return isMatchingBlockRoot && isCurrentBlockRoot;
-}
-
+/**
+ * Use cached block roots to avoid repeated state root lookups while matching the spec's is_attestation_same_slot behavior.
+ */
 export function isAttestationSameSlotRootCache(rootCache: RootCache, data: AttestationData): boolean {
   if (data.slot === 0) return true;
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -6484,7 +6484,7 @@
 - name: is_attestation_same_slot#gloas
   sources:
     - file: packages/state-transition/src/util/gloas.ts
-      search: export function isAttestationSameSlot(
+      search: export function isAttestationSameSlotRootCache(
   spec: |
     <spec fn="is_attestation_same_slot" fork="gloas" hash="0a194ce7">
     def is_attestation_same_slot(state: BeaconState, data: AttestationData) -> bool:


### PR DESCRIPTION
**Motivation**
- I noticed this in `glamsterdam-devnet-7` by panda tool, hope this fixes it

<img width="622" height="164" alt="Screenshot 2026-07-16 at 10 51 40" src="https://github.com/user-attachments/assets/1f851973-9204-453f-9653-0a9b785bd6b1" />



**Description**
- compute `isAttestationSameSlotRootCache()` once per block transition
- remove the naive version, we should not need it


**AI Assistance Disclosure**

- created with the help of Claude