### PR TITLE
feat: require minimum increment to forward bids over gossip

### DIFF
--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -16,24 +16,30 @@ import {IBeaconChain} from "../index.js";
 import {RegenCaller} from "../regen/index.js";
 
 /**
- * Minimum relative increment over the current highest bid required to forward a bid,
- * in basis points. With 3%, laddering from 1 gwei to 1 ETH takes ~700 bids.
+ * Relative increment over the current highest bid required to forward a bid, in basis points.
+ * With 3%, laddering from 1 gwei to 1 ETH takes ~256 bids given the floor and cap below, see
+ * https://github.com/ethereum/consensus-specs/pull/4792#issuecomment-3714553549.
  */
-const MIN_BID_INCREMENT_BPS = 300;
+const BID_INCREMENT_BPS = 300;
 /**
- * Minimum absolute increment over the current highest bid required to forward a bid.
- * Covers low bid values where the relative increment rounds to zero.
+ * Minimum absolute increment (0.0001 ETH). Covers low bid values where the relative increment
+ * is tiny and provides weak spam protection.
  */
-const MIN_BID_INCREMENT_GWEI = 1000;
+const BID_INCREMENT_FLOOR_GWEI = 100_000;
+/**
+ * Maximum absolute increment (0.01 ETH). Bounds the barrier for legitimate competition on
+ * high value blocks where the relative increment would suppress closely competing bids.
+ */
+const BID_INCREMENT_CAP_GWEI = 10_000_000;
 
 /**
  * Return the minimum value a new bid must have to be forwarded given the current highest bid.
  * Division before multiplication to stay within safe integer range for max gwei values.
  */
 export function getMinBidValue(currentHighestBid: number): number {
-  return (
-    currentHighestBid + Math.max(MIN_BID_INCREMENT_GWEI, Math.floor(currentHighestBid / 10_000) * MIN_BID_INCREMENT_BPS)
-  );
+  const relativeIncrement = Math.floor(currentHighestBid / 10_000) * BID_INCREMENT_BPS;
+  const increment = Math.min(Math.max(BID_INCREMENT_FLOOR_GWEI, relativeIncrement), BID_INCREMENT_CAP_GWEI);
+  return currentHighestBid + increment;
 }
 
 export async function validateApiExecutionPayloadBid(

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -15,6 +15,27 @@ import {ExecutionPayloadBidError, ExecutionPayloadBidErrorCode, GossipAction} fr
 import {IBeaconChain} from "../index.js";
 import {RegenCaller} from "../regen/index.js";
 
+/**
+ * Minimum relative increment over the current highest bid required to forward a bid,
+ * in basis points. With 3%, laddering from 1 gwei to 1 ETH takes ~700 bids.
+ */
+const MIN_BID_INCREMENT_BPS = 300;
+/**
+ * Minimum absolute increment over the current highest bid required to forward a bid.
+ * Covers low bid values where the relative increment rounds to zero.
+ */
+const MIN_BID_INCREMENT_GWEI = 1000;
+
+/**
+ * Return the minimum value a new bid must have to be forwarded given the current highest bid.
+ * Division before multiplication to stay within safe integer range for max gwei values.
+ */
+export function getMinBidValue(currentHighestBid: number): number {
+  return (
+    currentHighestBid + Math.max(MIN_BID_INCREMENT_GWEI, Math.floor(currentHighestBid / 10_000) * MIN_BID_INCREMENT_BPS)
+  );
+}
+
 export async function validateApiExecutionPayloadBid(
   chain: IBeaconChain,
   signedExecutionPayloadBid: gloas.SignedExecutionPayloadBid
@@ -231,8 +252,11 @@ async function validateExecutionPayloadBid(
 
   // [IGNORE] this bid is the highest value bid seen for the tuple
   // `(bid.slot, bid.parent_block_hash, bid.parent_block_root)`.
+  // As a DoS prevention measure, the bid must also exceed the current highest bid by a minimum
+  // increment, see https://github.com/ethereum/consensus-specs/pull/4831. This prevents spam
+  // from builders submitting numerous bids with minimal value increments.
   const bestBid = chain.executionPayloadBidPool.getBestBid(bid.slot, parentBlockHashHex, parentBlockRootHex);
-  if (bestBid !== null && bestBid.message.value >= bid.value) {
+  if (bestBid !== null && bid.value < getMinBidValue(bestBid.message.value)) {
     throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
       code: ExecutionPayloadBidErrorCode.BID_TOO_LOW,
       bidValue: bid.value,


### PR DESCRIPTION
Implements the DoS prevention measures note from https://github.com/ethereum/consensus-specs/pull/4831 for the `execution_payload_bid` topic. Bids are only forwarded if they exceed the current highest bid for their tuple by `min(max(0.0001 ETH, 3%), 0.01 ETH)`, so builders can't spam the network with minimal value increments. The 3% follows the analysis in https://github.com/ethereum/consensus-specs/pull/4792, the floor covers low bid values where the relative increment is tiny, and the cap avoids suppressing legitimate competition on high value blocks, see https://github.com/ethereum/consensus-specs/pull/4792#issuecomment-3714553549. With these values, laddering from 1 gwei to 1 ETH takes ~256 bids.