### PR TITLE
fix: use proposer lookahead for next epoch proposer cache

### DIFF
--- a/packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -2,8 +2,8 @@ import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {routes} from "@lodestar/api";
 import {getConfig} from "@lodestar/config/test-utils";
 import {ForkName, MAX_EFFECTIVE_BALANCE, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {BeaconStateAllForks, BeaconStateView} from "@lodestar/state-transition";
-import {Slot} from "@lodestar/types";
+import {BeaconStateAllForks, BeaconStateFulu, BeaconStateView} from "@lodestar/state-transition";
+import {Slot, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {SYNC_TOLERANCE_EPOCHS} from "../../../../../../src/api/impl/utils.js";
 import {getValidatorApi} from "../../../../../../src/api/impl/validator/index.js";
@@ -55,6 +55,10 @@ describe("get proposers api impl", () => {
       },
       config
     );
+    (state as BeaconStateFulu).proposerLookahead = ssz.fulu.ProposerLookahead.toViewDU([
+      ...Array.from({length: SLOTS_PER_EPOCH}, () => 0),
+      ...Array.from({length: SLOTS_PER_EPOCH}, () => 1),
+    ]);
     cachedState = createCachedBeaconStateTest(state, config);
 
     vi.spyOn(cachedState.epochCtx, "getBeaconProposersNextEpoch");
@@ -172,7 +176,7 @@ describe("get proposers api impl", () => {
     expect(currentProposers.map((p) => p.pubkey)).toEqual(nextProposers.map((p) => p.pubkey));
   });
 
-  it("should have different proposer validator indexes for current and next epoch", async () => {
+  it("should get proposer validator indexes from the state lookahead", async () => {
     const {data: currentProposers} = (await api.getProposerDutiesV2({epoch: currentEpoch})) as {
       data: routes.validator.ProposerDutyList;
     };
@@ -180,7 +184,8 @@ describe("get proposers api impl", () => {
       data: routes.validator.ProposerDutyList;
     };
 
-    expect(currentProposers.map((p) => p.validatorIndex)).not.toEqual(nextProposers.map((p) => p.validatorIndex));
+    expect(currentProposers.map((p) => p.validatorIndex)).toEqual(Array.from({length: SLOTS_PER_EPOCH}, () => 0));
+    expect(nextProposers.map((p) => p.validatorIndex)).toEqual(Array.from({length: SLOTS_PER_EPOCH}, () => 1));
   });
 
   it("should have different proposer slots for current and next epoch", async () => {

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -411,14 +411,21 @@ export class EpochCache {
     let proposers: ValidatorIndex[];
     let proposersNextEpoch: ProposersDeferred;
     if (currentEpoch >= config.FULU_FORK_EPOCH) {
-      // After fulu, use state.proposerLookahead for both current and next epoch proposers. Computing next
-      // epoch proposers from the unfiltered active shuffling would include slashed validators in gloas.
+      // After fulu, use state.proposerLookahead for current and next epoch proposers when available.
+      // Computing from the unfiltered active shuffling would include slashed validators in gloas.
       const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
       proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);
-      proposersNextEpoch = {
-        computed: true,
-        indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
-      };
+      if (proposerLookahead.length >= SLOTS_PER_EPOCH * 2) {
+        proposersNextEpoch = {
+          computed: true,
+          indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
+        };
+      } else {
+        proposersNextEpoch = {
+          computed: false,
+          seed: getSeed(state, nextEpoch, DOMAIN_BEACON_PROPOSER),
+        };
+      }
     } else {
       // We need to calculate Pre-fulu
       // Allow to create CachedBeaconState for empty states, or no active validators
@@ -717,10 +724,17 @@ export class EpochCache {
       // Populate proposer cache with lookahead from state
       const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
       this.proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);
-      this.proposersNextEpoch = {
-        computed: true,
-        indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
-      };
+
+      if (proposerLookahead.length >= SLOTS_PER_EPOCH * 2) {
+        this.proposersNextEpoch = {
+          computed: true,
+          indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
+        };
+      } else {
+        // This should not happen unless MIN_SEED_LOOKAHEAD is set to 0
+        // this ensures things don't break if the proposer lookahead is not long enough
+        this.proposersNextEpoch = {computed: false, seed: getSeed(state, epochAfterUpcoming, DOMAIN_BEACON_PROPOSER)};
+      }
     } else {
       // Need to calculate proposers pre-fulu
       const upcomingProposerSeed = getSeed(state, upcomingEpoch, DOMAIN_BEACON_PROPOSER);

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -415,17 +415,10 @@ export class EpochCache {
       // Computing from the unfiltered active shuffling would include slashed validators in gloas.
       const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
       proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);
-      if (proposerLookahead.length >= SLOTS_PER_EPOCH * 2) {
-        proposersNextEpoch = {
-          computed: true,
-          indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
-        };
-      } else {
-        proposersNextEpoch = {
-          computed: false,
-          seed: getSeed(state, nextEpoch, DOMAIN_BEACON_PROPOSER),
-        };
-      }
+      proposersNextEpoch = {
+        computed: true,
+        indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
+      };
     } else {
       // We need to calculate Pre-fulu
       // Allow to create CachedBeaconState for empty states, or no active validators
@@ -724,17 +717,10 @@ export class EpochCache {
       // Populate proposer cache with lookahead from state
       const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
       this.proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);
-
-      if (proposerLookahead.length >= SLOTS_PER_EPOCH * 2) {
-        this.proposersNextEpoch = {
-          computed: true,
-          indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
-        };
-      } else {
-        // This should not happen unless MIN_SEED_LOOKAHEAD is set to 0
-        // this ensures things don't break if the proposer lookahead is not long enough
-        this.proposersNextEpoch = {computed: false, seed: getSeed(state, epochAfterUpcoming, DOMAIN_BEACON_PROPOSER)};
-      }
+      this.proposersNextEpoch = {
+        computed: true,
+        indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
+      };
     } else {
       // Need to calculate proposers pre-fulu
       const upcomingProposerSeed = getSeed(state, upcomingEpoch, DOMAIN_BEACON_PROPOSER);

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -411,7 +411,7 @@ export class EpochCache {
     let proposers: ValidatorIndex[];
     let proposersNextEpoch: ProposersDeferred;
     if (currentEpoch >= config.FULU_FORK_EPOCH) {
-      // After fulu, use state.proposerLookahead for current and next epoch proposers when available.
+      // After fulu, use state.proposerLookahead for current and next epoch proposers.
       // Computing from the unfiltered active shuffling would include slashed validators in gloas.
       const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
       proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -411,8 +411,8 @@ export class EpochCache {
     let proposers: ValidatorIndex[];
     let proposersNextEpoch: ProposersDeferred;
     if (currentEpoch >= config.FULU_FORK_EPOCH) {
-      // Post-Fulu, state.proposerLookahead is authoritative. Recomputing the next epoch from the active
-      // shuffling is incorrect in Gloas because it can reintroduce slashed validators.
+      // After fulu, use state.proposerLookahead for both current and next epoch proposers. Computing next
+      // epoch proposers from the unfiltered active shuffling would include slashed validators in gloas.
       const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
       proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);
       proposersNextEpoch = {

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -408,12 +408,17 @@ export class EpochCache {
 
     const nextShuffling = cachedNextShuffling ?? computeEpochShuffling(state, nextActiveIndices, nextEpoch);
 
-    const currentProposerSeed = getSeed(state, currentEpoch, DOMAIN_BEACON_PROPOSER);
-
-    let proposers: number[];
+    let proposers: ValidatorIndex[];
+    let proposersNextEpoch: ProposersDeferred;
     if (currentEpoch >= config.FULU_FORK_EPOCH) {
-      // Overwrite proposers with state.proposerLookahead
-      proposers = (state as CachedBeaconStateFulu).proposerLookahead.getAll().slice(0, SLOTS_PER_EPOCH);
+      // Post-Fulu, state.proposerLookahead is authoritative. Recomputing the next epoch from the active
+      // shuffling is incorrect in Gloas because it can reintroduce slashed validators.
+      const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
+      proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);
+      proposersNextEpoch = {
+        computed: true,
+        indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
+      };
     } else {
       // We need to calculate Pre-fulu
       // Allow to create CachedBeaconState for empty states, or no active validators
@@ -421,17 +426,16 @@ export class EpochCache {
         currentShuffling.activeIndices.length > 0
           ? computeProposers(
               config.getForkSeqAtEpoch(currentEpoch),
-              currentProposerSeed,
+              getSeed(state, currentEpoch, DOMAIN_BEACON_PROPOSER),
               currentShuffling,
               effectiveBalanceIncrements
             )
           : [];
+      proposersNextEpoch = {
+        computed: false,
+        seed: getSeed(state, nextEpoch, DOMAIN_BEACON_PROPOSER),
+      };
     }
-
-    const proposersNextEpoch: ProposersDeferred = {
-      computed: false,
-      seed: getSeed(state, nextEpoch, DOMAIN_BEACON_PROPOSER),
-    };
 
     // Only after altair, compute the indices of the current sync committee
     const afterAltairFork = currentEpoch >= config.ALTAIR_FORK_EPOCH;
@@ -713,17 +717,10 @@ export class EpochCache {
       // Populate proposer cache with lookahead from state
       const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
       this.proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);
-
-      if (proposerLookahead.length >= SLOTS_PER_EPOCH * 2) {
-        this.proposersNextEpoch = {
-          computed: true,
-          indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
-        };
-      } else {
-        // This should not happen unless MIN_SEED_LOOKAHEAD is set to 0
-        // this ensures things don't break if the proposer lookahead is not long enough
-        this.proposersNextEpoch = {computed: false, seed: getSeed(state, epochAfterUpcoming, DOMAIN_BEACON_PROPOSER)};
-      }
+      this.proposersNextEpoch = {
+        computed: true,
+        indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
+      };
     } else {
       // Need to calculate proposers pre-fulu
       const upcomingProposerSeed = getSeed(state, upcomingEpoch, DOMAIN_BEACON_PROPOSER);

--- a/packages/state-transition/test/unit/cachedBeaconState.test.ts
+++ b/packages/state-transition/test/unit/cachedBeaconState.test.ts
@@ -1,7 +1,8 @@
 import {describe, expect, it, vi} from "vitest";
 import {fromHexString} from "@chainsafe/ssz";
-import {createBeaconConfig} from "@lodestar/config";
+import {createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
+import {FAR_FUTURE_EPOCH, MIN_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Epoch, RootHex, ssz} from "@lodestar/types";
 import {toHexString} from "@lodestar/utils";
 import {createPubkeyCache} from "../../src/cache/pubkeyCache.js";
@@ -78,6 +79,64 @@ describe("CachedBeaconState", () => {
     // Only commit state1 beforehand
     cp1.commit();
     expect(toHexString(cp1.serialize())).toBe(toHexString(cp2.serialize()));
+  });
+
+  it("reconstructs Gloas next proposers from the state lookahead", () => {
+    const chainConfig = createChainForkConfig({
+      ALTAIR_FORK_EPOCH: 0,
+      BELLATRIX_FORK_EPOCH: 0,
+      CAPELLA_FORK_EPOCH: 0,
+      DENEB_FORK_EPOCH: 0,
+      ELECTRA_FORK_EPOCH: 0,
+      FULU_FORK_EPOCH: 0,
+      GLOAS_FORK_EPOCH: 0,
+    });
+    const state = ssz.gloas.BeaconState.defaultViewDU();
+    state.slot = 2 * SLOTS_PER_EPOCH;
+
+    for (let i = 0; i < 16; i++) {
+      const validator = ssz.phase0.Validator.defaultViewDU();
+      validator.pubkey = Buffer.alloc(48, i + 1);
+      validator.effectiveBalance = 32e9;
+      validator.activationEligibilityEpoch = 0;
+      validator.activationEpoch = 0;
+      validator.exitEpoch = FAR_FUTURE_EPOCH;
+      validator.withdrawableEpoch = FAR_FUTURE_EPOCH;
+      validator.slashed = i !== 0;
+      state.validators.push(validator);
+      state.balances.push(32e9);
+      state.previousEpochParticipation.push(0);
+      state.currentEpochParticipation.push(0);
+      state.inactivityScores.push(0);
+    }
+
+    // Only validator 0 is eligible under Gloas proposer selection because the other active validators are slashed.
+    // Recomputing next proposers from the active shuffling would reintroduce those slashed validators.
+    const proposerLookahead = Array.from({length: (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH}, () => 0);
+    state.proposerLookahead = ssz.fulu.ProposerLookahead.toViewDU(proposerLookahead);
+    state.commit();
+
+    const cachedState = createCachedBeaconState(
+      state,
+      {
+        config: createBeaconConfig(chainConfig, state.genesisValidatorsRoot),
+        pubkeyCache: createPubkeyCache(),
+      },
+      {skipSyncCommitteeCache: true, skipSyncPubkeys: true}
+    );
+
+    const expectedNextProposers = proposerLookahead.slice(SLOTS_PER_EPOCH, 2 * SLOTS_PER_EPOCH);
+    const nextProposers = cachedState.epochCtx.getBeaconProposersNextEpoch();
+    expect(nextProposers).toEqual(expectedNextProposers);
+    expect(nextProposers.every((index) => !state.validators.getReadonly(index).slashed)).toBe(true);
+
+    const loadedState = loadCachedBeaconState(cachedState, state.serialize(), {
+      skipSyncCommitteeCache: true,
+      skipSyncPubkeys: true,
+    });
+    const loadedNextProposers = loadedState.epochCtx.getBeaconProposersNextEpoch();
+    expect(loadedNextProposers).toEqual(expectedNextProposers);
+    expect(loadedNextProposers.every((index) => !loadedState.validators.getReadonly(index).slashed)).toBe(true);
   });
 
   describe("loadCachedBeaconState", () => {

--- a/packages/state-transition/test/unit/cachedBeaconState.test.ts
+++ b/packages/state-transition/test/unit/cachedBeaconState.test.ts
@@ -2,14 +2,22 @@ import {describe, expect, it, vi} from "vitest";
 import {fromHexString} from "@chainsafe/ssz";
 import {createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
-import {FAR_FUTURE_EPOCH, MIN_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {
+  EPOCHS_PER_SLASHINGS_VECTOR,
+  FAR_FUTURE_EPOCH,
+  ForkSeq,
+  MIN_SEED_LOOKAHEAD,
+  SLOTS_PER_EPOCH,
+} from "@lodestar/params";
 import {Epoch, RootHex, ssz} from "@lodestar/types";
 import {toHexString} from "@lodestar/utils";
 import {createPubkeyCache} from "../../src/cache/pubkeyCache.js";
 import {createCachedBeaconState, loadCachedBeaconState} from "../../src/cache/stateCache.js";
 import {interopPubkeysCached} from "../../src/testUtils/interop.js";
 import {createCachedBeaconStateTest} from "../../src/testUtils/state.js";
+import {computeActivationExitEpoch} from "../../src/util/epoch.js";
 import {EpochShuffling, calculateShufflingDecisionRoot} from "../../src/util/epochShuffling.js";
+import {computeProposerIndices} from "../../src/util/seed.js";
 import {modifyStateSameValidator, newStateWithValidators} from "../utils/capella.js";
 
 describe("CachedBeaconState", () => {
@@ -92,36 +100,55 @@ describe("CachedBeaconState", () => {
       GLOAS_FORK_EPOCH: 0,
     });
     const state = ssz.gloas.BeaconState.defaultViewDU();
-    state.slot = 2 * SLOTS_PER_EPOCH;
+    const currentEpoch = 2;
+    state.slot = currentEpoch * SLOTS_PER_EPOCH;
 
-    for (let i = 0; i < 16; i++) {
+    const unslashedValidatorCount = SLOTS_PER_EPOCH;
+    const slashedExitEpoch = computeActivationExitEpoch(currentEpoch);
+    const slashedWithdrawableEpoch = currentEpoch + EPOCHS_PER_SLASHINGS_VECTOR;
+    // Keep the slashed validators active through the lookahead so the Gloas filter must exclude them.
+    for (let i = 0; i < 2 * unslashedValidatorCount; i++) {
       const validator = ssz.phase0.Validator.defaultViewDU();
       validator.pubkey = Buffer.alloc(48, i + 1);
       validator.effectiveBalance = 32e9;
       validator.activationEligibilityEpoch = 0;
       validator.activationEpoch = 0;
-      validator.exitEpoch = FAR_FUTURE_EPOCH;
-      validator.withdrawableEpoch = FAR_FUTURE_EPOCH;
-      validator.slashed = i !== 0;
+      validator.slashed = i >= unslashedValidatorCount;
+      validator.exitEpoch = validator.slashed ? slashedExitEpoch : FAR_FUTURE_EPOCH;
+      validator.withdrawableEpoch = validator.slashed ? slashedWithdrawableEpoch : FAR_FUTURE_EPOCH;
       state.validators.push(validator);
       state.balances.push(32e9);
       state.previousEpochParticipation.push(0);
       state.currentEpochParticipation.push(0);
       state.inactivityScores.push(0);
     }
+    state.commit();
 
-    // Only validator 0 is eligible under Gloas proposer selection because the other active validators are slashed.
-    // Recomputing next proposers from the active shuffling would reintroduce those slashed validators.
-    const proposerLookahead = Array.from({length: (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH}, () => 0);
+    const config = createBeaconConfig(chainConfig, state.genesisValidatorsRoot);
+    const seedCachedState = createCachedBeaconState(
+      state,
+      {config, pubkeyCache: createPubkeyCache()},
+      {skipSyncCommitteeCache: true, skipSyncPubkeys: true}
+    );
+    const unslashedActiveIndices = Uint32Array.from({length: unslashedValidatorCount}, (_, index) => index);
+    const proposerLookahead: number[] = [];
+    for (let epochOffset = 0; epochOffset <= MIN_SEED_LOOKAHEAD; epochOffset++) {
+      proposerLookahead.push(
+        ...computeProposerIndices(
+          ForkSeq.gloas,
+          seedCachedState,
+          {activeIndices: unslashedActiveIndices},
+          currentEpoch + epochOffset
+        )
+      );
+    }
+    expect(new Set(proposerLookahead).size).toBeGreaterThan(1);
     state.proposerLookahead = ssz.fulu.ProposerLookahead.toViewDU(proposerLookahead);
     state.commit();
 
     const cachedState = createCachedBeaconState(
       state,
-      {
-        config: createBeaconConfig(chainConfig, state.genesisValidatorsRoot),
-        pubkeyCache: createPubkeyCache(),
-      },
+      {config, pubkeyCache: createPubkeyCache()},
       {skipSyncCommitteeCache: true, skipSyncPubkeys: true}
     );
 


### PR DESCRIPTION
After fulu, use `state.proposerLookahead` to populate both current and next proposer caches. Recomputing next epoch proposers from the active shuffling can reintroduce slashed validators (since those are designed for pre-fulu without filtering) under gloas after loading a state. There also doesn't seem to be a good reason to recompute if we already have it in the state, so this change should also make state loading faster.