### PR TITLE
chore: avoid epoch transition when validating gossip columns

### DIFF
--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -2,15 +2,16 @@ import {ChainConfig, ChainForkConfig} from "@lodestar/config";
 import {
   KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH,
   KZG_COMMITMENTS_SUBTREE_INDEX,
+  MIN_SEED_LOOKAHEAD,
   NUMBER_OF_COLUMNS,
+  isForkPostFulu,
 } from "@lodestar/params";
 import {
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   getBlockHeaderProposerSignatureSetByHeaderSlot,
-  getBlockHeaderProposerSignatureSetByParentStateSlot,
 } from "@lodestar/state-transition";
-import {DataColumnSidecar, Root, Slot, SubnetID, fulu, gloas, ssz} from "@lodestar/types";
+import {DataColumnSidecar, Root, Slot, SubnetID, ValidatorIndex, fulu, gloas, ssz} from "@lodestar/types";
 import {byteArrayEquals, toRootHex, verifyMerkleBranch} from "@lodestar/utils";
 import {BeaconMetrics} from "../../metrics/metrics/beacon.js";
 import {Metrics} from "../../metrics/metrics.js";
@@ -104,19 +105,23 @@ export async function validateGossipFuluDataColumnSidecar(
     });
   }
 
-  // getBlockSlotState also checks for whether the current finalized checkpoint is an ancestor of the block.
-  // As a result, we throw an IGNORE (whereas the spec says we should REJECT for this scenario).
-  // this is something we should change this in the future to make the code airtight to the spec.
   // 7) [REJECT] The sidecar's block's parent passes validation.
-  const blockState = await chain.regen
-    .getBlockSlotState(parentBlock, blockHeader.slot, {dontTransferCache: true}, RegenCaller.validateGossipDataColumn)
-    .catch(() => {
-      throw new DataColumnSidecarGossipError(GossipAction.IGNORE, {
-        code: DataColumnSidecarErrorCode.PARENT_UNKNOWN,
-        parentRoot,
-        slot: blockHeader.slot,
-      });
-    });
+  // Post-fulu, we can use parent state to get expected proposer index thanks to proposer lookahead
+  const parentEpoch = computeEpochAtSlot(parentBlock.slot);
+  const blockEpoch = computeEpochAtSlot(blockHeader.slot);
+  const getProposerIndex = async (): Promise<ValidatorIndex> => {
+    if (isForkPostFulu(chain.config.getForkName(parentBlock.slot)) && blockEpoch - parentEpoch <= MIN_SEED_LOOKAHEAD) {
+      const parentState = await chain.regen.getState(parentBlock.stateRoot, RegenCaller.validateGossipDataColumn);
+      return parentState.getBeaconProposer(blockHeader.slot);
+    }
+    const blockState = await chain.regen.getBlockSlotState(
+      parentBlock,
+      blockHeader.slot,
+      {dontTransferCache: true},
+      RegenCaller.validateGossipDataColumn
+    );
+    return blockState.getBeaconProposer(blockHeader.slot);
+  };
 
   // 13) [REJECT] The sidecar is proposed by the expected proposer_index for the block's slot in the context of the current
   //              shuffling (defined by block_header.parent_root/block_header.slot). If the proposer_index cannot
