### PR TITLE
fix: accept Heze states in builder bid coverage

### DIFF
--- a/packages/state-transition/src/block/processExecutionPayloadBid.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadBid.ts
@@ -47,7 +47,7 @@ export function processExecutionPayloadBid(
     }
 
     // Verify that the builder has funds to cover the bid
-    if (!canBuilderCoverBid(state as CachedBeaconStateGloas, builderIndex, amount)) {
+    if (!canBuilderCoverBid(state, builderIndex, amount)) {
       throw Error(`Invalid execution payload bid: builder ${builderIndex} has insufficient balance`);
     }
 

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -17,7 +17,7 @@ import {BuilderIndex, Epoch, ValidatorIndex, gloas, ssz} from "@lodestar/types";
 import {AttestationData} from "@lodestar/types/phase0";
 import {byteArrayEquals} from "@lodestar/utils";
 import {ZERO_HASH} from "../constants/index.js";
-import {CachedBeaconStateFulu, CachedBeaconStateGloas} from "../types.js";
+import {CachedBeaconStateFulu, CachedBeaconStateGloas, CachedBeaconStateHeze} from "../types.js";
 import {computeDomain} from "./domain.js";
 import {computeEpochAtSlot} from "./epoch.js";
 import {computeEpochShuffling} from "./epochShuffling.js";
@@ -117,7 +117,7 @@ export function isGasLimitTargetCompatible(parentGasLimit: bigint, gasLimit: big
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-get_pending_balance_to_withdraw_for_builder
  */
 export function getPendingBalanceToWithdrawForBuilder(
-  state: CachedBeaconStateGloas,
+  state: CachedBeaconStateGloas | CachedBeaconStateHeze,
   builderIndex: BuilderIndex
 ): number {
   let pendingBalance = 0;
@@ -146,7 +146,7 @@ export function getPendingBalanceToWithdrawForBuilder(
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-can_builder_cover_bid
  */
 export function canBuilderCoverBid(
-  state: CachedBeaconStateGloas,
+  state: CachedBeaconStateGloas | CachedBeaconStateHeze,
   builderIndex: BuilderIndex,
   bidAmount: number
 ): boolean {


### PR DESCRIPTION
## Summary

- widen `canBuilderCoverBid` and its pending-balance helper to accept both Gloas and Heze cached states
- remove the stale `CachedBeaconStateGloas` cast from `processExecutionPayloadBid`

## Verification

- `pnpm --filter @lodestar/state-transition... build`
- `pnpm --filter @lodestar/state-transition check-types`
- `pnpm lint`
- `git diff --check`

AI-assisted by Lodekeeper.