### PR TITLE
fix: harden assertLinearChainSegment

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -249,7 +249,7 @@ export function getBeaconBlockApi({
               "api_reject_parent_unknown"
             );
             throw new BlockError(signedBlock, {
-              code: BlockErrorCode.PARENT_UNKNOWN,
+              code: BlockErrorCode.PARENT_BLOCK_UNKNOWN,
               parentRoot: toRootHex(signedBlock.message.parentRoot),
             });
           }
@@ -334,7 +334,8 @@ export function getBeaconBlockApi({
           .catch((e) => {
             if (
               e instanceof BlockError &&
-              (e.type.code === BlockErrorCode.PARENT_UNKNOWN || e.type.code === BlockErrorCode.PARENT_PAYLOAD_UNKNOWN)
+              (e.type.code === BlockErrorCode.PARENT_BLOCK_UNKNOWN ||
+                e.type.code === BlockErrorCode.PARENT_PAYLOAD_UNKNOWN)
             ) {
               chain.emitter.emit(ChainEvent.blockUnknownParent, {
                 blockInput: blockForImport,

--- a/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
+++ b/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
@@ -86,11 +86,22 @@ export function assertLinearChainSegment(
           // Maybe the previous slot's FULL envelope was orphaned — try falling back.
           // If even prevExecHash doesn't match, the segment is non-linear.
           if (bidParentHash !== prevExecHash) {
-            throw new BlockError(block, {
-              code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
-              parentRoot: toRootHex(block.message.parentRoot),
-              parentBlockHash: bidParentHash,
-            });
+            // i === 0 compares against the seeded fork-choice parent (segment boundary); i > 0
+            // compares against the in-segment predecessor's payload (broken link inside the segment).
+            throw new BlockError(
+              block,
+              i === 0
+                ? {
+                    code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
+                    parentRoot: toRootHex(block.message.parentRoot),
+                    parentBlockHash: bidParentHash,
+                  }
+                : {
+                    code: BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS,
+                    parentBlockHash: bidParentHash,
+                    expectedBlockHash: currentExecHash,
+                  }
+            );
           }
           if (lastFullSlot !== null && payloadEnvelopes !== null) {
             const orphanedInput = payloadEnvelopes.get(lastFullSlot);

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSanityChecks.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSanityChecks.ts
@@ -94,7 +94,7 @@ export function verifyBlocksSanityChecks(
       const parentRoot = toRootHex(block.message.parentRoot);
       const parentBlockDefaultStatus = chain.forkChoice.getBlockHexDefaultStatus(parentRoot);
       if (!parentBlockDefaultStatus) {
-        throw new BlockError(block, {code: BlockErrorCode.PARENT_UNKNOWN, parentRoot});
+        throw new BlockError(block, {code: BlockErrorCode.PARENT_BLOCK_UNKNOWN, parentRoot});
       }
 
       parentBlock = parentBlockDefaultStatus;

--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -8,8 +8,10 @@ import {GossipActionError} from "./gossipValidation.js";
 export enum BlockErrorCode {
   /** The prestate cannot be fetched */
   PRESTATE_MISSING = "BLOCK_ERROR_PRESTATE_MISSING",
-  /** The parent block was unknown. */
-  PARENT_UNKNOWN = "BLOCK_ERROR_PARENT_UNKNOWN",
+  /**
+   * The first block of a chain segment references a parentRoot unknown to fork-choice.
+   */
+  PARENT_BLOCK_UNKNOWN = "BLOCK_ERROR_PARENT_BLOCK_UNKNOWN",
   /** The block slot is greater than the present slot. */
   FUTURE_SLOT = "BLOCK_ERROR_FUTURE_SLOT",
   /** The block state_root does not match the generated state. */
@@ -38,7 +40,10 @@ export enum BlockErrorCode {
   NOT_FINALIZED_DESCENDANT = "BLOCK_ERROR_NOT_FINALIZED_DESCENDANT",
   /** The provided block is from an later slot than its parent. */
   NOT_LATER_THAN_PARENT = "BLOCK_ERROR_NOT_LATER_THAN_PARENT",
-  /** At least one block in the chain segment did not have it's parent root set to the root of the prior block. */
+  /**
+   * A block in the middle of a chain segment does not set its parentRoot to the previous block's root
+   * (broken parent-root link inside the segment).
+   */
   NON_LINEAR_PARENT_ROOTS = "BLOCK_ERROR_NON_LINEAR_PARENT_ROOTS",
   /** The slots of the blocks in the chain segment were not strictly increasing. */
   NON_LINEAR_SLOTS = "BLOCK_ERROR_NON_LINEAR_SLOTS",
@@ -71,8 +76,16 @@ export enum BlockErrorCode {
   TOO_MANY_BLOCK_OPERATIONS = "BLOCK_ERROR_TOO_MANY_BLOCK_OPERATIONS",
   /** The parent block's execution payload has been verified as invalid */
   PARENT_EXECUTION_INVALID = "BLOCK_ERROR_PARENT_EXECUTION_INVALID",
-  /** The block's parent execution payload (defined by bid.parent_block_hash) has not been seen */
+  /**
+   * [gloas] The first block of a chain segment references a parent execution payload
+   * (bid.parent_block_hash) unknown to fork-choice (segment boundary).
+   */
   PARENT_PAYLOAD_UNKNOWN = "BLOCK_ERROR_PARENT_PAYLOAD_UNKNOWN",
+  /**
+   * [gloas] A block in the middle of a chain segment has a bid.parent_block_hash that does not chain onto the
+   * previous block's execution payload (broken payload link inside the segment).
+   */
+  NON_LINEAR_PAYLOAD_ROOTS = "BLOCK_ERROR_NON_LINEAR_PAYLOAD_ROOTS",
   /** An execution payload envelope in the chain segment references a block root that does not match its slot's block */
   ENVELOPE_BLOCK_ROOT_MISMATCH = "BLOCK_ERROR_ENVELOPE_BLOCK_ROOT_MISMATCH",
 }
@@ -84,7 +97,7 @@ type ExecutionErrorStatus = Exclude<
 
 export type BlockErrorType =
   | {code: BlockErrorCode.PRESTATE_MISSING; error: Error}
-  | {code: BlockErrorCode.PARENT_UNKNOWN; parentRoot: RootHex}
+  | {code: BlockErrorCode.PARENT_BLOCK_UNKNOWN; parentRoot: RootHex}
   | {code: BlockErrorCode.FUTURE_SLOT; blockSlot: Slot; currentSlot: Slot}
   | {code: BlockErrorCode.STATE_ROOT_MISMATCH}
   | {code: BlockErrorCode.GENESIS_BLOCK}
@@ -122,7 +135,8 @@ export type BlockErrorType =
   | {code: BlockErrorCode.BID_PARENT_ROOT_MISMATCH; bidParentRoot: RootHex; blockParentRoot: RootHex}
   | {code: BlockErrorCode.TOO_MANY_BLOCK_OPERATIONS; name: string; count: number; limit: number}
   | {code: BlockErrorCode.PARENT_EXECUTION_INVALID; parentRoot: RootHex}
-  | {code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN; parentRoot: RootHex; parentBlockHash: RootHex};
+  | {code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN; parentRoot: RootHex; parentBlockHash: RootHex}
+  | {code: BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS; parentBlockHash: RootHex; expectedBlockHash: RootHex};
 
 export class BlockGossipError extends GossipActionError<BlockErrorType> {}
 

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -104,8 +104,8 @@ export async function validateGossipBlock(
     // 2. The parent is unknown to us, we probably want to download it since it might actually
     //    descend from the finalized root.
     // (Non-Lighthouse): Since we prune all blocks non-descendant from finalized checking the `db.block` database won't be useful to guard
-    // against known bad fork blocks, so we throw PARENT_UNKNOWN for cases (1) and (2)
-    throw new BlockGossipError(GossipAction.IGNORE, {code: BlockErrorCode.PARENT_UNKNOWN, parentRoot});
+    // against known bad fork blocks, so we throw PARENT_BLOCK_UNKNOWN for cases (1) and (2)
+    throw new BlockGossipError(GossipAction.IGNORE, {code: BlockErrorCode.PARENT_BLOCK_UNKNOWN, parentRoot});
   }
 
   // [IGNORE] The block's parent (defined by `block.parent_root`) passes all validation
@@ -244,7 +244,7 @@ export async function validateGossipBlock(
   const blockState = await chain.regen
     .getPreState(block, {dontTransferCache: true}, RegenCaller.validateGossipBlock)
     .catch(() => {
-      throw new BlockGossipError(GossipAction.IGNORE, {code: BlockErrorCode.PARENT_UNKNOWN, parentRoot});
+      throw new BlockGossipError(GossipAction.IGNORE, {code: BlockErrorCode.PARENT_BLOCK_UNKNOWN, parentRoot});
     });
 
   // in forky condition, make sure to populate ShufflingCache with regened state

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -176,7 +176,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
 
     // optimistically add gossip block to the seen cache
     // if validation fails, we will NOT forward this gossip block to peers
-    //   - if PARENT_UNKNOWN error, blockInput will then be queued inside BlockInputSync. If the gossip block is really invalid, it will be pruned there
+    //   - if PARENT_BLOCK_UNKNOWN error, blockInput will then be queued inside BlockInputSync. If the gossip block is really invalid, it will be pruned there
     //   - if other validator errors, blockInput will stay in the seen cache and will be pruned on finalization
     const blockInput = chain.seenBlockInputCache.getByBlock({
       block: signedBlock,
@@ -187,7 +187,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
     });
 
     // Optimistically seed the payload-envelope cache too, mirroring seenBlockInputCache above.
-    // This ensures we have PayloadEnvelopeInput, even through "PARENT_UNKNOWN" error
+    // This ensures we have PayloadEnvelopeInput, even through "PARENT_BLOCK_UNKNOWN" error
     // see https://github.com/ChainSafe/lodestar/issues/9475
     if (isForkPostGloas(fork)) {
       chain.seenPayloadEnvelopeInputCache.add({
@@ -227,7 +227,8 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       if (e instanceof BlockGossipError) {
         logger.debug("Gossip block has error", {slot, root: blockShortHex, code: e.type.code});
         if (
-          (e.type.code === BlockErrorCode.PARENT_UNKNOWN || e.type.code === BlockErrorCode.PARENT_PAYLOAD_UNKNOWN) &&
+          (e.type.code === BlockErrorCode.PARENT_BLOCK_UNKNOWN ||
+            e.type.code === BlockErrorCode.PARENT_PAYLOAD_UNKNOWN) &&
           blockInput
         ) {
           chain.emitter.emit(ChainEvent.blockUnknownParent, {
@@ -661,9 +662,9 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
               break;
             }
             // ALREADY_KNOWN should not happen with ignoreIfKnown=true above
-            // PARENT_UNKNOWN should not happen, we handled this in validateBeaconBlock() function above
+            // PARENT_BLOCK_UNKNOWN should not happen, we handled this in validateBeaconBlock() function above
             case BlockErrorCode.ALREADY_KNOWN:
-            case BlockErrorCode.PARENT_UNKNOWN:
+            case BlockErrorCode.PARENT_BLOCK_UNKNOWN:
             case BlockErrorCode.PRESTATE_MISSING:
             case BlockErrorCode.EXECUTION_ENGINE_ERROR:
               // Errors might indicate an issue with our node or the connected EL client

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -819,7 +819,7 @@ export class BlockInputSync {
           // case BlockErrorCode.ALREADY_KNOWN:
           // case BlockErrorCode.GENESIS_BLOCK:
 
-          case BlockErrorCode.PARENT_UNKNOWN:
+          case BlockErrorCode.PARENT_BLOCK_UNKNOWN:
           case BlockErrorCode.PRESTATE_MISSING:
             // Should not happen, mark as downloaded to try again latter
             this.logger.debug("Attempted to process block but its parent was still unknown", errorData, res.err);

--- a/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
@@ -205,7 +205,8 @@ describe("sync / unknown block sync thru gloas", () => {
             loggerNodeB.info("Error processing block", {slot: headInput.slot, code: e.type.code});
             if (
               e instanceof BlockError &&
-              (e.type.code === BlockErrorCode.PARENT_UNKNOWN || e.type.code === BlockErrorCode.PARENT_PAYLOAD_UNKNOWN)
+              (e.type.code === BlockErrorCode.PARENT_BLOCK_UNKNOWN ||
+                e.type.code === BlockErrorCode.PARENT_PAYLOAD_UNKNOWN)
             ) {
               // Expected
               bn2.chain.emitter.emit(ChainEvent.blockUnknownParent, {

--- a/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from "vitest";
 import {createChainForkConfig} from "@lodestar/config";
 import {chainConfig} from "@lodestar/config/default";
+import {ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName} from "@lodestar/params";
 import {SignedBeaconBlock, Slot, gloas, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
@@ -82,7 +83,7 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment with 
     );
   });
 
-  it("throws PARENT_PAYLOAD_UNKNOWN when FULL envelope's payload hash does not match next block's bid parentBlockHash", () => {
+  it("throws NON_LINEAR_PAYLOAD_ROOTS when a mid-segment block's bid parentBlockHash does not match the previous block's FULL payload hash", () => {
     const firstExecHash = Buffer.alloc(32, 0x11);
     const correctNextExecHash = Buffer.alloc(32, 0x22);
     const mismatchedNextExecHash = Buffer.alloc(32, 0x99);
@@ -96,7 +97,7 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment with 
 
     expectThrowsLodestarError(
       () => assertLinearChainSegment(config, [bi1, bi2], envelopes, null),
-      BlockErrorCode.PARENT_PAYLOAD_UNKNOWN
+      BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS
     );
   });
 
@@ -128,5 +129,39 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment with 
 
     const {warnings} = assertLinearChainSegment(config, [bi1, bi2], envelopes, null);
     expect(warnings).toBe(null);
+  });
+});
+
+describe("chain / blocks / utils / chainSegment / assertLinearChainSegment boundary (parentBlock provided)", () => {
+  const config = createChainForkConfig({...chainConfig, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
+  const seenTimestampSec = Date.now() / 1000;
+
+  function gloasBlockInput(slot: Slot, parentRoot: Uint8Array, bidParentBlockHash: Uint8Array): BlockInputNoData {
+    const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+    block.message.slot = slot;
+    block.message.parentRoot = parentRoot;
+    block.message.body.signedExecutionPayloadBid.message.parentBlockHash = bidParentBlockHash;
+    const blockRootHex = toRootHex(ssz.gloas.BeaconBlock.hashTreeRoot(block.message));
+    return BlockInputNoData.createFromBlock({
+      block: block as SignedBeaconBlock<typeof ForkName.gloas>,
+      blockRootHex,
+      forkName: ForkName.gloas,
+      daOutOfRange: false,
+      seenTimestampSec,
+      source: BlockInputSource.byRange,
+      peerIdStr: "peer",
+    });
+  }
+
+  it("throws PARENT_PAYLOAD_UNKNOWN when the first block's bid parentBlockHash mismatches the fork-choice parent (i === 0)", () => {
+    const parentExecHash = Buffer.alloc(32, 0x11);
+    const mismatchedBidHash = Buffer.alloc(32, 0x22);
+    const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), mismatchedBidHash);
+    const parentBlock = {slot: 9, executionPayloadBlockHash: toRootHex(parentExecHash)} as unknown as ProtoBlock;
+
+    expectThrowsLodestarError(
+      () => assertLinearChainSegment(config, [bi1], null, parentBlock),
+      BlockErrorCode.PARENT_PAYLOAD_UNKNOWN
+    );
   });
 });

--- a/packages/beacon-node/test/unit/chain/blocks/verifyBlocksSanityChecks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyBlocksSanityChecks.test.ts
@@ -37,11 +37,11 @@ describe("chain / blocks / verifyBlocksSanityChecks", () => {
     forkChoice.getBlockHexDefaultStatus.mockReturnValue({} as ProtoBlock);
   });
 
-  it("PARENT_UNKNOWN", () => {
+  it("PARENT_BLOCK_UNKNOWN", () => {
     forkChoice.getBlockHexDefaultStatus.mockReturnValue(null);
     expectThrowsLodestarError(
       () => verifyBlocksSanityChecks(modules, [block], null, {}),
-      BlockErrorCode.PARENT_UNKNOWN
+      BlockErrorCode.PARENT_BLOCK_UNKNOWN
     );
   });
 

--- a/packages/beacon-node/test/unit/chain/validation/block.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/block.test.ts
@@ -106,7 +106,7 @@ describe("gossip block validation", () => {
     );
   });
 
-  it("PARENT_UNKNOWN (fork-choice)", async () => {
+  it("PARENT_BLOCK_UNKNOWN (fork-choice)", async () => {
     // Return not known for proposed block
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce(null);
     // Return not known for parent block too
@@ -114,7 +114,7 @@ describe("gossip block validation", () => {
 
     await expectRejectedWithLodestarError(
       validateGossipBlock(config, chain, job, ForkName.phase0),
-      BlockErrorCode.PARENT_UNKNOWN
+      BlockErrorCode.PARENT_BLOCK_UNKNOWN
     );
   });
 
@@ -130,7 +130,7 @@ describe("gossip block validation", () => {
     );
   });
 
-  it("PARENT_UNKNOWN (regen)", async () => {
+  it("PARENT_BLOCK_UNKNOWN (regen)", async () => {
     // Return not known for proposed block
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce(null);
     // Returned parent block is latter than proposed block
@@ -140,7 +140,7 @@ describe("gossip block validation", () => {
 
     await expectRejectedWithLodestarError(
       validateGossipBlock(config, chain, job, ForkName.phase0),
-      BlockErrorCode.PARENT_UNKNOWN
+      BlockErrorCode.PARENT_BLOCK_UNKNOWN
     );
   });
 

--- a/packages/cli/test/utils/crucible/utils/syncing.ts
+++ b/packages/cli/test/utils/crucible/utils/syncing.ts
@@ -166,12 +166,15 @@ export async function assertUnknownBlockSync(env: Simulation): Promise<void> {
     });
   } catch (error) {
     const errorMessage = (error as Error).message;
-    // BLOCK_ERROR_PARENT_UNKNOWN is the expected response when the node hasn't seen this block yet.
+    // BLOCK_ERROR_PARENT_BLOCK_UNKNOWN is the expected response when the node hasn't seen this block yet.
     // BLOCK_ERROR_ALREADY_KNOWN can occur if the block propagates via gossip from connected peers
     // before the manual publish, which is a valid outcome — the node has the block either way.
-    if (!errorMessage.includes("BLOCK_ERROR_PARENT_UNKNOWN") && !errorMessage.includes("BLOCK_ERROR_ALREADY_KNOWN")) {
+    if (
+      !errorMessage.includes("BLOCK_ERROR_PARENT_BLOCK_UNKNOWN") &&
+      !errorMessage.includes("BLOCK_ERROR_ALREADY_KNOWN")
+    ) {
       env.tracker.record({
-        message: `Publishing unknown block should return "BLOCK_ERROR_PARENT_UNKNOWN" or "BLOCK_ERROR_ALREADY_KNOWN" got "${errorMessage}"`,
+        message: `Publishing unknown block should return "BLOCK_ERROR_PARENT_BLOCK_UNKNOWN" or "BLOCK_ERROR_ALREADY_KNOWN" got "${errorMessage}"`,
         slot: env.clock.currentSlot,
         assertionId: "unknownBlockParent",
       });


### PR DESCRIPTION
**Motivation**

- if an error is thrown in `assertLinearChainSegment()`, range sync wants to know if it's an error of this own batch, or previous batch

**Description**

- separate to 2 types of errors: `PARENT_UNKNOWN` means the parent block/payload of previous batch was not available in forkchoice, vs `NON_LINEAR` error, meaning one cannot link to another within this batch
- new `NON_LINEAR_PAYLOAD_ROOTS` for that purpose
- refactor `PARENT_UNKNOWN` to `PARENT_BLOCK_UNKNOWN` to distinguish to `PARENT_PAYLOAD_UNKNOWN`

part of #9667

**AI Assistance Disclosure**

- created with the help of Claude
