### PR TITLE
test: enable gloas fast_confirmation spec tests

### DIFF
--- a/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
+++ b/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
@@ -48,28 +48,28 @@ import {
   BlockInputNoData,
   BlockInputPreData,
   BlockInputSource,
-} from "../../../src/chain/blocks/blockInput/index.ts";
-import {AttestationImportOpt, BlobSidecarValidation} from "../../../src/chain/blocks/types.ts";
+} from "../../../src/chain/blocks/blockInput/index.js";
+import {AttestationImportOpt, BlobSidecarValidation} from "../../../src/chain/blocks/types.js";
 import {
   verifyExecutionPayloadEnvelope,
   verifyExecutionPayloadEnvelopeSignature,
-} from "../../../src/chain/blocks/verifyExecutionPayloadEnvelope.ts";
-import {BeaconChain, ChainEvent} from "../../../src/chain/index.ts";
-import {defaultChainOptions} from "../../../src/chain/options.ts";
-import {RegenCaller} from "../../../src/chain/regen/index.ts";
-import {validateFuluBlockDataColumnSidecars} from "../../../src/chain/validation/dataColumnSidecar.ts";
-import {ZERO_HASH_HEX} from "../../../src/constants/constants.ts";
-import {ExecutionPayloadStatus} from "../../../src/execution/engine/interface.ts";
-import {ExecutionEngineMockBackend} from "../../../src/execution/engine/mock.ts";
-import {getExecutionEngineFromBackend} from "../../../src/execution/index.ts";
-import {computePreFuluKzgCommitmentsInclusionProof} from "../../../src/util/blobs.ts";
-import {ClockEvent} from "../../../src/util/clock.ts";
-import {ClockStopped} from "../../mocks/clock.ts";
-import {getMockedBeaconDb} from "../../mocks/mockedBeaconDb.ts";
-import {assertCorrectProgressiveBalances} from "../config.ts";
-import {ethereumConsensusSpecsTests} from "../specTestVersioning.ts";
-import {specTestIterator} from "../utils/specTestIterator.ts";
-import {RunnerType, TestRunnerFn} from "../utils/types.ts";
+} from "../../../src/chain/blocks/verifyExecutionPayloadEnvelope.js";
+import {BeaconChain, ChainEvent} from "../../../src/chain/index.js";
+import {defaultChainOptions} from "../../../src/chain/options.js";
+import {RegenCaller} from "../../../src/chain/regen/index.js";
+import {validateFuluBlockDataColumnSidecars} from "../../../src/chain/validation/dataColumnSidecar.js";
+import {ZERO_HASH_HEX} from "../../../src/constants/constants.js";
+import {ExecutionPayloadStatus} from "../../../src/execution/engine/interface.js";
+import {ExecutionEngineMockBackend} from "../../../src/execution/engine/mock.js";
+import {getExecutionEngineFromBackend} from "../../../src/execution/index.js";
+import {computePreFuluKzgCommitmentsInclusionProof} from "../../../src/util/blobs.js";
+import {ClockEvent} from "../../../src/util/clock.js";
+import {ClockStopped} from "../../mocks/clock.js";
+import {getMockedBeaconDb} from "../../mocks/mockedBeaconDb.js";
+import {assertCorrectProgressiveBalances} from "../config.js";
+import {ethereumConsensusSpecsTests} from "../specTestVersioning.js";
+import {specTestIterator} from "../utils/specTestIterator.js";
+import {RunnerType, TestRunnerFn} from "../utils/types.js";
 
 const ANCHOR_STATE_FILE_NAME = "anchor_state";
 const ANCHOR_BLOCK_FILE_NAME = "anchor_block";

--- a/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
+++ b/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
@@ -26,6 +26,7 @@ import {
   createCachedBeaconState,
   createPubkeyCache,
   isExecutionStateType,
+  isGloasStateType,
   signedBlockToSignedHeader,
   syncPubkeys,
 } from "@lodestar/state-transition";
