### PR TITLE
fix: avoid payload prep failures on gloas reorgs

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1837,8 +1837,17 @@ export function getValidatorApi(
           try {
             await validateGossipProposerPreferences(chain, signed);
 
-            chain.proposerPreferencesPool.add(signed, {local: true});
-            await network.publishProposerPreferences(signed);
+            try {
+              await network.publishProposerPreferences(signed);
+            } catch (e) {
+              chain.proposerPreferencesPool.remove(signed);
+              throw e;
+            }
+            chain.proposerPreferencesPool.markLocal(
+              signed.message.proposalSlot,
+              toRootHex(signed.message.dependentRoot),
+              signed.message.validatorIndex
+            );
             chain.emitter.emit(routes.events.EventType.proposerPreferences, {
               version: config.getForkName(signed.message.proposalSlot),
               data: signed,

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1837,7 +1837,7 @@ export function getValidatorApi(
           try {
             await validateGossipProposerPreferences(chain, signed);
 
-            chain.proposerPreferencesPool.add(signed);
+            chain.proposerPreferencesPool.add(signed, {local: true});
             await network.publishProposerPreferences(signed);
             chain.emitter.emit(routes.events.EventType.proposerPreferences, {
               version: config.getForkName(signed.message.proposalSlot),
@@ -1851,6 +1851,21 @@ export function getValidatorApi(
             };
 
             if (e instanceof ProposerPreferencesError && e.type.code === ProposerPreferencesErrorCode.ALREADY_KNOWN) {
+              const known = chain.proposerPreferencesPool.get(
+                signed.message.proposalSlot,
+                toRootHex(signed.message.dependentRoot)
+              );
+              if (
+                known !== null &&
+                toRootHex(ssz.gloas.SignedProposerPreferences.hashTreeRoot(known)) ===
+                  toRootHex(ssz.gloas.SignedProposerPreferences.hashTreeRoot(signed))
+              ) {
+                chain.proposerPreferencesPool.markLocal(
+                  signed.message.proposalSlot,
+                  toRootHex(signed.message.dependentRoot),
+                  signed.message.validatorIndex
+                );
+              }
               logger.debug("Ignoring known signed proposer preferences", logCtx);
               return;
             }

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -6,6 +6,7 @@ import {
   ForkChoiceError,
   ForkChoiceErrorCode,
   NotReorgedReason,
+  ProtoBlock,
   getSafeExecutionBlockHash,
 } from "@lodestar/fork-choice";
 import {
@@ -28,6 +29,7 @@ import {
 import {Attestation, BeaconBlock, altair, capella, electra, isGloasBeaconBlock, phase0, ssz} from "@lodestar/types";
 import {isErrorAborted, toRootHex} from "@lodestar/utils";
 import {GENESIS_SLOT, ZERO_HASH_HEX} from "../../constants/index.js";
+import {getShufflingDependentRoot} from "../../util/dependentRoot.js";
 import {callInNextEventLoop} from "../../util/eventLoop.js";
 import {isOptimisticBlock} from "../../util/forkChoice.js";
 import {isQueueErrorAborted} from "../../util/queue/index.js";
@@ -382,9 +384,14 @@ export async function importBlock(
     const proposalSlot = blockSlot + 1;
     try {
       const proposerIndex = postState.getBeaconProposer(proposalSlot);
-      const feeRecipient = this.beaconProposerCache.get(proposerIndex);
+      // Pre-Gloas local proposers are identified by prepareBeaconProposer fee-recipient registrations.
+      // Gloas proposers submit signed preferences instead; track only preferences submitted through
+      // our validator API, since gossip preferences from remote proposers must not suppress local EL FCUs.
+      const hasLocalProposerPreparation =
+        this.beaconProposerCache.get(proposerIndex) !== undefined ||
+        hasLocalGloasProposerPreferences(this, blockSummary, proposalSlot, proposerIndex);
 
-      if (feeRecipient) {
+      if (hasLocalProposerPreparation) {
         // We would set this to true if
         //  1) This is a gossip block
         //  2) We are proposer of next slot
@@ -669,5 +676,29 @@ export function addAttestationPostElectra(
         true
       );
     }
+  }
+}
+
+function hasLocalGloasProposerPreferences(
+  chain: BeaconChain,
+  headBlock: ProtoBlock,
+  proposalSlot: number,
+  proposerIndex: number
+): boolean {
+  if (chain.config.getForkSeq(proposalSlot) < ForkSeq.gloas) {
+    return false;
+  }
+
+  try {
+    const proposalEpoch = computeEpochAtSlot(proposalSlot);
+    const dependentRoot = getShufflingDependentRoot(
+      chain.forkChoice,
+      proposalEpoch,
+      computeEpochAtSlot(headBlock.slot),
+      headBlock
+    );
+    return chain.proposerPreferencesPool.isKnownLocal(proposalSlot, dependentRoot, proposerIndex);
+  } catch {
+    return false;
   }
 }

--- a/packages/beacon-node/src/chain/opPools/proposerPreferencesPool.ts
+++ b/packages/beacon-node/src/chain/opPools/proposerPreferencesPool.ts
@@ -46,6 +46,22 @@ export class ProposerPreferencesPool {
     return true;
   }
 
+  remove(signed: gloas.SignedProposerPreferences): boolean {
+    const {proposalSlot, dependentRoot} = signed.message;
+    const rootHex = toRootHex(dependentRoot);
+    const byRoot = this.bySlot.get(proposalSlot);
+    if (byRoot?.get(rootHex) !== signed) {
+      return false;
+    }
+
+    byRoot.delete(rootHex);
+    this.localKeys.delete(this.getKey(proposalSlot, rootHex));
+    if (byRoot.size === 0) {
+      this.bySlot.delete(proposalSlot);
+    }
+    return true;
+  }
+
   add(signed: gloas.SignedProposerPreferences, opts?: {local?: boolean}): void {
     const {proposalSlot, dependentRoot} = signed.message;
     const rootHex = toRootHex(dependentRoot);

--- a/packages/beacon-node/src/chain/opPools/proposerPreferencesPool.ts
+++ b/packages/beacon-node/src/chain/opPools/proposerPreferencesPool.ts
@@ -16,6 +16,11 @@ import {toRootHex} from "@lodestar/utils";
  */
 export class ProposerPreferencesPool {
   private readonly bySlot = new Map<Slot, Map<RootHex, gloas.SignedProposerPreferences>>();
+  private readonly localKeys = new Set<string>();
+
+  private getKey(slot: Slot, dependentRootHex: RootHex): string {
+    return `${slot}-${dependentRootHex}`;
+  }
 
   /** Lookup for bid validation: matches `(bid.slot, get_shuffling_dependent_root(store, bid.parent_block_root, epoch))`. */
   get(slot: Slot, dependentRootHex: RootHex): gloas.SignedProposerPreferences | null {
@@ -26,7 +31,22 @@ export class ProposerPreferencesPool {
     return this.get(proposalSlot, dependentRoot)?.message.validatorIndex === validatorIndex;
   }
 
-  add(signed: gloas.SignedProposerPreferences): void {
+  isKnownLocal(proposalSlot: Slot, dependentRoot: RootHex, validatorIndex: ValidatorIndex): boolean {
+    return (
+      this.isKnown(proposalSlot, dependentRoot, validatorIndex) &&
+      this.localKeys.has(this.getKey(proposalSlot, dependentRoot))
+    );
+  }
+
+  markLocal(proposalSlot: Slot, dependentRoot: RootHex, validatorIndex: ValidatorIndex): boolean {
+    if (!this.isKnown(proposalSlot, dependentRoot, validatorIndex)) {
+      return false;
+    }
+    this.localKeys.add(this.getKey(proposalSlot, dependentRoot));
+    return true;
+  }
+
+  add(signed: gloas.SignedProposerPreferences, opts?: {local?: boolean}): void {
     const {proposalSlot, dependentRoot} = signed.message;
     const rootHex = toRootHex(dependentRoot);
     let byRoot = this.bySlot.get(proposalSlot);
@@ -35,6 +55,9 @@ export class ProposerPreferencesPool {
       this.bySlot.set(proposalSlot, byRoot);
     }
     byRoot.set(rootHex, signed);
+    if (opts?.local === true) {
+      this.localKeys.add(this.getKey(proposalSlot, rootHex));
+    }
   }
 
   /** API read-out: flatten across branches, optionally filtered by slot. */
@@ -57,7 +80,15 @@ export class ProposerPreferencesPool {
    */
   prune(currentSlot: Slot): void {
     for (const slot of this.bySlot.keys()) {
-      if (slot < currentSlot) this.bySlot.delete(slot);
+      if (slot < currentSlot) {
+        const byRoot = this.bySlot.get(slot);
+        if (byRoot) {
+          for (const dependentRootHex of byRoot.keys()) {
+            this.localKeys.delete(this.getKey(slot, dependentRootHex));
+          }
+        }
+        this.bySlot.delete(slot);
+      }
     }
   }
 }

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {getSafeExecutionBlockHash} from "@lodestar/fork-choice";
+import {getSafeExecutionBlockHashForHead} from "@lodestar/fork-choice";
 import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH, isForkPostBellatrix, isForkPostGloas} from "@lodestar/params";
 import {
   IBeaconStateView,
@@ -196,7 +196,7 @@ export class PrepareNextSlotScheduler {
             computeTimeAtSlot(this.config, prepareSlot, this.chain.genesisTime) - Date.now() / 1000;
           this.metrics?.blockPayload.payloadAdvancePrepTime.observe(preparationTime);
 
-          const safeBlockHash = getSafeExecutionBlockHash(this.chain.forkChoice);
+          const safeBlockHash = getSafeExecutionBlockHashForHead(this.chain.forkChoice, updatedHead);
           const finalizedBlockHash =
             this.chain.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
 

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {IForkChoice, ProtoBlock, getSafeExecutionBlockHash} from "@lodestar/fork-choice";
+import {IForkChoice, ProtoBlock, getSafeExecutionBlockHashForHead} from "@lodestar/fork-choice";
 import {
   BUILDER_INDEX_SELF_BUILD,
   ForkName,
@@ -262,7 +262,7 @@ export async function produceBlockBody<T extends BlockType>(
     // TODO GLOAS: support non self-building here, the block type differentiation between
     // full and blinded no longer makes sense in gloas, it might be a good idea to move
     // this into a completely separate function and have pre/post gloas more separated
-    const safeBlockHash = getSafeExecutionBlockHash(this.forkChoice);
+    const safeBlockHash = getSafeExecutionBlockHashForHead(this.forkChoice, parentBlock);
     const finalizedBlockHash = this.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
     // TODO GLOAS: post-Gloas, proposer feeRecipient is also carried (signed) in
     // ProposerPreferencesPool. Consider using this unified cache instead
@@ -404,7 +404,7 @@ export async function produceBlockBody<T extends BlockType>(
       throw new Error("Expected Bellatrix state for execution block production");
     }
 
-    const safeBlockHash = getSafeExecutionBlockHash(this.forkChoice);
+    const safeBlockHash = getSafeExecutionBlockHashForHead(this.forkChoice, parentBlock);
     const finalizedBlockHash = this.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
     const feeRecipient = requestedFeeRecipient ?? this.beaconProposerCache.getOrDefault(proposerIndex);
     const feeRecipientType = requestedFeeRecipient

--- a/packages/beacon-node/test/unit/chain/opPools/proposerPreferencesPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/proposerPreferencesPool.test.ts
@@ -62,6 +62,20 @@ describe("chain / opPools / ProposerPreferencesPool", () => {
     expect(pool.isKnownLocal(10, rootAHex, 1)).toBe(false);
   });
 
+  it("removes only the exact stored entry and clears the local marker", () => {
+    const prefs = makePrefs(10, 1, rootA);
+    const replacement = makePrefs(10, 1, rootA);
+    pool.add(prefs, {local: true});
+
+    expect(pool.remove(replacement)).toBe(false);
+    expect(pool.get(10, rootAHex)).toBe(prefs);
+    expect(pool.isKnownLocal(10, rootAHex, 1)).toBe(true);
+
+    expect(pool.remove(prefs)).toBe(true);
+    expect(pool.get(10, rootAHex)).toBeNull();
+    expect(pool.isKnownLocal(10, rootAHex, 1)).toBe(false);
+  });
+
   it("returns null for unknown dependent_root at a known slot", () => {
     pool.add(makePrefs(10, 1, rootA));
     expect(pool.get(10, rootBHex)).toBeNull();

--- a/packages/beacon-node/test/unit/chain/opPools/proposerPreferencesPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/proposerPreferencesPool.test.ts
@@ -39,6 +39,29 @@ describe("chain / opPools / ProposerPreferencesPool", () => {
     expect(pool.get(10, rootAHex)).toBe(prefs);
   });
 
+  it("distinguishes gossip entries from locally submitted entries", () => {
+    pool.add(makePrefs(10, 1, rootA));
+    expect(pool.isKnown(10, rootAHex, 1)).toBe(true);
+    expect(pool.isKnownLocal(10, rootAHex, 1)).toBe(false);
+
+    pool.add(makePrefs(10, 1, rootA), {local: true});
+    expect(pool.isKnownLocal(10, rootAHex, 1)).toBe(true);
+  });
+
+  it("can mark an existing gossip entry as local without replacing it", () => {
+    const prefs = makePrefs(10, 1, rootA);
+    pool.add(prefs);
+
+    expect(pool.markLocal(10, rootAHex, 1)).toBe(true);
+    expect(pool.get(10, rootAHex)).toBe(prefs);
+    expect(pool.isKnownLocal(10, rootAHex, 1)).toBe(true);
+  });
+
+  it("does not mark unknown entries as local", () => {
+    expect(pool.markLocal(10, rootAHex, 1)).toBe(false);
+    expect(pool.isKnownLocal(10, rootAHex, 1)).toBe(false);
+  });
+
   it("returns null for unknown dependent_root at a known slot", () => {
     pool.add(makePrefs(10, 1, rootA));
     expect(pool.get(10, rootBHex)).toBeNull();
@@ -68,12 +91,14 @@ describe("chain / opPools / ProposerPreferencesPool", () => {
   });
 
   it("prune drops slots < currentSlot but retains currentSlot and later", () => {
-    pool.add(makePrefs(10, 1, rootA));
+    pool.add(makePrefs(10, 1, rootA), {local: true});
     pool.add(makePrefs(11, 2, rootA));
-    pool.add(makePrefs(12, 3, rootA));
+    pool.add(makePrefs(12, 3, rootA), {local: true});
     pool.prune(11);
     expect(pool.get(10, rootAHex)).toBeNull();
+    expect(pool.isKnownLocal(10, rootAHex, 1)).toBe(false);
     expect(pool.get(11, rootAHex)).not.toBeNull();
     expect(pool.get(12, rootAHex)).not.toBeNull();
+    expect(pool.isKnownLocal(12, rootAHex, 3)).toBe(true);
   });
 });

--- a/packages/fork-choice/src/forkChoice/safeBlocks.ts
+++ b/packages/fork-choice/src/forkChoice/safeBlocks.ts
@@ -1,6 +1,7 @@
 import {ZERO_HASH_HEX} from "@lodestar/params";
 import {Root, RootHex} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
+import type {ProtoBlock} from "../protoArray/interface.js";
 import {IForkChoice} from "./interface.js";
 
 /**
@@ -31,5 +32,38 @@ export function getSafeExecutionBlockHash(forkChoice: IForkChoice): RootHex {
       return confirmedBlock.executionPayloadBlockHash;
     }
   }
+  return ZERO_HASH_HEX;
+}
+
+/**
+ * Get a safe execution payload hash compatible with a specific FCU head.
+ *
+ * `safeBlockHash` must be equal to or an ancestor of `headBlockHash`. During
+ * proposer-head reorg production the selected head can intentionally be an
+ * ancestor of fork choice's current/confirmed head, so the global safe block may
+ * no longer belong to the chain defined by the FCU head.
+ */
+export function getSafeExecutionBlockHashForHead(forkChoice: IForkChoice, headBlock: ProtoBlock): RootHex {
+  const confirmedRoot = forkChoice.getConfirmedRoot();
+  if (!confirmedRoot) {
+    return ZERO_HASH_HEX;
+  }
+
+  const confirmedBlock = forkChoice.getBlockHexDefaultStatus(confirmedRoot);
+  if (!confirmedBlock?.executionPayloadBlockHash) {
+    return ZERO_HASH_HEX;
+  }
+
+  if (
+    forkChoice.isDescendant(
+      confirmedBlock.blockRoot,
+      confirmedBlock.payloadStatus,
+      headBlock.blockRoot,
+      headBlock.payloadStatus
+    )
+  ) {
+    return confirmedBlock.executionPayloadBlockHash;
+  }
+
   return ZERO_HASH_HEX;
 }

--- a/packages/fork-choice/test/unit/forkChoice/safeBlocks.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/safeBlocks.test.ts
@@ -1,0 +1,78 @@
+import {describe, expect, it, vi} from "vitest";
+import {ZERO_HASH_HEX} from "@lodestar/params";
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
+import {
+  ExecutionStatus,
+  IForkChoice,
+  PayloadStatus,
+  ProtoBlock,
+  getSafeExecutionBlockHashForHead,
+} from "../../../src/index.js";
+
+const rootA = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const rootB = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const hashA = "0x1111111111111111111111111111111111111111111111111111111111111111";
+const hashB = "0x2222222222222222222222222222222222222222222222222222222222222222";
+
+function block(blockRoot: string, executionPayloadBlockHash: string, payloadStatus = PayloadStatus.FULL): ProtoBlock {
+  return {
+    slot: 1,
+    blockRoot,
+    parentRoot: ZERO_HASH_HEX,
+    stateRoot: ZERO_HASH_HEX,
+    targetRoot: ZERO_HASH_HEX,
+    justifiedEpoch: 0,
+    justifiedRoot: ZERO_HASH_HEX,
+    finalizedEpoch: 0,
+    finalizedRoot: ZERO_HASH_HEX,
+    unrealizedJustifiedEpoch: 0,
+    unrealizedJustifiedRoot: ZERO_HASH_HEX,
+    unrealizedFinalizedEpoch: 0,
+    unrealizedFinalizedRoot: ZERO_HASH_HEX,
+    timeliness: true,
+    payloadStatus,
+    parentBlockHash: ZERO_HASH_HEX,
+    executionPayloadBlockHash,
+    executionPayloadNumber: 1,
+    executionPayloadGasLimit: 30_000_000,
+    executionStatus: ExecutionStatus.Valid,
+    dataAvailabilityStatus: DataAvailabilityStatus.Available,
+  } as ProtoBlock;
+}
+
+function forkChoice(confirmedBlock: ProtoBlock | null, isDescendant: boolean): IForkChoice {
+  return {
+    getConfirmedRoot: vi.fn().mockReturnValue(confirmedBlock?.blockRoot ?? ZERO_HASH_HEX),
+    getBlockHexDefaultStatus: vi.fn().mockReturnValue(confirmedBlock),
+    isDescendant: vi.fn().mockReturnValue(isDescendant),
+  } as unknown as IForkChoice;
+}
+
+describe("getSafeExecutionBlockHashForHead", () => {
+  it("returns confirmed execution hash when confirmed block is compatible with the FCU head", () => {
+    const confirmedBlock = block(rootA, hashA);
+    const headBlock = block(rootB, hashB);
+    const fc = forkChoice(confirmedBlock, true);
+
+    expect(getSafeExecutionBlockHashForHead(fc, headBlock)).toBe(hashA);
+    expect(fc.isDescendant).toHaveBeenCalledWith(rootA, PayloadStatus.FULL, rootB, PayloadStatus.FULL);
+  });
+
+  it("returns zero hash when confirmed block is not an ancestor of the FCU head", () => {
+    const confirmedBlock = block(rootB, hashB);
+    const reorgHead = block(rootA, hashA);
+    const fc = forkChoice(confirmedBlock, false);
+
+    expect(getSafeExecutionBlockHashForHead(fc, reorgHead)).toBe(ZERO_HASH_HEX);
+    expect(fc.isDescendant).toHaveBeenCalledWith(rootB, PayloadStatus.FULL, rootA, PayloadStatus.FULL);
+  });
+
+  it("returns zero hash when confirmed block has no execution payload hash", () => {
+    const confirmedBlock = block(rootA, hashA);
+    confirmedBlock.executionPayloadBlockHash = null;
+    const fc = forkChoice(confirmedBlock, true);
+
+    expect(getSafeExecutionBlockHashForHead(fc, block(rootB, hashB))).toBe(ZERO_HASH_HEX);
+    expect(fc.isDescendant).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Motivation

Replaces the closed #9721 canonical-head retry workaround. If Gloas proposer-head selection intentionally builds on a weak-block parent, payload preparation must keep the Engine FCU inputs coherent with that selected head and avoid canonicalizing the EL to a weak late child when the next proposer is local.

## Description

- Add `getSafeExecutionBlockHashForHead()` so payload prep sends a safe hash only when the confirmed block is ancestor/equal to the selected FCU head.
- Track locally submitted Gloas proposer preferences separately from gossiped remote preferences.
- Use local Gloas proposer preferences in `importBlock` FCU suppression, so a weak late block does not advance the EL canonical head before a local proposer-boost reorg duty.
- Mark duplicate local proposer-preference submissions as local without replacing the already-verified pool entry.

## Testing

- `pnpm build`
- `pnpm vitest run --project unit packages/fork-choice/test/unit/forkChoice/safeBlocks.test.ts packages/beacon-node/test/unit/api/impl/validator/produceBlockV4.test.ts packages/beacon-node/test/unit/chain/opPools/proposerPreferencesPool.test.ts`
- `pnpm --filter @lodestar/fork-choice check-types`
- `pnpm --filter @lodestar/beacon-node check-types`
- `pnpm lint`

AI assistance: implemented with Lodekeeper/Codex assistance.