### PR TITLE
feat: classify range sync batch processing fault

### DIFF
--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -8,7 +8,7 @@ import {BlockError, BlockErrorCode, isBlockErrorAborted} from "../errors/index.j
 import {BlockProcessOpts} from "../options.js";
 import {IBlockInput} from "./blockInput/types.js";
 import {importBlock} from "./importBlock.js";
-import {importExecutionPayload} from "./importExecutionPayload.js";
+import {PayloadError, importExecutionPayload} from "./importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {FullyVerifiedBlock, ImportBlockOpts} from "./types.js";
 import {assertLinearChainSegment} from "./utils/chainSegment.js";
@@ -63,6 +63,10 @@ export async function processBlocks(
   if (blocks.length === 0) {
     return; // TODO: or throw?
   }
+
+  // Set only while importExecutionPayload is in flight, so the catch below can report which payload
+  // a PayloadError belongs to. PayloadError carries no block reference of its own.
+  let importingPayload: PayloadEnvelopeInput | undefined;
 
   try {
     const {relevantBlocks, parentSlots, parentBlock} = verifyBlocksSanityChecks(this, blocks, payloadEnvelopes, opts);
@@ -149,7 +153,9 @@ export async function processBlocks(
         if (payloadDA === undefined) {
           throw new Error(`Missing payload DA status for slot ${slot}`);
         }
+        importingPayload = payloadInput;
         await importExecutionPayload.call(this, payloadInput, payloadDA, {validSignature: false});
+        importingPayload = undefined;
       }
 
       await nextEventLoop();
@@ -159,13 +165,21 @@ export async function processBlocks(
       return; // Ignore
     }
 
-    // above functions should only throw BlockError
+    // above functions should only throw BlockError, or PayloadError from the gloas payload import
     const err = getBlockError(e, blocks[0].getBlock());
 
     // TODO: De-duplicate with logic above
     // ChainEvent.errorBlock
-    if (!(err instanceof BlockError)) {
+    if (!(err instanceof BlockError) && !(err instanceof PayloadError)) {
       this.logger.debug("Non BlockError received", {}, err);
+    } else if (err instanceof PayloadError) {
+      if (!opts.disableOnBlockError) {
+        this.logger.debug(
+          "Payload error",
+          {slot: importingPayload?.slot ?? null, blockRoot: importingPayload?.blockRootHex ?? null},
+          err
+        );
+      }
     } else if (!opts.disableOnBlockError) {
       this.logger.debug("Block error", {slot: err.signedBlock.message.slot}, err);
 
@@ -196,8 +210,12 @@ export async function processBlocks(
   }
 }
 
-function getBlockError(e: unknown, block: SignedBeaconBlock): BlockError {
+function getBlockError(e: unknown, block: SignedBeaconBlock): BlockError | PayloadError {
   if (e instanceof BlockError) {
+    return e;
+  }
+
+  if (e instanceof PayloadError) {
     return e;
   }
 

--- a/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
+++ b/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
@@ -86,11 +86,22 @@ export function assertLinearChainSegment(
           // Maybe the previous slot's FULL envelope was orphaned — try falling back.
           // If even prevExecHash doesn't match, the segment is non-linear.
           if (bidParentHash !== prevExecHash) {
-            throw new BlockError(block, {
-              code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
-              parentRoot: toRootHex(block.message.parentRoot),
-              parentBlockHash: bidParentHash,
-            });
+            // i === 0 compares against the seeded fork-choice parent (segment boundary); i > 0
+            // compares against the in-segment predecessor's payload (broken link inside the segment).
+            throw new BlockError(
+              block,
+              i === 0
+                ? {
+                    code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
+                    parentRoot: toRootHex(block.message.parentRoot),
+                    parentBlockHash: bidParentHash,
+                  }
+                : {
+                    code: BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS,
+                    parentBlockHash: bidParentHash,
+                    expectedBlockHash: currentExecHash,
+                  }
+            );
           }
           if (lastFullSlot !== null && payloadEnvelopes !== null) {
             const orphanedInput = payloadEnvelopes.get(lastFullSlot);

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -201,7 +201,7 @@ export async function verifyBlockExecutionPayload(
         invalidateFromParentBlockHash: toRootHex(executionPayloadEnabled.parentHash),
       };
       const execError = new BlockError(block, {
-        code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
+        code: BlockErrorCode.EXECUTION_ENGINE_INVALID,
         execStatus: execResult.status,
         errorMessage: execResult.validationError ?? "",
       });

--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -66,6 +66,12 @@ export enum BlockErrorCode {
   TRANSACTIONS_TOO_BIG = "BLOCK_ERROR_TRANSACTIONS_TOO_BIG",
   /** Execution engine is unavailable, syncing, or api call errored. Peers must not be downscored on this code */
   EXECUTION_ENGINE_ERROR = "BLOCK_ERROR_EXECUTION_ERROR",
+  /**
+   * Execution engine returned a definitive INVALID verdict on the payload. Unlike
+   * EXECUTION_ENGINE_ERROR this is evidence about the data itself, not a local malfunction, so
+   * whoever served the block MAY be downscored. Mirrors PayloadErrorCode.EXECUTION_ENGINE_INVALID.
+   */
+  EXECUTION_ENGINE_INVALID = "BLOCK_ERROR_EXECUTION_INVALID",
   /** The blobs are unavailable */
   DATA_UNAVAILABLE = "BLOCK_ERROR_DATA_UNAVAILABLE",
   /** Block contains too many kzg commitments */
@@ -92,6 +98,15 @@ type ExecutionErrorStatus = Exclude<
   ExecutionPayloadStatus,
   ExecutionPayloadStatus.VALID | ExecutionPayloadStatus.ACCEPTED | ExecutionPayloadStatus.SYNCING
 >;
+
+/**
+ * Statuses where the execution engine could NOT render a verdict on the payload: it is unreachable
+ * (UNAVAILABLE), errored (ELERROR), or returned a malformed/client-specific response
+ * (INVALID_BLOCK_HASH, dropped from engine_newPayloadV2+). None of these are evidence about the
+ * data, so peers must not be downscored on them. A definitive INVALID carries
+ * BlockErrorCode.EXECUTION_ENGINE_INVALID instead.
+ */
+type ExecutionEngineErrorStatus = Exclude<ExecutionErrorStatus, ExecutionPayloadStatus.INVALID>;
 
 export type BlockErrorType =
   | {code: BlockErrorCode.PRESTATE_MISSING; error: Error}
@@ -127,7 +142,12 @@ export type BlockErrorType =
   | {code: BlockErrorCode.TOO_MUCH_GAS_USED; gasUsed: number; gasLimit: number}
   | {code: BlockErrorCode.SAME_PARENT_HASH; blockHash: RootHex}
   | {code: BlockErrorCode.TRANSACTIONS_TOO_BIG; size: number; max: number}
-  | {code: BlockErrorCode.EXECUTION_ENGINE_ERROR; execStatus: ExecutionErrorStatus; errorMessage: string}
+  | {code: BlockErrorCode.EXECUTION_ENGINE_ERROR; execStatus: ExecutionEngineErrorStatus; errorMessage: string}
+  | {
+      code: BlockErrorCode.EXECUTION_ENGINE_INVALID;
+      execStatus: ExecutionPayloadStatus.INVALID;
+      errorMessage: string;
+    }
   | {code: BlockErrorCode.DATA_UNAVAILABLE}
   | {code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS; blobKzgCommitmentsLen: number; commitmentLimit: number}
   | {code: BlockErrorCode.BID_PARENT_ROOT_MISMATCH; bidParentRoot: RootHex; blockParentRoot: RootHex}

--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -42,7 +42,7 @@ export enum BlockErrorCode {
   NOT_LATER_THAN_PARENT = "BLOCK_ERROR_NOT_LATER_THAN_PARENT",
   /**
    * A block in the middle of a chain segment does not set its parentRoot to the previous block's root
-   * (broken parent-root link inside the segment). Cf. PARENT_UNKNOWN for the segment's first block.
+   * (broken parent-root link inside the segment).
    */
   NON_LINEAR_PARENT_ROOTS = "BLOCK_ERROR_NON_LINEAR_PARENT_ROOTS",
   /** The slots of the blocks in the chain segment were not strictly increasing. */

--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -8,7 +8,9 @@ import {GossipActionError} from "./gossipValidation.js";
 export enum BlockErrorCode {
   /** The prestate cannot be fetched */
   PRESTATE_MISSING = "BLOCK_ERROR_PRESTATE_MISSING",
-  /** The parent block was unknown. */
+  /**
+   * The first block of a chain segment references a parentRoot unknown to fork-choice.
+   */
   PARENT_UNKNOWN = "BLOCK_ERROR_PARENT_UNKNOWN",
   /** The block slot is greater than the present slot. */
   FUTURE_SLOT = "BLOCK_ERROR_FUTURE_SLOT",
@@ -38,7 +40,10 @@ export enum BlockErrorCode {
   NOT_FINALIZED_DESCENDANT = "BLOCK_ERROR_NOT_FINALIZED_DESCENDANT",
   /** The provided block is from an later slot than its parent. */
   NOT_LATER_THAN_PARENT = "BLOCK_ERROR_NOT_LATER_THAN_PARENT",
-  /** At least one block in the chain segment did not have it's parent root set to the root of the prior block. */
+  /**
+   * A block in the middle of a chain segment does not set its parentRoot to the previous block's root
+   * (broken parent-root link inside the segment). Cf. PARENT_UNKNOWN for the segment's first block.
+   */
   NON_LINEAR_PARENT_ROOTS = "BLOCK_ERROR_NON_LINEAR_PARENT_ROOTS",
   /** The slots of the blocks in the chain segment were not strictly increasing. */
   NON_LINEAR_SLOTS = "BLOCK_ERROR_NON_LINEAR_SLOTS",
@@ -69,8 +74,16 @@ export enum BlockErrorCode {
   BID_PARENT_ROOT_MISMATCH = "BLOCK_ERROR_BID_PARENT_ROOT_MISMATCH",
   /** The parent block's execution payload has been verified as invalid */
   PARENT_EXECUTION_INVALID = "BLOCK_ERROR_PARENT_EXECUTION_INVALID",
-  /** The block's parent execution payload (defined by bid.parent_block_hash) has not been seen */
+  /**
+   * [gloas] The first block of a chain segment references a parent execution payload
+   * (bid.parent_block_hash) unknown to fork-choice (segment boundary).
+   */
   PARENT_PAYLOAD_UNKNOWN = "BLOCK_ERROR_PARENT_PAYLOAD_UNKNOWN",
+  /**
+   * [gloas] A block in the middle of a chain segment has a bid.parent_block_hash that does not chain onto the
+   * previous block's execution payload (broken payload link inside the segment).
+   */
+  NON_LINEAR_PAYLOAD_ROOTS = "BLOCK_ERROR_NON_LINEAR_PAYLOAD_ROOTS",
   /** An execution payload envelope in the chain segment references a block root that does not match its slot's block */
   ENVELOPE_BLOCK_ROOT_MISMATCH = "BLOCK_ERROR_ENVELOPE_BLOCK_ROOT_MISMATCH",
 }
@@ -119,7 +132,8 @@ export type BlockErrorType =
   | {code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS; blobKzgCommitmentsLen: number; commitmentLimit: number}
   | {code: BlockErrorCode.BID_PARENT_ROOT_MISMATCH; bidParentRoot: RootHex; blockParentRoot: RootHex}
   | {code: BlockErrorCode.PARENT_EXECUTION_INVALID; parentRoot: RootHex}
-  | {code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN; parentRoot: RootHex; parentBlockHash: RootHex};
+  | {code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN; parentRoot: RootHex; parentBlockHash: RootHex}
+  | {code: BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS; parentBlockHash: RootHex; expectedBlockHash: RootHex};
 
 export class BlockGossipError extends GossipActionError<BlockErrorType> {}
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -666,8 +666,13 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
             case BlockErrorCode.PARENT_UNKNOWN:
             case BlockErrorCode.PRESTATE_MISSING:
             case BlockErrorCode.EXECUTION_ENGINE_ERROR:
-              // Errors might indicate an issue with our node or the connected EL client
+              // Errors might indicate an issue with our node or the connected EL client.
               logLevel = LogLevel.error;
+              break;
+            case BlockErrorCode.EXECUTION_ENGINE_INVALID:
+              // the peer served a bad block
+              core.reportPeer(peerIdStr, PeerAction.LowToleranceError, "BadGossipBlock");
+              logLevel = LogLevel.warn;
               break;
             default:
               // TODO: Should it use PeerId or string?

--- a/packages/beacon-node/src/sync/constants.ts
+++ b/packages/beacon-node/src/sync/constants.ts
@@ -15,12 +15,11 @@ export const MAX_BATCH_DOWNLOAD_ATTEMPTS = 5;
 export const RATE_LIMITED_PEER_BACKOFF_MS = 5_000;
 
 /**
- * Consider batch faulty after downloading and processing this number of times
- * as in https://github.com/ChainSafe/lodestar/issues/8147 we cannot proceed the sync chain if there is unknown parent
- * from prior batch. For example a peer may send us a non-canonical chain segment or not returning all blocks
- * in that case we should throw error and `RangeSync` should remove that error chain and add a new one.
+ * How many times a batch may be re-downloaded + re-processed before it is considered faulty.
+ * Shared budget (via `failedProcessingAttempts`) for both `processBatch` error tiers: a batch's
+ * own processing failure, and a later batch failing to build on it (`validationError`).
  **/
-export const MAX_BATCH_PROCESSING_ATTEMPTS = 0;
+export const MAX_BATCH_PROCESSING_ATTEMPTS = 3;
 
 /**
  * Number of slots to offset batches.

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -42,7 +42,7 @@ export enum BatchStatus {
 export type Attempt = {
   /** The peer that made the attempt */
   peers: PeerIdStr[];
-  /** The hash of the blocks of the attempt */
+  /** The hash of the blocks + envelopes of the attempt */
   hash: RootHex;
   /**
    * True if this attempt's failure is evidence that the peers served bad data, so they may be
@@ -71,6 +71,7 @@ export type DownloadSuccessState = {
   status: BatchStatus.AwaitingProcessing;
   blocks: IBlockInput[];
   payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null;
+  attempt: Attempt;
 };
 
 export type BatchState =
@@ -424,10 +425,17 @@ export class Batch {
   }
 
   /**
-   * Gives a list of peers from which this batch has had a failed download or processing attempt.
+   * Gives a list of peers from which this batch has had a failed download or processing attempt, so
+   * `peerBalancer` skips them on the next attempt.
+   *
+   * Execution-engine failures are included for ONLY attributable peers
    */
   getFailedPeers(): PeerIdStr[] {
-    return [...this.failedDownloadAttempts, ...this.failedProcessingAttempts.flatMap((a) => a.peers)];
+    return [
+      ...this.failedDownloadAttempts,
+      ...this.failedProcessingAttempts.flatMap((a) => a.peers),
+      ...this.executionErrorAttempts.filter((a) => a.peerAttributable).flatMap((a) => a.peers),
+    ];
   }
 
   /**
@@ -603,7 +611,12 @@ export class Batch {
     }
 
     if (allComplete) {
-      this.state = {status: BatchStatus.AwaitingProcessing, blocks, payloadEnvelopes: newPayloadEnvelopes};
+      const attempt: Attempt = {
+        peers: this.getSuccessfulPeers(),
+        hash: hashBlocks(blocks, newPayloadEnvelopes),
+        peerAttributable: false,
+      };
+      this.state = {status: BatchStatus.AwaitingProcessing, blocks, payloadEnvelopes: newPayloadEnvelopes, attempt};
     } else {
       this.state = {status: BatchStatus.AwaitingDownload, blocks, payloadEnvelopes: newPayloadEnvelopes};
       this.requests = this.getRequests(blocks);
@@ -660,21 +673,11 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.AwaitingProcessing));
     }
 
-    const blocks = this.state.blocks;
-    const payloadEnvelopes = this.state.payloadEnvelopes;
-    const hash = hashBlocks(blocks, payloadEnvelopes); // id (blocks + gloas payloads) to detect bad attempts
-    // Reset successfulDownloads in case another download attempt needs to be made. When Attempt is successful or not
-    // the peers that the data came from will be handled by the Attempt that goes for processing.
-    const peers = this.getSuccessfulPeers();
+    const {blocks, payloadEnvelopes, attempt} = this.state;
+    // No need to track successfulDownloads anymore, the batch goes to Processing status
     this.successfulDownloads.clear();
-    // `peerAttributable` is only known once processing fails, see routeProcessingFailure()
-    this.state = {
-      status: BatchStatus.Processing,
-      blocks,
-      payloadEnvelopes,
-      attempt: {peers, hash, peerAttributable: false},
-    };
-    return {blocks, payloadEnvelopes, peers};
+    this.state = {status: BatchStatus.Processing, blocks, payloadEnvelopes, attempt};
+    return {blocks, payloadEnvelopes, peers: attempt.peers};
   }
 
   /**
@@ -710,6 +713,7 @@ export class Batch {
       status: BatchStatus.AwaitingProcessing,
       blocks: this.state.blocks,
       payloadEnvelopes: this.state.payloadEnvelopes,
+      attempt: this.state.attempt,
     };
   }
 

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -5,6 +5,7 @@ import {LodestarError, byteArrayEquals, prettyPrintIndices, toRootHex} from "@lo
 import {isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {IBlockInput} from "../../chain/blocks/blockInput/types.js";
 import {isDaOutOfRange} from "../../chain/blocks/blockInput/utils.js";
+import {PayloadError, PayloadErrorCode} from "../../chain/blocks/importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "../../chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {BlockError, BlockErrorCode} from "../../chain/errors/index.js";
 import {ZERO_HASH} from "../../constants/constants.js";
@@ -43,6 +44,12 @@ export type Attempt = {
   peers: PeerIdStr[];
   /** The hash of the blocks of the attempt */
   hash: RootHex;
+  /**
+   * True if this attempt's failure is evidence that the peers served bad data, so they may be
+   * downscored. False when our own execution engine is either unavailable,
+   * or errored) — that is our malfunction.
+   */
+  peerAttributable: boolean;
 };
 
 type TrackedRequest = {
@@ -424,6 +431,13 @@ export class Batch {
   }
 
   /**
+   * Attempts whose failure is evidence the peers served bad data, so they may be downscored.
+   */
+  getPeerAttributableAttempts(): Attempt[] {
+    return [...this.failedProcessingAttempts, ...this.executionErrorAttempts].filter((a) => a.peerAttributable);
+  }
+
+  /**
    * True only if the peer has already returned a successful response for the current request.
    * A by_range success may update `this.requests` to parent_payload, and the same peer is then
    * still eligible for the newly discovered parent payload data.
@@ -653,7 +667,13 @@ export class Batch {
     // the peers that the data came from will be handled by the Attempt that goes for processing.
     const peers = this.getSuccessfulPeers();
     this.successfulDownloads.clear();
-    this.state = {status: BatchStatus.Processing, blocks, payloadEnvelopes, attempt: {peers, hash}};
+    // `peerAttributable` is only known once processing fails, see routeProcessingFailure()
+    this.state = {
+      status: BatchStatus.Processing,
+      blocks,
+      payloadEnvelopes,
+      attempt: {peers, hash, peerAttributable: false},
+    };
     return {blocks, payloadEnvelopes, peers};
   }
 
@@ -701,11 +721,7 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.Processing));
     }
 
-    if (err instanceof BlockError && err.type.code === BlockErrorCode.EXECUTION_ENGINE_ERROR) {
-      this.onExecutionEngineError(this.state.attempt);
-    } else {
-      this.onProcessingError(this.state.attempt);
-    }
+    this.routeProcessingFailure(err, this.state.attempt);
   }
 
   /**
@@ -716,11 +732,7 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.AwaitingValidation));
     }
 
-    if (err instanceof BlockError && err.type.code === BlockErrorCode.EXECUTION_ENGINE_ERROR) {
-      this.onExecutionEngineError(this.state.attempt);
-    } else {
-      this.onProcessingError(this.state.attempt);
-    }
+    this.routeProcessingFailure(err, this.state.attempt);
   }
 
   /**
@@ -732,6 +744,23 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.AwaitingValidation));
     }
     return this.state.attempt;
+  }
+
+  /**
+   * Record a failed processing attempt, and tag whether its peers may be downscored for it.
+   */
+  private routeProcessingFailure(err: Error, attempt: Attempt): void {
+    const code = err instanceof BlockError || err instanceof PayloadError ? err.type.code : null;
+    const isExecutionInvalid =
+      code === BlockErrorCode.EXECUTION_ENGINE_INVALID || code === PayloadErrorCode.EXECUTION_ENGINE_INVALID;
+    const isExecutionError =
+      code === BlockErrorCode.EXECUTION_ENGINE_ERROR || code === PayloadErrorCode.EXECUTION_ENGINE_ERROR;
+
+    if (isExecutionInvalid || isExecutionError) {
+      this.onExecutionEngineError({...attempt, peerAttributable: isExecutionInvalid});
+    } else {
+      this.onProcessingError({...attempt, peerAttributable: true});
+    }
   }
 
   private onExecutionEngineError(attempt: Attempt): void {

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -648,7 +648,7 @@ export class Batch {
 
     const blocks = this.state.blocks;
     const payloadEnvelopes = this.state.payloadEnvelopes;
-    const hash = hashBlocks(blocks, this.config); // tracks blocks to report peer on processing error
+    const hash = hashBlocks(blocks, payloadEnvelopes); // id (blocks + gloas payloads) to detect bad attempts
     // Reset successfulDownloads in case another download attempt needs to be made. When Attempt is successful or not
     // the peers that the data came from will be handled by the Attempt that goes for processing.
     const peers = this.getSuccessfulPeers();

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -674,6 +674,26 @@ export class Batch {
   }
 
   /**
+   * Processing -> AwaitingProcessing
+   *
+   * The batch's own blocks are valid but processing failed because a PREVIOUS batch did not
+   * deliver the parent (`PARENT_UNKNOWN` on this batch's first block). Keep the downloaded
+   * blocks and re-process once the previous batch is repaired. Unlike {@link processingError}
+   * this does NOT re-download and does NOT record a failed attempt against this batch.
+   */
+  retainForReprocessing(): void {
+    if (this.state.status !== BatchStatus.Processing) {
+      throw new BatchError(this.wrongStatusErrorType(BatchStatus.Processing));
+    }
+
+    this.state = {
+      status: BatchStatus.AwaitingProcessing,
+      blocks: this.state.blocks,
+      payloadEnvelopes: this.state.payloadEnvelopes,
+    };
+  }
+
+  /**
    * Processing -> AwaitingDownload
    */
   processingError(err: Error): void {
@@ -704,7 +724,8 @@ export class Batch {
   }
 
   /**
-   * AwaitingValidation -> Done
+   * AwaitingValidation -> Done (no status transition: `advanceChain` deletes the batch right
+   * after this call, so it only returns the winning Attempt for peer scoring).
    */
   validationSuccess(): Attempt {
     if (this.state.status !== BatchStatus.AwaitingValidation) {

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -23,7 +23,9 @@ import {Batch, BatchError, BatchErrorCode, BatchMetadata, BatchStatus} from "./b
 import {
   ChainPeersBalancer,
   PeerSyncInfo,
+  ProcessingFaultKind,
   batchStartEpochIsAfterSlot,
+  classifyProcessingFault,
   computeHighestTarget,
   getBatchSlotRange,
   getNextBatchToProcess,
@@ -355,7 +357,8 @@ export class SyncChain {
 
       // If a batch exceeds it's retry limit, maybe downscore peers.
       // shouldDownscoreOnBatchError() functions enforces that all BatchErrorCode values are covered
-      if (e instanceof BatchError) {
+      // Head-sync peers may legitimately be on different forks so we don't report peer in this case.
+      if (e instanceof BatchError && this.syncType === RangeSyncType.Finalized) {
         const shouldReportPeer = shouldReportPeerOnBatchError(e.type.code);
         if (shouldReportPeer) {
           for (const peer of this.peerset.keys()) {
@@ -708,23 +711,44 @@ export class SyncChain {
       this.triggerBatchProcessor();
     } else {
       this.logger.verbose("Batch process error", logCtx, res.err);
-      batch.processingError(res.err); // Throws after MAX_BATCH_PROCESSING_ATTEMPTS
 
-      // At least one block was successfully verified and imported, so we can be sure all
-      // previous batches are valid and we only need to download the current failed batch.
-      // TODO: Disabled for now
-      // if (res.err instanceof ChainSegmentError && res.err.importedBlocks > 0) {
-      //   this.advanceChain(batch.startEpoch);
-      // }
-
-      // The current batch could not be processed, so either this or previous batches are invalid.
-      // All previous batches (AwaitingValidation) are potentially faulty and marked for retry.
-      // Progress will be drop back to `this.startEpoch`
-      for (const pendingBatch of this.batches.values()) {
-        if (pendingBatch.startEpoch < batch.startEpoch) {
-          this.logger.verbose("Batch validation error", {id: this.logId, ...pendingBatch.getMetadata()});
-          pendingBatch.validationError(res.err); // Throws after MAX_BATCH_PROCESSING_ATTEMPTS
+      // Reset every previous AwaitingValidation batch so it re-downloads; throws after
+      // MAX_BATCH_PROCESSING_ATTEMPTS. The status guard matches validationError's precondition:
+      // by the ordering invariant all previous batches are AwaitingValidation here, but if that
+      // ever breaks we skip rather than throw WRONG_STATUS (which would tear the chain down).
+      const invalidatePreviousBatches = (): void => {
+        for (const pendingBatch of this.batches.values()) {
+          if (
+            pendingBatch.startEpoch < batch.startEpoch &&
+            pendingBatch.state.status === BatchStatus.AwaitingValidation
+          ) {
+            this.logger.verbose("Batch validation error", {id: this.logId, ...pendingBatch.getMetadata()});
+            pendingBatch.validationError(res.err);
+          }
         }
+      };
+
+      // Localize the fault so we only re-download the batch(es) actually at fault, instead of
+      // tearing the whole chain down on any error. See classifyProcessingFault.
+      const prevBatch = this.batches.get(batch.startEpoch - EPOCHS_PER_BATCH);
+      switch (classifyProcessingFault(res.err, batch, prevBatch)) {
+        case ProcessingFaultKind.ThisBatch:
+          // This batch's own blocks are bad/short => re-download it only.
+          batch.processingError(res.err);
+          break;
+
+        case ProcessingFaultKind.PreviousBatch:
+          // This batch is valid; retain its blocks (no re-download, no failed attempt) and
+          // invalidate the previous batch(es). It re-processes once the parent arrives.
+          batch.retainForReprocessing();
+          invalidatePreviousBatches();
+          break;
+
+        case ProcessingFaultKind.Ambiguous:
+          // Could be this batch's leading withhold or the previous batch's short tail => hedge both.
+          batch.processingError(res.err);
+          invalidatePreviousBatches();
+          break;
       }
     }
 
@@ -746,17 +770,21 @@ export class SyncChain {
         this.batches.delete(batchKey);
         this.validatedEpochs += EPOCHS_PER_BATCH;
 
-        // The last batch attempt is right, all others are wrong. Penalize other peers
+        // The last batch attempt is right, all others are wrong. Penalize other peers.
+        // Only during finalized sync: head-sync peers may be on different forks, so an attempt
+        // that disagreed with the winning one is not necessarily misbehavior, just a different fork.
         const attemptOk = batch.validationSuccess();
-        for (const attempt of batch.failedProcessingAttempts) {
-          if (attempt.hash !== attemptOk.hash) {
-            for (const badAttemptPeer of attempt.peers) {
-              if (attemptOk.peers.find((goodPeer) => goodPeer === badAttemptPeer)) {
-                // The same peer corrected its previous attempt
-                this.reportPeer(badAttemptPeer, PeerAction.MidToleranceError, "SyncChainInvalidBatchSelf");
-              } else {
-                // A different peer sent an bad batch
-                this.reportPeer(badAttemptPeer, PeerAction.LowToleranceError, "SyncChainInvalidBatchOther");
+        if (this.syncType === RangeSyncType.Finalized) {
+          for (const attempt of batch.failedProcessingAttempts) {
+            if (attempt.hash !== attemptOk.hash) {
+              for (const badAttemptPeer of attempt.peers) {
+                if (attemptOk.peers.find((goodPeer) => goodPeer === badAttemptPeer)) {
+                  // The same peer corrected its previous attempt
+                  this.reportPeer(badAttemptPeer, PeerAction.MidToleranceError, "SyncChainInvalidBatchSelf");
+                } else {
+                  // A different peer sent an bad batch
+                  this.reportPeer(badAttemptPeer, PeerAction.LowToleranceError, "SyncChainInvalidBatchOther");
+                }
               }
             }
           }

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -358,9 +358,12 @@ export class SyncChain {
       // If a batch exceeds it's retry limit, maybe downscore peers.
       // shouldDownscoreOnBatchError() functions enforces that all BatchErrorCode values are covered
       if (e instanceof BatchError) {
-        const shouldReportPeer = shouldReportPeerOnBatchError(e.type.code);
+        // The batch is still in `this.batches` here: only advanceChain() deletes from the map, and
+        // the pruneBlockInputs loop above does not clear it.
+        const shouldReportPeer = shouldReportPeerOnBatchError(e.type.code, this.batches.get(e.type.startEpoch));
         if (shouldReportPeer) {
-          for (const peer of this.peerset.keys()) {
+          // `peers` narrows the report to the peers actually at fault, else report the whole peerset
+          for (const peer of shouldReportPeer.peers ?? this.peerset.keys()) {
             this.reportPeer(peer, shouldReportPeer.action, shouldReportPeer.reason);
           }
         }
@@ -715,7 +718,9 @@ export class SyncChain {
       // MAX_BATCH_PROCESSING_ATTEMPTS. The status guard matches validationError's precondition:
       // by the ordering invariant all previous batches are AwaitingValidation here, but if that
       // ever breaks we skip rather than throw WRONG_STATUS (which would tear the chain down).
-      const invalidatePreviousBatches = (): void => {
+      // Returns how many batches were actually reset, so callers can detect the no-op case.
+      const invalidatePreviousBatches = (): number => {
+        let invalidatedCount = 0;
         for (const pendingBatch of this.batches.values()) {
           if (
             pendingBatch.startEpoch < batch.startEpoch &&
@@ -723,8 +728,10 @@ export class SyncChain {
           ) {
             this.logger.verbose("Batch validation error", {id: this.logId, ...pendingBatch.getMetadata()});
             pendingBatch.validationError(res.err);
+            invalidatedCount++;
           }
         }
+        return invalidatedCount;
       };
 
       // Localize the fault so we only re-download the batch(es) actually at fault, instead of
@@ -737,10 +744,12 @@ export class SyncChain {
           break;
 
         case ProcessingFaultKind.PreviousBatch:
-          // This batch is valid; retain its blocks (no re-download, no failed attempt) and
-          // invalidate the previous batch(es). It re-processes once the parent arrives.
-          batch.retainForReprocessing();
-          invalidatePreviousBatches();
+          // make sure there is at least one batch invalidated. Otherwise still mark this batch as processingError.
+          if (invalidatePreviousBatches() === 0) {
+            batch.processingError(res.err);
+          } else {
+            batch.retainForReprocessing();
+          }
           break;
 
         case ProcessingFaultKind.Ambiguous:
@@ -770,9 +779,9 @@ export class SyncChain {
         this.validatedEpochs += EPOCHS_PER_BATCH;
 
         // The winning attempt is right; any prior attempt with a different segment id (blocks +
-        // gloas payloads, see hashBlocks) delivered bad data => penalize its peers
+        // gloas payloads, see hashBlocks) delivered bad data => penalize its peers.
         const attemptOk = batch.validationSuccess();
-        for (const attempt of [...batch.failedProcessingAttempts, ...batch.executionErrorAttempts]) {
+        for (const attempt of batch.getPeerAttributableAttempts()) {
           if (attempt.hash !== attemptOk.hash) {
             for (const badAttemptPeer of attempt.peers) {
               if (attemptOk.peers.find((goodPeer) => goodPeer === badAttemptPeer)) {
@@ -834,21 +843,31 @@ export class SyncChain {
  * If peer should not be downscored, returns null.
  */
 export function shouldReportPeerOnBatchError(
-  code: BatchErrorCode
-): {action: PeerAction.LowToleranceError; reason: string} | null {
+  code: BatchErrorCode,
+  batch: Batch | undefined
+): {action: PeerAction.LowToleranceError; reason: string; peers?: PeerIdStr[]} | null {
   switch (code) {
     // A batch could not be processed after max retry limit. It's likely that all peers
     // in this chain are sending invalid batches repeatedly so are either malicious or faulty.
-    // We drop the chain and report all peers.
+    // We drop the chain and report all peers (`peers` omitted).
     // There are some edge cases with forks that could cause this situation, but it's unlikely.
     case BatchErrorCode.MAX_PROCESSING_ATTEMPTS:
       return {action: PeerAction.LowToleranceError, reason: "SyncChainMaxProcessingAttempts"};
+
+    // Blameless when our own execution engine was merely unreachable or errored. But if any attempt
+    // drew a definitive INVALID verdict the data really was bad, so report the peers that served
+    // those attempts — and only those, not the whole peerset.
+    case BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS: {
+      const peers = [...new Set(batch?.getPeerAttributableAttempts().flatMap((attempt) => attempt.peers) ?? [])];
+      return peers.length > 0
+        ? {action: PeerAction.LowToleranceError, reason: "SyncChainMaxExecutionEngineInvalid", peers}
+        : null;
+    }
 
     // TODO: Should peers be reported for MAX_DOWNLOAD_ATTEMPTS?
     case BatchErrorCode.MAX_DOWNLOAD_ATTEMPTS:
     case BatchErrorCode.INVALID_COUNT:
     case BatchErrorCode.WRONG_STATUS:
-    case BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS:
       return null;
   }
 }

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -357,8 +357,7 @@ export class SyncChain {
 
       // If a batch exceeds it's retry limit, maybe downscore peers.
       // shouldDownscoreOnBatchError() functions enforces that all BatchErrorCode values are covered
-      // Head-sync peers may legitimately be on different forks so we don't report peer in this case.
-      if (e instanceof BatchError && this.syncType === RangeSyncType.Finalized) {
+      if (e instanceof BatchError) {
         const shouldReportPeer = shouldReportPeerOnBatchError(e.type.code);
         if (shouldReportPeer) {
           for (const peer of this.peerset.keys()) {
@@ -770,21 +769,18 @@ export class SyncChain {
         this.batches.delete(batchKey);
         this.validatedEpochs += EPOCHS_PER_BATCH;
 
-        // The last batch attempt is right, all others are wrong. Penalize other peers.
-        // Only during finalized sync: head-sync peers may be on different forks, so an attempt
-        // that disagreed with the winning one is not necessarily misbehavior, just a different fork.
+        // The winning attempt is right; any prior attempt with a different segment id (blocks +
+        // gloas payloads, see hashBlocks) delivered bad data => penalize its peers
         const attemptOk = batch.validationSuccess();
-        if (this.syncType === RangeSyncType.Finalized) {
-          for (const attempt of batch.failedProcessingAttempts) {
-            if (attempt.hash !== attemptOk.hash) {
-              for (const badAttemptPeer of attempt.peers) {
-                if (attemptOk.peers.find((goodPeer) => goodPeer === badAttemptPeer)) {
-                  // The same peer corrected its previous attempt
-                  this.reportPeer(badAttemptPeer, PeerAction.MidToleranceError, "SyncChainInvalidBatchSelf");
-                } else {
-                  // A different peer sent an bad batch
-                  this.reportPeer(badAttemptPeer, PeerAction.LowToleranceError, "SyncChainInvalidBatchOther");
-                }
+        for (const attempt of [...batch.failedProcessingAttempts, ...batch.executionErrorAttempts]) {
+          if (attempt.hash !== attemptOk.hash) {
+            for (const badAttemptPeer of attempt.peers) {
+              if (attemptOk.peers.find((goodPeer) => goodPeer === badAttemptPeer)) {
+                // The same peer corrected its previous attempt
+                this.reportPeer(badAttemptPeer, PeerAction.MidToleranceError, "SyncChainInvalidBatchSelf");
+              } else {
+                // A different peer sent an bad batch
+                this.reportPeer(badAttemptPeer, PeerAction.LowToleranceError, "SyncChainInvalidBatchOther");
               }
             }
           }

--- a/packages/beacon-node/src/sync/range/utils/batches.ts
+++ b/packages/beacon-node/src/sync/range/utils/batches.ts
@@ -1,6 +1,7 @@
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, Slot} from "@lodestar/types";
+import {BlockError, BlockErrorCode} from "../../../chain/errors/index.js";
 import {BATCH_SLOT_OFFSET, EPOCHS_PER_BATCH} from "../../constants.js";
 import {Batch, BatchStatus} from "../batch.js";
 
@@ -116,4 +117,61 @@ export function isSyncChainDone(batches: Batch[], lastEpochWithProcessBlocks: Ep
   }
 
   return batchStartEpochIsAfterSlot(lastEpochWithProcessBlocks, targetSlot);
+}
+
+/**
+ * Where a batch processing error should be attributed, so we re-download only the batch(es)
+ * actually at fault instead of tearing the whole chain down on any error.
+ */
+export enum ProcessingFaultKind {
+  /** This batch's own blocks are bad/short => re-download this batch. */
+  ThisBatch = "ThisBatch",
+  /** This batch is valid; a previous batch didn't deliver the parent => retain & re-process
+   * this batch, invalidate the previous batch(es). */
+  PreviousBatch = "PreviousBatch",
+  /** Could be either (this batch's leading withhold or the previous batch's short tail) =>
+   * hedge: re-download this batch AND invalidate the previous batch(es). */
+  Ambiguous = "Ambiguous",
+}
+
+/**
+ * Classify a `processChainSegment` error for `batch`.
+ *
+ * Relies on the invariant that when `batch` is processed, every earlier batch is
+ * `AwaitingValidation` = already imported (see `getNextBatchToProcess`). Given that:
+ * - Non-parent errors (bad signature/state/payload) are always this batch's own fault.
+ * - `PARENT_UNKNOWN`/`PARENT_PAYLOAD_UNKNOWN` fires on the batch's first not-yet-imported
+ *   block. If that block is anchored at `startSlot`, the missing parent lies before the batch
+ *   => previous-batch fault. Otherwise the missing parent could live inside this batch's own
+ *   leading range — certain only if the previous batch delivered a full tail (a block/payload
+ *   at `startSlot - 1`), else ambiguous.
+ *
+ * NOTE: this attribution assumes a single canonical chain and is precise for finalized sync.
+ * Head-sync peers may be on different forks; the actions are still safe there (retries can
+ * converge onto the target fork), but peer penalization on teardown is gated to finalized sync.
+ */
+export function classifyProcessingFault(err: Error, batch: Batch, prevBatch: Batch | undefined): ProcessingFaultKind {
+  if (!(err instanceof BlockError)) return ProcessingFaultKind.ThisBatch;
+  const {code} = err.type;
+  // Only the segment-boundary parent codes can implicate a previous batch. Everything else —
+  // including the internal-linkage codes NON_LINEAR_PARENT_ROOTS / NON_LINEAR_PAYLOAD_ROOTS — is
+  // this batch's own bad data. PARENT_UNKNOWN/PARENT_PAYLOAD_UNKNOWN are guaranteed to fire only
+  // on a segment's first block (see verifyBlocksSanityChecks and chainSegment's i === 0 branch).
+  if (code !== BlockErrorCode.PARENT_UNKNOWN && code !== BlockErrorCode.PARENT_PAYLOAD_UNKNOWN) {
+    return ProcessingFaultKind.ThisBatch;
+  }
+
+  // PARENT_UNKNOWN/PARENT_PAYLOAD_UNKNOWN always fires on the batch's first not-yet-imported block.
+  const firstBlockSlot = err.signedBlock.message.slot;
+  // Anchored at the batch start => the missing parent is before this batch => previous-batch fault.
+  if (firstBlockSlot === batch.startSlot) return ProcessingFaultKind.PreviousBatch;
+
+  // firstBlockSlot > startSlot: this-batch fault ONLY if the previous batch delivered a full
+  // tail (a block/payload at startSlot - 1). Otherwise it is ambiguous.
+  const prevTailSlot = batch.startSlot - 1;
+  const prevHasFullTail =
+    code === BlockErrorCode.PARENT_PAYLOAD_UNKNOWN
+      ? (prevBatch?.getPayloadEnvelopes()?.get(prevTailSlot)?.hasPayloadEnvelope() ?? false)
+      : (prevBatch?.getBlocks().some((b) => b.slot === prevTailSlot) ?? false);
+  return prevHasFullTail ? ProcessingFaultKind.ThisBatch : ProcessingFaultKind.Ambiguous;
 }

--- a/packages/beacon-node/src/sync/range/utils/batches.ts
+++ b/packages/beacon-node/src/sync/range/utils/batches.ts
@@ -147,8 +147,9 @@ export enum ProcessingFaultKind {
  *   at `startSlot - 1`), else ambiguous.
  *
  * NOTE: this attribution assumes a single canonical chain and is precise for finalized sync.
- * Head-sync peers may be on different forks; the actions are still safe there (retries can
- * converge onto the target fork), but peer penalization on teardown is gated to finalized sync.
+ * Head-sync peers may be on different forks; the actions (re-download / invalidate) are still safe
+ * there, as retries can converge onto the target fork. Peer reporting on teardown applies to both
+ * sync types, see `SyncChain.sync`.
  */
 export function classifyProcessingFault(err: Error, batch: Batch, prevBatch: Batch | undefined): ProcessingFaultKind {
   if (!(err instanceof BlockError)) return ProcessingFaultKind.ThisBatch;
@@ -164,7 +165,9 @@ export function classifyProcessingFault(err: Error, batch: Batch, prevBatch: Bat
   // PARENT_UNKNOWN/PARENT_PAYLOAD_UNKNOWN always fires on the batch's first not-yet-imported block.
   const firstBlockSlot = err.signedBlock.message.slot;
   // Anchored at the batch start => the missing parent is before this batch => previous-batch fault.
-  if (firstBlockSlot === batch.startSlot) return ProcessingFaultKind.PreviousBatch;
+  if (firstBlockSlot === batch.startSlot) {
+    return prevBatch === undefined ? ProcessingFaultKind.ThisBatch : ProcessingFaultKind.PreviousBatch;
+  }
 
   // firstBlockSlot > startSlot: this-batch fault ONLY if the previous batch delivered a full
   // tail (a block/payload at startSlot - 1). Otherwise it is ambiguous.

--- a/packages/beacon-node/src/sync/range/utils/batches.ts
+++ b/packages/beacon-node/src/sync/range/utils/batches.ts
@@ -124,13 +124,13 @@ export function isSyncChainDone(batches: Batch[], lastEpochWithProcessBlocks: Ep
  * actually at fault instead of tearing the whole chain down on any error.
  */
 export enum ProcessingFaultKind {
-  /** This batch's own blocks are bad/short => re-download this batch. */
+  // This batch's own blocks are bad/short => re-download this batch.
   ThisBatch = "ThisBatch",
-  /** This batch is valid; a previous batch didn't deliver the parent => retain & re-process
-   * this batch, invalidate the previous batch(es). */
+  // This batch is valid; a previous batch didn't deliver the parent => retain & re-process
+  // this batch, invalidate the previous batch(es)
   PreviousBatch = "PreviousBatch",
-  /** Could be either (this batch's leading withhold or the previous batch's short tail) =>
-   * hedge: re-download this batch AND invalidate the previous batch(es). */
+  // Could be either (this batch's leading withhold or the previous batch's short tail)
+  // => re-download this batch AND invalidate the previous batch(es).
   Ambiguous = "Ambiguous",
 }
 
@@ -140,8 +140,8 @@ export enum ProcessingFaultKind {
  * Relies on the invariant that when `batch` is processed, every earlier batch is
  * `AwaitingValidation` = already imported (see `getNextBatchToProcess`). Given that:
  * - Non-parent errors (bad signature/state/payload) are always this batch's own fault.
- * - `PARENT_UNKNOWN`/`PARENT_PAYLOAD_UNKNOWN` fires on the batch's first not-yet-imported
- *   block. If that block is anchored at `startSlot`, the missing parent lies before the batch
+ * - `PARENT_UNKNOWN`/`PARENT_PAYLOAD_UNKNOWN` fires on the batch's first block.
+ *   If that block is anchored at `startSlot`, the missing parent lies before the batch
  *   => previous-batch fault. Otherwise the missing parent could live inside this batch's own
  *   leading range — certain only if the previous batch delivered a full tail (a block/payload
  *   at `startSlot - 1`), else ambiguous.

--- a/packages/beacon-node/src/sync/range/utils/hashBlocks.ts
+++ b/packages/beacon-node/src/sync/range/utils/hashBlocks.ts
@@ -40,9 +40,7 @@ export function hashBlocks(blocks: IBlockInput[], payloadEnvelopes: Map<Slot, Pa
   buf.writeUInt32LE(blocks.length, 0);
   let offset = BLOCK_COUNT_SIZE;
 
-  // all zeros, and allocUnsafe means skipping the write entirely would yield a non-deterministic id.
   for (const block of blocks) {
-    // `blockRootHex` is cached thanks to cachePermanentRootStruct, so this avoids re-hashing
     buf.set(fromHex(block.blockRootHex), offset);
     offset += ROOT_SIZE;
     buf.set(block.getBlock().signature, offset);
@@ -51,11 +49,12 @@ export function hashBlocks(blocks: IBlockInput[], payloadEnvelopes: Map<Slot, Pa
 
   for (const [, envelope] of envelopes) {
     const signedEnvelope = envelope.getPayloadEnvelope();
+    // envelope's root is cached thanks to cachePermanentRootStruct, so this avoids re-hashing
     buf.set(ssz.gloas.ExecutionPayloadEnvelope.hashTreeRoot(signedEnvelope.message), offset);
     offset += ROOT_SIZE;
     buf.set(signedEnvelope.signature, offset);
     offset += SIGNATURE_SIZE;
   }
 
-  return toRootHex(digest(buf.subarray(0, offset)));
+  return toRootHex(digest(buf));
 }

--- a/packages/beacon-node/src/sync/range/utils/hashBlocks.ts
+++ b/packages/beacon-node/src/sync/range/utils/hashBlocks.ts
@@ -1,26 +1,61 @@
+import {digest} from "@chainsafe/as-sha256";
 import {RootHex, Slot, ssz} from "@lodestar/types";
-import {toRootHex} from "@lodestar/utils";
+import {fromHex, toRootHex} from "@lodestar/utils";
 import {IBlockInput} from "../../../chain/blocks/blockInput/types.js";
 import {PayloadEnvelopeInput} from "../../../chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 
+const ROOT_SIZE = 32;
+const SIGNATURE_SIZE = 96;
+/** Every block and every payload envelope contributes a fixed-size (root, signature) entry */
+const ENTRY_SIZE = ROOT_SIZE + SIGNATURE_SIZE;
+/** uint32 LE count of block entries, so the block and envelope sections cannot be confused */
+const BLOCK_COUNT_SIZE = 4;
+
 /**
- * String to uniquely identify a batch attempt (its blocks AND payloads). Used for peer scoring and to
+ * Root uniquely identifying a batch attempt (its blocks AND payloads). Used for peer scoring and to
  * compare if two attempts are equivalent.
+ *
+ * Signatures are part of the id for BOTH blocks and payload envelopes, not just their message roots:
+ * a peer serving a correct message with a garbage signature would otherwise produce the same id as
+ * the honest attempt and escape scoring in `SyncChain.advanceChain`. Signatures are not verified at
+ * download time, only during processChainSegment (block signatures in verifyBlocksSignatures,
+ * envelope signatures in importExecutionPayload).
+ *
+ * Entries are written as raw bytes into a single exactly-sized buffer and digested once, so an
+ * `Attempt` retains 32 bytes rather than the ~16 KB a full 32-slot gloas batch would need if the
+ * roots and signatures were concatenated as hex. sha256 (not a 64-bit hash) because a peer that
+ * could force a collision with the winning attempt would escape peer scoring.
  */
 export function hashBlocks(blocks: IBlockInput[], payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null): RootHex {
-  // blocks are stored slot-sorted (see Batch.downloadingSuccess)
-  const blockRoots = blocks.map((block) => block.blockRootHex).join(",");
+  // Envelopes without a payload carry no attributable data, so they are skipped entirely. A `null`
+  // map and a map whose entries all lack a payload are therefore equivalent, which is intended.
+  const envelopes =
+    payloadEnvelopes && payloadEnvelopes.size > 0
+      ? Array.from(payloadEnvelopes.entries())
+          .filter(([, envelope]) => envelope.hasPayloadEnvelope())
+          .sort(([slotA], [slotB]) => slotA - slotB)
+      : [];
 
-  let envelopeRoots = "";
-  if (payloadEnvelopes && payloadEnvelopes.size > 0) {
-    envelopeRoots = Array.from(payloadEnvelopes.entries())
-      .filter(([, envelope]) => envelope.hasPayloadEnvelope())
-      .sort(([slotA], [slotB]) => slotA - slotB)
-      .map(([, envelope]) =>
-        toRootHex(ssz.gloas.ExecutionPayloadEnvelope.hashTreeRoot(envelope.getPayloadEnvelope().message))
-      )
-      .join(",");
+  const buf = Buffer.allocUnsafe(BLOCK_COUNT_SIZE + (blocks.length + envelopes.length) * ENTRY_SIZE);
+  buf.writeUInt32LE(blocks.length, 0);
+  let offset = BLOCK_COUNT_SIZE;
+
+  // all zeros, and allocUnsafe means skipping the write entirely would yield a non-deterministic id.
+  for (const block of blocks) {
+    // `blockRootHex` is cached thanks to cachePermanentRootStruct, so this avoids re-hashing
+    buf.set(fromHex(block.blockRootHex), offset);
+    offset += ROOT_SIZE;
+    buf.set(block.getBlock().signature, offset);
+    offset += SIGNATURE_SIZE;
   }
 
-  return `${blockRoots}|${envelopeRoots}`;
+  for (const [, envelope] of envelopes) {
+    const signedEnvelope = envelope.getPayloadEnvelope();
+    buf.set(ssz.gloas.ExecutionPayloadEnvelope.hashTreeRoot(signedEnvelope.message), offset);
+    offset += ROOT_SIZE;
+    buf.set(signedEnvelope.signature, offset);
+    offset += SIGNATURE_SIZE;
+  }
+
+  return toRootHex(digest(buf.subarray(0, offset)));
 }

--- a/packages/beacon-node/src/sync/range/utils/hashBlocks.ts
+++ b/packages/beacon-node/src/sync/range/utils/hashBlocks.ts
@@ -1,27 +1,26 @@
-import {ChainForkConfig} from "@lodestar/config";
-import {RootHex, SignedBeaconBlock} from "@lodestar/types";
+import {RootHex, Slot, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {IBlockInput} from "../../../chain/blocks/blockInput/types.js";
+import {PayloadEnvelopeInput} from "../../../chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 
 /**
- * String to uniquely identify block segments. Used for peer scoring and to compare if batches are equivalent.
+ * String to uniquely identify a batch attempt (its blocks AND payloads). Used for peer scoring and to
+ * compare if two attempts are equivalent.
  */
-export function hashBlocks(blocks: IBlockInput[], config: ChainForkConfig): RootHex {
-  switch (blocks.length) {
-    case 0:
-      return "0x";
-    case 1: {
-      const block0 = blocks[0].getBlock();
-      return toRootHex(config.getForkTypes(block0.message.slot).SignedBeaconBlock.hashTreeRoot(block0));
-    }
-    default: {
-      const block0 = blocks[0].getBlock();
-      const blockN = blocks.at(-1)?.getBlock() as SignedBeaconBlock;
-      return (
-        // TODO(fulu): should we be doing checks for presence to make sure these do not blow up?
-        toRootHex(config.getForkTypes(block0.message.slot).SignedBeaconBlock.hashTreeRoot(block0)) +
-        toRootHex(config.getForkTypes(blockN.message.slot).SignedBeaconBlock.hashTreeRoot(blockN))
-      );
-    }
+export function hashBlocks(blocks: IBlockInput[], payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null): RootHex {
+  // blocks are stored slot-sorted (see Batch.downloadingSuccess)
+  const blockRoots = blocks.map((block) => block.blockRootHex).join(",");
+
+  let envelopeRoots = "";
+  if (payloadEnvelopes && payloadEnvelopes.size > 0) {
+    envelopeRoots = Array.from(payloadEnvelopes.entries())
+      .filter(([, envelope]) => envelope.hasPayloadEnvelope())
+      .sort(([slotA], [slotB]) => slotA - slotB)
+      .map(([, envelope]) =>
+        toRootHex(ssz.gloas.ExecutionPayloadEnvelope.hashTreeRoot(envelope.getPayloadEnvelope().message))
+      )
+      .join(",");
   }
+
+  return `${blockRoots}|${envelopeRoots}`;
 }

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -841,8 +841,14 @@ export class BlockInputSync {
 
           case BlockErrorCode.EXECUTION_ENGINE_ERROR:
             // Removing the block(s) without penalizing the peers, hoping for EL to
-            // recover on a latter download + verify attempt
+            // recover on a latter download + verify attempt.
             this.removeAllDescendants(pendingBlock);
+            break;
+
+          case BlockErrorCode.EXECUTION_ENGINE_INVALID:
+            // the peer served a bad block
+            this.logger.debug("Execution engine rejected block from unknown parent sync", errorData, res.err);
+            this.removeAndDownScoreAllDescendants(pendingBlock);
             break;
 
           default:

--- a/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from "vitest";
 import {createChainForkConfig} from "@lodestar/config";
 import {chainConfig} from "@lodestar/config/default";
+import {ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName} from "@lodestar/params";
 import {SignedBeaconBlock, Slot, gloas, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
@@ -82,7 +83,7 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment with 
     );
   });
 
-  it("throws PARENT_PAYLOAD_UNKNOWN when FULL envelope's payload hash does not match next block's bid parentBlockHash", () => {
+  it("throws NON_LINEAR_PAYLOAD_ROOTS when a mid-segment block's bid parentBlockHash does not match the previous block's FULL payload hash", () => {
     const firstExecHash = Buffer.alloc(32, 0x11);
     const correctNextExecHash = Buffer.alloc(32, 0x22);
     const mismatchedNextExecHash = Buffer.alloc(32, 0x99);
@@ -96,7 +97,7 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment with 
 
     expectThrowsLodestarError(
       () => assertLinearChainSegment(config, [bi1, bi2], envelopes, null),
-      BlockErrorCode.PARENT_PAYLOAD_UNKNOWN
+      BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS
     );
   });
 
@@ -128,5 +129,39 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment with 
 
     const {warnings} = assertLinearChainSegment(config, [bi1, bi2], envelopes, null);
     expect(warnings).toBe(null);
+  });
+});
+
+describe("chain / blocks / utils / chainSegment / assertLinearChainSegment boundary (parentBlock provided)", () => {
+  const config = createChainForkConfig({...chainConfig, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
+  const seenTimestampSec = Date.now() / 1000;
+
+  function gloasBlockInput(slot: Slot, parentRoot: Uint8Array, bidParentBlockHash: Uint8Array): BlockInputNoData {
+    const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+    block.message.slot = slot;
+    block.message.parentRoot = parentRoot;
+    block.message.body.signedExecutionPayloadBid.message.parentBlockHash = bidParentBlockHash;
+    const blockRootHex = toRootHex(ssz.gloas.BeaconBlock.hashTreeRoot(block.message));
+    return BlockInputNoData.createFromBlock({
+      block: block as SignedBeaconBlock<typeof ForkName.gloas>,
+      blockRootHex,
+      forkName: ForkName.gloas,
+      daOutOfRange: false,
+      seenTimestampSec,
+      source: BlockInputSource.byRange,
+      peerIdStr: "peer",
+    });
+  }
+
+  it("throws PARENT_PAYLOAD_UNKNOWN when the first block's bid parentBlockHash mismatches the fork-choice parent (i === 0)", () => {
+    const parentExecHash = Buffer.alloc(32, 0x11);
+    const mismatchedBidHash = Buffer.alloc(32, 0x22);
+    const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), mismatchedBidHash);
+    const parentBlock = {slot: 9, executionPayloadBlockHash: toRootHex(parentExecHash)} as unknown as ProtoBlock;
+
+    expectThrowsLodestarError(
+      () => assertLinearChainSegment(config, [bi1], null, parentBlock),
+      BlockErrorCode.PARENT_PAYLOAD_UNKNOWN
+    );
   });
 });

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -593,4 +593,58 @@ describe("sync / range / batch", async () => {
       })
     );
   });
+
+  describe("retainForReprocessing", () => {
+    const startEpoch = 0;
+
+    function batchInProcessing(): Batch {
+      const batch = new Batch(startEpoch, config, clock, custodyConfig, false, undefined, Number.MAX_SAFE_INTEGER);
+      batch.startDownloading(peerSyncMeta);
+      batch.downloadingSuccess(
+        peer,
+        [
+          BlockInputPreData.createFromBlock({
+            block: ssz.capella.SignedBeaconBlock.defaultValue(),
+            blockRootHex: "0x1234",
+            source: BlockInputSource.byRoot,
+            seenTimestampSec: Date.now() / 1000,
+            forkName: ForkName.capella,
+            daOutOfRange: false,
+          }),
+        ],
+        null
+      );
+      batch.startProcessing();
+      return batch;
+    }
+
+    it("Processing -> AwaitingProcessing, keeps blocks and records no failed attempt", () => {
+      const batch = batchInProcessing();
+      expect(batch.state.status).toBe(BatchStatus.Processing);
+      const blocksBefore = batch.getBlocks();
+
+      batch.retainForReprocessing();
+
+      expect(batch.state.status).toBe(BatchStatus.AwaitingProcessing);
+      // blocks are retained, not cleared for re-download
+      expect(batch.getBlocks()).toBe(blocksBefore);
+      // this batch is not at fault, so no failed attempt / failed peer is recorded against it
+      expect(batch.failedProcessingAttempts.length).toBe(0);
+      expect(batch.getFailedPeers().length).toBe(0);
+    });
+
+    it("Should throw on inconsistent state - retainForReprocessing", () => {
+      const batch = new Batch(startEpoch, config, clock, custodyConfig, false, undefined, Number.MAX_SAFE_INTEGER);
+
+      expectThrowsLodestarError(
+        () => batch.retainForReprocessing(),
+        new BatchError({
+          code: BatchErrorCode.WRONG_STATUS,
+          startEpoch,
+          status: BatchStatus.AwaitingDownload,
+          expectedStatus: BatchStatus.Processing,
+        })
+      );
+    });
+  });
 });

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -649,6 +649,40 @@ describe("sync / range / batch", async () => {
         })
       );
     });
+
+    // Regression: retain used to drop the attempt, so on reprocess startProcessing rebuilt it from an
+    // already-cleared successfulDownloads => peers: []. A later peer-attributable failure of the
+    // retained bytes would then avoid scoring the original sender.
+    it("preserves the original peer across retain: a non-EL failure on reprocess is still attributed", () => {
+      const batch = batchInProcessing(); // downloadingSuccess(peer) -> startProcessing
+      batch.retainForReprocessing();
+      batch.startProcessing(); // reprocess the retained bytes
+      batch.processingError(
+        new BlockError(ssz.phase0.SignedBeaconBlock.defaultValue(), {code: BlockErrorCode.NON_LINEAR_SLOTS})
+      );
+
+      expect(batch.failedProcessingAttempts).toHaveLength(1);
+      expect(batch.failedProcessingAttempts[0].peers).toEqual([peer]);
+    });
+
+    it("preserves the original peer across retain: an EL INVALID on reprocess is attributable", () => {
+      const batch = batchInProcessing();
+      batch.retainForReprocessing();
+      batch.startProcessing();
+      batch.processingError(
+        new BlockError(ssz.phase0.SignedBeaconBlock.defaultValue(), {
+          code: BlockErrorCode.EXECUTION_ENGINE_INVALID,
+          execStatus: ExecutionPayloadStatus.INVALID,
+          errorMessage: "bal is empty",
+        })
+      );
+
+      expect(batch.executionErrorAttempts).toHaveLength(1);
+      expect(batch.executionErrorAttempts[0].peerAttributable).toBe(true);
+      expect(batch.executionErrorAttempts[0].peers).toEqual([peer]);
+      // and it must be excluded from the next retry
+      expect(batch.getFailedPeers()).toContain(peer);
+    });
   });
 
   describe("processing failure routing", () => {
@@ -864,12 +898,36 @@ describe("sync / range / batch", async () => {
       });
     });
 
-    it("getFailedPeers excludes a peer whose only failure was an execution engine error", () => {
+    it("getFailedPeers excludes a peer whose only failure was a local execution engine error", () => {
       const batch = downloadedBatch();
       batch.startProcessing();
       batch.processingError(executionErrorBlockError(ExecutionPayloadStatus.ELERROR));
 
+      // local EL error is blameless => peer stays retryable
       expect(batch.getFailedPeers()).not.toContain(peer);
+    });
+
+    it("getFailedPeers includes a peer that served a definitively invalid payload (BlockError)", () => {
+      const batch = downloadedBatch();
+      batch.startProcessing();
+      batch.processingError(executionInvalidBlockError());
+
+      // stored in executionErrorAttempts but peer-attributable => must not be retried
+      expect(batch.getFailedPeers()).toContain(peer);
+    });
+
+    it("getFailedPeers includes a peer that served a definitively invalid payload (PayloadError)", () => {
+      const batch = downloadedBatch();
+      batch.startProcessing();
+      batch.processingError(
+        new PayloadError({
+          code: PayloadErrorCode.EXECUTION_ENGINE_INVALID,
+          execStatus: ExecutionPayloadStatus.INVALID,
+          errorMessage: "bal is empty",
+        })
+      );
+
+      expect(batch.getFailedPeers()).toContain(peer);
     });
   });
 });

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -9,8 +9,11 @@ import {
   BlockInputPreData,
 } from "../../../../src/chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource} from "../../../../src/chain/blocks/blockInput/types.js";
+import {PayloadError, PayloadErrorCode} from "../../../../src/chain/blocks/importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
+import {BlockError, BlockErrorCode} from "../../../../src/chain/errors/index.js";
+import {ExecutionPayloadStatus} from "../../../../src/execution/index.js";
 import {computeNodeIdFromPrivateKey} from "../../../../src/network/subnets/index.js";
 import {Batch, BatchError, BatchErrorCode, BatchStatus} from "../../../../src/sync/range/batch.js";
 import {getBatchSlotRange} from "../../../../src/sync/range/utils/index.js";
@@ -645,6 +648,228 @@ describe("sync / range / batch", async () => {
           expectedStatus: BatchStatus.Processing,
         })
       );
+    });
+  });
+
+  describe("processing failure routing", () => {
+    const startEpoch = 0;
+
+    function downloadedBatch(): Batch {
+      const batch = new Batch(startEpoch, config, clock, custodyConfig, false, undefined, Number.MAX_SAFE_INTEGER);
+      batch.startDownloading(peerSyncMeta);
+      batch.downloadingSuccess(
+        peer,
+        [
+          BlockInputPreData.createFromBlock({
+            block: ssz.capella.SignedBeaconBlock.defaultValue(),
+            blockRootHex: "0x1234",
+            source: BlockInputSource.byRoot,
+            seenTimestampSec: Date.now() / 1000,
+            forkName: ForkName.capella,
+            daOutOfRange: false,
+          }),
+        ],
+        null
+      );
+      return batch;
+    }
+
+    function blockError(type: ConstructorParameters<typeof BlockError>[1]): BlockError {
+      return new BlockError(ssz.phase0.SignedBeaconBlock.defaultValue(), type);
+    }
+
+    const executionInvalidBlockError = (): BlockError =>
+      blockError({
+        code: BlockErrorCode.EXECUTION_ENGINE_INVALID,
+        execStatus: ExecutionPayloadStatus.INVALID,
+        errorMessage: "bal is empty",
+      });
+
+    type ExecutionEngineErrorStatus =
+      | ExecutionPayloadStatus.ELERROR
+      | ExecutionPayloadStatus.UNAVAILABLE
+      | ExecutionPayloadStatus.INVALID_BLOCK_HASH;
+
+    const executionErrorBlockError = (execStatus: ExecutionEngineErrorStatus): BlockError =>
+      blockError({code: BlockErrorCode.EXECUTION_ENGINE_ERROR, execStatus, errorMessage: "el is down"});
+
+    describe("processingError", () => {
+      const executionEngineErrorStatuses: ExecutionEngineErrorStatus[] = [
+        ExecutionPayloadStatus.ELERROR,
+        ExecutionPayloadStatus.UNAVAILABLE,
+        ExecutionPayloadStatus.INVALID_BLOCK_HASH,
+      ];
+
+      it.each(executionEngineErrorStatuses)(
+        "EXECUTION_ENGINE_ERROR (%s) => executionErrorAttempts, not peer attributable",
+        (execStatus) => {
+          const batch = downloadedBatch();
+          batch.startProcessing();
+          batch.processingError(executionErrorBlockError(execStatus));
+
+          expect(batch.failedProcessingAttempts.length).toBe(0);
+          expect(batch.executionErrorAttempts.length).toBe(1);
+          expect(batch.executionErrorAttempts[0].peerAttributable).toBe(false);
+          expect(batch.getPeerAttributableAttempts()).toEqual([]);
+          expect(batch.state.status).toBe(BatchStatus.AwaitingDownload);
+        }
+      );
+
+      it("EXECUTION_ENGINE_INVALID => executionErrorAttempts, peer attributable", () => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(executionInvalidBlockError());
+
+        // shares the EL budget rather than the processing budget
+        expect(batch.failedProcessingAttempts.length).toBe(0);
+        expect(batch.executionErrorAttempts.length).toBe(1);
+        expect(batch.executionErrorAttempts[0].peerAttributable).toBe(true);
+        expect(batch.getPeerAttributableAttempts().flatMap((a) => a.peers)).toEqual([peer]);
+      });
+
+      it("PayloadError EXECUTION_ENGINE_ERROR => executionErrorAttempts, not peer attributable", () => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(
+          new PayloadError({
+            code: PayloadErrorCode.EXECUTION_ENGINE_ERROR,
+            execStatus: ExecutionPayloadStatus.ELERROR,
+            errorMessage: "el is down",
+          })
+        );
+
+        expect(batch.failedProcessingAttempts.length).toBe(0);
+        expect(batch.executionErrorAttempts.length).toBe(1);
+        expect(batch.executionErrorAttempts[0].peerAttributable).toBe(false);
+      });
+
+      it("PayloadError EXECUTION_ENGINE_INVALID => executionErrorAttempts, peer attributable", () => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(
+          new PayloadError({
+            code: PayloadErrorCode.EXECUTION_ENGINE_INVALID,
+            execStatus: ExecutionPayloadStatus.INVALID,
+            errorMessage: "bal is empty",
+          })
+        );
+
+        expect(batch.executionErrorAttempts.length).toBe(1);
+        expect(batch.executionErrorAttempts[0].peerAttributable).toBe(true);
+      });
+
+      it("non execution error => failedProcessingAttempts, peer attributable", () => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(blockError({code: BlockErrorCode.NON_LINEAR_SLOTS}));
+
+        expect(batch.executionErrorAttempts.length).toBe(0);
+        expect(batch.failedProcessingAttempts.length).toBe(1);
+        expect(batch.failedProcessingAttempts[0].peerAttributable).toBe(true);
+        expect(batch.getFailedPeers()).toContain(peer);
+      });
+
+      it("mixed EL statuses share one budget and trip MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS", () => {
+        const errors = [
+          executionErrorBlockError(ExecutionPayloadStatus.ELERROR),
+          executionInvalidBlockError(),
+          executionErrorBlockError(ExecutionPayloadStatus.UNAVAILABLE),
+        ];
+
+        const batch = downloadedBatch();
+        for (const err of errors) {
+          batch.startProcessing();
+          batch.processingError(err);
+          // re-download so the batch can be processed again
+          batch.startDownloading(peerSyncMeta);
+          batch.downloadingSuccess(
+            peer,
+            [
+              BlockInputPreData.createFromBlock({
+                block: ssz.capella.SignedBeaconBlock.defaultValue(),
+                blockRootHex: "0x1234",
+                source: BlockInputSource.byRoot,
+                seenTimestampSec: Date.now() / 1000,
+                forkName: ForkName.capella,
+                daOutOfRange: false,
+              }),
+            ],
+            null
+          );
+        }
+        expect(batch.executionErrorAttempts.length).toBe(3);
+
+        // the 4th EL failure exceeds MAX_BATCH_PROCESSING_ATTEMPTS
+        batch.startProcessing();
+        expectThrowsLodestarError(
+          () => batch.processingError(executionErrorBlockError(ExecutionPayloadStatus.ELERROR)),
+          new BatchError({
+            code: BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS,
+            startEpoch,
+            status: BatchStatus.Processing,
+          })
+        );
+      });
+    });
+
+    describe("validationError", () => {
+      function batchAwaitingValidation(): Batch {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingSuccess();
+        return batch;
+      }
+
+      it("EXECUTION_ENGINE_ERROR => executionErrorAttempts, not peer attributable", () => {
+        const batch = batchAwaitingValidation();
+        batch.validationError(executionErrorBlockError(ExecutionPayloadStatus.ELERROR));
+
+        expect(batch.failedProcessingAttempts.length).toBe(0);
+        expect(batch.executionErrorAttempts.length).toBe(1);
+        expect(batch.executionErrorAttempts[0].peerAttributable).toBe(false);
+        expect(batch.getPeerAttributableAttempts()).toEqual([]);
+      });
+
+      it("EXECUTION_ENGINE_INVALID => executionErrorAttempts, peer attributable", () => {
+        const batch = batchAwaitingValidation();
+        batch.validationError(executionInvalidBlockError());
+
+        expect(batch.executionErrorAttempts.length).toBe(1);
+        expect(batch.executionErrorAttempts[0].peerAttributable).toBe(true);
+        expect(batch.getPeerAttributableAttempts().length).toBe(1);
+      });
+
+      it("PayloadError EXECUTION_ENGINE_ERROR => executionErrorAttempts, not peer attributable", () => {
+        const batch = batchAwaitingValidation();
+        batch.validationError(
+          new PayloadError({
+            code: PayloadErrorCode.EXECUTION_ENGINE_ERROR,
+            execStatus: ExecutionPayloadStatus.UNAVAILABLE,
+            errorMessage: "el is down",
+          })
+        );
+
+        expect(batch.failedProcessingAttempts.length).toBe(0);
+        expect(batch.executionErrorAttempts.length).toBe(1);
+        expect(batch.executionErrorAttempts[0].peerAttributable).toBe(false);
+      });
+
+      it("non execution error => failedProcessingAttempts, peer attributable", () => {
+        const batch = batchAwaitingValidation();
+        batch.validationError(blockError({code: BlockErrorCode.NON_LINEAR_SLOTS}));
+
+        expect(batch.executionErrorAttempts.length).toBe(0);
+        expect(batch.failedProcessingAttempts.length).toBe(1);
+        expect(batch.failedProcessingAttempts[0].peerAttributable).toBe(true);
+      });
+    });
+
+    it("getFailedPeers excludes a peer whose only failure was an execution engine error", () => {
+      const batch = downloadedBatch();
+      batch.startProcessing();
+      batch.processingError(executionErrorBlockError(ExecutionPayloadStatus.ELERROR));
+
+      expect(batch.getFailedPeers()).not.toContain(peer);
     });
   });
 });

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -15,7 +15,7 @@ import {RangeSyncType} from "../../../../src/sync/utils/remoteSyncType.js";
 import {Clock} from "../../../../src/util/clock.js";
 import {CustodyConfig} from "../../../../src/util/dataColumns.js";
 import {linspace} from "../../../../src/util/numpy.js";
-import {validPeerIdStr} from "../../../utils/peer.js";
+import {getRandPeerIdStr, validPeerIdStr} from "../../../utils/peer.js";
 
 describe("sync / range / chain", () => {
   const testCases: {
@@ -392,6 +392,71 @@ describe("sync / range / chain", () => {
     });
 
     expect(downloads).toBeGreaterThanOrEqual(2);
+  });
+
+  describe("batch teardown peer reporting", () => {
+    // Reject every block so the first batch exhausts MAX_BATCH_PROCESSING_ATTEMPTS and the chain
+    // tears down. Needs several peers because each processing failure excludes the peer it used
+    // from the next re-download attempt (getFailedPeers).
+    async function runToTeardown(syncType: RangeSyncType): Promise<ReturnType<typeof vi.fn>> {
+      const reportPeerSpy = vi.fn();
+      const processChainSegment: SyncChainFns["processChainSegment"] = async () => {
+        throw Error("always reject to force teardown");
+      };
+      const downloadByRange: SyncChainFns["downloadByRange"] = async (_peer, request) => {
+        const blocks: IBlockInput[] = [];
+        for (let i = request.startSlot; i < request.startSlot + request.count; i += 1) {
+          blocks.push(
+            BlockInputPreData.createFromBlock({
+              block: {message: generateEmptyBlock(i), signature: ACCEPT_BLOCK},
+              blockRootHex: "0x00",
+              forkName: config.getForkName(i),
+              daOutOfRange: false,
+              source: BlockInputSource.byRange,
+              seenTimestampSec: Math.floor(Date.now() / 1000),
+            })
+          );
+        }
+        return {result: {blocks, payloadEnvelopes: null}, warnings: null};
+      };
+
+      const target: ChainTarget = {slot: computeStartSlotAtEpoch(16), root: ZERO_HASH};
+      const clock = new Clock({config, genesisTime: 0, signal: new AbortController().signal});
+      const peers = await Promise.all(Array.from({length: 6}, () => getRandPeerIdStr()));
+
+      await new Promise<void>((resolve) => {
+        const onEnd: SyncChainFns["onEnd"] = () => resolve(); // resolves on teardown (err) or done
+        const chain = new SyncChain(
+          0,
+          target,
+          syncType,
+          logSyncChainFns(logger, {
+            processChainSegment,
+            downloadByRange,
+            getConnectedPeerSyncMeta,
+            reportPeer: reportPeerSpy,
+            pruneBlockInputs,
+            onEnd,
+          }),
+          {config, logger, clock, custodyConfig, metrics: null},
+          undefined
+        );
+        for (const p of peers) chain.addPeer(p, target);
+        chain.startSyncing(0);
+      });
+
+      return reportPeerSpy;
+    }
+
+    it("finalized sync reports peers on teardown", async () => {
+      const reportPeerSpy = await runToTeardown(RangeSyncType.Finalized);
+      expect(reportPeerSpy).toHaveBeenCalled();
+    });
+
+    it("head sync does not penalize peers on teardown", async () => {
+      const reportPeerSpy = await runToTeardown(RangeSyncType.Head);
+      expect(reportPeerSpy).not.toHaveBeenCalled();
+    });
   });
 
   function generateEmptyBlock(slot: Slot): phase0.BeaconBlock {

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -453,9 +453,9 @@ describe("sync / range / chain", () => {
       expect(reportPeerSpy).toHaveBeenCalled();
     });
 
-    it("head sync does not penalize peers on teardown", async () => {
+    it("head sync also reports peers on teardown", async () => {
       const reportPeerSpy = await runToTeardown(RangeSyncType.Head);
-      expect(reportPeerSpy).not.toHaveBeenCalled();
+      expect(reportPeerSpy).toHaveBeenCalled();
     });
   });
 

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -8,8 +8,11 @@ import {Epoch, Slot, phase0, ssz} from "@lodestar/types";
 import {Logger, fromHex} from "@lodestar/utils";
 import {BlockInputPreData} from "../../../../src/chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource, IBlockInput} from "../../../../src/chain/blocks/blockInput/types.js";
+import {BlockError, BlockErrorCode} from "../../../../src/chain/errors/index.js";
 import {ZERO_HASH} from "../../../../src/constants/index.js";
+import {ExecutionPayloadStatus} from "../../../../src/execution/index.js";
 import type {Metrics} from "../../../../src/metrics/metrics.js";
+import {BatchError, BatchErrorCode} from "../../../../src/sync/range/batch.js";
 import {ChainTarget, SyncChain, SyncChainFns} from "../../../../src/sync/range/chain.js";
 import {RangeSyncType} from "../../../../src/sync/utils/remoteSyncType.js";
 import {Clock} from "../../../../src/util/clock.js";
@@ -398,11 +401,13 @@ describe("sync / range / chain", () => {
     // Reject every block so the first batch exhausts MAX_BATCH_PROCESSING_ATTEMPTS and the chain
     // tears down. Needs several peers because each processing failure excludes the peer it used
     // from the next re-download attempt (getFailedPeers).
-    async function runToTeardown(syncType: RangeSyncType): Promise<ReturnType<typeof vi.fn>> {
-      const reportPeerSpy = vi.fn();
-      const processChainSegment: SyncChainFns["processChainSegment"] = async () => {
+    async function runToTeardown(
+      syncType: RangeSyncType,
+      processChainSegment: SyncChainFns["processChainSegment"] = async () => {
         throw Error("always reject to force teardown");
-      };
+      }
+    ): Promise<{reportPeerSpy: ReturnType<typeof vi.fn>; err: Error | null}> {
+      const reportPeerSpy = vi.fn();
       const downloadByRange: SyncChainFns["downloadByRange"] = async (_peer, request) => {
         const blocks: IBlockInput[] = [];
         for (let i = request.startSlot; i < request.startSlot + request.count; i += 1) {
@@ -424,8 +429,9 @@ describe("sync / range / chain", () => {
       const clock = new Clock({config, genesisTime: 0, signal: new AbortController().signal});
       const peers = await Promise.all(Array.from({length: 6}, () => getRandPeerIdStr()));
 
-      await new Promise<void>((resolve) => {
-        const onEnd: SyncChainFns["onEnd"] = () => resolve(); // resolves on teardown (err) or done
+      let timer: NodeJS.Timeout | undefined;
+      const ended = new Promise<Error | null>((resolve) => {
+        const onEnd: SyncChainFns["onEnd"] = (err) => resolve(err ?? null); // teardown (err) or done
         const chain = new SyncChain(
           0,
           target,
@@ -445,17 +451,82 @@ describe("sync / range / chain", () => {
         chain.startSyncing(0);
       });
 
-      return reportPeerSpy;
+      // A stalled SyncChain never calls onEnd, so fail fast and loudly rather than letting the whole
+      // suite time out with no explanation.
+      const err = await Promise.race([
+        ended,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(Error("SyncChain stalled: onEnd never called")), 5000);
+        }),
+      ]).finally(() => clearTimeout(timer));
+
+      return {reportPeerSpy, err};
     }
 
     it("finalized sync reports peers on teardown", async () => {
-      const reportPeerSpy = await runToTeardown(RangeSyncType.Finalized);
+      const {reportPeerSpy} = await runToTeardown(RangeSyncType.Finalized);
       expect(reportPeerSpy).toHaveBeenCalled();
     });
 
     it("head sync also reports peers on teardown", async () => {
-      const reportPeerSpy = await runToTeardown(RangeSyncType.Head);
+      const {reportPeerSpy} = await runToTeardown(RangeSyncType.Head);
       expect(reportPeerSpy).toHaveBeenCalled();
+    });
+
+    // Regression: PARENT_UNKNOWN on the first block of the chain's FIRST batch used to classify as
+    // PreviousBatch, which retains the batch without recording an attempt and with nothing to
+    // invalidate => the chain never re-downloads, never reaches MAX_BATCH_PROCESSING_ATTEMPTS, and
+    // stalls silently in Syncing.
+    it("first batch failing PARENT_UNKNOWN at startSlot tears down instead of stalling", async () => {
+      const processChainSegment: SyncChainFns["processChainSegment"] = async (blocks) => {
+        // blocks[0].slot is the batch's startSlot, so this is the "parent is before this batch" case
+        const signedBlock = blocks[0].getBlock();
+        throw new BlockError(signedBlock, {code: BlockErrorCode.PARENT_UNKNOWN, parentRoot: "0x00"});
+      };
+
+      const {err} = await runToTeardown(RangeSyncType.Finalized, processChainSegment);
+
+      expect(err).toBeInstanceOf(BatchError);
+      expect((err as BatchError).type.code).toBe(BatchErrorCode.MAX_PROCESSING_ATTEMPTS);
+    });
+
+    it("does not report peers when teardown is caused by execution engine errors", async () => {
+      const processChainSegment: SyncChainFns["processChainSegment"] = async (blocks) => {
+        throw new BlockError(blocks[0].getBlock(), {
+          code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
+          execStatus: ExecutionPayloadStatus.ELERROR,
+          errorMessage: "el is down",
+        });
+      };
+
+      const {reportPeerSpy, err} = await runToTeardown(RangeSyncType.Finalized, processChainSegment);
+
+      expect((err as BatchError).type.code).toBe(BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS);
+      // our EL malfunctioning is not evidence against any peer
+      expect(reportPeerSpy).not.toHaveBeenCalled();
+    });
+
+    it("reports only the offending peers when teardown is caused by INVALID payloads", async () => {
+      const processChainSegment: SyncChainFns["processChainSegment"] = async (blocks) => {
+        throw new BlockError(blocks[0].getBlock(), {
+          code: BlockErrorCode.EXECUTION_ENGINE_INVALID,
+          execStatus: ExecutionPayloadStatus.INVALID,
+          errorMessage: "bal is empty",
+        });
+      };
+
+      const {reportPeerSpy, err} = await runToTeardown(RangeSyncType.Finalized, processChainSegment);
+
+      expect((err as BatchError).type.code).toBe(BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS);
+      expect(reportPeerSpy).toHaveBeenCalled();
+
+      const reportedPeers = reportPeerSpy.mock.calls.map(([peerId]) => peerId);
+      // only the peers that actually served an INVALID attempt, each reported once
+      expect(new Set(reportedPeers).size).toBe(reportedPeers.length);
+      expect(reportedPeers.length).toBeLessThan(6);
+      for (const call of reportPeerSpy.mock.calls) {
+        expect(call[2]).toBe("SyncChainMaxExecutionEngineInvalid");
+      }
     });
   });
 

--- a/packages/beacon-node/test/unit/sync/range/utils/batches.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/utils/batches.test.ts
@@ -308,12 +308,30 @@ describe("sync / range / batches", () => {
       );
     });
 
-    it("PARENT_UNKNOWN at startSlot => PreviousBatch (regardless of prevBatch)", () => {
+    it("PARENT_UNKNOWN at startSlot with a previous batch => PreviousBatch", () => {
       const err = parentError(BlockErrorCode.PARENT_UNKNOWN, startSlot);
-      expect(classifyProcessingFault(err, batch, undefined)).toBe(ProcessingFaultKind.PreviousBatch);
       expect(classifyProcessingFault(err, batch, fakeBatch(prevStartSlot, [startSlot - 1]))).toBe(
         ProcessingFaultKind.PreviousBatch
       );
+    });
+
+    // Regression: returning PreviousBatch here makes SyncChain retainForReprocessing() the batch with
+    // nothing to invalidate, so no failed attempt is ever recorded and the chain stalls silently.
+    it("PARENT_UNKNOWN at startSlot with no previous batch => ThisBatch (first batch must not stall)", () => {
+      const err = parentError(BlockErrorCode.PARENT_UNKNOWN, startSlot);
+      expect(classifyProcessingFault(err, batch, undefined)).toBe(ProcessingFaultKind.ThisBatch);
+    });
+
+    it("PARENT_PAYLOAD_UNKNOWN at startSlot with a previous batch => PreviousBatch", () => {
+      const err = parentError(BlockErrorCode.PARENT_PAYLOAD_UNKNOWN, startSlot);
+      expect(classifyProcessingFault(err, batch, fakeBatch(prevStartSlot, [], [startSlot - 1]))).toBe(
+        ProcessingFaultKind.PreviousBatch
+      );
+    });
+
+    it("PARENT_PAYLOAD_UNKNOWN at startSlot with no previous batch => ThisBatch", () => {
+      const err = parentError(BlockErrorCode.PARENT_PAYLOAD_UNKNOWN, startSlot);
+      expect(classifyProcessingFault(err, batch, undefined)).toBe(ProcessingFaultKind.ThisBatch);
     });
 
     it("PARENT_UNKNOWN after startSlot, prev batch delivered tail block => ThisBatch", () => {

--- a/packages/beacon-node/test/unit/sync/range/utils/batches.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/utils/batches.test.ts
@@ -1,9 +1,13 @@
 import {describe, expect, it} from "vitest";
 import {config} from "@lodestar/config/default";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {Epoch, Slot} from "@lodestar/types";
+import {Epoch, Slot, ssz} from "@lodestar/types";
+import {IBlockInput} from "../../../../../src/chain/blocks/blockInput/types.js";
+import {BlockError, BlockErrorCode} from "../../../../../src/chain/errors/index.js";
 import {Batch, BatchStatus} from "../../../../../src/sync/range/batch.js";
 import {
+  ProcessingFaultKind,
+  classifyProcessingFault,
   getNextBatchToProcess,
   isSyncChainDone,
   toBeDownloadedStartEpoch,
@@ -248,4 +252,97 @@ describe("sync / range / batches", () => {
     if (status === BatchStatus.AwaitingValidation) return batch;
     throw Error(`Unknown status: ${status}`);
   }
+
+  describe("classifyProcessingFault", () => {
+    // Lightweight stubs: classifyProcessingFault only reads startSlot / getBlocks / getPayloadEnvelopes
+    function fakeBatch(startSlot: Slot, blockSlots: Slot[] = [], payloadSlots: Slot[] = []): Batch {
+      return {
+        startSlot,
+        getBlocks: () => blockSlots.map((slot) => ({slot}) as IBlockInput),
+        getPayloadEnvelopes: () =>
+          payloadSlots.length > 0
+            ? new Map(payloadSlots.map((slot) => [slot, {hasPayloadEnvelope: () => true}]))
+            : null,
+      } as unknown as Batch;
+    }
+
+    function parentError(
+      code: BlockErrorCode.PARENT_UNKNOWN | BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
+      slot: Slot
+    ): BlockError {
+      const signedBlock = ssz.phase0.SignedBeaconBlock.defaultValue();
+      signedBlock.message.slot = slot;
+      const type =
+        code === BlockErrorCode.PARENT_PAYLOAD_UNKNOWN
+          ? {code, parentRoot: "0x00", parentBlockHash: "0x00"}
+          : {code, parentRoot: "0x00"};
+      return new BlockError(signedBlock, type);
+    }
+
+    const startSlot = 2 * SLOTS_PER_EPOCH; // batch n starts at an epoch boundary
+    const prevStartSlot = startSlot - SLOTS_PER_EPOCH;
+    const batch = fakeBatch(startSlot);
+
+    it("non-parent BlockError => ThisBatch", () => {
+      const signedBlock = ssz.phase0.SignedBeaconBlock.defaultValue();
+      signedBlock.message.slot = startSlot;
+      const err = new BlockError(signedBlock, {code: BlockErrorCode.NON_LINEAR_SLOTS});
+      expect(classifyProcessingFault(err, batch, undefined)).toBe(ProcessingFaultKind.ThisBatch);
+    });
+
+    it("non-BlockError => ThisBatch", () => {
+      expect(classifyProcessingFault(new Error("boom"), batch, undefined)).toBe(ProcessingFaultKind.ThisBatch);
+    });
+
+    it("internal-linkage codes (NON_LINEAR_PAYLOAD_ROOTS) => ThisBatch, never escalate", () => {
+      const signedBlock = ssz.phase0.SignedBeaconBlock.defaultValue();
+      signedBlock.message.slot = startSlot + 1; // mid-segment slot, would be Ambiguous if it were a parent code
+      const err = new BlockError(signedBlock, {
+        code: BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS,
+        parentBlockHash: "0x00",
+        expectedBlockHash: "0x11",
+      });
+      // prevBatch with a trailing gap would push a parent code to Ambiguous; a non-parent code must not.
+      expect(classifyProcessingFault(err, batch, fakeBatch(prevStartSlot, [startSlot - 3]))).toBe(
+        ProcessingFaultKind.ThisBatch
+      );
+    });
+
+    it("PARENT_UNKNOWN at startSlot => PreviousBatch (regardless of prevBatch)", () => {
+      const err = parentError(BlockErrorCode.PARENT_UNKNOWN, startSlot);
+      expect(classifyProcessingFault(err, batch, undefined)).toBe(ProcessingFaultKind.PreviousBatch);
+      expect(classifyProcessingFault(err, batch, fakeBatch(prevStartSlot, [startSlot - 1]))).toBe(
+        ProcessingFaultKind.PreviousBatch
+      );
+    });
+
+    it("PARENT_UNKNOWN after startSlot, prev batch delivered tail block => ThisBatch", () => {
+      const err = parentError(BlockErrorCode.PARENT_UNKNOWN, startSlot + 1);
+      expect(classifyProcessingFault(err, batch, fakeBatch(prevStartSlot, [startSlot - 1]))).toBe(
+        ProcessingFaultKind.ThisBatch
+      );
+    });
+
+    it("PARENT_UNKNOWN after startSlot, prev batch missing tail block => Ambiguous", () => {
+      const err = parentError(BlockErrorCode.PARENT_UNKNOWN, startSlot + 1);
+      expect(classifyProcessingFault(err, batch, fakeBatch(prevStartSlot, [startSlot - 3]))).toBe(
+        ProcessingFaultKind.Ambiguous
+      );
+    });
+
+    it("PARENT_UNKNOWN after startSlot, prevBatch undefined => Ambiguous", () => {
+      const err = parentError(BlockErrorCode.PARENT_UNKNOWN, startSlot + 1);
+      expect(classifyProcessingFault(err, batch, undefined)).toBe(ProcessingFaultKind.Ambiguous);
+    });
+
+    it("PARENT_PAYLOAD_UNKNOWN after startSlot keys off prev batch tail payload", () => {
+      const err = parentError(BlockErrorCode.PARENT_PAYLOAD_UNKNOWN, startSlot + 1);
+      // payload present at startSlot - 1 => ThisBatch
+      expect(classifyProcessingFault(err, batch, fakeBatch(prevStartSlot, [], [startSlot - 1]))).toBe(
+        ProcessingFaultKind.ThisBatch
+      );
+      // payload absent => Ambiguous
+      expect(classifyProcessingFault(err, batch, fakeBatch(prevStartSlot, [], []))).toBe(ProcessingFaultKind.Ambiguous);
+    });
+  });
 });

--- a/packages/beacon-node/test/unit/sync/range/utils/hashBlocks.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/utils/hashBlocks.test.ts
@@ -1,0 +1,160 @@
+import {describe, expect, it} from "vitest";
+import {ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {IBlockInput} from "../../../../../src/chain/blocks/blockInput/types.js";
+import {PayloadEnvelopeInput} from "../../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
+import {hashBlocks} from "../../../../../src/sync/range/utils/hashBlocks.js";
+
+describe("sync / range / utils / hashBlocks", () => {
+  // Roots must be a full 32 bytes: hashBlocks writes them into an allocUnsafe buffer at a fixed
+  // stride, so a short root would leave uninitialized memory and a non-deterministic id.
+  function rootHex(seed: number): string {
+    return toRootHex(Buffer.alloc(32, seed));
+  }
+
+  // Lightweight stubs: hashBlocks only reads blockRootHex / hasBlock / getBlock().signature on blocks
+  // and hasPayloadEnvelope / getPayloadEnvelope on envelopes.
+  function fakeBlock(blockRootHex: string, signature = Buffer.alloc(96, 0)): IBlockInput {
+    return {
+      blockRootHex,
+      hasBlock: () => true,
+      getBlock: () => ({signature}),
+    } as unknown as IBlockInput;
+  }
+
+  // `builderIndex` distinguishes envelopes; ExecutionPayloadEnvelope has no slot field, the slot only
+  // exists as the Map key that hashBlocks sorts on.
+  function fakeEnvelope(
+    builderIndex: number,
+    hasPayload = true,
+    signature = Buffer.alloc(96, 0)
+  ): PayloadEnvelopeInput {
+    const signedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    signedEnvelope.message.builderIndex = builderIndex;
+    signedEnvelope.signature = signature;
+    return {
+      hasPayloadEnvelope: () => hasPayload,
+      getPayloadEnvelope: () => signedEnvelope,
+    } as unknown as PayloadEnvelopeInput;
+  }
+
+  // The id is retained on every Attempt, so it must not grow with batch size. Concatenating roots
+  // and signatures instead of digesting them would be ~16 KB for a full 32-slot gloas batch.
+  it("returns a fixed-size root regardless of batch size", () => {
+    const one = hashBlocks([fakeBlock(rootHex(0xaa))], null);
+    const manyBlocks = Array.from({length: 32}, (_, i) => fakeBlock(rootHex(i)));
+    const manyEnvelopes = new Map(Array.from({length: 32}, (_, i) => [i, fakeEnvelope(i)]));
+    const many = hashBlocks(manyBlocks, manyEnvelopes);
+
+    expect(one).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(many).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(many.length).toBe(one.length);
+  });
+
+  it("identical blocks and signatures produce identical ids", () => {
+    const blocks = [fakeBlock(rootHex(0xaa)), fakeBlock(rootHex(0xbb))];
+    const same = [fakeBlock(rootHex(0xaa)), fakeBlock(rootHex(0xbb))];
+
+    expect(hashBlocks(blocks, null)).toBe(hashBlocks(same, null));
+  });
+
+  // Regression: blockRootHex is the root of block.message, so a peer serving the correct message with
+  // a garbage signature would otherwise collide with the honest attempt and escape peer scoring.
+  it("identical block messages with different signatures produce different ids", () => {
+    const honest = [fakeBlock(rootHex(0xaa), Buffer.alloc(96, 0))];
+    const forgedSignature = [fakeBlock(rootHex(0xaa), Buffer.alloc(96, 1))];
+
+    expect(hashBlocks(honest, null)).not.toBe(hashBlocks(forgedSignature, null));
+  });
+
+  it("different block roots produce different ids", () => {
+    expect(hashBlocks([fakeBlock(rootHex(0xaa))], null)).not.toBe(hashBlocks([fakeBlock(rootHex(0xbb))], null));
+  });
+
+  // Failing loudly beats substituting a placeholder signature: zeros would make this collide with a
+  // real block whose signature is all zeros, and writing nothing would leave allocUnsafe garbage.
+  // Unreachable in practice — startProcessing() requires every block to be present.
+  it("throws when a block is not available rather than producing an ambiguous id", () => {
+    const withoutBlock = {
+      blockRootHex: rootHex(0xaa),
+      hasBlock: () => false,
+      getBlock: () => {
+        throw Error("MISSING_BLOCK");
+      },
+    } as unknown as IBlockInput;
+
+    expect(() => hashBlocks([withoutBlock], null)).toThrow();
+  });
+
+  it("envelope ordering is slot-stable regardless of Map insertion order", () => {
+    const blocks = [fakeBlock(rootHex(0xaa))];
+    // distinct envelopes, so a wrong sort would actually change the id
+    const ascending = new Map([
+      [1, fakeEnvelope(11)],
+      [2, fakeEnvelope(22)],
+    ]);
+    const descending = new Map([
+      [2, fakeEnvelope(22)],
+      [1, fakeEnvelope(11)],
+    ]);
+
+    expect(hashBlocks(blocks, ascending)).toBe(hashBlocks(blocks, descending));
+    // sanity: the two envelopes really are different, so the assertion above is not vacuous
+    expect(hashBlocks(blocks, new Map([[1, fakeEnvelope(11)]]))).not.toBe(
+      hashBlocks(blocks, new Map([[1, fakeEnvelope(22)]]))
+    );
+  });
+
+  it("different envelopes produce different ids", () => {
+    const blocks = [fakeBlock(rootHex(0xaa))];
+    const one = new Map([[1, fakeEnvelope(11)]]);
+    const other = new Map([[1, fakeEnvelope(22)]]);
+
+    expect(hashBlocks(blocks, one)).not.toBe(hashBlocks(blocks, other));
+  });
+
+  // Same hole as the block-side signature case: the envelope id is the root of the *message*, so
+  // without folding in the signature a forged-signature envelope collides with the honest one and
+  // escapes peer scoring, even though it fails with PayloadErrorCode.INVALID_SIGNATURE.
+  it("identical envelope messages with different signatures produce different ids", () => {
+    const blocks = [fakeBlock(rootHex(0xaa))];
+    const honest = new Map([[1, fakeEnvelope(11, true, Buffer.alloc(96, 0))]]);
+    const forgedSignature = new Map([[1, fakeEnvelope(11, true, Buffer.alloc(96, 1))]]);
+
+    expect(hashBlocks(blocks, honest)).not.toBe(hashBlocks(blocks, forgedSignature));
+  });
+
+  // The id is built in an allocUnsafe buffer, so every allocated byte must be written. A batch where
+  // only some blocks carry a payload is the case most likely to leave an unwritten tail; if it did,
+  // the id would vary run to run as the Buffer pool changes underneath it.
+  it("is deterministic when only some blocks have a payload envelope", () => {
+    const blocks = Array.from({length: 32}, (_, i) => fakeBlock(rootHex(i)));
+    const build = (): Map<number, PayloadEnvelopeInput> =>
+      new Map(Array.from({length: 32}, (_, i) => [i, fakeEnvelope(i, i % 7 === 0)]));
+
+    const ids = new Set<string>();
+    for (let round = 0; round < 50; round++) {
+      // dirty the Buffer pool between runs so unwritten bytes would differ
+      Buffer.allocUnsafe(64 * 1024).fill(round % 251);
+      ids.add(hashBlocks(blocks, build()));
+    }
+
+    expect(ids.size).toBe(1);
+  });
+
+  // Intended equivalence: an envelope without a payload carries no attributable data
+  it("null envelopes and envelopes that all lack a payload produce the same id", () => {
+    const blocks = [fakeBlock(rootHex(0xaa))];
+    const noPayloads = new Map([
+      [1, fakeEnvelope(11, false)],
+      [2, fakeEnvelope(22, false)],
+    ]);
+
+    expect(hashBlocks(blocks, noPayloads)).toBe(hashBlocks(blocks, null));
+  });
+
+  it("does not throw on an empty blocks array", () => {
+    expect(() => hashBlocks([], null)).not.toThrow();
+    expect(hashBlocks([], null)).not.toBe(hashBlocks([fakeBlock(rootHex(0xaa))], null));
+  });
+});

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -223,7 +223,7 @@ export const ExecutionPayloadEnvelope = new ContainerType(
     beaconBlockRoot: Root,
     parentBeaconBlockRoot: Root,
   },
-  {typeName: "ExecutionPayloadEnvelope", jsonCase: "eth2"}
+  {typeName: "ExecutionPayloadEnvelope", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
 
 export const SignedExecutionPayloadEnvelope = new ContainerType(


### PR DESCRIPTION
**Motivation**

- we forced to create a new sync chain via setting `MAX_BATCH_PROCESSING_ATTEMPTS = 0`in #8150
- this is too strict, in glamsterdam-devnet-7, when a peer returned an invalid payload in range sync, we have to drop all downloaded blocks and create new sync chain https://discord.com/channels/593655374469660673/1372263082415493200/1526735532103569468
- Batch validationError() current does not work well, we need heuristic to know when we need to invalidate previous batches


**Description**

- reset `MAX_BATCH_PROCESSING_ATTEMPTS` to 3 again
- based on `processChainSegment()` BlockError code of batch `n`, we classify if it's batch `n` error, or batch `n - 1` or ambiguous and handle accordingly, see `classifyProcessingFault()` in `batches.ts` util
  - to do that, we separate 2 errors: "PARENT_UNKNOWN" block error happen at the 1st block of chain segment
  - if error happen in the middle, it's `NON_LINEAR` error
- the other advantage of `classifyProcessingFault()` is to handle 0-block batch in #9417 (through i want to make sure devnet sync works well first)
- add `Batch.retainForReprocessing()` when the current batch itself is good, we retain and invalidate previous batches

**AI Assistance Disclosure**
- created with the help of Claude

cc @ensi321  