### PR TITLE
fix: validate proposer preferences dependent root

### DIFF
--- a/packages/beacon-node/src/chain/errors/proposerPreferences.ts
+++ b/packages/beacon-node/src/chain/errors/proposerPreferences.ts
@@ -32,7 +32,7 @@ export type ProposerPreferencesErrorType =
       code: ProposerPreferencesErrorCode.INVALID_DEPENDENT_ROOT_SLOT;
       dependentRoot: RootHex;
       dependentBlockSlot: Slot;
-      dependentRootPivotSlot: Slot;
+      dependentRootSlot: Slot;
       dependentEpoch: Epoch;
     }
   | {

--- a/packages/beacon-node/src/chain/errors/proposerPreferences.ts
+++ b/packages/beacon-node/src/chain/errors/proposerPreferences.ts
@@ -1,10 +1,12 @@
-import {RootHex, Slot, ValidatorIndex} from "@lodestar/types";
+import {Epoch, RootHex, Slot, ValidatorIndex} from "@lodestar/types";
 import {GossipActionError} from "./gossipValidation.js";
 
 export enum ProposerPreferencesErrorCode {
   INVALID_EPOCH = "PROPOSER_PREFERENCES_ERROR_INVALID_EPOCH",
   PROPOSAL_SLOT_PASSED = "PROPOSER_PREFERENCES_ERROR_PROPOSAL_SLOT_PASSED",
   UNKNOWN_DEPENDENT_ROOT = "PROPOSER_PREFERENCES_ERROR_UNKNOWN_DEPENDENT_ROOT",
+  INVALID_DEPENDENT_ROOT_SLOT = "PROPOSER_PREFERENCES_ERROR_INVALID_DEPENDENT_ROOT_SLOT",
+  INVALID_DEPENDENT_ROOT = "PROPOSER_PREFERENCES_ERROR_INVALID_DEPENDENT_ROOT",
   INVALID_PROPOSER = "PROPOSER_PREFERENCES_ERROR_INVALID_PROPOSER",
   ALREADY_KNOWN = "PROPOSER_PREFERENCES_ERROR_ALREADY_KNOWN",
   INVALID_SIGNATURE = "PROPOSER_PREFERENCES_ERROR_INVALID_SIGNATURE",
@@ -25,6 +27,18 @@ export type ProposerPreferencesErrorType =
       code: ProposerPreferencesErrorCode.UNKNOWN_DEPENDENT_ROOT;
       proposalSlot: Slot;
       dependentRoot: RootHex;
+    }
+  | {
+      code: ProposerPreferencesErrorCode.INVALID_DEPENDENT_ROOT_SLOT;
+      dependentRoot: RootHex;
+      dependentRootSlot: Slot;
+      dependentEpoch: Epoch;
+    }
+  | {
+      code: ProposerPreferencesErrorCode.INVALID_DEPENDENT_ROOT;
+      dependentRoot: RootHex;
+      dependentRootSlot: Slot;
+      dependentEpoch: Epoch;
     }
   | {
       code: ProposerPreferencesErrorCode.INVALID_PROPOSER;

--- a/packages/beacon-node/src/chain/errors/proposerPreferences.ts
+++ b/packages/beacon-node/src/chain/errors/proposerPreferences.ts
@@ -31,13 +31,14 @@ export type ProposerPreferencesErrorType =
   | {
       code: ProposerPreferencesErrorCode.INVALID_DEPENDENT_ROOT_SLOT;
       dependentRoot: RootHex;
-      dependentRootSlot: Slot;
+      dependentBlockSlot: Slot;
+      dependentRootPivotSlot: Slot;
       dependentEpoch: Epoch;
     }
   | {
       code: ProposerPreferencesErrorCode.INVALID_DEPENDENT_ROOT;
       dependentRoot: RootHex;
-      dependentRootSlot: Slot;
+      dependentBlockSlot: Slot;
       dependentEpoch: Epoch;
     }
   | {

--- a/packages/beacon-node/src/chain/validation/proposerPreferences.ts
+++ b/packages/beacon-node/src/chain/validation/proposerPreferences.ts
@@ -1,12 +1,12 @@
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
-import {MIN_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {GENESIS_SLOT, MIN_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   createSingleSignatureSetFromComponents,
   getProposerPreferencesSigningRoot,
 } from "@lodestar/state-transition";
-import {Epoch, ValidatorIndex, gloas} from "@lodestar/types";
+import {Epoch, Slot, ValidatorIndex, gloas} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {GossipAction, ProposerPreferencesError, ProposerPreferencesErrorCode} from "../errors/index.js";
 import {IBeaconChain} from "../index.js";
@@ -56,11 +56,11 @@ export async function validateGossipProposerPreferences(
   }
 
   const dependentEpoch = proposalEpoch - MIN_SEED_LOOKAHEAD;
-  const dependentEpochStartSlot = computeStartSlotAtEpoch(dependentEpoch);
+  const dependentRootSlot = getDependentRootSlot(dependentEpoch);
 
   // [REJECT] The slot of the block with root `preferences.dependent_root` is strictly less than
   // `compute_start_slot_at_epoch(compute_epoch_at_slot(preferences.proposal_slot) - MIN_SEED_LOOKAHEAD)`.
-  if (dependentBlock.slot >= dependentEpochStartSlot) {
+  if (dependentBlock.slot > dependentRootSlot) {
     throw new ProposerPreferencesError(GossipAction.REJECT, {
       code: ProposerPreferencesErrorCode.INVALID_DEPENDENT_ROOT_SLOT,
       dependentRoot: dependentRootHex,
@@ -162,7 +162,7 @@ export async function validateGossipProposerPreferences(
  */
 export function isValidDependentRoot(forkChoice: IForkChoice, dependentBlock: ProtoBlock, epoch: Epoch): boolean {
   const epochStartSlot = computeStartSlotAtEpoch(epoch);
-  if (dependentBlock.slot >= epochStartSlot) {
+  if (dependentBlock.slot > getDependentRootSlot(epoch)) {
     return false;
   }
 
@@ -173,4 +173,9 @@ export function isValidDependentRoot(forkChoice: IForkChoice, dependentBlock: Pr
   }
 
   return dependentBlock.blockRoot === forkChoice.getHeadRoot();
+}
+
+/** Return the target slot used to select a dependent root for `epoch`, clamped to genesis. */
+function getDependentRootSlot(epoch: Epoch): Slot {
+  return Math.max(GENESIS_SLOT, computeStartSlotAtEpoch(epoch) - 1);
 }

--- a/packages/beacon-node/src/chain/validation/proposerPreferences.ts
+++ b/packages/beacon-node/src/chain/validation/proposerPreferences.ts
@@ -56,15 +56,16 @@ export async function validateGossipProposerPreferences(
   }
 
   const dependentEpoch = proposalEpoch - MIN_SEED_LOOKAHEAD;
-  const dependentRootSlot = getDependentRootSlot(dependentEpoch);
+  const dependentRootPivotSlot = getDependentRootPivotSlot(dependentEpoch);
 
   // [REJECT] The slot of the block with root `preferences.dependent_root` is strictly less than
   // `compute_start_slot_at_epoch(compute_epoch_at_slot(preferences.proposal_slot) - MIN_SEED_LOOKAHEAD)`.
-  if (dependentBlock.slot > dependentRootSlot) {
+  if (dependentBlock.slot > dependentRootPivotSlot) {
     throw new ProposerPreferencesError(GossipAction.REJECT, {
       code: ProposerPreferencesErrorCode.INVALID_DEPENDENT_ROOT_SLOT,
       dependentRoot: dependentRootHex,
-      dependentRootSlot: dependentBlock.slot,
+      dependentBlockSlot: dependentBlock.slot,
+      dependentRootPivotSlot,
       dependentEpoch,
     });
   }
@@ -75,7 +76,7 @@ export async function validateGossipProposerPreferences(
     throw new ProposerPreferencesError(GossipAction.IGNORE, {
       code: ProposerPreferencesErrorCode.INVALID_DEPENDENT_ROOT,
       dependentRoot: dependentRootHex,
-      dependentRootSlot: dependentBlock.slot,
+      dependentBlockSlot: dependentBlock.slot,
       dependentEpoch,
     });
   }
@@ -162,7 +163,7 @@ export async function validateGossipProposerPreferences(
  */
 export function isValidDependentRoot(forkChoice: IForkChoice, dependentBlock: ProtoBlock, epoch: Epoch): boolean {
   const epochStartSlot = computeStartSlotAtEpoch(epoch);
-  if (dependentBlock.slot > getDependentRootSlot(epoch)) {
+  if (dependentBlock.slot > getDependentRootPivotSlot(epoch)) {
     return false;
   }
 
@@ -175,7 +176,7 @@ export function isValidDependentRoot(forkChoice: IForkChoice, dependentBlock: Pr
   return dependentBlock.blockRoot === forkChoice.getHeadRoot();
 }
 
-/** Return the target slot used to select a dependent root for `epoch`, clamped to genesis. */
-function getDependentRootSlot(epoch: Epoch): Slot {
+/** Return the pivot slot used to select a dependent root for `epoch`, clamped to genesis. */
+function getDependentRootPivotSlot(epoch: Epoch): Slot {
   return Math.max(GENESIS_SLOT, computeStartSlotAtEpoch(epoch) - 1);
 }

--- a/packages/beacon-node/src/chain/validation/proposerPreferences.ts
+++ b/packages/beacon-node/src/chain/validation/proposerPreferences.ts
@@ -56,16 +56,16 @@ export async function validateGossipProposerPreferences(
   }
 
   const dependentEpoch = proposalEpoch - MIN_SEED_LOOKAHEAD;
-  const dependentRootPivotSlot = getDependentRootPivotSlot(dependentEpoch);
+  const dependentRootSlot = getDependentRootSlot(dependentEpoch);
 
   // [REJECT] The slot of the block with root `preferences.dependent_root` is strictly less than
   // `compute_start_slot_at_epoch(compute_epoch_at_slot(preferences.proposal_slot) - MIN_SEED_LOOKAHEAD)`.
-  if (dependentBlock.slot > dependentRootPivotSlot) {
+  if (dependentBlock.slot > dependentRootSlot) {
     throw new ProposerPreferencesError(GossipAction.REJECT, {
       code: ProposerPreferencesErrorCode.INVALID_DEPENDENT_ROOT_SLOT,
       dependentRoot: dependentRootHex,
       dependentBlockSlot: dependentBlock.slot,
-      dependentRootPivotSlot,
+      dependentRootSlot,
       dependentEpoch,
     });
   }
@@ -163,7 +163,7 @@ export async function validateGossipProposerPreferences(
  */
 export function isValidDependentRoot(forkChoice: IForkChoice, dependentBlock: ProtoBlock, epoch: Epoch): boolean {
   const epochStartSlot = computeStartSlotAtEpoch(epoch);
-  if (dependentBlock.slot > getDependentRootPivotSlot(epoch)) {
+  if (dependentBlock.slot > getDependentRootSlot(epoch)) {
     return false;
   }
 
@@ -176,7 +176,7 @@ export function isValidDependentRoot(forkChoice: IForkChoice, dependentBlock: Pr
   return dependentBlock.blockRoot === forkChoice.getHeadRoot();
 }
 
-/** Return the pivot slot used to select a dependent root for `epoch`, clamped to genesis. */
-function getDependentRootPivotSlot(epoch: Epoch): Slot {
+/** Return the slot used to select a dependent root for `epoch`, clamped to genesis. */
+function getDependentRootSlot(epoch: Epoch): Slot {
   return Math.max(GENESIS_SLOT, computeStartSlotAtEpoch(epoch) - 1);
 }

--- a/packages/beacon-node/src/chain/validation/proposerPreferences.ts
+++ b/packages/beacon-node/src/chain/validation/proposerPreferences.ts
@@ -1,17 +1,19 @@
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
+import {MIN_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
   computeEpochAtSlot,
+  computeStartSlotAtEpoch,
   createSingleSignatureSetFromComponents,
   getProposerPreferencesSigningRoot,
 } from "@lodestar/state-transition";
-import {ValidatorIndex, gloas} from "@lodestar/types";
+import {Epoch, ValidatorIndex, gloas} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {GossipAction, ProposerPreferencesError, ProposerPreferencesErrorCode} from "../errors/index.js";
 import {IBeaconChain} from "../index.js";
 
 /**
  * Validates a gossiped `SignedProposerPreferences` per
- * https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md#proposer_preferences
+ * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/gloas/p2p-interface.md#new-proposer_preferences
  */
 export async function validateGossipProposerPreferences(
   chain: IBeaconChain,
@@ -22,9 +24,9 @@ export async function validateGossipProposerPreferences(
   const dependentRootHex = toRootHex(dependentRoot);
   const proposalEpoch = computeEpochAtSlot(proposalSlot);
 
-  // [IGNORE] `preferences.proposal_slot` is in the current or next epoch.
+  // [IGNORE] `preferences.proposal_slot` is within the proposer lookahead.
   const currentEpoch = chain.clock.currentEpoch;
-  if (proposalEpoch < currentEpoch || proposalEpoch > currentEpoch + 1) {
+  if (proposalEpoch < currentEpoch || proposalEpoch > currentEpoch + MIN_SEED_LOOKAHEAD) {
     throw new ProposerPreferencesError(GossipAction.IGNORE, {
       code: ProposerPreferencesErrorCode.INVALID_EPOCH,
       proposalSlot,
@@ -44,21 +46,55 @@ export async function validateGossipProposerPreferences(
   }
 
   // [IGNORE] The block with root `dependent_root` has been seen by the node.
+  const dependentBlock = chain.forkChoice.getBlockHexDefaultStatus(dependentRootHex);
+  if (dependentBlock === null) {
+    throw new ProposerPreferencesError(GossipAction.IGNORE, {
+      code: ProposerPreferencesErrorCode.UNKNOWN_DEPENDENT_ROOT,
+      proposalSlot,
+      dependentRoot: dependentRootHex,
+    });
+  }
+
+  const dependentEpoch = proposalEpoch - MIN_SEED_LOOKAHEAD;
+  const dependentEpochStartSlot = computeStartSlotAtEpoch(dependentEpoch);
+
+  // [REJECT] The slot of the block with root `preferences.dependent_root` is strictly less than
+  // `compute_start_slot_at_epoch(compute_epoch_at_slot(preferences.proposal_slot) - MIN_SEED_LOOKAHEAD)`.
+  if (dependentBlock.slot >= dependentEpochStartSlot) {
+    throw new ProposerPreferencesError(GossipAction.REJECT, {
+      code: ProposerPreferencesErrorCode.INVALID_DEPENDENT_ROOT_SLOT,
+      dependentRoot: dependentRootHex,
+      dependentRootSlot: dependentBlock.slot,
+      dependentEpoch,
+    });
+  }
+
+  // [IGNORE] `is_valid_dependent_root(store, preferences.dependent_root, epoch)` returns `True`,
+  // where `epoch` is `compute_epoch_at_slot(preferences.proposal_slot) - MIN_SEED_LOOKAHEAD`.
+  if (!isValidDependentRoot(chain.forkChoice, dependentBlock, dependentEpoch)) {
+    throw new ProposerPreferencesError(GossipAction.IGNORE, {
+      code: ProposerPreferencesErrorCode.INVALID_DEPENDENT_ROOT,
+      dependentRoot: dependentRootHex,
+      dependentRootSlot: dependentBlock.slot,
+      dependentEpoch,
+    });
+  }
+
   // Resolve the proposer lookahead for the message's branch via head state (fast path) or
   // the previous-root checkpoint state (populated by `processSlotsToNearestCheckpoint` for
-  // any imported branch crossing into `proposalEpoch - 1`). The head-state path also handles
+  // any imported branch crossing into `dependentEpoch`). The head-state path also handles
   // narrow timing windows where the checkpoint state isn't yet populated.
   const headState = chain.getHeadState();
   let proposers: ValidatorIndex[] | null = null;
   if (headState.epoch === proposalEpoch && headState.currentDecisionRoot === dependentRootHex) {
     proposers = headState.currentProposers;
-  } else if (headState.epoch === proposalEpoch - 1 && headState.nextDecisionRoot === dependentRootHex) {
+  } else if (headState.epoch === dependentEpoch && headState.nextDecisionRoot === dependentRootHex) {
     proposers = headState.nextProposers;
   } else {
     // Sync lookup only to not trigger disk reload from gossip input.
-    const checkpointState = chain.regen.getCheckpointStateSync({epoch: proposalEpoch - 1, rootHex: dependentRootHex});
+    const checkpointState = chain.regen.getCheckpointStateSync({epoch: dependentEpoch, rootHex: dependentRootHex});
     if (checkpointState !== null) {
-      // State is at `proposalEpoch - 1`, so proposers for `proposalSlot` (next epoch from
+      // State is at `dependentEpoch`, so proposers for `proposalSlot` (next epoch from
       // the state's perspective) live in `nextProposers`.
       proposers = checkpointState.nextProposers;
     }
@@ -117,4 +153,24 @@ export async function validateGossipProposerPreferences(
   }
 
   chain.proposerPreferencesPool.add(signedProposerPreferences);
+}
+
+/**
+ * Check whether `dependentBlock` is a viable shuffling-dependent root for `epoch`:
+ * it is before the epoch boundary and either has a direct child at or after
+ * the boundary, or is the current fork-choice head.
+ */
+export function isValidDependentRoot(forkChoice: IForkChoice, dependentBlock: ProtoBlock, epoch: Epoch): boolean {
+  const epochStartSlot = computeStartSlotAtEpoch(epoch);
+  if (dependentBlock.slot >= epochStartSlot) {
+    return false;
+  }
+
+  for (const block of forkChoice.getBlockSummariesByParentRoot(dependentBlock.blockRoot)) {
+    if (block.slot >= epochStartSlot) {
+      return true;
+    }
+  }
+
+  return dependentBlock.blockRoot === forkChoice.getHeadRoot();
 }


### PR DESCRIPTION
Reject proposer preferences if the dependent root is not strictly before the start of the lookahead epoch. Ignore dependent roots that neither have a direct child at or after the epoch boundary nor match the current fork-choice head.

see https://github.com/ethereum/consensus-specs/pull/5443