### PR TITLE
chore: use tsc for builder package scripts

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -23,11 +23,11 @@
   ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json",
     "build:release": "pnpm clean && pnpm run build",
     "build:watch": "pnpm run build --watch",
     "check-build": "node -e \"(async function() { await import('./lib/index.js') })()\"",
-    "check-types": "tsgo",
+    "check-types": "tsc",
     "lint": "biome check src/ test/",
     "lint:fix": "pnpm run lint --write",
     "test:unit": "vitest run --project unit --project unit-minimal",


### PR DESCRIPTION
## Motivation
The `unstable` Build (24) job is failing after #9575 because `packages/builder` still invokes `tsgo`, but the TypeScript 7 migration removed `@typescript/native-preview` and standardizes on the `tsc` binary.

Failing job: https://github.com/ChainSafe/lodestar/actions/runs/30917514809/job/92019306639

## Description
- replace `packages/builder` `build` script `tsgo -p tsconfig.build.json` with `tsc -p tsconfig.build.json`
- replace `packages/builder` `check-types` script `tsgo` with `tsc`

This matches the rest of the workspace after the TS7 migration and does not require lockfile changes because `typescript@7.0.2` is already a root devDependency.

## Verification
- `pnpm build`
- `pnpm --filter @lodestar/builder check-types`
- `pnpm --filter @lodestar/builder check-build`
- `pnpm lint`
- `pnpm check-types`

## AI disclosure
Reviewed and committed with AI assistance.

🤖 Generated with AI assistance