### PR TITLE
fix: retry Gloas block production on canonical head

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -868,10 +868,12 @@ export function getValidatorApi(
       await waitForSlot(slot);
 
       const parentBlock = chain.getProposerHead(slot);
+      const canonicalHead = chain.forkChoice.getHead();
       const {blockRoot: parentBlockRootHex, slot: parentSlot} = parentBlock;
       const parentBlockRoot = fromHex(parentBlockRootHex);
       notOnOutOfRangeData(parentBlockRoot);
       metrics?.blockProductionSlotDelta.set(slot - parentSlot);
+      let selectedParentBlock = parentBlock;
 
       const graffitiBytes = toGraffitiBytes(
         getBlockGraffiti(graffiti, getLodestarClientVersion(opts), chain.executionEngine.clientVersion, {
@@ -967,6 +969,7 @@ export function getValidatorApi(
         raceTimeoutMs: BLOCK_PRODUCTION_RACE_TIMEOUT_MS,
         signal: controller.signal,
       });
+      const bidResultPending = bidResult.status === "pending";
 
       let bestResult: typeof engineResult | null = null;
       let source: ProducedBlockSource = ProducedBlockSource.engine;
@@ -1022,6 +1025,68 @@ export function getValidatorApi(
         });
       }
 
+      if (bestResult === null && engineResult.status === "rejected" && !bidResultPending) {
+        const canRetryCanonicalHead =
+          canonicalHead.blockRoot !== parentBlock.blockRoot && canonicalHead.slot + 1 === slot;
+        if (canRetryCanonicalHead) {
+          const reason =
+            builderBid === null ? EngineBlockSelectionReason.BuilderNoBid : EngineBlockSelectionReason.BuilderError;
+
+          logger.warn("Retrying local block production on canonical head after proposer reorg production failed", {
+            ...logCtx,
+            canonicalHeadSlot: canonicalHead.slot,
+            canonicalHeadRoot: canonicalHead.blockRoot,
+            canonicalHeadBlockHash: canonicalHead.executionPayloadBlockHash,
+            engineReason: String(engineResult.reason),
+            bidReason: bidResult.status === "rejected" ? String(bidResult.reason) : bidResult.status,
+          });
+
+          const canonicalCommonBlockBodyPromise = chain.produceCommonBlockBody({
+            slot,
+            parentBlock: canonicalHead,
+            randaoReveal,
+            graffiti: graffitiBytes,
+          });
+
+          try {
+            const retryStartedAt = Date.now();
+            const engineBlockPromise = timed(ProducedBlockSource.engine, () =>
+              chain.produceBlock({
+                ...baseAttrs,
+                parentBlock: canonicalHead,
+                commonBlockBodyPromise: canonicalCommonBlockBodyPromise,
+              })
+            );
+            const engineBlock = await engineBlockPromise;
+            const durationMs = Date.now() - retryStartedAt;
+            bestResult = {promise: engineBlockPromise, status: "fulfilled", value: engineBlock, durationMs};
+            source = ProducedBlockSource.engine;
+            selectedParentBlock = canonicalHead;
+            metrics?.blockProductionSlotDelta.set(slot - canonicalHead.slot);
+            metrics?.blockProductionSelectionResults.inc({source: ProducedBlockSource.engine, reason});
+            logger.info("Selected local block: canonical head retry after proposer reorg production failed", {
+              reason,
+              ...logCtx,
+              durationMs,
+              canonicalHeadSlot: canonicalHead.slot,
+              canonicalHeadRoot: canonicalHead.blockRoot,
+              canonicalHeadBlockHash: canonicalHead.executionPayloadBlockHash,
+            });
+          } catch (e) {
+            logger.warn(
+              "Canonical head local block production retry failed",
+              {
+                ...logCtx,
+                canonicalHeadSlot: canonicalHead.slot,
+                canonicalHeadRoot: canonicalHead.blockRoot,
+                canonicalHeadBlockHash: canonicalHead.executionPayloadBlockHash,
+              },
+              e as Error
+            );
+          }
+        }
+      }
+
       if (bestResult === null || bestResult.status !== "fulfilled") {
         const engineReason = engineResult.status === "rejected" ? engineResult.reason : engineResult.status;
         const bidReason = bidResult.status === "rejected" ? bidResult.reason : bidResult.status;
@@ -1043,6 +1108,9 @@ export function getValidatorApi(
       const blockRoot = toRootHex(config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block));
       logger.verbose("Produced block", {
         ...logCtx,
+        parentSlot: selectedParentBlock.slot,
+        parentBlockRoot: selectedParentBlock.blockRoot,
+        parentBlockHash: selectedParentBlock.executionPayloadBlockHash,
         executionPayloadValue,
         consensusBlockValue,
         root: blockRoot,

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV4.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV4.test.ts
@@ -27,7 +27,7 @@ describe("api/validator - produceBlockV4", () => {
   const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
   const config = createBeaconConfig(chainConfig, genesisValidatorsRoot);
 
-  const slot = 1;
+  const slot = 2;
   const feeRecipient = "0xccccccccccccccccccccccccccccccccccccccaa";
   const graffiti = "a".repeat(32);
 
@@ -59,6 +59,7 @@ describe("api/validator - produceBlockV4", () => {
     vi.mocked(modules.chain.clock.msFromSlot).mockReturnValue(0);
     vi.spyOn(modules.sync, "state", "get").mockReturnValue(SyncState.Synced);
     modules.chain.getProposerHead.mockReturnValue(parentBlock);
+    modules.chain.forkChoice.getHead.mockReturnValue(parentBlock);
     modules.chain.forkChoice.getBlockDefaultStatus.mockReturnValue(zeroProtoBlock);
     modules.chain.forkChoice.shouldBuildOnFull.mockReturnValue(true);
     modules.chain.produceBlock.mockImplementation(async (attrs: {builderBid?: unknown}) => ({
@@ -143,6 +144,60 @@ describe("api/validator - produceBlockV4", () => {
 
     expect(modules.chain.produceBlock).toHaveBeenCalledTimes(1);
     expect(block).toEqual(engineBlock);
+  });
+
+  it("retries local production on the canonical head if proposer reorg local production fails", async () => {
+    const reorgParentBlock = {
+      ...parentBlock,
+      slot: slot - 2,
+      blockRoot: "0x2222222222222222222222222222222222222222222222222222222222222222",
+      executionPayloadBlockHash: "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    } as ProtoBlock;
+
+    modules.chain.getProposerHead.mockReturnValue(reorgParentBlock);
+    modules.chain.forkChoice.getHead.mockReturnValue(parentBlock);
+    modules.chain.builderCircuitBreaker.isActive.mockReturnValue(false);
+    modules.chain.executionPayloadBidPool.getBestBid.mockReturnValue(null);
+    modules.chain.produceBlock
+      .mockRejectedValueOnce(new Error("Received invalid payloadId=null"))
+      .mockResolvedValueOnce({
+        block: engineBlock,
+        executionPayloadValue: BigInt(0),
+        consensusBlockValue: BigInt(0),
+      });
+
+    const {data: block} = await api.produceBlockV4({slot, randaoReveal, graffiti, feeRecipient, includePayload: false});
+
+    expect(modules.chain.produceBlock).toHaveBeenCalledTimes(2);
+    expect(modules.chain.produceBlock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({parentBlock: reorgParentBlock})
+    );
+    expect(modules.chain.produceBlock).toHaveBeenNthCalledWith(2, expect.objectContaining({parentBlock}));
+    expect(block).toEqual(engineBlock);
+  });
+
+  it("does not retry local production if canonical head cannot directly parent the block", async () => {
+    const reorgParentBlock = {
+      ...parentBlock,
+      slot: slot - 2,
+      blockRoot: "0x2222222222222222222222222222222222222222222222222222222222222222",
+      executionPayloadBlockHash: "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    } as ProtoBlock;
+    const oldCanonicalHead = {...parentBlock, slot: slot - 2} as ProtoBlock;
+
+    modules.chain.getProposerHead.mockReturnValue(reorgParentBlock);
+    modules.chain.forkChoice.getHead.mockReturnValue(oldCanonicalHead);
+    modules.chain.builderCircuitBreaker.isActive.mockReturnValue(false);
+    modules.chain.executionPayloadBidPool.getBestBid.mockReturnValue(null);
+    modules.chain.produceBlock.mockRejectedValueOnce(new Error("Received invalid payloadId=null"));
+
+    await expect(
+      api.produceBlockV4({slot, randaoReveal, graffiti, feeRecipient, includePayload: false})
+    ).rejects.toThrow("Received invalid payloadId=null");
+
+    expect(modules.chain.produceBlock).toHaveBeenCalledTimes(1);
+    expect(modules.chain.produceBlock).toHaveBeenCalledWith(expect.objectContaining({parentBlock: reorgParentBlock}));
   });
 
   it("ignores builder bids when the builder circuit breaker is active", async () => {


### PR DESCRIPTION
## Motivation

On glamsterdam-devnet-7, `lodestar-reth-1` missed slot 100992 after `produceBlockV4` selected a proposer-head reorg parent and the local EL build rejected with `payloadId=null`. No builder block was available, so Lodestar surfaced the local production error and missed the duty.

Current `unstable` already blocks proposer-head reorgs at epoch boundaries, so the exact devnet slot may have been running an older image. This still leaves the same missed-block class for valid non-boundary proposer-head reorgs when the reorg build fails locally but the canonical head is still usable.

## Description

- Captures the canonical fork-choice head at the start of Gloas `produceBlockV4`.
- If the selected proposer-head reorg parent fails local block production, and no builder block won the race, retries local production once on the canonical head when it directly parents the requested proposal slot.
- Keeps normal proposer-head reorg behavior unchanged when the reorg build succeeds.
- Avoids retrying when the builder result is still pending or the canonical head cannot directly parent the block.
- Updates final production logging / slot-delta metrics to reflect the canonical parent when the retry path is selected.

## Testing

- `pnpm build`
- `pnpm vitest run --project unit packages/beacon-node/test/unit/api/impl/validator/produceBlockV4.test.ts`
- `pnpm --filter @lodestar/beacon-node check-types`
- `pnpm exec biome check packages/beacon-node/src/api/impl/validator/index.ts packages/beacon-node/test/unit/api/impl/validator/produceBlockV4.test.ts`
- `pnpm lint`

## AI Assistance

Prepared with AI assistance by Lodekeeper.