### PR TITLE
fix: get proposer from head state in prepareNextSlot

### DIFF
--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -1,7 +1,14 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {getSafeExecutionBlockHash} from "@lodestar/fork-choice";
-import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH, isForkPostBellatrix, isForkPostGloas} from "@lodestar/params";
+import {
+  ForkPostBellatrix,
+  ForkSeq,
+  SLOTS_PER_EPOCH,
+  isForkPostBellatrix,
+  isForkPostFulu,
+  isForkPostGloas,
+} from "@lodestar/params";
 import {
   IBeaconStateView,
   IBeaconStateViewBellatrix,
@@ -11,7 +18,7 @@ import {
   isStatePostBellatrix,
   isStatePostGloas,
 } from "@lodestar/state-transition";
-import {Bytes32, Slot} from "@lodestar/types";
+import {Bytes32, Slot, ValidatorIndex} from "@lodestar/types";
 import {Logger, fromHex, isErrorAborted, sleep} from "@lodestar/utils";
 import {GENESIS_SLOT, ZERO_HASH_HEX} from "../constants/constants.js";
 import {BuilderStatus} from "../execution/builder/http.js";
@@ -111,29 +118,36 @@ export class PrepareNextSlotScheduler {
         : null;
       const start = Date.now();
       // No need to wait for this or the clock drift
-      // Pre Bellatrix: we only do precompute state transition for the last slot of epoch
-      // For Bellatrix, we always do the `processSlots()` to prepare payload for the next slot
-      const prepareState = await this.chain.regen.getBlockSlotState(
-        headBlock,
-        prepareSlot,
-        // the slot 0 of next epoch will likely use this Previous Root Checkpoint state for state transition so we transfer cache here
-        // the resulting state with cache will be cached in Checkpoint State Cache which is used for the upcoming block processing
-        // for other slots dontTransferCached=true because we don't run state transition on this state
-        {dontTransferCache: !isEpochTransition},
-        RegenCaller.precomputeEpoch
-      );
-
       if (isForkPostBellatrix(fork)) {
-        const proposerIndex = prepareState.getBeaconProposer(prepareSlot);
+        let preparedState: IBeaconStateView | undefined;
+
+        const getProposerIndex = async (): Promise<ValidatorIndex> => {
+          if (isForkPostFulu(fork)) {
+            // getBeaconProposer covers the current + next epoch; should not throw
+            // PROPOSER_EPOCH_MISMATCH here due to the PREPARE_EPOCH_LIMIT check above.
+            return this.chain.getHeadState().getBeaconProposer(prepareSlot);
+          }
+          // the slot 0 of next epoch will likely use this Previous Root Checkpoint state for state transition so we transfer cache here
+          // the resulting state with cache will be cached in Checkpoint State Cache which is used for the upcoming block processing
+          // for other slots dontTransferCached=true because we don't run state transition on this state
+          preparedState = await this.chain.regen.getBlockSlotState(
+            headBlock,
+            prepareSlot,
+            {dontTransferCache: !isEpochTransition},
+            RegenCaller.precomputeEpoch
+          );
+          return preparedState.getBeaconProposer(prepareSlot);
+        };
+
+        const proposerIndex = await getProposerIndex();
         const feeRecipient = this.chain.beaconProposerCache.get(proposerIndex);
-        let updatedPrepareState = prepareState;
 
         if (feeRecipient) {
           // If we are proposing next slot, we need to predict if we can proposer-boost-reorg or not
           const proposerHead = this.chain.predictProposerHead(clockSlot);
           const {slot: proposerHeadSlot, blockRoot: proposerHeadRoot} = proposerHead;
 
-          // If we predict we can reorg, update prepareState with proposer head block
+          // If we predict we can reorg, we build on the proposer head (parent) block instead
           if (proposerHeadRoot !== headRoot || proposerHeadSlot !== headSlot) {
             this.logger.verbose("Weak head detected. May build on parent block instead", {
               proposerHeadSlot,
@@ -142,13 +156,6 @@ export class PrepareNextSlotScheduler {
               headRoot,
             });
             this.metrics?.weakHeadDetected.inc();
-            updatedPrepareState = await this.chain.regen.getBlockSlotState(
-              proposerHead,
-              prepareSlot,
-              // only transfer cache if epoch transition because that's the state we will use to stateTransition() the 1st block of epoch
-              {dontTransferCache: !isEpochTransition},
-              RegenCaller.predictProposerHead
-            );
             updatedHead = proposerHead;
           }
 
@@ -165,30 +172,41 @@ export class PrepareNextSlotScheduler {
           }
         }
 
-        if (!isStatePostBellatrix(updatedPrepareState)) {
+        // post-fulu we'll always reach here because preparedState is undefined
+        if (preparedState === undefined || updatedHead !== headBlock) {
+          preparedState = await this.chain.regen.getBlockSlotState(
+            updatedHead,
+            prepareSlot,
+            // only transfer cache if epoch transition because that's the state we will use to stateTransition() the 1st block of epoch
+            {dontTransferCache: !isEpochTransition},
+            updatedHead === headBlock ? RegenCaller.precomputeEpoch : RegenCaller.predictProposerHead
+          );
+        }
+
+        if (!isStatePostBellatrix(preparedState)) {
           throw new Error("Expected Bellatrix state for payload attributes");
         }
 
         let parentBlockHash: Bytes32;
         // Apply parent payload once here as it's reused by EL prep and SSE emit below
-        let stateAfterParentPayload: IBeaconStateViewBellatrix = updatedPrepareState;
-        if (isStatePostGloas(updatedPrepareState)) {
+        let stateAfterParentPayload: IBeaconStateViewBellatrix = preparedState;
+        if (isStatePostGloas(preparedState)) {
           // Spec: should_build_on_full(store, head, slot) - see produceBlockBody.ts for context.
           if (this.chain.forkChoice.shouldBuildOnFull(updatedHead, prepareSlot)) {
-            parentBlockHash = updatedPrepareState.latestExecutionPayloadBid.blockHash;
+            parentBlockHash = preparedState.latestExecutionPayloadBid.blockHash;
             // Skip applying parent payload unless we're proposing the next slot or have to emit payload_attributes events
             if (feeRecipient !== undefined || this.chain.opts.emitPayloadAttributes === true) {
               const parentExecutionRequests = await this.chain.getParentExecutionRequests(
                 updatedHead.slot,
                 updatedHead.blockRoot
               );
-              stateAfterParentPayload = updatedPrepareState.withParentPayloadApplied(parentExecutionRequests);
+              stateAfterParentPayload = preparedState.withParentPayloadApplied(parentExecutionRequests);
             }
           } else {
-            parentBlockHash = updatedPrepareState.latestExecutionPayloadBid.parentBlockHash;
+            parentBlockHash = preparedState.latestExecutionPayloadBid.parentBlockHash;
           }
         } else {
-          parentBlockHash = updatedPrepareState.latestExecutionPayloadHeader.blockHash;
+          parentBlockHash = preparedState.latestExecutionPayloadHeader.blockHash;
         }
 
         if (feeRecipient) {
@@ -221,7 +239,7 @@ export class PrepareNextSlotScheduler {
           });
         }
 
-        this.computeStateHashTreeRoot(updatedPrepareState, isEpochTransition);
+        this.computeStateHashTreeRoot(preparedState, isEpochTransition);
 
         // If emitPayloadAttributes is true emit a SSE payloadAttributes event for
         // every slot. Without the flag, only emit the event if we are proposing in the next slot.
@@ -239,7 +257,14 @@ export class PrepareNextSlotScheduler {
           this.chain.emitter.emit(routes.events.EventType.payloadAttributes, {data, version: fork});
         }
       } else {
-        this.computeStateHashTreeRoot(prepareState, isEpochTransition);
+        // Pre-bellatrix only reaches here at an epoch transition to precompute the next epoch state
+        const preparedState = await this.chain.regen.getBlockSlotState(
+          headBlock,
+          prepareSlot,
+          {dontTransferCache: !isEpochTransition},
+          RegenCaller.precomputeEpoch
+        );
+        this.computeStateHashTreeRoot(preparedState, isEpochTransition);
       }
 
       // assuming there is no reorg, it caches the checkpoint state & helps avoid doing a full state transition in the next slot

--- a/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
+++ b/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
@@ -143,6 +143,40 @@ describe("PrepareNextSlot scheduler", () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
+  it("post-fulu - should read proposer from head state and dial only the proposer head on reorg", async () => {
+    getForkStub.mockReturnValue(ForkName.fulu);
+    const headBlock = {...zeroProtoBlock, blockRoot: "0xhead", slot: SLOTS_PER_EPOCH - 3} as ProtoBlock;
+    // predicted proposer-boost-reorg: build on the parent block instead of the canonical head
+    const proposerHead = {...zeroProtoBlock, blockRoot: "0xparent", slot: SLOTS_PER_EPOCH - 4} as ProtoBlock;
+    chainStub.recomputeForkChoiceHead.mockReturnValue(headBlock);
+    chainStub.predictProposerHead.mockReturnValue(proposerHead);
+    forkChoiceStub.getFinalizedBlock.mockReturnValue({} as ProtoBlock);
+    updateBuilderStatus.mockReturnValue(void 0);
+
+    const headState = generateCachedBellatrixState();
+    vi.spyOn(headState.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
+    chainStub.getHeadState.mockReturnValue(new BeaconStateView(headState));
+    regenStub.getBlockSlotState.mockResolvedValue(new BeaconStateView(generateCachedBellatrixState()));
+    beaconProposerCacheStub.get.mockReturnValue("0x fee recipient address");
+    (executionEngineStub as unknown as {payloadIdCache: PayloadIdCache}).payloadIdCache = new PayloadIdCache();
+
+    await Promise.all([
+      scheduler.prepareForNextSlot(SLOTS_PER_EPOCH - 2),
+      vi.advanceTimersByTimeAsync((config.SLOT_DURATION_MS * 2) / 3),
+    ]);
+
+    // proposer comes from the head state, so no dial is needed just to learn it
+    expect(chainStub.getHeadState).toHaveBeenCalled();
+    // a single dial, on the proposer head (reorg parent) - not two dials
+    expect(regenStub.getBlockSlotState).toHaveBeenCalledOnce();
+    expect(regenStub.getBlockSlotState).toHaveBeenCalledWith(
+      proposerHead,
+      SLOTS_PER_EPOCH - 1,
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
   it("gloas - should update builder circuit breaker instead of builder status", async () => {
     getForkStub.mockReturnValue(ForkName.gloas);
     chainStub.recomputeForkChoiceHead.mockReturnValue({...zeroProtoBlock, slot: SLOTS_PER_EPOCH - 3} as ProtoBlock);
@@ -150,6 +184,8 @@ describe("PrepareNextSlot scheduler", () => {
     forkChoiceStub.getFinalizedBlock.mockReturnValue({} as ProtoBlock);
     const state = generateCachedBellatrixState();
     vi.spyOn(state.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
+    // post-fulu (gloas): proposer is read from the head state, not from a dialed prepare state
+    chainStub.getHeadState.mockReturnValue(new BeaconStateView(state));
     regenStub.getBlockSlotState.mockResolvedValue(new BeaconStateView(state));
     beaconProposerCacheStub.get.mockReturnValue("0x fee recipient address");
     (executionEngineStub as unknown as {payloadIdCache: PayloadIdCache}).payloadIdCache = new PayloadIdCache();


### PR DESCRIPTION
**Motivation**

- we call `regen.getBlockSlotState()` twice in prepareNextSlot, which means a potential double epoch transition
- the 1st preparedState is just to get proposer index. Post fulu, we can just get it from the head state, because the head state is close to the clock slot

**Description**

- post-fulu, get proposer index from the head state
- then define `preparedState` once

more discussion on that is at https://discord.com/channels/593655374469660673/1372263082415493200/1533884072957317211

**AI Assistance Disclosure**

- created with the help of Claude
