### PR TITLE
fix: split execution engine errors

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -201,7 +201,7 @@ export async function verifyBlockExecutionPayload(
         invalidateFromParentBlockHash: toRootHex(executionPayloadEnabled.parentHash),
       };
       const execError = new BlockError(block, {
-        code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
+        code: BlockErrorCode.EXECUTION_ENGINE_INVALID,
         execStatus: execResult.status,
         errorMessage: execResult.validationError ?? "",
       });

--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -61,6 +61,12 @@ export enum BlockErrorCode {
   TRANSACTIONS_TOO_BIG = "BLOCK_ERROR_TRANSACTIONS_TOO_BIG",
   /** Execution engine is unavailable, syncing, or api call errored. Peers must not be downscored on this code */
   EXECUTION_ENGINE_ERROR = "BLOCK_ERROR_EXECUTION_ERROR",
+  /**
+   * Execution engine returned a definitive INVALID verdict on the payload. Unlike
+   * EXECUTION_ENGINE_ERROR this is evidence about the data itself, not a local malfunction, so
+   * whoever served the block MAY be downscored. Mirrors PayloadErrorCode.EXECUTION_ENGINE_INVALID.
+   */
+  EXECUTION_ENGINE_INVALID = "BLOCK_ERROR_EXECUTION_INVALID",
   /** The blobs are unavailable */
   DATA_UNAVAILABLE = "BLOCK_ERROR_DATA_UNAVAILABLE",
   /** Block contains too many kzg commitments */
@@ -81,6 +87,15 @@ type ExecutionErrorStatus = Exclude<
   ExecutionPayloadStatus,
   ExecutionPayloadStatus.VALID | ExecutionPayloadStatus.ACCEPTED | ExecutionPayloadStatus.SYNCING
 >;
+
+/**
+ * Statuses where the execution engine could NOT render a verdict on the payload: it is unreachable
+ * (UNAVAILABLE), errored (ELERROR), or returned a malformed/client-specific response
+ * (INVALID_BLOCK_HASH, dropped from engine_newPayloadV2+). None of these are evidence about the
+ * data, so peers must not be downscored on them. A definitive INVALID carries
+ * BlockErrorCode.EXECUTION_ENGINE_INVALID instead.
+ */
+type ExecutionEngineErrorStatus = Exclude<ExecutionErrorStatus, ExecutionPayloadStatus.INVALID>;
 
 export type BlockErrorType =
   | {code: BlockErrorCode.PRESTATE_MISSING; error: Error}
@@ -116,7 +131,12 @@ export type BlockErrorType =
   | {code: BlockErrorCode.TOO_MUCH_GAS_USED; gasUsed: number; gasLimit: number}
   | {code: BlockErrorCode.SAME_PARENT_HASH; blockHash: RootHex}
   | {code: BlockErrorCode.TRANSACTIONS_TOO_BIG; size: number; max: number}
-  | {code: BlockErrorCode.EXECUTION_ENGINE_ERROR; execStatus: ExecutionErrorStatus; errorMessage: string}
+  | {code: BlockErrorCode.EXECUTION_ENGINE_ERROR; execStatus: ExecutionEngineErrorStatus; errorMessage: string}
+  | {
+      code: BlockErrorCode.EXECUTION_ENGINE_INVALID;
+      execStatus: ExecutionPayloadStatus.INVALID;
+      errorMessage: string;
+    }
   | {code: BlockErrorCode.DATA_UNAVAILABLE}
   | {code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS; blobKzgCommitmentsLen: number; commitmentLimit: number}
   | {code: BlockErrorCode.BID_PARENT_ROOT_MISMATCH; bidParentRoot: RootHex; blockParentRoot: RootHex}

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -666,8 +666,13 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
             case BlockErrorCode.PARENT_UNKNOWN:
             case BlockErrorCode.PRESTATE_MISSING:
             case BlockErrorCode.EXECUTION_ENGINE_ERROR:
-              // Errors might indicate an issue with our node or the connected EL client
+              // Errors might indicate an issue with our node or the connected EL client.
               logLevel = LogLevel.error;
+              break;
+            case BlockErrorCode.EXECUTION_ENGINE_INVALID:
+              // the peer served a bad block
+              core.reportPeer(peerIdStr, PeerAction.LowToleranceError, "ExecutionEngineInvalid");
+              logLevel = LogLevel.warn;
               break;
             default:
               // TODO: Should it use PeerId or string?

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -841,8 +841,14 @@ export class BlockInputSync {
 
           case BlockErrorCode.EXECUTION_ENGINE_ERROR:
             // Removing the block(s) without penalizing the peers, hoping for EL to
-            // recover on a latter download + verify attempt
+            // recover on a latter download + verify attempt.
             this.removeAllDescendants(pendingBlock);
+            break;
+
+          case BlockErrorCode.EXECUTION_ENGINE_INVALID:
+            // the peer served a bad block
+            this.logger.debug("Execution engine rejected block from unknown parent sync", errorData, res.err);
+            this.removeAndDownScoreAllDescendants(pendingBlock);
             break;
 
           default:

--- a/packages/beacon-node/test/unit/network/processor/gossipHandlers.test.ts
+++ b/packages/beacon-node/test/unit/network/processor/gossipHandlers.test.ts
@@ -1,0 +1,155 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {BeaconConfig, createBeaconConfig} from "@lodestar/config";
+import {config as defaultConfig} from "@lodestar/config/default";
+import {testLogger} from "@lodestar/logger/test-utils";
+import {ForkName} from "@lodestar/params";
+import {SignedBeaconBlock, ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {BlockInputBlobs} from "../../../../src/chain/blocks/blockInput/blockInput.js";
+import {BlockInputSource} from "../../../../src/chain/blocks/blockInput/types.js";
+import {BlockError, BlockErrorCode} from "../../../../src/chain/errors/blockError.js";
+import {ChainEventEmitter, IBeaconChain} from "../../../../src/chain/index.js";
+import {SeenBlockInput} from "../../../../src/chain/seenCache/seenGossipBlockInput.js";
+import {validateGossipBlock} from "../../../../src/chain/validation/index.js";
+import {ExecutionPayloadStatus} from "../../../../src/execution/index.js";
+import {INetworkCore} from "../../../../src/network/core/index.js";
+import {NetworkEventBus} from "../../../../src/network/events.js";
+import {GossipType, SequentialGossipHandler} from "../../../../src/network/gossip/interface.js";
+import {PeerAction} from "../../../../src/network/peers/index.js";
+import {AggregatorTracker} from "../../../../src/network/processor/aggregatorTracker.js";
+import {getGossipHandlers} from "../../../../src/network/processor/gossipHandlers.js";
+import {CustodyConfig} from "../../../../src/util/dataColumns.js";
+import {PeerIdStr} from "../../../../src/util/peerId.js";
+import {ClockStopped} from "../../../mocks/clock.js";
+
+vi.mock("../../../../src/chain/validation/index.js", async (importActual) => {
+  const mod = await importActual<typeof import("../../../../src/chain/validation/index.js")>();
+  return {
+    ...mod,
+    validateGossipBlock: vi.fn(),
+  };
+});
+
+describe("getGossipHandlers", () => {
+  const denebConfig = createBeaconConfig(
+    {
+      ...defaultConfig,
+      ALTAIR_FORK_EPOCH: 0,
+      BELLATRIX_FORK_EPOCH: 0,
+      CAPELLA_FORK_EPOCH: 0,
+      DENEB_FORK_EPOCH: 0,
+      ELECTRA_FORK_EPOCH: Infinity,
+      FULU_FORK_EPOCH: Infinity,
+      GLOAS_FORK_EPOCH: Infinity,
+    },
+    Buffer.alloc(32, 0)
+  );
+
+  beforeEach(() => {
+    vi.mocked(validateGossipBlock).mockResolvedValue({skippedSlots: 0});
+  });
+
+  it("does not report the gossip peer when block processing hits an execution engine error", async () => {
+    const {core} = await runBeaconBlockProcessingError(denebConfig, BlockErrorCode.EXECUTION_ENGINE_ERROR);
+
+    expect(core.reportPeer).not.toHaveBeenCalled();
+  });
+
+  it("reports the gossip peer when block processing gets a definitive execution INVALID verdict", async () => {
+    const {core, peerIdStr} = await runBeaconBlockProcessingError(denebConfig, BlockErrorCode.EXECUTION_ENGINE_INVALID);
+
+    expect(core.reportPeer).toHaveBeenCalledOnce();
+    expect(core.reportPeer).toHaveBeenCalledWith(peerIdStr, PeerAction.LowToleranceError, "ExecutionEngineInvalid");
+  });
+});
+
+async function runBeaconBlockProcessingError(
+  config: BeaconConfig,
+  code: BlockErrorCode.EXECUTION_ENGINE_ERROR | BlockErrorCode.EXECUTION_ENGINE_INVALID
+): Promise<{
+  core: Pick<INetworkCore, "reportPeer">;
+  peerIdStr: PeerIdStr;
+}> {
+  const logger = testLogger();
+  const peerIdStr = "16Uiu2HAmTestGossipPeer" as PeerIdStr;
+  const signedBlock = ssz.deneb.SignedBeaconBlock.defaultValue();
+  signedBlock.message.slot = 1;
+  const blockRootHex = toRootHex(ssz.deneb.BeaconBlock.hashTreeRoot(signedBlock.message));
+  const blockInput = BlockInputBlobs.createFromBlock({
+    block: signedBlock,
+    blockRootHex,
+    forkName: ForkName.deneb,
+    daOutOfRange: false,
+    source: BlockInputSource.gossip,
+    seenTimestampSec: 0,
+    peerIdStr,
+  });
+  const error = getExecutionBlockError(signedBlock, code);
+  const core = {reportPeer: vi.fn()} as Pick<INetworkCore, "reportPeer">;
+  const chain = {
+    clock: new ClockStopped(1),
+    custodyConfig: {sampledColumns: [], custodyColumns: []} as unknown as CustodyConfig,
+    emitter: new ChainEventEmitter(),
+    getBlobsTracker: {triggerGetBlobs: vi.fn()},
+    logger,
+    processBlock: vi.fn().mockRejectedValue(error),
+    seenBlockInputCache: {
+      getByBlock: vi.fn().mockReturnValue(blockInput),
+      prune: vi.fn(),
+    } as unknown as SeenBlockInput,
+    seenPayloadEnvelopeInputCache: {
+      add: vi.fn(),
+      get: vi.fn().mockReturnValue(undefined),
+      prune: vi.fn(),
+    } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
+    serializedCache: {set: vi.fn()},
+  } as unknown as IBeaconChain;
+
+  const handlers = getGossipHandlers(
+    {
+      aggregatorTracker: {} as AggregatorTracker,
+      chain,
+      config,
+      core: core as INetworkCore,
+      events: new NetworkEventBus(),
+      logger,
+      metrics: null,
+    },
+    {}
+  );
+  const beaconBlockHandler = handlers[GossipType.beacon_block] as SequentialGossipHandler<GossipType.beacon_block>;
+
+  await beaconBlockHandler({
+    gossipData: {
+      serializedData: ssz.deneb.SignedBeaconBlock.serialize(signedBlock),
+    },
+    peerIdStr,
+    seenTimestampSec: 0,
+    topic: {
+      boundary: {fork: ForkName.deneb, epoch: 0},
+      type: GossipType.beacon_block,
+    },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  return {core, peerIdStr};
+}
+
+function getExecutionBlockError(
+  signedBlock: SignedBeaconBlock<typeof ForkName.deneb>,
+  code: BlockErrorCode.EXECUTION_ENGINE_ERROR | BlockErrorCode.EXECUTION_ENGINE_INVALID
+): BlockError {
+  if (code === BlockErrorCode.EXECUTION_ENGINE_ERROR) {
+    return new BlockError(signedBlock, {
+      code,
+      execStatus: ExecutionPayloadStatus.ELERROR,
+      errorMessage: "execution engine offline",
+    });
+  }
+
+  return new BlockError(signedBlock, {
+    code,
+    execStatus: ExecutionPayloadStatus.INVALID,
+    errorMessage: "invalid payload",
+  });
+}

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -9,7 +9,7 @@ import {ForkName} from "@lodestar/params";
 import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
 import {SignedBeaconBlock, gloas, ssz} from "@lodestar/types";
 import {notNullish, sleep, toRootHex} from "@lodestar/utils";
-import {BlockInputNoData} from "../../../src/chain/blocks/blockInput/blockInput.js";
+import {BlockInputNoData, BlockInputPreData} from "../../../src/chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource, DAType, IBlockInput} from "../../../src/chain/blocks/blockInput/types.js";
 import {PayloadError, PayloadErrorCode} from "../../../src/chain/blocks/importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
@@ -624,6 +624,139 @@ describe("UnknownBlockSync", () => {
           expect(events.listenerCount(routes.events.EventType.executionPayload)).toBe(0);
           expect(service.isSubscribedToNetwork()).toBe(false);
         }
+      });
+    }
+  });
+
+  describe("block processing execution errors", () => {
+    const executionErrorCases = [
+      {
+        code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
+        error: (block: SignedBeaconBlock) =>
+          new BlockError(block, {
+            code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
+            execStatus: ExecutionPayloadStatus.ELERROR,
+            errorMessage: "execution engine offline",
+          }),
+        logsInvalidBranch: false,
+      },
+      {
+        code: BlockErrorCode.EXECUTION_ENGINE_INVALID,
+        error: (block: SignedBeaconBlock) =>
+          new BlockError(block, {
+            code: BlockErrorCode.EXECUTION_ENGINE_INVALID,
+            execStatus: ExecutionPayloadStatus.INVALID,
+            errorMessage: "invalid payload",
+          }),
+        logsInvalidBranch: true,
+      },
+    ];
+
+    for (const {code, error, logsInvalidBranch} of executionErrorCases) {
+      it(`handles ${code} without live unknown-block peer reporting`, async () => {
+        const peer = await getRandPeerIdStr();
+        const block = ssz.phase0.SignedBeaconBlock.defaultValue();
+        block.message.slot = 1;
+        block.message.parentRoot = Buffer.alloc(32, 0xaa);
+
+        const blockRoot = ssz.phase0.BeaconBlock.hashTreeRoot(block.message);
+        const blockRootHex = toRootHex(blockRoot);
+        const parentRootHex = toRootHex(block.message.parentRoot);
+        const networkEvents = new NetworkEventBus();
+        const reportPeer = vi.fn();
+
+        const networkForTest = {
+          events: networkEvents,
+          getConnectedPeers: () => [peer],
+          getConnectedPeerSyncMeta: () => ({
+            peerId: peer,
+            client: "execution-error-test-client",
+            custodyColumns: [],
+            earliestAvailableSlot: 0,
+          }),
+          custodyConfig: {sampledColumns: [], sampleGroups: [[]]} as unknown as CustodyConfig,
+          sendBeaconBlocksByRoot: vi.fn().mockResolvedValue([block]),
+          reportPeer,
+        } as unknown as INetwork;
+
+        const processBlock = vi.fn().mockRejectedValue(error(block));
+        const chainForTest = {
+          emitter: new ChainEventEmitter(),
+          clock: new ClockStopped(0),
+          forkChoice: {
+            hasBlockHex: vi.fn().mockImplementation((root: string) => root === parentRootHex),
+            hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
+            getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
+          } as unknown as IForkChoice,
+          genesisTime: 0,
+          custodyConfig: {sampledColumns: [], custodyColumns: []} as unknown as CustodyConfig,
+          processBlock,
+          seenBlockInputCache: {
+            getByBlock: ({
+              block,
+              blockRootHex,
+              seenTimestampSec,
+              source,
+              peerIdStr,
+            }: {
+              block: SignedBeaconBlock;
+              blockRootHex: string;
+              seenTimestampSec: number;
+              source: BlockInputSource;
+              peerIdStr?: PeerIdStr;
+            }) =>
+              BlockInputPreData.createFromBlock({
+                block,
+                blockRootHex,
+                forkName: ForkName.phase0,
+                daOutOfRange: false,
+                seenTimestampSec,
+                source,
+                peerIdStr,
+              }),
+            prune: vi.fn(),
+          } as unknown as SeenBlockInput,
+          seenBlockProposers: {isKnown: vi.fn().mockReturnValue(false)} as unknown as SeenBlockProposers,
+          seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
+            get: vi.fn().mockReturnValue(undefined),
+            prune: vi.fn(),
+          } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
+        } as unknown as IBeaconChain;
+
+        const debug = vi.fn();
+        const loggerForTest = Object.assign(Object.create(logger), {debug}) as typeof logger;
+        service = new BlockInputSync(
+          minimalConfig,
+          networkForTest,
+          chainForTest,
+          loggerForTest,
+          null,
+          defaultSyncOptions
+        );
+        service.subscribeToNetwork();
+
+        networkEvents.emit(NetworkEvent.peerConnected, {
+          peer,
+          status: {} as never,
+          custodyColumns: [],
+          clientAgent: "execution-error-test-client",
+        });
+        chainForTest.emitter.emit(ChainEvent.unknownBlockRoot, {
+          rootHex: blockRootHex,
+          peer,
+          source: BlockInputSource.gossip,
+        });
+
+        await sleep(20);
+
+        expect(processBlock).toHaveBeenCalledOnce();
+        expect(reportPeer).not.toHaveBeenCalled();
+        expect(
+          debug.mock.calls.some(([message]) => message === "Execution engine rejected block from unknown parent sync")
+        ).toBe(logsInvalidBranch);
+
+        service.close();
       });
     }
   });


### PR DESCRIPTION
**Motivation**

- when `EXECUTION_ENGINE_ERRORS` range sync wants to know if it's EL unavailable, or the payload is invalid in order to handle retry/penalize peers appropriately

**Description**

Split execution payload processing failures into:
- `EXECUTION_ENGINE_ERROR`: EL unavailable, errored, or malformed response
- `EXECUTION_ENGINE_INVALID`: EL `INVALID` verdict, peer-attributable

part of #9667

**AI Assistance Disclosure**

- created with the help of Claude