### PR TITLE
fix: upgrade attestations to gloas types during block production

### DIFF
--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -212,7 +212,7 @@ export class AggregatedAttestationPool {
     forkChoice: IForkChoice,
     shufflingCache: ShufflingCache,
     state: IBeaconStateView
-  ): Attestation[] {
+  ): electra.Attestation[] {
     const forkSeq = ForkSeq[fork];
     if (forkSeq < ForkSeq.electra) {
       throw new Error("Does not support producing blocks for pre-electra forks anymore");

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -24,6 +24,8 @@ import {
   isStatePostBellatrix,
   isStatePostCapella,
   isStatePostGloas,
+  upgradeAttestationToGloas,
+  upgradeAttesterSlashingToGloas,
 } from "@lodestar/state-transition";
 import {
   BLSPubkey,
@@ -1006,11 +1008,11 @@ export async function produceCommonBlockBody<T extends BlockType>(
   //     logger.error("Attestation did not transfer to op pool", {}, e);
   //   }
   // }
-  const [attesterSlashings, proposerSlashings, voluntaryExits, blsToExecutionChanges] =
+  const [opPoolAttesterSlashings, proposerSlashings, voluntaryExits, blsToExecutionChanges] =
     this.opPool.getSlashingsAndExits(currentState, blockType, this.metrics);
 
   const endAttestations = stepsMetrics?.startTimer();
-  const attestations = this.aggregatedAttestationPool.getAttestationsForBlock(
+  const opPoolAttestations = this.aggregatedAttestationPool.getAttestationsForBlock(
     fork,
     this.forkChoice,
     this.shufflingCache,
@@ -1019,6 +1021,11 @@ export async function produceCommonBlockBody<T extends BlockType>(
   endAttestations?.({
     step: BlockProductionStep.attestations,
   });
+
+  const attestations = isForkPostGloas(fork) ? opPoolAttestations.map(upgradeAttestationToGloas) : opPoolAttestations;
+  const attesterSlashings = isForkPostGloas(fork)
+    ? opPoolAttesterSlashings.map(upgradeAttesterSlashingToGloas)
+    : opPoolAttesterSlashings;
 
   const blockBody: Omit<CommonBlockBody, "blsToExecutionChanges" | "syncAggregate"> = {
     randaoReveal,

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -41,6 +41,11 @@ export type {EpochTransitionStep} from "./epoch/index.js";
 export {type BeaconStateTransitionMetrics, getMetrics} from "./metrics.js";
 export * from "./rewards/index.js";
 export * from "./signatureSets/index.js";
+export {
+  upgradeAttestationToGloas,
+  upgradeAttesterSlashingToGloas,
+  upgradeIndexedAttestationToGloas,
+} from "./slot/upgradeStateToGloas.js";
 export * from "./stateTransition.js";
 export {BeaconStateView} from "./stateView/beaconStateView.js";
 export {

--- a/packages/state-transition/src/slot/index.ts
+++ b/packages/state-transition/src/slot/index.ts
@@ -9,7 +9,12 @@ export {upgradeStateToCapella} from "./upgradeStateToCapella.js";
 export {upgradeStateToDeneb} from "./upgradeStateToDeneb.js";
 export {upgradeStateToElectra} from "./upgradeStateToElectra.js";
 export {upgradeStateToFulu} from "./upgradeStateToFulu.js";
-export {upgradeStateToGloas} from "./upgradeStateToGloas.js";
+export {
+  upgradeAttestationToGloas,
+  upgradeAttesterSlashingToGloas,
+  upgradeIndexedAttestationToGloas,
+  upgradeStateToGloas,
+} from "./upgradeStateToGloas.js";
 
 /**
  * Dial state to next slot. Common for all forks

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -1,6 +1,7 @@
 import {getNodesAtDepth} from "@chainsafe/persistent-merkle-tree";
 import {
   BasicType,
+  BitArray,
   CompositeType,
   CompositeView,
   CompositeViewDU,
@@ -11,7 +12,7 @@ import {
   ValueOf,
 } from "@chainsafe/ssz";
 import {PAYLOAD_BUILDER_VERSION, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
-import {ssz} from "@lodestar/types";
+import {electra, gloas, ssz} from "@lodestar/types";
 import {toPubkeyHex} from "@lodestar/utils";
 import {isValidDepositSignature} from "../block/processDeposit.js";
 import {getCachedBeaconState} from "../cache/stateCache.js";
@@ -114,6 +115,42 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
   stateGloas["clearCache"]();
 
   return stateGloas;
+}
+
+export function upgradeAttestationToGloas(pre: electra.Attestation): gloas.Attestation {
+  return {
+    aggregationBits: cloneBitArray(pre.aggregationBits),
+    data: pre.data,
+    signature: pre.signature,
+    committeeBits: cloneBitArray(pre.committeeBits),
+  };
+}
+
+export function upgradeIndexedAttestationToGloas(pre: electra.IndexedAttestation): gloas.IndexedAttestation {
+  return {
+    attestingIndices: [...pre.attestingIndices],
+    data: pre.data,
+    signature: pre.signature,
+  };
+}
+
+export function upgradeAttesterSlashingToGloas(pre: electra.AttesterSlashing): gloas.AttesterSlashing {
+  return {
+    attestation1: upgradeIndexedAttestationBigintToGloas(pre.attestation1),
+    attestation2: upgradeIndexedAttestationBigintToGloas(pre.attestation2),
+  };
+}
+
+function upgradeIndexedAttestationBigintToGloas(pre: electra.IndexedAttestationBigint): gloas.IndexedAttestationBigint {
+  return {
+    attestingIndices: [...pre.attestingIndices],
+    data: pre.data,
+    signature: pre.signature,
+  };
+}
+
+function cloneBitArray(bitArray: BitArray): BitArray {
+  return bitArray.clone();
 }
 
 /**

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -126,7 +126,19 @@ export function upgradeAttestationToGloas(pre: electra.Attestation): gloas.Attes
   };
 }
 
-export function upgradeIndexedAttestationToGloas(pre: electra.IndexedAttestation): gloas.IndexedAttestation {
+export function upgradeIndexedAttestationToGloas(pre: electra.IndexedAttestation): gloas.IndexedAttestation;
+export function upgradeIndexedAttestationToGloas(pre: electra.IndexedAttestationBigint): gloas.IndexedAttestationBigint;
+export function upgradeIndexedAttestationToGloas(
+  pre: electra.IndexedAttestation | electra.IndexedAttestationBigint
+): gloas.IndexedAttestation | gloas.IndexedAttestationBigint {
+  if (isIndexedAttestationBigint(pre)) {
+    return {
+      attestingIndices: [...pre.attestingIndices],
+      data: pre.data,
+      signature: pre.signature,
+    };
+  }
+
   return {
     attestingIndices: [...pre.attestingIndices],
     data: pre.data,
@@ -136,21 +148,19 @@ export function upgradeIndexedAttestationToGloas(pre: electra.IndexedAttestation
 
 export function upgradeAttesterSlashingToGloas(pre: electra.AttesterSlashing): gloas.AttesterSlashing {
   return {
-    attestation1: upgradeIndexedAttestationBigintToGloas(pre.attestation1),
-    attestation2: upgradeIndexedAttestationBigintToGloas(pre.attestation2),
-  };
-}
-
-function upgradeIndexedAttestationBigintToGloas(pre: electra.IndexedAttestationBigint): gloas.IndexedAttestationBigint {
-  return {
-    attestingIndices: [...pre.attestingIndices],
-    data: pre.data,
-    signature: pre.signature,
+    attestation1: upgradeIndexedAttestationToGloas(pre.attestation1),
+    attestation2: upgradeIndexedAttestationToGloas(pre.attestation2),
   };
 }
 
 function cloneBitArray(bitArray: BitArray): BitArray {
   return bitArray.clone();
+}
+
+function isIndexedAttestationBigint(
+  attestation: electra.IndexedAttestation | electra.IndexedAttestationBigint
+): attestation is electra.IndexedAttestationBigint {
+  return typeof attestation.data.slot === "bigint";
 }
 
 /**

--- a/packages/state-transition/test/unit/upgradeState.test.ts
+++ b/packages/state-transition/test/unit/upgradeState.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "vitest";
+import {BitArray} from "@chainsafe/ssz";
 import {ChainForkConfig, createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {config as chainConfig} from "@lodestar/config/default";
 import {FAR_FUTURE_EPOCH, ForkName} from "@lodestar/params";
@@ -7,7 +8,12 @@ import {createPubkeyCache} from "../../src/cache/pubkeyCache.js";
 import {CachedBeaconStateFulu, createCachedBeaconState} from "../../src/cache/stateCache.js";
 import {upgradeStateToDeneb} from "../../src/slot/upgradeStateToDeneb.js";
 import {upgradeStateToElectra} from "../../src/slot/upgradeStateToElectra.js";
-import {upgradeStateToGloas} from "../../src/slot/upgradeStateToGloas.js";
+import {
+  upgradeAttestationToGloas,
+  upgradeAttesterSlashingToGloas,
+  upgradeIndexedAttestationToGloas,
+  upgradeStateToGloas,
+} from "../../src/slot/upgradeStateToGloas.js";
 
 describe("upgradeState", () => {
   it("upgradeStateToDeneb", () => {
@@ -130,6 +136,51 @@ describe("upgradeState", () => {
     // Full state still merkleizes and round-trips
     expect(() => gloasState.hashTreeRoot()).not.toThrow();
     expect(() => gloasState.toValue()).not.toThrow();
+  });
+
+  it("upgradeAttestationToGloas copies Fulu attestation bitlists into Gloas values", () => {
+    const attestation = ssz.electra.Attestation.defaultValue();
+    attestation.aggregationBits = BitArray.fromBitLen(4);
+    attestation.aggregationBits.set(0, true);
+    attestation.committeeBits.set(0, true);
+
+    const upgraded = upgradeAttestationToGloas(attestation);
+
+    expect(upgraded).toEqual(attestation);
+    expect(upgraded.aggregationBits).not.toBe(attestation.aggregationBits);
+    expect(upgraded.committeeBits).not.toBe(attestation.committeeBits);
+    expect(ssz.gloas.Attestation.deserialize(ssz.gloas.Attestation.serialize(upgraded))).toEqual(upgraded);
+
+    attestation.aggregationBits.set(0, false);
+    attestation.committeeBits.set(0, false);
+    expect(upgraded.aggregationBits.get(0)).toBe(true);
+    expect(upgraded.committeeBits.get(0)).toBe(true);
+  });
+
+  it("upgradeIndexedAttestationToGloas copies Fulu attesting indices into Gloas values", () => {
+    const indexedAttestation = ssz.electra.IndexedAttestation.defaultValue();
+    indexedAttestation.attestingIndices = [1, 3, 5];
+
+    const upgraded = upgradeIndexedAttestationToGloas(indexedAttestation);
+
+    expect(upgraded).toEqual(indexedAttestation);
+    expect(upgraded.attestingIndices).not.toBe(indexedAttestation.attestingIndices);
+    expect(ssz.gloas.IndexedAttestation.deserialize(ssz.gloas.IndexedAttestation.serialize(upgraded))).toEqual(
+      upgraded
+    );
+  });
+
+  it("upgradeAttesterSlashingToGloas upgrades both indexed attestations", () => {
+    const attesterSlashing = ssz.electra.AttesterSlashing.defaultValue();
+    attesterSlashing.attestation1.attestingIndices = [2, 4];
+    attesterSlashing.attestation2.attestingIndices = [6, 8];
+
+    const upgraded = upgradeAttesterSlashingToGloas(attesterSlashing);
+
+    expect(upgraded).toEqual(attesterSlashing);
+    expect(upgraded.attestation1.attestingIndices).not.toBe(attesterSlashing.attestation1.attestingIndices);
+    expect(upgraded.attestation2.attestingIndices).not.toBe(attesterSlashing.attestation2.attestingIndices);
+    expect(ssz.gloas.AttesterSlashing.deserialize(ssz.gloas.AttesterSlashing.serialize(upgraded))).toEqual(upgraded);
   });
 });
 

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -415,11 +415,6 @@ exceptions:
     - finalized_root_gindex_at_slot#gloas
     - next_sync_committee_gindex_at_slot#gloas
 
-    # gloas (attestation upgrade helpers; lodestar ssz types are structurally cross-fork compatible)
-    - upgrade_attestation_to_gloas#gloas
-    - upgrade_attester_slashing_to_gloas#gloas
-    - upgrade_indexed_attestation_to_gloas#gloas
-
     # computed helpers replacing config vars (added in alpha.3)
     # the following are hardcoded in config files rather than computed at runtime
     - compute_max_request_blob_sidecars#deneb

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -12454,7 +12454,7 @@
 - name: upgrade_indexed_attestation_to_gloas#gloas
   sources:
     - file: packages/state-transition/src/slot/upgradeStateToGloas.ts
-      search: export function upgradeIndexedAttestationToGloas(
+      search: 'export function upgradeIndexedAttestationToGloas(pre: electra.IndexedAttestation):'
   spec: |
     <spec fn="upgrade_indexed_attestation_to_gloas" fork="gloas" hash="b13fb8df">
     def upgrade_indexed_attestation_to_gloas(pre: fulu.IndexedAttestation) -> IndexedAttestation:

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -12424,7 +12424,9 @@
     </spec>
 
 - name: upgrade_attestation_to_gloas#gloas
-  sources: []
+  sources:
+    - file: packages/state-transition/src/slot/upgradeStateToGloas.ts
+      search: export function upgradeAttestationToGloas(
   spec: |
     <spec fn="upgrade_attestation_to_gloas" fork="gloas" hash="efd969bf">
     def upgrade_attestation_to_gloas(pre: fulu.Attestation) -> Attestation:
@@ -12437,7 +12439,9 @@
     </spec>
 
 - name: upgrade_attester_slashing_to_gloas#gloas
-  sources: []
+  sources:
+    - file: packages/state-transition/src/slot/upgradeStateToGloas.ts
+      search: export function upgradeAttesterSlashingToGloas(
   spec: |
     <spec fn="upgrade_attester_slashing_to_gloas" fork="gloas" hash="35f9184f">
     def upgrade_attester_slashing_to_gloas(pre: fulu.AttesterSlashing) -> AttesterSlashing:
@@ -12448,7 +12452,9 @@
     </spec>
 
 - name: upgrade_indexed_attestation_to_gloas#gloas
-  sources: []
+  sources:
+    - file: packages/state-transition/src/slot/upgradeStateToGloas.ts
+      search: export function upgradeIndexedAttestationToGloas(
   spec: |
     <spec fn="upgrade_indexed_attestation_to_gloas" fork="gloas" hash="b13fb8df">
     def upgrade_indexed_attestation_to_gloas(pre: fulu.IndexedAttestation) -> IndexedAttestation:


### PR DESCRIPTION
**Motivation**

Port of two outstanding fixes from the `glamsterdam-devnet-7` branch (#9587) that never landed on `unstable` (see discussion in https://github.com/ChainSafe/lodestar/pull/9689#discussion_r3632915578).

The aggregated attestation pool and op pool hold electra-typed attestations and attester slashings. When producing the first gloas blocks after the fork, these were packed into the gloas block body without upgrading them to gloas types (EIP-7688 progressive containers). This also implements the `upgrade_attestation_to_gloas`, `upgrade_indexed_attestation_to_gloas` and `upgrade_attester_slashing_to_gloas` spec functions, which were tracked as unimplemented in `specrefs/functions.yml` (`sources: []`).

**Description**

- Add `upgradeAttestationToGloas`, `upgradeIndexedAttestationToGloas` (with bigint overload) and `upgradeAttesterSlashingToGloas` helpers to `upgradeStateToGloas.ts`, per https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/gloas/fork.md
- Map op-pool attestations and attester slashings through the upgrade helpers in `produceCommonBlockBody` when producing post-gloas blocks
- Type `AggregatedAttestationPool.getAttestationsForBlock` return as `electra.Attestation[]` to make the pre-fork typing explicit
- Wire the three spec functions in `specrefs/functions.yml` (verified stable against `ethspecify process`)

Cherry-picked from `glamsterdam-devnet-7` (eeb1c13685, a8c50ce4b6, original author @nflaig); only conflict resolution was keeping `unstable`'s optimized list-migration internals in `upgradeStateToGloas.ts`.

**AI Assistance Disclosure**

- [x] I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Cherry-pick selection, conflict resolution and verification done with AI assistance (Claude Code); original commits authored by @nflaig on the devnet-7 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)