### PR TITLE
fix: use UintBn64 for gloas ExecutionPayloadBid.gasLimit

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyExecutionPayloadEnvelope.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyExecutionPayloadEnvelope.ts
@@ -61,7 +61,7 @@ export function verifyExecutionPayloadEnvelope(
       `Prev randao mismatch between bid and payload bid=${toHex(bid.prevRandao)} payload=${toHex(payload.prevRandao)}`
     );
   }
-  if (bid.gasLimit !== payload.gasLimit) {
+  if (bid.gasLimit !== BigInt(payload.gasLimit)) {
     throw new Error(`Gas limit mismatch between payload and bid payload=${payload.gasLimit} bid=${bid.gasLimit}`);
   }
   if (!byteArrayEquals(bid.blockHash, payload.blockHash)) {

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -345,7 +345,7 @@ export async function produceBlockBody<T extends BlockType>(
       blockHash: executionPayload.blockHash,
       prevRandao: currentState.getRandaoMix(currentState.epoch),
       feeRecipient: executionPayload.feeRecipient,
-      gasLimit: executionPayload.gasLimit,
+      gasLimit: BigInt(executionPayload.gasLimit),
       builderIndex: BUILDER_INDEX_SELF_BUILD,
       slot: blockSlot,
       value: 0,

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -219,7 +219,7 @@ async function validateExecutionPayloadBid(
   // [IGNORE] `is_gas_limit_target_compatible(parent_gas_limit, bid.gas_limit, target_gas_limit)`,
   // where `parent_gas_limit` is the `gas_limit` of the parent execution payload and
   // `target_gas_limit` is `proposer_preferences.target_gas_limit`.
-  const bidGasLimit = bid.gasLimit;
+  const bidGasLimit = Number(bid.gasLimit);
   const parentGasLimit = parentPayloadVariant.executionPayloadGasLimit;
   const targetGasLimit = proposerPreferences.message.targetGasLimit;
   if (!isGasLimitTargetCompatible(parentGasLimit, bidGasLimit, targetGasLimit)) {

--- a/packages/beacon-node/src/chain/validatorMonitor.ts
+++ b/packages/beacon-node/src/chain/validatorMonitor.ts
@@ -469,7 +469,7 @@ export function createValidatorMonitor(
         proposerIndex,
         src,
         builderIndex: bid.builderIndex,
-        gasLimit: bid.gasLimit,
+        gasLimit: Number(bid.gasLimit),
         value: bid.value.toString(),
         parentBlockRoot: toRootHex(bid.parentBlockRoot),
         parentBlockHash: toRootHex(bid.parentBlockHash),

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -706,7 +706,7 @@ export function getBlockRootFromPayloadAttestationMessageSerialized(data: Uint8A
  *   blockHash: Bytes32            (32 bytes)
  *   prevRandao: Bytes32           (32 bytes)
  *   feeRecipient: ExecutionAddress(20 bytes)
- *   gasLimit: UintNum64           (8 bytes)
+ *   gasLimit: UintBn64            (8 bytes)
  *   builderIndex: BuilderIndex    (8 bytes)
  *   slot: Slot                    (8 bytes)  ← absolute offset 264
  */

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -70,7 +70,7 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
   stateGloasView.currentSyncCommittee = stateGloasCloned.currentSyncCommittee;
   stateGloasView.nextSyncCommittee = stateGloasCloned.nextSyncCommittee;
   stateGloasView.latestExecutionPayloadBid.blockHash = stateFulu.latestExecutionPayloadHeader.blockHash;
-  stateGloasView.latestExecutionPayloadBid.gasLimit = stateFulu.latestExecutionPayloadHeader.gasLimit;
+  stateGloasView.latestExecutionPayloadBid.gasLimit = BigInt(stateFulu.latestExecutionPayloadHeader.gasLimit);
   stateGloasView.latestExecutionPayloadBid.executionRequestsRoot = ssz.gloas.ExecutionRequests.hashTreeRoot(
     ssz.gloas.ExecutionRequests.defaultValue()
   );

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -323,7 +323,10 @@ export const ExecutionPayloadBid = new ProgressiveContainerType(
     blockHash: Bytes32,
     prevRandao: Bytes32,
     feeRecipient: ExecutionAddress,
-    gasLimit: UintNum64,
+    // gasLimit is a uint64 with no bound in process_execution_payload_bid (the gas-limit target
+    // check is gossip-only), so a block can carry any value; use UintBn64 so the bid hashTreeRoot
+    // matches exact-uint64 clients for values above 2**53.
+    gasLimit: UintBn64,
     builderIndex: BuilderIndex,
     slot: Slot,
     value: UintNum64,


### PR DESCRIPTION
`ExecutionPayloadBid.gasLimit` is a `uint64` with no bound in `process_execution_payload_bid` (the gas-limit-target check lives in gossip validation only). Back it with `UintBn64` (exact) instead of `UintNum64` (float64, lossy above 2**53) so the bid hashTreeRoot stays exact across the full uint64 range; narrowed to `number` only where it feeds the number-typed gas-limit math and metrics. Gloas-only, no mainnet impact.