### PR TITLE
docs(cli): update Node version badge in README.md to 24.x

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,7 +3,7 @@
 [![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/aMxzVcr)
 [![Eth Consensus Spec v1.5.0](https://img.shields.io/badge/ETH%20consensus--spec-1.5.0-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.5.0)
 ![ES Version](https://img.shields.io/badge/ES-2021-yellow)
-![Node Version](https://img.shields.io/badge/node-12.x-green)
+![Node Version](https://img.shields.io/badge/node-24.x-green)
 
 > This package is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project
 


### PR DESCRIPTION
## Description
This PR updates the Node.js version badge in `packages/cli/README.md` to reflect the current repository engine requirement.

## Details
Updated `node-12.x` badge -> `node-24.x` to match `package.json`'s `engines.node` requirement (`^24.13.0`).