### PR TITLE
fix: scan all proto array nodes when counting payload reveals

### DIFF
--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -679,18 +679,11 @@ export class ProtoArray {
   getPayloadRevealCounts(fromSlot: Slot, toSlot: Slot): {blocksPresent: number; payloadsRevealed: number} {
     let blocksPresent = 0;
     let payloadsRevealed = 0;
-    // Iterate backward as recent blocks are at the end of the nodes array. Only break on block
-    // nodes below the window since FULL variants are appended late when the envelope is imported
-    for (let i = this.nodes.length - 1; i >= 0; i--) {
-      const node = this.nodes[i];
-      if (node.slot < fromSlot) {
-        if (isGloasBlock(node) && node.payloadStatus === PayloadStatus.FULL) {
-          continue;
-        }
-        break;
-      }
+    // Full scan, nodes are in import order not slot order (an old block can be imported after newer
+    // ones during sync or reorg resolution), so we cannot stop early on an out-of-window slot
+    for (const node of this.nodes) {
       // Count each gloas block once via its PENDING variant, pre-gloas nodes are FULL only
-      if (node.slot > toSlot || node.payloadStatus !== PayloadStatus.PENDING) {
+      if (node.slot < fromSlot || node.slot > toSlot || node.payloadStatus !== PayloadStatus.PENDING) {
         continue;
       }
       blocksPresent++;

--- a/packages/fork-choice/test/unit/protoArray/gloas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/gloas.test.ts
@@ -187,7 +187,7 @@ describe("Gloas Fork Choice", () => {
       }
 
       // Reveal the below-window payload last so its FULL node is appended after the in-window
-      // nodes, backward iteration must skip it instead of breaking on its slot
+      // nodes, the scan must skip it instead of counting or stopping on it
       for (const blockRoot of ["0x04", "0x02"]) {
         protoArray.onExecutionPayload(
           blockRoot,
@@ -204,6 +204,26 @@ describe("Gloas Fork Choice", () => {
       expect(protoArray.getPayloadRevealCounts(gloasForkSlot + 2, currentSlot)).toEqual({
         blocksPresent: 2,
         payloadsRevealed: 1,
+      });
+    });
+
+    it("counts in-window blocks even when an older block is imported afterwards", () => {
+      const currentSlot = gloasForkSlot + 3;
+      const protoArray = ProtoArray.initialize(
+        createTestBlock(gloasForkSlot - 1, genesisRoot, "0x00"),
+        gloasForkSlot - 1
+      );
+
+      // Two in-window blocks
+      protoArray.onBlock(createTestBlock(gloasForkSlot + 2, "0x03", genesisRoot, genesisRoot), currentSlot, null);
+      protoArray.onBlock(createTestBlock(gloasForkSlot + 3, "0x04", genesisRoot, genesisRoot), currentSlot, null);
+      // Old block below the window imported last, so its PENDING node lands at the end of the array.
+      // The scan must not stop on it and miss the in-window nodes inserted earlier (nodes are not slot ordered)
+      protoArray.onBlock(createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot), currentSlot, null);
+
+      expect(protoArray.getPayloadRevealCounts(gloasForkSlot + 2, currentSlot)).toEqual({
+        blocksPresent: 2,
+        payloadsRevealed: 0,
       });
     });
   });


### PR DESCRIPTION
**Motivation**

`getPayloadRevealCounts` (used by the builder circuit breaker) iterated the proto array backward and stopped at the first out-of-window block node, assuming nodes are ordered by slot. Nodes are in import order, not slot order, an older block can be imported after newer ones (a late block on a competing branch, or ancestors imported while resolving a heavier fork), so its `PENDING` node lands at the end of the array. The backward scan then breaks on that trailing out-of-window node and misses the in-window nodes inserted earlier, undercounting blocks present and faults.

The truncated counts can wrongly activate or deactivate the circuit breaker, which fails open (fewer faults observed) exactly during the instability where out-of-order imports are common, leading to the wrong bid source being selected.

Pointed out by codex in https://github.com/ChainSafe/lodestar/pull/9674#discussion_r3605013012

**Description**

- replace the early `break` with a full scan that skips out-of-window nodes, matching the pre-gloas `getSlotsPresent`
- add a regression test importing an older block after newer in-window blocks