### PR TITLE
fix: avoid peer scoring on local payload errors

### DIFF
--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -5,6 +5,7 @@ import {LodestarError, byteArrayEquals, prettyPrintIndices, toRootHex} from "@lo
 import {isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {IBlockInput} from "../../chain/blocks/blockInput/types.js";
 import {isDaOutOfRange} from "../../chain/blocks/blockInput/utils.js";
+import {PayloadError, PayloadErrorCode} from "../../chain/blocks/importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "../../chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {BlockError, BlockErrorCode} from "../../chain/errors/index.js";
 import {ZERO_HASH} from "../../constants/constants.js";
@@ -702,7 +703,7 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.Processing));
     }
 
-    if (err instanceof BlockError && err.type.code === BlockErrorCode.EXECUTION_ENGINE_ERROR) {
+    if (isExecutionEngineError(err)) {
       this.onExecutionEngineError(this.state.attempt);
     } else {
       this.onProcessingError(this.state.attempt);
@@ -717,7 +718,7 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.AwaitingValidation));
     }
 
-    if (err instanceof BlockError && err.type.code === BlockErrorCode.EXECUTION_ENGINE_ERROR) {
+    if (isExecutionEngineError(err)) {
       this.onExecutionEngineError(this.state.attempt);
     } else {
       this.onProcessingError(this.state.attempt);
@@ -787,3 +788,19 @@ type BatchErrorMetadata = {
 };
 
 export class BatchError extends LodestarError<BatchErrorType & BatchErrorMetadata> {}
+
+function isExecutionEngineError(err: Error): boolean {
+  if (!(err instanceof BlockError)) {
+    return false;
+  }
+
+  if (err.type.code === BlockErrorCode.EXECUTION_ENGINE_ERROR) {
+    return true;
+  }
+
+  return (
+    err.type.code === BlockErrorCode.BEACON_CHAIN_ERROR &&
+    err.type.error instanceof PayloadError &&
+    err.type.error.type.code === PayloadErrorCode.EXECUTION_ENGINE_ERROR
+  );
+}

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -9,10 +9,13 @@ import {
   BlockInputPreData,
 } from "../../../../src/chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource} from "../../../../src/chain/blocks/blockInput/types.js";
+import {PayloadError, PayloadErrorCode} from "../../../../src/chain/blocks/importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
 import {BlockError, BlockErrorCode} from "../../../../src/chain/errors/index.js";
+import {ExecutionPayloadStatus} from "../../../../src/execution/index.js";
 import {computeNodeIdFromPrivateKey} from "../../../../src/network/subnets/index.js";
+import {MAX_BATCH_PROCESSING_ATTEMPTS} from "../../../../src/sync/constants.js";
 import {Batch, BatchError, BatchErrorCode, BatchStatus} from "../../../../src/sync/range/batch.js";
 import {getBatchSlotRange} from "../../../../src/sync/range/utils/index.js";
 import {CustodyConfig} from "../../../../src/util/dataColumns.js";
@@ -137,6 +140,31 @@ describe("sync / range / batch", async () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
+  function downloadBlock(batch: Batch): void {
+    batch.startDownloading(peerSyncMeta);
+    batch.downloadingSuccess(
+      peer,
+      [
+        BlockInputPreData.createFromBlock({
+          block: ssz.capella.SignedBeaconBlock.defaultValue(),
+          blockRootHex: "0x1234",
+          source: BlockInputSource.byRoot,
+          seenTimestampSec: Date.now() / 1000,
+          forkName: ForkName.capella,
+          daOutOfRange: false,
+        }),
+      ],
+      null
+    );
+  }
+
+  function batchInProcessing(startEpoch = 0): Batch {
+    const batch = new Batch(startEpoch, config, clock, custodyConfig, false, undefined, Number.MAX_SAFE_INTEGER);
+    downloadBlock(batch);
+    batch.startProcessing();
+    return batch;
+  }
 
   describe("getRequests", () => {
     describe("PreDeneb", () => {
@@ -595,29 +623,45 @@ describe("sync / range / batch", async () => {
     );
   });
 
-  describe("retainForReprocessing", () => {
+  describe("processingError", () => {
     const startEpoch = 0;
 
-    function batchInProcessing(): Batch {
-      const batch = new Batch(startEpoch, config, clock, custodyConfig, false, undefined, Number.MAX_SAFE_INTEGER);
-      batch.startDownloading(peerSyncMeta);
-      batch.downloadingSuccess(
-        peer,
-        [
-          BlockInputPreData.createFromBlock({
-            block: ssz.capella.SignedBeaconBlock.defaultValue(),
-            blockRootHex: "0x1234",
-            source: BlockInputSource.byRoot,
-            seenTimestampSec: Date.now() / 1000,
-            forkName: ForkName.capella,
-            daOutOfRange: false,
-          }),
-        ],
-        null
+    it("treats wrapped payload execution engine errors as local execution failures", () => {
+      const batch = batchInProcessing(startEpoch);
+      const error = new BlockError(ssz.phase0.SignedBeaconBlock.defaultValue(), {
+        code: BlockErrorCode.BEACON_CHAIN_ERROR,
+        error: new PayloadError({
+          code: PayloadErrorCode.EXECUTION_ENGINE_ERROR,
+          execStatus: ExecutionPayloadStatus.ELERROR,
+          errorMessage: "execution engine unavailable",
+        }),
+      });
+
+      for (let i = 0; i < MAX_BATCH_PROCESSING_ATTEMPTS; i++) {
+        batch.processingError(error);
+
+        expect(batch.state.status).toBe(BatchStatus.AwaitingDownload);
+        expect(batch.failedProcessingAttempts).toHaveLength(0);
+        expect(batch.executionErrorAttempts).toHaveLength(i + 1);
+
+        downloadBlock(batch);
+        batch.startProcessing();
+      }
+
+      expectThrowsLodestarError(
+        () => batch.processingError(error),
+        new BatchError({
+          code: BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS,
+          startEpoch,
+          status: BatchStatus.Processing,
+        })
       );
-      batch.startProcessing();
-      return batch;
-    }
+      expect(batch.failedProcessingAttempts).toHaveLength(0);
+    });
+  });
+
+  describe("retainForReprocessing", () => {
+    const startEpoch = 0;
 
     it("Processing -> AwaitingProcessing, keeps blocks and records no failed attempt", () => {
       const batch = batchInProcessing();

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -638,11 +638,21 @@ describe("sync / range / batch", async () => {
       });
 
       for (let i = 0; i < MAX_BATCH_PROCESSING_ATTEMPTS; i++) {
+        const attempt = i + 1;
+
         batch.processingError(error);
 
-        expect(batch.state.status).toBe(BatchStatus.AwaitingDownload);
-        expect(batch.failedProcessingAttempts).toHaveLength(0);
-        expect(batch.executionErrorAttempts).toHaveLength(i + 1);
+        expect(batch.state.status, `attempt ${attempt}: batch should await redownload`).toBe(
+          BatchStatus.AwaitingDownload
+        );
+        expect(
+          batch.failedProcessingAttempts,
+          `attempt ${attempt}: local execution errors should not count as peer-attributable failures`
+        ).toHaveLength(0);
+        expect(
+          batch.executionErrorAttempts,
+          `attempt ${attempt}: local execution errors should be tracked`
+        ).toHaveLength(attempt);
 
         downloadBlock(batch);
         batch.startProcessing();


### PR DESCRIPTION
## Motivation

Range sync currently classifies a `BlockErrorCode.BEACON_CHAIN_ERROR` wrapping `PayloadErrorCode.EXECUTION_ENGINE_ERROR` as a generic processing failure. After enough retries, those attempts land in `failedProcessingAttempts`, and range sync can downscore peers even though the actual failure is local EL/import trouble.

This showed up on glamsterdam-devnet-7 deathstar: Lodestar received sync batches, failed importing a Gloas payload because `snooper-engine -> execution:8551` refused connections, then burned through peer scores and isolated itself.

Fixes #9754.

## Description

- Treat wrapped payload `EXECUTION_ENGINE_ERROR` as a local execution-engine failure in range sync batch processing/validation.
- Keep peer-attributable payload failures on the normal processing-failure path.
- Add unit coverage that the wrapped local EL error increments execution-error attempts and does not add failed processing attempts.

## Verification

- `pnpm vitest run --project unit packages/beacon-node/test/unit/sync/range/batch.test.ts`
- `pnpm lint`
- `pnpm check-types`

AI-assisted by Lodekeeper.