### PR TITLE
test(beacon-node): cover REST query string array parsing at boundary sizes

### DIFF
--- a/packages/beacon-node/test/unit/api/rest/queryStringArrayParsing.test.ts
+++ b/packages/beacon-node/test/unit/api/rest/queryStringArrayParsing.test.ts
@@ -86,18 +86,18 @@ describe("RestApiServer query string array parsing", () => {
     for (const n of ACCEPTED_COUNTS) {
       it(`parses ${n} comma-separated ids as an array`, async () => {
         const res = await server.fastify.inject({method: "GET", url: `/validators?${commaQuery("id", n)}`});
-        expect(res.statusCode).toBe(200);
+        expect(res.statusCode, `comma-separated id query with ${n} items should be accepted (200)`).toBe(200);
         const {id} = res.json() as {id: unknown[]};
-        expect(Array.isArray(id)).toBe(true);
-        expect(id).toHaveLength(n);
+        expect(Array.isArray(id), `comma-separated id query with ${n} items should parse as an array`).toBe(true);
+        expect(id, `comma-separated id query should preserve all ${n} parsed items`).toHaveLength(n);
       });
 
       it(`parses ${n} repeated ids as an array`, async () => {
         const res = await server.fastify.inject({method: "GET", url: `/validators?${repeatedQuery("id", n)}`});
-        expect(res.statusCode).toBe(200);
+        expect(res.statusCode, `repeated id query with ${n} items should be accepted (200)`).toBe(200);
         const {id} = res.json() as {id: unknown[]};
-        expect(Array.isArray(id)).toBe(true);
-        expect(id).toHaveLength(n);
+        expect(Array.isArray(id), `repeated id query with ${n} items should parse as an array`).toBe(true);
+        expect(id, `repeated id query should preserve all ${n} parsed items`).toHaveLength(n);
       });
     }
 

--- a/packages/beacon-node/test/unit/api/rest/queryStringArrayParsing.test.ts
+++ b/packages/beacon-node/test/unit/api/rest/queryStringArrayParsing.test.ts
@@ -1,0 +1,132 @@
+import {FastifyInstance} from "fastify";
+import {afterAll, beforeAll, describe, expect, it} from "vitest";
+import {testLogger} from "@lodestar/logger/test-utils";
+import {NUMBER_OF_COLUMNS} from "@lodestar/params";
+import {RestApiServer, RestApiServerModules, RestApiServerOpts} from "../../../../src/api/rest/base.js";
+
+/**
+ * Regression coverage for https://github.com/ChainSafe/lodestar/issues/9672.
+ *
+ * After the v1.44.0 `qs` bump, requests like `GET .../validators?id=a,b,c,...` with more than
+ * 20 comma-separated ids started failing with `id must be array` (400). Root cause: `qs`'s default
+ * `arrayLimit` (20) is below the beacon-API `maxItems` for the validator `id` query (64), so anything
+ * over 20 items was parsed as an object instead of an array and rejected by the `type: "array"` schema.
+ * #9673 fixed it by raising the querystring `arrayLimit` to `NUMBER_OF_COLUMNS`.
+ *
+ * These tests exercise the real {@link RestApiServer} so they are bound to the production querystring
+ * parser configured in `base.ts` (rather than a stand-alone Fastify instance with a copied config).
+ * If the `arrayLimit` override regresses, the 21/64/65-item cases below fail exactly as #9672 did.
+ */
+
+/** Exposes the protected Fastify instance so tests can register a route and inject requests. */
+class TestRestApiServer extends RestApiServer {
+  get fastify(): FastifyInstance {
+    return this.server;
+  }
+}
+
+// Mirrors `Schema.UintOrStringArray`, the schema used by `getStateValidators` / `getStateValidatorBalances`
+// for the `id` query param (packages/api/src/beacon/routes/beacon/state.ts).
+const uintOrStringArraySchema = {
+  querystring: {
+    type: "object",
+    properties: {id: {type: "array", items: {anyOf: [{type: "string"}, {type: "integer"}]}}},
+  },
+};
+
+// Mirrors `Schema.UintArray`, the schema used by `getDebugDataColumnSidecars` for the `indices` query param
+// (packages/api/src/beacon/routes/debug.ts) — the param that requires the `NUMBER_OF_COLUMNS` limit.
+const uintArraySchema = {
+  querystring: {
+    type: "object",
+    properties: {indices: {type: "array", items: {type: "integer", minimum: 0}}},
+  },
+};
+
+/**
+ * Representative boundary item counts (rather than exhaustively enumerating 1..64).
+ * - 1: single value, exercises Ajv `coerceTypes: "array"` scalar-to-array coercion
+ * - 20: last count accepted under `qs`'s default `arrayLimit`
+ * - 21: first count that regressed in #9672 (would parse as object under the default limit)
+ * - 64: beacon-API `maxItems` for the validator `id` query, must be supported
+ * - 65: above the spec `maxItems` and still accepted — we deliberately do not hard-cap server-side
+ * - NUMBER_OF_COLUMNS: the configured `arrayLimit`, the largest array any beacon-API query carries
+ */
+const ACCEPTED_COUNTS = [1, 20, 21, 64, 65, NUMBER_OF_COLUMNS];
+// First count that overflows `arrayLimit`; `qs` returns an object and schema validation rejects it (400).
+const OVERFLOW_COUNT = NUMBER_OF_COLUMNS + 1;
+
+function commaQuery(param: string, n: number): string {
+  return `${param}=${Array.from({length: n}, (_, i) => i).join(",")}`;
+}
+
+function repeatedQuery(param: string, n: number): string {
+  return Array.from({length: n}, (_, i) => `${param}=${i}`).join("&");
+}
+
+describe("RestApiServer query string array parsing", () => {
+  let server: TestRestApiServer;
+
+  beforeAll(async () => {
+    const opts: RestApiServerOpts = {port: 0};
+    const modules: RestApiServerModules = {logger: testLogger(), metrics: null};
+    server = new TestRestApiServer(opts, modules);
+
+    server.fastify.get("/validators", {schema: uintOrStringArraySchema}, async (req) => req.query);
+    server.fastify.get("/data-column-sidecars", {schema: uintArraySchema}, async (req) => req.query);
+
+    await server.fastify.ready();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  describe("validator id query (maxItems=64, Schema.UintOrStringArray)", () => {
+    for (const n of ACCEPTED_COUNTS) {
+      it(`parses ${n} comma-separated ids as an array`, async () => {
+        const res = await server.fastify.inject({method: "GET", url: `/validators?${commaQuery("id", n)}`});
+        expect(res.statusCode).toBe(200);
+        const {id} = res.json() as {id: unknown[]};
+        expect(Array.isArray(id)).toBe(true);
+        expect(id).toHaveLength(n);
+      });
+
+      it(`parses ${n} repeated ids as an array`, async () => {
+        const res = await server.fastify.inject({method: "GET", url: `/validators?${repeatedQuery("id", n)}`});
+        expect(res.statusCode).toBe(200);
+        const {id} = res.json() as {id: unknown[]};
+        expect(Array.isArray(id)).toBe(true);
+        expect(id).toHaveLength(n);
+      });
+    }
+
+    it(`rejects ${OVERFLOW_COUNT} comma-separated ids with the #9672 error`, async () => {
+      const res = await server.fastify.inject({method: "GET", url: `/validators?${commaQuery("id", OVERFLOW_COUNT)}`});
+      expect(res.statusCode).toBe(400);
+      expect(res.json().message).toContain("must be array");
+    });
+
+    it(`rejects ${OVERFLOW_COUNT} repeated ids with the #9672 error`, async () => {
+      const res = await server.fastify.inject({
+        method: "GET",
+        url: `/validators?${repeatedQuery("id", OVERFLOW_COUNT)}`,
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().message).toContain("must be array");
+    });
+  });
+
+  describe("data-column indices query (maxItems=NUMBER_OF_COLUMNS, Schema.UintArray)", () => {
+    it(`parses a full custody set of ${NUMBER_OF_COLUMNS} indices as an array`, async () => {
+      const res = await server.fastify.inject({
+        method: "GET",
+        url: `/data-column-sidecars?${commaQuery("indices", NUMBER_OF_COLUMNS)}`,
+      });
+      expect(res.statusCode).toBe(200);
+      const {indices} = res.json() as {indices: unknown[]};
+      expect(Array.isArray(indices)).toBe(true);
+      expect(indices).toHaveLength(NUMBER_OF_COLUMNS);
+    });
+  });
+});


### PR DESCRIPTION
## Motivation

Regression coverage for #9672. After the v1.44.0 `qs` bump, `GET /eth/v1/beacon/states/{state_id}/validators?id=a,b,c,...` with more than 20 comma-separated ids started failing with `id must be array` (400): `qs`'s default `arrayLimit` (20) is below the beacon-API `maxItems` (64) for the validator `id` query, so anything over 20 items was parsed as an object instead of an array and rejected by the `type: "array"` schema. #9673 fixed it by raising the querystring `arrayLimit` to `NUMBER_OF_COLUMNS`, but no test guards the behavior.

This is PR 1 of 2 for the ask in #9672 (unit coverage that would have caught the regression); a separate PR adds e2e coverage against a real running node.

## Description

Adds a `RestApiServer`-level unit test that exercises query-string array parsing at representative boundary sizes.

Key point: the test drives the **real** `RestApiServer`, so it is bound to the production querystring parser configured in `base.ts` (rather than a stand-alone Fastify instance with a copied parser config). If the `arrayLimit` override regresses, the 21/64/65-item cases fail exactly as #9672 did.

- Covers the validator `id` query (`Schema.UintOrStringArray`, `maxItems=64`) and the data-column `indices` query (`Schema.UintArray`, `maxItems=NUMBER_OF_COLUMNS`).
- Representative boundary sizes — `1, 20, 21, 64, 65, NUMBER_OF_COLUMNS` — for both comma-separated (`?id=a,b,c`) and repeated (`?id=a&id=b`) wire forms, rather than exhaustively enumerating `1..64`.
- Asserts that **more than 64 items are still accepted** (`65` passes): Lodestar intentionally does not hard-cap validator `id` arrays server-side at the spec `maxItems`. The only cap is the `qs` `arrayLimit` (`NUMBER_OF_COLUMNS`), beyond which `qs` returns an object and schema validation rejects it (`129` → 400 with the exact `id must be array` message from #9672).

Test-only change; no source behavior is modified.

🤖 Generated with AI assistance
