### PR TITLE
fix: use UintBn64 for gloas ExecutionPayloadBid.executionPayment

### DIFF
--- a/packages/beacon-node/src/chain/errors/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/errors/executionPayloadBid.ts
@@ -31,7 +31,7 @@ export type ExecutionPayloadBidErrorType =
   | {
       code: ExecutionPayloadBidErrorCode.NON_ZERO_EXECUTION_PAYMENT;
       builderIndex: BuilderIndex;
-      executionPayment: number;
+      executionPayment: bigint;
     }
   | {
       code: ExecutionPayloadBidErrorCode.BID_ALREADY_KNOWN;

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -349,7 +349,7 @@ export async function produceBlockBody<T extends BlockType>(
       builderIndex: BUILDER_INDEX_SELF_BUILD,
       slot: blockSlot,
       value: 0,
-      executionPayment: 0,
+      executionPayment: 0n,
       blobKzgCommitments: blobsBundle.commitments,
       executionRequestsRoot: ssz.gloas.ExecutionRequests.hashTreeRoot(executionRequests as gloas.ExecutionRequests),
     };

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -184,7 +184,7 @@ async function validateExecutionPayloadBid(
   }
 
   // [REJECT] `bid.execution_payment` is zero.
-  if (bid.executionPayment !== 0) {
+  if (bid.executionPayment !== 0n) {
     throw new ExecutionPayloadBidError(GossipAction.REJECT, {
       code: ExecutionPayloadBidErrorCode.NON_ZERO_EXECUTION_PAYMENT,
       builderIndex: bid.builderIndex,

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -327,7 +327,9 @@ export const ExecutionPayloadBid = new ProgressiveContainerType(
     builderIndex: BuilderIndex,
     slot: Slot,
     value: UintNum64,
-    executionPayment: UintNum64,
+    // executionPayment is a uint64 with no bound in process_execution_payload_bid, so a block can
+    // carry any value; use UintBn64 so the hashTreeRoot matches exact-uint64 clients for values > 2**53.
+    executionPayment: UintBn64,
     blobKzgCommitments: BlobKzgCommitments,
     executionRequestsRoot: Root,
   },


### PR DESCRIPTION
`ExecutionPayloadBid.executionPayment` is a `uint64` with no bound in `process_execution_payload_bid`. Back it with `UintBn64` (exact) instead of `UintNum64` (float64, lossy above 2**53) so the bid hashTreeRoot stays exact across the full uint64 range. Gloas-only, no mainnet impact.