### PR TITLE
refactor: move validator clock util to state-transition

### DIFF
--- a/packages/state-transition/src/util/clock.ts
+++ b/packages/state-transition/src/util/clock.ts
@@ -1,8 +1,9 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {GENESIS_SLOT, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {computeEpochAtSlot, computeTimeAtSlot, getCurrentSlot} from "@lodestar/state-transition";
 import {Epoch, Slot, TimeSeconds} from "@lodestar/types";
 import {ErrorAborted, Logger, isErrorAborted, sleep} from "@lodestar/utils";
+import {computeEpochAtSlot} from "./epoch.js";
+import {computeTimeAtSlot, getCurrentSlot} from "./slot.js";
 
 type RunEveryFn = (slot: Slot, signal: AbortSignal) => Promise<void>;
 

--- a/packages/state-transition/src/util/index.ts
+++ b/packages/state-transition/src/util/index.ts
@@ -6,6 +6,7 @@ export * from "./balance.js";
 export * from "./blindedBlock.js";
 export * from "./blockRoot.js";
 export * from "./capella.js";
+export * from "./clock.js";
 export * from "./computeAnchorCheckpoint.js";
 export * from "./deposit.js";
 export * from "./domain.js";

--- a/packages/state-transition/test/unit/util/clock.test.ts
+++ b/packages/state-transition/test/unit/util/clock.test.ts
@@ -2,11 +2,11 @@ import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {BeaconConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {Logger} from "@lodestar/utils";
 import {Clock, getCurrentSlotAround} from "../../../src/util/clock.js";
-import {testLogger} from "../../utils/logger.js";
 
 describe("util / Clock", () => {
-  const logger = testLogger();
+  const logger: Logger = {error: vi.fn(), warn: vi.fn(), info: vi.fn(), verbose: vi.fn(), debug: vi.fn()};
   let controller: AbortController;
 
   beforeEach(() => {

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -1,12 +1,12 @@
 import {ApiClient} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkName, isForkPostElectra, isForkPostGloas} from "@lodestar/params";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {IClock, computeEpochAtSlot} from "@lodestar/state-transition";
 import {SignedAggregateAndProof, SingleAttestation, Slot, phase0, ssz} from "@lodestar/types";
 import {prettyBytes, sleep, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";
 import {PubkeyHex} from "../types.js";
-import {IClock, LoggerVc} from "../util/index.js";
+import {LoggerVc} from "../util/index.js";
 import {AttDutyAndProof, AttestationDutiesService} from "./attestationDuties.js";
 import {ChainHeaderTracker} from "./chainHeaderTracker.js";
 import {ValidatorEventEmitter} from "./emitter.js";

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -1,11 +1,11 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {computeEpochAtSlot, isAggregatorFromCommitteeLength, isStartSlotOfEpoch} from "@lodestar/state-transition";
+import {IClock, computeEpochAtSlot, isAggregatorFromCommitteeLength, isStartSlotOfEpoch} from "@lodestar/state-transition";
 import {BLSSignature, Epoch, RootHex, Slot, ValidatorIndex} from "@lodestar/types";
 import {sleep, toPubkeyHex} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";
 import {PubkeyHex} from "../types.js";
-import {IClock, LoggerVc, batchItems} from "../util/index.js";
+import {LoggerVc, batchItems} from "../util/index.js";
 import {ChainHeaderTracker, HeadEventData} from "./chainHeaderTracker.js";
 import {SyncingStatusTracker} from "./syncingStatusTracker.js";
 import {ValidatorStore} from "./validatorStore.js";

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -1,6 +1,11 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {IClock, computeEpochAtSlot, isAggregatorFromCommitteeLength, isStartSlotOfEpoch} from "@lodestar/state-transition";
+import {
+  IClock,
+  computeEpochAtSlot,
+  isAggregatorFromCommitteeLength,
+  isStartSlotOfEpoch,
+} from "@lodestar/state-transition";
 import {BLSSignature, Epoch, RootHex, Slot, ValidatorIndex} from "@lodestar/types";
 import {sleep, toPubkeyHex} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -1,6 +1,7 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {BUILDER_INDEX_SELF_BUILD, ForkPostGloas, isForkPostGloas} from "@lodestar/params";
+import {IClock} from "@lodestar/state-transition";
 import {
   BLSPubkey,
   BLSSignature,
@@ -16,7 +17,7 @@ import {
 import {extendError, prettyBytes, prettyWeiToEth, toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";
 import {PubkeyHex} from "../types.js";
-import {IClock, LoggerVc} from "../util/index.js";
+import {LoggerVc} from "../util/index.js";
 import {BlockDutiesService, GENESIS_SLOT} from "./blockDuties.js";
 import {ValidatorStore} from "./validatorStore.js";
 

--- a/packages/validator/src/services/blockDuties.ts
+++ b/packages/validator/src/services/blockDuties.ts
@@ -1,12 +1,12 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {isForkPostGloas} from "@lodestar/params";
-import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {IClock, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {BLSPubkey, Epoch, RootHex, Slot} from "@lodestar/types";
 import {sleep, toPubkeyHex} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";
 import {PubkeyHex} from "../types.js";
-import {IClock, LoggerVc} from "../util/index.js";
+import {LoggerVc} from "../util/index.js";
 import {ChainHeaderTracker, HeadEventData} from "./chainHeaderTracker.js";
 import {ValidatorStore} from "./validatorStore.js";
 

--- a/packages/validator/src/services/doppelgangerService.ts
+++ b/packages/validator/src/services/doppelgangerService.ts
@@ -1,11 +1,10 @@
 import {ApiClient, routes} from "@lodestar/api";
-import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {IClock, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, ValidatorIndex} from "@lodestar/types";
 import {Logger, fromHex, sleep, truncBytes} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";
 import {ISlashingProtection} from "../slashingProtection/index.js";
 import {ProcessShutdownCallback, PubkeyHex} from "../types.js";
-import {IClock} from "../util/index.js";
 import {IndicesService} from "./indices.js";
 
 // The number of epochs that must be checked before we assume that there are

--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -1,9 +1,10 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
 import {GENESIS_EPOCH, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {IClock} from "@lodestar/state-transition";
 import {Epoch, bellatrix} from "@lodestar/types";
 import {Metrics} from "../metrics.js";
-import {IClock, LoggerVc, batchItems} from "../util/index.js";
+import {LoggerVc, batchItems} from "../util/index.js";
 import {ValidatorStore} from "./validatorStore.js";
 
 const REGISTRATION_CHUNK_SIZE = 512;

--- a/packages/validator/src/services/proposerPreferences.ts
+++ b/packages/validator/src/services/proposerPreferences.ts
@@ -1,11 +1,11 @@
 import {ApiClient} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {SLOTS_PER_EPOCH, isForkPostGloas} from "@lodestar/params";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {IClock, computeEpochAtSlot} from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot, gloas} from "@lodestar/types";
 import {fromHex, toPubkeyHex} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";
-import {IClock, LoggerVc} from "../util/index.js";
+import {LoggerVc} from "../util/index.js";
 import {BlockDutiesService} from "./blockDuties.js";
 import {ValidatorStore} from "./validatorStore.js";
 

--- a/packages/validator/src/services/ptc.ts
+++ b/packages/validator/src/services/ptc.ts
@@ -1,11 +1,12 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {isForkPostGloas} from "@lodestar/params";
+import {IClock} from "@lodestar/state-transition";
 import {Slot, gloas} from "@lodestar/types";
 import {prettyBytes, sleep, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";
 import {PubkeyHex} from "../types.js";
-import {IClock, LoggerVc} from "../util/index.js";
+import {LoggerVc} from "../util/index.js";
 import {ChainHeaderTracker} from "./chainHeaderTracker.js";
 import {ExecutionPayloadAvailableEventData, ValidatorEvent, ValidatorEventEmitter} from "./emitter.js";
 import {PtcDutiesService} from "./ptcDuties.js";

--- a/packages/validator/src/services/ptcDuties.ts
+++ b/packages/validator/src/services/ptcDuties.ts
@@ -1,12 +1,12 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {SLOTS_PER_EPOCH, isForkPostGloas} from "@lodestar/params";
-import {computeEpochAtSlot, isStartSlotOfEpoch} from "@lodestar/state-transition";
+import {IClock, computeEpochAtSlot, isStartSlotOfEpoch} from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot, ValidatorIndex} from "@lodestar/types";
 import {toPubkeyHex} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";
 import {PubkeyHex} from "../types.js";
-import {IClock, LoggerVc} from "../util/index.js";
+import {LoggerVc} from "../util/index.js";
 import {ChainHeaderTracker, HeadEventData} from "./chainHeaderTracker.js";
 import {SyncingStatusTracker} from "./syncingStatusTracker.js";
 import {ValidatorStore} from "./validatorStore.js";

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -1,11 +1,12 @@
 import {ApiClient} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkName, isForkPostAltair} from "@lodestar/params";
+import {IClock} from "@lodestar/state-transition";
 import {CommitteeIndex, Root, Slot, altair} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";
 import {PubkeyHex} from "../types.js";
-import {IClock, LoggerVc} from "../util/index.js";
+import {LoggerVc} from "../util/index.js";
 import {ChainHeaderTracker} from "./chainHeaderTracker.js";
 import {ValidatorEventEmitter} from "./emitter.js";
 import {SyncCommitteeDutiesService, SyncDutyAndProofs} from "./syncCommitteeDuties.js";

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -2,6 +2,7 @@ import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
 import {
+  IClock,
   computeEpochAtSlot,
   computeSyncPeriodAtEpoch,
   computeSyncPeriodAtSlot,
@@ -12,7 +13,7 @@ import {BLSSignature, Epoch, Slot, SyncPeriod, ValidatorIndex} from "@lodestar/t
 import {toPubkeyHex} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";
 import {PubkeyHex} from "../types.js";
-import {IClock, LoggerVc} from "../util/index.js";
+import {LoggerVc} from "../util/index.js";
 import {SyncingStatusTracker} from "./syncingStatusTracker.js";
 import {syncCommitteeIndicesToSubnets} from "./utils.js";
 import {ValidatorStore} from "./validatorStore.js";

--- a/packages/validator/src/services/syncingStatusTracker.ts
+++ b/packages/validator/src/services/syncingStatusTracker.ts
@@ -1,8 +1,8 @@
 import {ApiClient, routes} from "@lodestar/api";
+import {IClock} from "@lodestar/state-transition";
 import {Slot} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {BeaconHealth, Metrics} from "../metrics.js";
-import {IClock} from "../util/clock.js";
 
 export type SyncingStatus = routes.node.SyncingStatus;
 

--- a/packages/validator/src/util/index.ts
+++ b/packages/validator/src/util/index.ts
@@ -1,5 +1,4 @@
 export * from "./batch.js";
-export * from "./clock.js";
 export * from "./difference.js";
 export * from "./logger.js";
 export * from "./url.js";

--- a/packages/validator/src/util/logger.ts
+++ b/packages/validator/src/util/logger.ts
@@ -1,6 +1,6 @@
 import {ApiError} from "@lodestar/api";
+import {IClock} from "@lodestar/state-transition";
 import {LogData, Logger, isErrorAborted} from "@lodestar/utils";
-import {IClock} from "./clock.js";
 
 export type LoggerVc = Logger & {
   isSyncing(e: Error): void;

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -6,7 +6,7 @@ import {
   assertEqualParams,
   createBeaconConfig,
 } from "@lodestar/config";
-import {computeEpochAtSlot, getCurrentSlot} from "@lodestar/state-transition";
+import {Clock, ClockOptions, IClock, computeEpochAtSlot, getCurrentSlot} from "@lodestar/state-transition";
 import {BLSPubkey, phase0, ssz} from "@lodestar/types";
 import {Genesis} from "@lodestar/types/phase0";
 import {Logger, toPrintableUrl, toRootHex} from "@lodestar/utils";
@@ -29,7 +29,6 @@ import {SyncingStatusTracker} from "./services/syncingStatusTracker.js";
 import {Signer, ValidatorProposerConfig, ValidatorStore, defaultOptions} from "./services/validatorStore.js";
 import {ISlashingProtection, Interchange, InterchangeFormatVersion} from "./slashingProtection/index.js";
 import {LodestarValidatorDatabaseController, ProcessShutdownCallback, PubkeyHex} from "./types.js";
-import {Clock, ClockOptions, IClock} from "./util/clock.js";
 import {getLoggerVc} from "./util/index.js";
 
 export type ValidatorModules = {

--- a/packages/validator/test/utils/clock.ts
+++ b/packages/validator/test/utils/clock.ts
@@ -1,5 +1,5 @@
+import {IClock} from "@lodestar/state-transition";
 import {Epoch, Slot} from "@lodestar/types";
-import {IClock} from "../../src/util/index.js";
 
 type RunEveryFn = (slot: Slot, signal: AbortSignal) => Promise<void>;
 


### PR DESCRIPTION
## Motivation

Make the validator `Clock` util reusable by the upcoming builder client (EPF7 Forgestar), the same way `assertEqualParams` was recently lifted to `@lodestar/config`. Follow-up to that builder-refactor series.

## Description

Moves `Clock`, `IClock`, `ClockOptions`, `TimeItem` and `getCurrentSlotAround` from `packages/validator/src/util/clock.ts` to `packages/state-transition/src/util/clock.ts`.

**Why `state-transition` and not `config`?** The clock is built directly on state-transition's slot helpers — `getCurrentSlot`, `computeEpochAtSlot`, `computeTimeAtSlot` — so state-transition is its natural dependency floor: the move needs zero new deps, and both the validator and a future builder client already sit above state-transition. It can't follow `assertEqualParams` into `@lodestar/config`, because config sits *below* state-transition (`state-transition → config`), so importing those slot helpers from config would be a circular dependency.

Consumers now import `IClock` from `@lodestar/state-transition` directly (no barrel re-export shim), matching how `assertEqualParams` consumers import from `@lodestar/config`.

The unit test moves alongside the code to `packages/state-transition/test/unit/util/clock.test.ts`. `state-transition` doesn't carry logger test infra (`@lodestar/logger` is not a devDep there), so the test uses a small `vi.fn()` logger stub instead of `testLogger()` — the logger is only a constructor arg and was never asserted. Happy to add the devDep and use `getEnvLogger` instead if preferred.

No behavior change.