@@ -124,7 +129,13 @@ export async function validateGossipFuluDataColumnSidecar(
   //              while proposers for the block's branch are calculated -- in such a case do not REJECT, instead IGNORE
   //              this message.
   const proposerIndex = blockHeader.proposerIndex;
-  const expectedProposerIndex = blockState.getBeaconProposer(blockHeader.slot);
+  const expectedProposerIndex = await getProposerIndex().catch(() => {
+    throw new DataColumnSidecarGossipError(GossipAction.IGNORE, {
+      code: DataColumnSidecarErrorCode.PARENT_UNKNOWN,
+      parentRoot,
+      slot: blockHeader.slot,
+    });
+  });
 
   if (proposerIndex !== expectedProposerIndex) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
@@ -137,9 +148,8 @@ export async function validateGossipFuluDataColumnSidecar(
   // 5) [REJECT] The proposer signature of sidecar.signed_block_header, is valid with respect to the block_header.proposer_index pubkey.
   const signature = dataColumnSidecar.signedBlockHeader.signature;
   if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockHeader.slot, blockRootHex, signature)) {
-    const signatureSet = getBlockHeaderProposerSignatureSetByParentStateSlot(
+    const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(
       chain.config,
-      blockState.slot,
       dataColumnSidecar.signedBlockHeader
     );
 

--- a/packages/beacon-node/test/unit/chain/validation/dataColumnSidecar.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/dataColumnSidecar.test.ts
@@ -1,12 +1,22 @@
-import {describe, expect, it} from "vitest";
-import {ForkName, NUMBER_OF_COLUMNS} from "@lodestar/params";
-import {gloas, ssz} from "@lodestar/types";
-import {DataColumnSidecarValidationError} from "../../../../src/chain/errors/dataColumnSidecarError.js";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {ProtoBlock} from "@lodestar/fork-choice";
+import {ForkName, NUMBER_OF_COLUMNS, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {IBeaconStateView} from "@lodestar/state-transition";
+import {fulu, gloas, ssz} from "@lodestar/types";
 import {
+  DataColumnSidecarErrorCode,
+  DataColumnSidecarValidationError,
+} from "../../../../src/chain/errors/dataColumnSidecarError.js";
+import {
+  computeSubnetForDataColumnSidecar,
   validateFuluBlockDataColumnSidecars,
   validateGloasBlockDataColumnSidecars,
+  validateGossipFuluDataColumnSidecar,
 } from "../../../../src/chain/validation/dataColumnSidecar.js";
-import {generateBlockWithColumnSidecars} from "../../../utils/blocksAndData.js";
+import {ZERO_HASH} from "../../../../src/constants/index.js";
+import {MockedBeaconChain, getMockedBeaconChain} from "../../../mocks/mockedBeaconChain.js";
+import {FULU_FORK_EPOCH, config, generateBlockWithColumnSidecars} from "../../../utils/blocksAndData.js";
+import {expectRejectedWithLodestarError} from "../../../utils/errors.js";
 
 describe("validateFuluBlockDataColumnSidecars", () => {
   const {block, blockRoot, columnSidecars} = generateBlockWithColumnSidecars({forkName: ForkName.fulu});
@@ -232,5 +242,75 @@ describe("validateGloasBlockDataColumnSidecars", () => {
     await expect(
       validateGloasBlockDataColumnSidecars(block.message.slot, blockRoot, blockKzgCommitments, [invalidSidecar])
     ).rejects.toThrow(DataColumnSidecarValidationError);
+  });
+});
+
+describe("validateGossipFuluDataColumnSidecar - proposer lookup", () => {
+  // Block deep inside fulu so its recent-epoch parents are also post-fulu.
+  const deepFulu = generateBlockWithColumnSidecars({
+    forkName: ForkName.fulu,
+    slot: (FULU_FORK_EPOCH + 2) * SLOTS_PER_EPOCH,
+  }).columnSidecars[0] as fulu.DataColumnSidecar;
+  // Block at the very first fulu slot, so a parent one slot back is pre-fulu (fork transition boundary).
+  const fuluBoundary = generateBlockWithColumnSidecars({
+    forkName: ForkName.fulu,
+    slot: FULU_FORK_EPOCH * SLOTS_PER_EPOCH,
+  }).columnSidecars[0] as fulu.DataColumnSidecar;
+
+  let chain: MockedBeaconChain;
+
+  beforeEach(() => {
+    chain = getMockedBeaconChain({config});
+  });
+
+  // Wire the mocked chain to reach step 13 for `sidecar` with the parent at `parentSlot`. A wrong expected
+  // proposer forces a REJECT there (before signature/inclusion/kzg), isolating the state-lookup branch.
+  function setup(sidecar: fulu.DataColumnSidecar, parentSlot: number): number {
+    const wrongProposer = sidecar.signedBlockHeader.message.proposerIndex + 1;
+    vi.spyOn(chain.clock, "currentSlotWithGossipDisparity", "get").mockReturnValue(
+      sidecar.signedBlockHeader.message.slot
+    );
+    chain.forkChoice.getFinalizedCheckpoint.mockReturnValue({epoch: 0, root: ZERO_HASH, rootHex: ""});
+    chain.forkChoice.getBlockHexDefaultStatus.mockReturnValue({slot: parentSlot, stateRoot: "0x00"} as ProtoBlock);
+    const stateStub = {getBeaconProposer: () => wrongProposer} as unknown as IBeaconStateView;
+    chain.regen.getState.mockResolvedValue(stateStub);
+    chain.regen.getBlockSlotState.mockResolvedValue(stateStub);
+    return computeSubnetForDataColumnSidecar(chain.config, sidecar);
+  }
+
+  it("reads the proposer via getState (no dial) when a post-fulu parent is within MIN_SEED_LOOKAHEAD", async () => {
+    const subnet = setup(deepFulu, deepFulu.signedBlockHeader.message.slot - 1);
+
+    await expectRejectedWithLodestarError(
+      validateGossipFuluDataColumnSidecar(chain, deepFulu, subnet, null),
+      DataColumnSidecarErrorCode.INCORRECT_PROPOSER
+    );
+
+    expect(chain.regen.getState).toHaveBeenCalledOnce();
+    expect(chain.regen.getBlockSlotState).not.toHaveBeenCalled();
+  });
+
+  it("dials via getBlockSlotState when the block is more than MIN_SEED_LOOKAHEAD epochs after its parent", async () => {
+    const subnet = setup(deepFulu, deepFulu.signedBlockHeader.message.slot - 2 * SLOTS_PER_EPOCH);
+
+    await expectRejectedWithLodestarError(
+      validateGossipFuluDataColumnSidecar(chain, deepFulu, subnet, null),
+      DataColumnSidecarErrorCode.INCORRECT_PROPOSER
+    );
+
+    expect(chain.regen.getBlockSlotState).toHaveBeenCalledOnce();
+    expect(chain.regen.getState).not.toHaveBeenCalled();
+  });
+
+  it("dials via getBlockSlotState when the parent is pre-fulu (fork transition boundary)", async () => {
+    const subnet = setup(fuluBoundary, fuluBoundary.signedBlockHeader.message.slot - 1);
+
+    await expectRejectedWithLodestarError(
+      validateGossipFuluDataColumnSidecar(chain, fuluBoundary, subnet, null),
+      DataColumnSidecarErrorCode.INCORRECT_PROPOSER
+    );
+
+    expect(chain.regen.getBlockSlotState).toHaveBeenCalledOnce();
+    expect(chain.regen.getState).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
**Motivation**

- similar to #9762, we don't want to use `getBlockSlotState()` when validating gossip columns, because that could be an epoch transition there, it happened on mainnet

<img width="1385" height="373" alt="Screenshot 2026-08-05 at 14 51 45" src="https://github.com/user-attachments/assets/178c5c0e-dc2a-40f6-a80c-69fea4131582" />


**Description**

- post-fulu, we can just use parent state to get proposer index instead


**AI Assistance Disclosure**

- created with the help of Claude