@@ -57,6 +58,7 @@ import {
 import {BeaconChain, ChainEvent} from "../../../src/chain/index.js";
 import {defaultChainOptions} from "../../../src/chain/options.js";
 import {RegenCaller} from "../../../src/chain/regen/index.js";
+import {getShufflingForAttestationVerification} from "../../../src/chain/validation/attestation.js";
 import {validateFuluBlockDataColumnSidecars} from "../../../src/chain/validation/dataColumnSidecar.js";
 import {ZERO_HASH_HEX} from "../../../src/constants/constants.js";
 import {ExecutionPayloadStatus} from "../../../src/execution/engine/interface.js";
@@ -64,6 +66,7 @@ import {ExecutionEngineMockBackend} from "../../../src/execution/engine/mock.js"
 import {getExecutionEngineFromBackend} from "../../../src/execution/index.js";
 import {computePreFuluKzgCommitmentsInclusionProof} from "../../../src/util/blobs.js";
 import {ClockEvent} from "../../../src/util/clock.js";
+import {getShufflingDependentRoot} from "../../../src/util/dependentRoot.js";
 import {ClockStopped} from "../../mocks/clock.js";
 import {getMockedBeaconDb} from "../../mocks/mockedBeaconDb.js";
 import {assertCorrectProgressiveBalances} from "../config.js";
@@ -97,9 +100,11 @@ const fastConfirmationTest =
         const clock = new ClockStopped(currentSlot);
         const executionEngineBackend = new ExecutionEngineMockBackend({
           onlyPredefinedResponses: opts.onlyPredefinedResponses,
-          genesisBlockHash: isExecutionStateType(anchorState)
-            ? toHexString(anchorState.latestExecutionPayloadHeader.blockHash)
-            : ZERO_HASH_HEX,
+          genesisBlockHash: isGloasStateType(anchorState)
+            ? toHexString(anchorState.latestBlockHash)
+            : isExecutionStateType(anchorState)
+              ? toHexString(anchorState.latestExecutionPayloadHeader.blockHash)
+              : ZERO_HASH_HEX,
         });
 
         const controller = new AbortController();
@@ -181,10 +186,25 @@ const fastConfirmationTest =
               logger.debug(`Step ${i}/${stepsLen} attestation`, {root: step.attestation, valid: Boolean(step.valid)});
               const attestation = testcase.attestations.get(step.attestation);
               if (!attestation) throw Error(`No attestation ${step.attestation}`);
-              const headState = chain.getHeadState();
               const attDataRootHex = toHexString(sszTypesFor(fork).AttestationData.hashTreeRoot(attestation.data));
               const attEpoch = computeEpochAtSlot(attestation.data.slot);
-              const decisionRoot = headState.getShufflingDecisionRoot(attEpoch);
+              const attHeadBlock = chain.forkChoice.getBlockHexDefaultStatus(toHex(attestation.data.beaconBlockRoot));
+              if (attHeadBlock === null) {
+                throw Error(`No attested block ${toHexString(attestation.data.beaconBlockRoot)}`);
+              }
+              const attHeadBlockEpoch = computeEpochAtSlot(attHeadBlock.slot);
+              const decisionRoot = getShufflingDependentRoot(
+                chain.forkChoice,
+                attEpoch,
+                attHeadBlockEpoch,
+                attHeadBlock
+              );
+              await getShufflingForAttestationVerification(
+                chain,
+                attEpoch,
+                attHeadBlock,
+                RegenCaller.validateGossipAttestation
+              );
               chain.forkChoice.onAttestation(
                 chain.shufflingCache.getIndexedAttestation(attEpoch, decisionRoot, ForkSeq[fork], attestation),
                 attDataRootHex

--- a/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
+++ b/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
@@ -4,7 +4,7 @@ import {expect} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
 import {createBeaconConfig} from "@lodestar/config";
 import {getConfig} from "@lodestar/config/test-utils";
-import {CheckpointWithHex, ForkChoice} from "@lodestar/fork-choice";
+import {CheckpointWithHex, ExecutionStatus, ForkChoice} from "@lodestar/fork-choice";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {
   ACTIVE_PRESET,
@@ -20,6 +20,8 @@ import {InputType} from "@lodestar/spec-test-util";
 import {
   BeaconStateAllForks,
   BeaconStateView,
+  DataAvailabilityStatus,
+  IBeaconStateViewGloas,
   computeEpochAtSlot,
   createCachedBeaconState,
   createPubkeyCache,
@@ -35,6 +37,7 @@ import {
   SignedBeaconBlock,
   deneb,
   fulu,
+  gloas,
   ssz,
   sszTypesFor,
 } from "@lodestar/types";
@@ -47,8 +50,13 @@ import {
   BlockInputSource,
 } from "../../../src/chain/blocks/blockInput/index.ts";
 import {AttestationImportOpt, BlobSidecarValidation} from "../../../src/chain/blocks/types.ts";
+import {
+  verifyExecutionPayloadEnvelope,
+  verifyExecutionPayloadEnvelopeSignature,
+} from "../../../src/chain/blocks/verifyExecutionPayloadEnvelope.ts";
 import {BeaconChain, ChainEvent} from "../../../src/chain/index.ts";
 import {defaultChainOptions} from "../../../src/chain/options.ts";
+import {RegenCaller} from "../../../src/chain/regen/index.ts";
 import {validateFuluBlockDataColumnSidecars} from "../../../src/chain/validation/dataColumnSidecar.ts";
 import {ZERO_HASH_HEX} from "../../../src/constants/constants.ts";
 import {ExecutionPayloadStatus} from "../../../src/execution/engine/interface.ts";
@@ -60,7 +68,7 @@ import {ClockStopped} from "../../mocks/clock.ts";
 import {getMockedBeaconDb} from "../../mocks/mockedBeaconDb.ts";
 import {assertCorrectProgressiveBalances} from "../config.ts";
 import {ethereumConsensusSpecsTests} from "../specTestVersioning.ts";
-import {defaultSkipOpts, specTestIterator} from "../utils/specTestIterator.ts";
+import {specTestIterator} from "../utils/specTestIterator.ts";
 import {RunnerType, TestRunnerFn} from "../utils/types.ts";
 
 const ANCHOR_STATE_FILE_NAME = "anchor_state";
@@ -70,6 +78,7 @@ const BLOBS_FILE_NAME = "^(blobs)_([0-9a-zA-Z]+)$";
 const COLUMN_FILE_NAME = "^(column)_([0-9a-zA-Z]+)$";
 const ATTESTATION_FILE_NAME = "^(attestation)_([0-9a-zA-Z])+$";
 const ATTESTER_SLASHING_FILE_NAME = "^(attester_slashing)_([0-9a-zA-Z])+$";
+const EXECUTION_PAYLOAD_ENVELOPE_FILE_NAME = "^(execution_payload_envelope)_([0-9a-zA-Z]+)$";
 
 const logger = testLogger("spec-test");
 
@@ -379,6 +388,68 @@ const fastConfirmationTest =
               }
             }
 
+            // execution_payload step for Gloas (ePBS) tests
+            else if (isExecutionPayload(step)) {
+              const isValid = Boolean(step.valid ?? true);
+              logger.debug(`Step ${i}/${stepsLen} execution_payload`, {
+                envelope: step.execution_payload,
+                valid: isValid,
+              });
+              const envelope = testcase.executionPayloadEnvelopes.get(step.execution_payload);
+              if (!envelope) throw Error(`No execution payload envelope ${step.execution_payload}`);
+
+              try {
+                const beaconBlockRoot = toHex(envelope.message.beaconBlockRoot);
+                const blockHash = toHex(envelope.message.payload.blockHash);
+                const blockNumber = envelope.message.payload.blockNumber;
+                const gasLimit = envelope.message.payload.gasLimit;
+
+                // Verify envelope against the state
+                const protoBlock = chain.forkChoice.getBlockHexDefaultStatus(beaconBlockRoot);
+                if (!protoBlock) throw Error(`Block not found for root ${beaconBlockRoot}`);
+                const blockState = await chain.regen.getBlockSlotState(
+                  protoBlock,
+                  protoBlock.slot,
+                  {dontTransferCache: true},
+                  RegenCaller.processBlock
+                );
+                verifyExecutionPayloadEnvelope(beaconConfig, blockState as IBeaconStateViewGloas, envelope.message);
+
+                // fast_confirmation vectors are generated with bls_setting=2 (signatures are not
+                // required to be valid), so only verify signatures when bls_setting=1.
+                if (testcase.meta?.bls_setting === BigInt(1)) {
+                  const sigValid = await verifyExecutionPayloadEnvelopeSignature(
+                    beaconConfig,
+                    blockState as IBeaconStateViewGloas,
+                    pubkeyCache,
+                    envelope,
+                    blockState.latestBlockHeader.proposerIndex,
+                    chain.bls
+                  );
+                  if (!sigValid) throw Error("Invalid execution payload envelope signature");
+                }
+
+                // Add predefined VALID status for the payload's block hash so the EL mock accepts it
+                executionEngineBackend.addPredefinedPayloadStatus(blockHash, {
+                  status: ExecutionPayloadStatus.VALID,
+                  latestValidHash: null,
+                  validationError: null,
+                });
+
+                (chain.forkChoice as ForkChoice).onExecutionPayload(
+                  beaconBlockRoot,
+                  blockHash,
+                  blockNumber,
+                  gasLimit,
+                  ExecutionStatus.Valid,
+                  DataAvailabilityStatus.Available
+                );
+                if (!isValid) throw Error("Expect error since this is a negative test");
+              } catch (e) {
+                if (isValid || (e as Error).message === "Expect error since this is a negative test") throw e;
+              }
+            }
+
             // Optional step for optimistic sync tests.
             else if (isOnPayloadInfoStep(step)) {
               logger.debug(`Step ${i}/${stepsLen} payload_status`, {blockHash: step.block_hash});
@@ -409,6 +480,16 @@ const fastConfirmationTest =
                   {slot: bnToNum(step.checks.head.slot), root: step.checks.head.root},
                   `Invalid head at step ${i}`
                 );
+                if (step.checks.head.payload_status !== undefined) {
+                  // Map our PayloadStatus enum to spec's numbering:
+                  // Spec: EMPTY=0, FULL=1, PENDING=2
+                  // Ours: PENDING=0, EMPTY=1, FULL=2
+                  const payloadStatusToSpec: Record<number, number> = {0: 2, 1: 0, 2: 1};
+                  expect(payloadStatusToSpec[head.payloadStatus]).toEqualWithMessage(
+                    bnToNum(step.checks.head.payload_status),
+                    `Invalid head payload status at step ${i}`
+                  );
+                }
               }
 
               if (step.checks.proposer_boost_root) {
@@ -518,12 +599,14 @@ const fastConfirmationTest =
           [COLUMN_FILE_NAME]: ssz.fulu.DataColumnSidecar,
           [ATTESTATION_FILE_NAME]: sszTypesFor(fork).Attestation,
           [ATTESTER_SLASHING_FILE_NAME]: sszTypesFor(fork).AttesterSlashing,
+          [EXECUTION_PAYLOAD_ENVELOPE_FILE_NAME]: ssz.gloas.SignedExecutionPayloadEnvelope,
         },
         mapToTestCase: (t: Record<string, any>) => {
           // t has input file name as key
           const blocks = new Map<string, SignedBeaconBlock>();
           const blobs = new Map<string, deneb.Blobs>();
           const columns = new Map<string, fulu.DataColumnSidecar>();
+          const executionPayloadEnvelopes = new Map<string, gloas.SignedExecutionPayloadEnvelope>();
           const attestations = new Map<string, Attestation>();
           const attesterSlashings = new Map<string, AttesterSlashing>();
           for (const key in t) {
@@ -540,6 +623,10 @@ const fastConfirmationTest =
             const columnMatch = key.match(COLUMN_FILE_NAME);
             if (columnMatch) {
               columns.set(key, t[key]);
+            }
+            const envelopeMatch = key.match(EXECUTION_PAYLOAD_ENVELOPE_FILE_NAME);
+            if (envelopeMatch) {
+              executionPayloadEnvelopes.set(key, t[key]);
             }
             const attMatch = key.match(ATTESTATION_FILE_NAME);
             if (attMatch) {
@@ -558,6 +645,7 @@ const fastConfirmationTest =
             blocks,
             blobs,
             columns,
+            executionPayloadEnvelopes,
             attestations,
             attesterSlashings,
           };
@@ -595,7 +683,14 @@ function toSpecTestCheckpoint(checkpoint: CheckpointWithHex): SpecTestCheckpoint
   };
 }
 
-type Step = OnTick | OnAttestation | OnAttesterSlashing | OnBlock | OnPayloadInfo | Checks;
+type Step =
+  | OnTick
+  | OnAttestation
+  | OnAttesterSlashing
+  | OnBlock
+  | OnExecutionPayloadEnvelope
+  | OnPayloadInfo
+  | Checks;
 
 type SpecTestCheckpoint = {epoch: bigint; root: string};
 
@@ -636,6 +731,13 @@ type OnBlock = {
   valid?: number;
 };
 
+type OnExecutionPayloadEnvelope = {
+  /** the name of the `execution_payload_envelope_<32-byte-root>.ssz_snappy` file. To execute `on_execution_payload(store, signed_envelope)` */
+  execution_payload: string;
+  /** optional, default to `true`. */
+  valid?: number;
+};
+
 type OnPayloadInfo = {
   /** Encoded 32-byte value of payload's block hash. */
   block_hash: string;
@@ -654,6 +756,8 @@ type Checks = {
     head?: {
       slot: bigint;
       root: string;
+      /** Spec numbering: EMPTY=0, FULL=1, PENDING=2. Only present post-Gloas. */
+      payload_status?: bigint;
     };
     time: bigint;
     justified_checkpoint?: SpecTestCheckpoint;
@@ -686,6 +790,7 @@ type FastConfirmationTestCase = {
   blocks: Map<string, SignedBeaconBlock>;
   blobs: Map<string, deneb.Blobs>;
   columns: Map<string, fulu.DataColumnSidecar>;
+  executionPayloadEnvelopes: Map<string, gloas.SignedExecutionPayloadEnvelope>;
   attestations: Map<string, Attestation>;
   attesterSlashings: Map<string, AttesterSlashing>;
 };
@@ -706,6 +811,10 @@ function isBlock(step: Step): step is OnBlock {
   return typeof (step as OnBlock).block === "string";
 }
 
+function isExecutionPayload(step: Step): step is OnExecutionPayloadEnvelope {
+  return typeof (step as OnExecutionPayloadEnvelope).execution_payload === "string";
+}
+
 function isOnPayloadInfoStep(step: Step): step is OnPayloadInfo {
   return typeof (step as OnPayloadInfo).block_hash === "string";
 }
@@ -714,21 +823,6 @@ function isCheck(step: Step): step is Checks {
   return typeof (step as Checks).checks === "object";
 }
 
-specTestIterator(
-  path.join(ethereumConsensusSpecsTests.outputDir, "tests", ACTIVE_PRESET),
-  {
-    fast_confirmation: {type: RunnerType.default, fn: fastConfirmationTest({onlyPredefinedResponses: false})},
-  },
-  {
-    ...defaultSkipOpts,
-    skippedRunners: [],
-    skippedTestSuites: [
-      ...(defaultSkipOpts.skippedTestSuites ?? []),
-      // TODO-GLOAS: lodestar's fast-confirmation rule is block-root based and does not model the
-      // ePBS payload_status dimension required by specs/gloas/fast-confirmation.md (PTC payload
-      // presence/timeliness, get_node_for_root with PAYLOAD_STATUS_PENDING). Head/justified/
-      // finalized/proposer-head all match; only getConfirmedRoot diverges.
-      /^gloas\/fast_confirmation\/.*/,
-    ],
-  }
-);
+specTestIterator(path.join(ethereumConsensusSpecsTests.outputDir, "tests", ACTIVE_PRESET), {
+  fast_confirmation: {type: RunnerType.default, fn: fastConfirmationTest({onlyPredefinedResponses: false})},
+});

--- a/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
+++ b/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
@@ -683,14 +683,7 @@ function toSpecTestCheckpoint(checkpoint: CheckpointWithHex): SpecTestCheckpoint
   };
 }
 
-type Step =
-  | OnTick
-  | OnAttestation
-  | OnAttesterSlashing
-  | OnBlock
-  | OnExecutionPayloadEnvelope
-  | OnPayloadInfo
-  | Checks;
+type Step = OnTick | OnAttestation | OnAttesterSlashing | OnBlock | OnExecutionPayloadEnvelope | OnPayloadInfo | Checks;
 
 type SpecTestCheckpoint = {epoch: bigint; root: string};
 


### PR DESCRIPTION
**Motivation**

After updating to consensus-specs v1.7.0-alpha.12, the entire `gloas/fast_confirmation/*` suite was skipped because the fast-confirmation runner could not process the Gloas (ePBS) vector inputs. All 183 gloas cases failed at deserialization before reaching any confirmation assertion. This restores the gloas portion of the coverage tracked in #9690.

Spec references:

- [ethereum/consensus-specs#5376](https://github.com/ethereum/consensus-specs/pull/5376) — enables `fast_confirmation` test generation for Gloas (and Heze), producing the vectors handled here; also disables BLS in FCR test generation, which is why envelope signature verification is gated on `bls_setting=1`
- [`specs/gloas/fast-confirmation.md`](https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/fast-confirmation.md) — the Gloas modifications to the FCR spec ([ethereum/consensus-specs#5278](https://github.com/ethereum/consensus-specs/pull/5278), [ethereum/consensus-specs#5249](https://github.com/ethereum/consensus-specs/pull/5249))
- [ethereum/consensus-specs#5249](https://github.com/ethereum/consensus-specs/pull/5249) — fork-choice redesign that added the nested `payload_status` to `head` checks, asserted by this PR

**Description**

Port the Gloas execution-payload-envelope support from the fork-choice runner into the fast-confirmation runner:

- Register `execution_payload_envelope_*.ssz_snappy` files with `ssz.gloas.SignedExecutionPayloadEnvelope` and collect them into the test case (previously every gloas case failed to load with `Cannot find ssz type for inputName execution_payload_envelope_*`).
- Handle `execution_payload` steps: verify the envelope against the block state, register the payload hash as VALID with the mock execution engine, and call `forkChoice.onExecutionPayload()`.
- Skip envelope signature verification unless `bls_setting=1` — FCR vectors are generated with BLS disabled (consensus-specs #5376), mirroring how the runner already treats block signatures.
- Assert the `payload_status` nested inside `head` checks (new check shape in the gloas FCR vectors), mapping spec numbering (EMPTY=0, FULL=1, PENDING=2) to Lodestar's enum.
- Remove the `/^gloas\/fast_confirmation\/.*/` suite skip. The old skip comment attributed the failures to unmodeled PTC payload-status semantics; the actual cause was purely missing runner support — no FCR implementation change was needed.
- Align the runner with `glamsterdam-devnet-7`: resolve attestation shuffling from the attested block via `getShufflingDependentRoot` (spec [ethereum/consensus-specs#5374](https://github.com/ethereum/consensus-specs/pull/5374)) and seed the mock execution engine from `latestBlockHash` for gloas anchor states.

The two `is_one_confirmed_fails_*` cases from #9690 remain skipped and will be addressed in a follow-up PR (one needs the runner to replay the generator's `on_fast_confirmation` schedule; the other hits an upstream vector-generation artifact).

Results (minimal preset): `gloas/fast_confirmation` 181 passed / 2 skipped; full fast_confirmation suite across all forks 1243 passed / 6 skipped / 0 failed.

Refs #9690

**AI Assistance Disclosure**

- [x] I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Diagnosis and implementation done with AI assistance (Claude Code); all changes reviewed and tests executed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
