### PR TITLE
fix: distinguish 404 from real errors when waiting for genesis

### DIFF
--- a/packages/validator/src/genesis.ts
+++ b/packages/validator/src/genesis.ts
@@ -1,4 +1,4 @@
-import {ApiClient} from "@lodestar/api";
+import {ApiClient, ApiError, HttpStatusCode} from "@lodestar/api";
 import {Genesis} from "@lodestar/types/phase0";
 import {Logger, sleep} from "@lodestar/utils";
 
@@ -10,9 +10,11 @@ export async function waitForGenesis(api: ApiClient, logger: Logger, signal?: Ab
     try {
       return (await api.beacon.getGenesis()).value();
     } catch (e) {
-      // TODO: Search for a 404 error which indicates that genesis has not yet occurred.
-      // Note: Lodestar API does not become online after genesis is found
-      logger.info("Waiting for genesis", {message: (e as Error).message});
+      if (e instanceof ApiError && e.status === HttpStatusCode.NOT_FOUND) {
+        logger.info("Waiting for genesis", {message: e.message});
+      } else {
+        logger.warn("Failed to fetch genesis", {message: (e as Error).message});
+      }
       await sleep(WAITING_FOR_GENESIS_POLL_MS, signal);
     }
   }


### PR DESCRIPTION
**Motivation**

`waitForGenesis` polls `GET /eth/v1/beacon/genesis` until genesis is known. It caught **every** error the same way and logged it at `info`, which is where the long-standing TODO lived:

```ts
// TODO: Search for a 404 error which indicates that genesis has not yet occurred.
```

Per the [beacon-APIs spec](https://ethereum.github.io/beacon-APIs/#/Beacon/getGenesis), the endpoint returns `404` when chain genesis info is not yet known. So a `404` is the expected "still waiting" signal, whereas any other failure (node unreachable, `5xx`, …) is a real problem that was being silently swallowed at `info`.

**Description**

- `404` (`ApiError` with `status === HttpStatusCode.NOT_FOUND`) → `info` "Waiting for genesis" (expected, as before).
- Any other error → `warn` "Failed to fetch genesis" so real issues surface.
- Retry semantics unchanged: the loop keeps polling every 12s in both cases.

Implements the existing TODO. Verified against the `@lodestar/api` error model: `ApiResponse.value()` → `assertOk()` throws `new ApiError(msg, status, operationId)` on non-2xx, and `ApiError`/`HttpStatusCode` are public exports.

This mirrors the same fix in the EPF "Forgestar" builder's duplicated `waitForGenesis` (by @markolazic01) so the two copies stay in sync.

Build, lint, and type-check pass.

🤖 Generated with AI assistance