### PR TITLE
fix(metrics): properly order BLS job wait histogram buckets

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -424,7 +424,7 @@ export function createLodestarMetrics(
       jobWaitTime: register.histogram({
         name: "lodestar_bls_thread_pool_queue_job_wait_time_seconds",
         help: "Time from job added to the queue to starting the job in seconds",
-        buckets: [0.01, 0.02, 0.5, 0.1, 0.3, 1],
+        buckets: [0.01, 0.02, 0.1, 0.3, 0.5, 1],
       }),
       queueLength: register.gauge({
         name: "lodestar_bls_thread_pool_queue_length",


### PR DESCRIPTION
**Motivation**

The buckets for `lodestar_bls_thread_pool_queue_job_wait_time_seconds` are not ordered, which results in values below 0.5 to be incorrectly included in the 0.1 and 0.3 buckets.

This wasn't and isn't an issue since we average using `_sum / _count`, but imo still worth fixing for correctness.

**Description**

The fix is just to properly reorder the buckets.

**Repro**

Here's a simple repro you can do with a bash script:

```bash
   d=$(mktemp -d) && cd "$d" &&
   npm init -y >/dev/null &&
   npm install --silent prom-client@15.1.3 &&
   node -e '
   const {Histogram, Registry} = require("prom-client");

   const register = new Registry();
   const histogram = new Histogram({
     name: "test_wait_seconds",
     help: "test",
     buckets: [0.01, 0.02, 0.5, 0.1, 0.3, 1],
     registers: [register],
   });

   [0.015, 0.05, 0.2, 0.4, 0.8].forEach((value) => {
     histogram.observe(value);
   });

   register.metrics().then(console.log);
   '
```

this incorrectly produces


 ```text
   test_wait_seconds_bucket{le="0.01"} 0
   test_wait_seconds_bucket{le="0.02"} 1
   test_wait_seconds_bucket{le="0.5"} 4
   test_wait_seconds_bucket{le="0.1"} 4
   test_wait_seconds_bucket{le="0.3"} 4
   test_wait_seconds_bucket{le="1"} 5
 ```

**AI Assistance Disclosure**

Found this while looking at metrics for blst-z with assistance of sol
