### PR TITLE
test(beacon-node): add e2e beacon-api query array length compliance tests

### DIFF
--- a/packages/beacon-node/test/e2e/api/impl/beacon/state/queryArrayCompliance.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/beacon/state/queryArrayCompliance.test.ts
@@ -16,7 +16,7 @@ import {getDevBeaconNode} from "../../../../../utils/node/beacon.js";
  * querystring `arrayLimit` was below the spec `maxItems`. The unit coverage in the sibling PR pins the
  * parser at the `RestApiServer` level; this suite exercises the full request path against a running node.
  *
- * Scope — an audit of every query-array param across the beacon-API surface shows only two carry more
+ * Scope: an audit of every query-array param across the beacon-API surface shows only two carry more
  * than ~20 items in normal client usage, and both are validator-id queries covered here:
  *   - `getStateValidators` / `getStateValidatorBalances` `id` (maxItems=64)
  *   - `getDebugDataColumnSidecars` `indices` (maxItems=NUMBER_OF_COLUMNS)
@@ -61,13 +61,13 @@ describe("beacon-api query string array length compliance", () => {
     it(`getStateValidators accepts ${n} validator ids`, async () => {
       const validatorIds = Array.from({length: n}, (_, i) => i);
       const validators = (await client.getStateValidators({stateId: "head", validatorIds})).value();
-      expect(validators).toHaveLength(n);
+      expect(validators, `getStateValidators should return ${n} validators for ${n} requested ids`).toHaveLength(n);
     });
 
     it(`getStateValidatorBalances accepts ${n} validator ids`, async () => {
       const validatorIds = Array.from({length: n}, (_, i) => i);
       const balances = (await client.getStateValidatorBalances({stateId: "head", validatorIds})).value();
-      expect(balances).toHaveLength(n);
+      expect(balances, `getStateValidatorBalances should return ${n} balances for ${n} requested ids`).toHaveLength(n);
     });
   }
 

--- a/packages/beacon-node/test/e2e/api/impl/beacon/state/queryArrayCompliance.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/beacon/state/queryArrayCompliance.test.ts
@@ -1,0 +1,83 @@
+import {afterAll, beforeAll, describe, expect, it} from "vitest";
+import {ApiClient, getClient} from "@lodestar/api";
+import {createBeaconConfig} from "@lodestar/config";
+import {chainConfig as chainConfigDef} from "@lodestar/config/default";
+import {LogLevel, testLogger} from "@lodestar/logger/test-utils";
+import {NUMBER_OF_COLUMNS} from "@lodestar/params";
+import {fetch} from "@lodestar/utils";
+import {BeaconNode} from "../../../../../../src/node/nodejs.js";
+import {getDevBeaconNode} from "../../../../../utils/node/beacon.js";
+
+/**
+ * beacon-API spec compliance: query-string arrays must accept at least the documented `maxItems`.
+ *
+ * Guards against regressions like https://github.com/ChainSafe/lodestar/issues/9672, where more than
+ * 20 comma-separated validator `id` values were rejected with `id must be array` (400) because the
+ * querystring `arrayLimit` was below the spec `maxItems`. The unit coverage in the sibling PR pins the
+ * parser at the `RestApiServer` level; this suite exercises the full request path against a running node.
+ *
+ * Scope — an audit of every query-array param across the beacon-API surface shows only two carry more
+ * than ~20 items in normal client usage, and both are validator-id queries covered here:
+ *   - `getStateValidators` / `getStateValidatorBalances` `id` (maxItems=64)
+ *   - `getDebugDataColumnSidecars` `indices` (maxItems=NUMBER_OF_COLUMNS)
+ * All other query arrays (event `topics`, validator `status`, peer `state`/`direction`, blob `indices`,
+ * `versioned_hashes`) are enum- or per-block-bounded well under the old default limit and never regressed.
+ * The data-column `indices` path requires a Fulu block with columns to exercise end-to-end and is covered
+ * at the unit level; it is a candidate for a follow-up here.
+ */
+describe("beacon-api query string array length compliance", () => {
+  const restPort = 9601;
+  const config = createBeaconConfig(chainConfigDef, Buffer.alloc(32, 0xaa));
+  // Must exceed the largest id we query (NUMBER_OF_COLUMNS) so every requested index is a real validator.
+  const validatorCount = 512;
+  const baseUrl = `http://127.0.0.1:${restPort}`;
+
+  let bn: BeaconNode;
+  let client: ApiClient["beacon"];
+
+  beforeAll(async () => {
+    bn = await getDevBeaconNode({
+      params: chainConfigDef,
+      options: {
+        sync: {isSingleNode: true},
+        network: {allowPublishToZeroPeers: true},
+        api: {rest: {enabled: true, port: restPort}},
+        chain: {blsVerifyAllMainThread: true},
+      },
+      validatorCount,
+      logger: testLogger("Node-A", {level: LogLevel.warn}),
+    });
+    client = getClient({baseUrl}, {config}).beacon;
+  }, 60_000);
+
+  afterAll(async () => {
+    await bn.close();
+  });
+
+  // 64 is the beacon-API `maxItems` for validator id; NUMBER_OF_COLUMNS is the configured server cap.
+  const itemCounts = [64, NUMBER_OF_COLUMNS];
+
+  for (const n of itemCounts) {
+    it(`getStateValidators accepts ${n} validator ids`, async () => {
+      const validatorIds = Array.from({length: n}, (_, i) => i);
+      const validators = (await client.getStateValidators({stateId: "head", validatorIds})).value();
+      expect(validators).toHaveLength(n);
+    });
+
+    it(`getStateValidatorBalances accepts ${n} validator ids`, async () => {
+      const validatorIds = Array.from({length: n}, (_, i) => i);
+      const balances = (await client.getStateValidatorBalances({stateId: "head", validatorIds})).value();
+      expect(balances).toHaveLength(n);
+    });
+  }
+
+  // The @lodestar/api client serializes arrays as repeat-format (`id=a&id=b`); the original #9672 report
+  // used comma-separated values (`id=a,b,c`). Exercise that exact wire form with a raw request.
+  it("accepts 64 comma-separated validator ids (the #9672 wire form)", async () => {
+    const ids = Array.from({length: 64}, (_, i) => i).join(",");
+    const res = await fetch(`${baseUrl}/eth/v1/beacon/states/head/validators?id=${ids}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {data: unknown[]};
+    expect(body.data).toHaveLength(64);
+  });
+});


### PR DESCRIPTION
## Motivation

Follow-up to #9672 and the sibling unit-test PR #9712. Per the request in #9672, this adds an **e2e** suite that spins up a real beacon node and verifies our REST server is beacon-API spec compliant for query-string array lengths, so a regression that makes us non-compliant (like the `qs` `arrayLimit` regression, where >20 comma-separated `id` values returned `id must be array`/400) is caught end-to-end, not just at the parser level.

This is PR 2 of 2 (PR 1 = #9712, `RestApiServer` unit coverage).

## Description

Boots a dev beacon node with the REST API enabled and exercises the validator-id query endpoints via the typed `@lodestar/api` client and a raw request:

- `getStateValidators` and `getStateValidatorBalances` with **64** ids (the beacon-API `maxItems`) and **`NUMBER_OF_COLUMNS`** ids (the configured server cap).
- The exact comma-separated wire form from the #9672 report (`?id=a,b,c,...`) via a raw request — the `@lodestar/api` client serializes arrays as repeat-format (`id=a&id=b`), so the comma form is tested directly.

## Scope — beacon-API query-array audit

Nico asked to check "other cases too". I audited every query-string array param across the beacon-API route definitions. Only the validator-`id` queries carry more than ~20 items in normal client usage (a VC resolving its managed validators), and they are the exact #9672 surface:

| Endpoint | Param | Schema | maxItems |
|---|---|---|---|
| `getStateValidators` | `id` | `UintOrStringArray` | 64 |
| `getStateValidatorBalances` | `id` | `UintOrStringArray` | 64 |
| `getDebugDataColumnSidecars` | `indices` | `UintArray` | `NUMBER_OF_COLUMNS` (128) |

All other query arrays — event `topics`, validator `status`, peer `state`/`direction`, blob `indices`, `versioned_hashes` — are enum- or per-block-bounded well under the old default limit (20) and never tripped the regression.

The data-column `indices` path needs a Fulu block carrying columns to exercise end-to-end; it's covered at the unit level in #9712 and noted in-file as a follow-up here.

Test-only change; no source behavior is modified.

🤖 Generated with AI assistance
