### PR TITLE
chore: avoid scheduling infinite waitFor timeout

### DIFF
--- a/packages/utils/src/waitFor.ts
+++ b/packages/utils/src/waitFor.ts
@@ -26,10 +26,13 @@ export function waitFor(condition: () => boolean, opts: WaitForOpts = {}): Promi
 
     let onDone: () => void = () => {};
 
-    const timeoutId = setTimeout(() => {
-      onDone();
-      reject(new TimeoutError());
-    }, timeout);
+    const timeoutId =
+      timeout === Infinity
+        ? undefined
+        : setTimeout(() => {
+            onDone();
+            reject(new TimeoutError());
+          }, timeout);
 
     const intervalId = setInterval(() => {
       if (condition()) {
@@ -45,7 +48,9 @@ export function waitFor(condition: () => boolean, opts: WaitForOpts = {}): Promi
     if (signal) signal.addEventListener("abort", onAbort);
 
     onDone = () => {
-      clearTimeout(timeoutId);
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
       clearInterval(intervalId);
       if (signal) signal.removeEventListener("abort", onAbort);
     };

--- a/packages/utils/test/unit/waitFor.test.ts
+++ b/packages/utils/test/unit/waitFor.test.ts
@@ -19,6 +19,15 @@ describe("waitFor", () => {
     await waitFor(() => condition, {interval, timeout});
   });
 
+  it("Should not time out if timeout is omitted", async () => {
+    let condition = false;
+    setTimeout(() => {
+      condition = true;
+    }, timeout);
+
+    await expect(waitFor(() => condition, {interval: 5})).resolves.toBeUndefined();
+  });
+
   it("Should reject with TimeoutError if condition does not become true within timeout", async () => {
     await expect(waitFor(() => false, {interval, timeout})).rejects.toThrow(TimeoutError);
   });


### PR DESCRIPTION
**Motivation**

`waitFor()` defaults `timeout` to `Infinity`, but passing `Infinity` to Node.js `setTimeout()` emits a `TimeoutOverflowWarning` and clamps the delay to 1 ms.

This is a latent API bug rather than a currently observed Lodestar production failure. The only current in-repository production caller passes an explicit finite timeout. However, `timeout` is optional and `waitFor` is exported from `@lodestar/utils`, so omitted-timeout calls do not behave as intended for external and future callers.



**Description**


Skip creating the timeout timer when `timeout` is `Infinity`, and add a regression test covering the omitted-timeout behavior.

Closes https://github.com/ChainSafe/lodestar/issues/9734



**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

<!-- Insert any AI assistance disclosure here -->

I use OpenAI Codex to write the test case.