### PR TITLE
chore: fix typo in validator config verification log

### DIFF
--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -362,7 +362,7 @@ export class Validator {
 
     const res = await api.config.getSpec();
     assertEqualParams(config, res.value());
-    logger.info("Verified connected beacon node and validator have same the config");
+    logger.info("Verified connected beacon node and validator have the same config");
 
     await assertEqualGenesis(opts, genesis);
     logger.info("Verified connected beacon node and validator have the same genesisValidatorRoot");


### PR DESCRIPTION
## Motivation

Fix a small grammar typo in the log line emitted after the validator verifies it shares the same config as the connected beacon node.

## Description

`packages/validator/src/validator.ts`:

```diff
-    logger.info("Verified connected beacon node and validator have same the config");
+    logger.info("Verified connected beacon node and validator have the same config");
```

Matches the phrasing of the sibling line right below it (`"...have the same genesisValidatorRoot"`).

The same string also appears as pasted example log output in two docs pages (`docs/pages/run/getting-started/quick-start-custom-guide.md`, `docs/pages/run/validator-management/vc-configuration.md`). Left untouched intentionally — those are illustrative log snapshots, not hand-edited here.

No behavior change.
