### PR TITLE
ci: pass Docker tag inputs via env before shell

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -34,13 +34,15 @@ runs:
     - name: Node.js version
       id: node
       shell: bash
+      env:
+        NODE_VERSION: ${{ inputs.node }}
       run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
 
     - name: Create cache key
       id: build-cache
       shell: bash
       # This build cache will be reused among different jobs for the same commit
-      run: echo "key=build-cache-${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node }}-${{ github.sha }}" >> $GITHUB_OUTPUT
+      run: echo "key=build-cache-${{ runner.os }}-${{ runner.arch }}-node-${NODE_VERSION}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
     - name: Restore build
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/build-debug-node.yml
+++ b/.github/workflows/build-debug-node.yml
@@ -37,10 +37,16 @@ jobs:
         working-directory: "nodejs"
 
       - name: Create destination folder
-        run: mkdir -p ${{ github.workspace }}/nodejs-debug-build-${{ github.event.inputs.version }}
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+          WORKSPACE: ${{ github.workspace }}
+        run: mkdir -p "${WORKSPACE}/nodejs-debug-build-${VERSION}"
 
       - name: Copy nodejs debug build
-        run: cp out/Debug/node ${{ github.workspace }}/nodejs-debug-build-${{ github.event.inputs.version }}
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+          WORKSPACE: ${{ github.workspace }}
+        run: cp out/Debug/node "${WORKSPACE}/nodejs-debug-build-${VERSION}"
         working-directory: "nodejs"
 
       - name: Upload build to artifacts

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,33 +40,45 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push lodestar
+        env:
+          IMAGE_TAG: ${{ inputs.tag }}
+          ARCH: ${{ matrix.arch }}
         run: >
           docker buildx build . --push
-          --tag chainsafe/lodestar:${{ inputs.tag }}-${{ matrix.arch }}
-          --platform linux/${{ matrix.arch }}
+          --tag "chainsafe/lodestar:${IMAGE_TAG}-${ARCH}"
+          --platform "linux/${ARCH}"
           --build-arg COMMIT=$(git rev-parse HEAD)
 
       - name: Sanity check lodestar (${{ matrix.arch }})
+        env:
+          IMAGE_TAG: ${{ inputs.tag }}
+          ARCH: ${{ matrix.arch }}
         run: |
-          docker run -d --name lodestar-sanity-${{ matrix.arch }} -p 9596:9596 chainsafe/lodestar:${{ inputs.tag }}-${{ matrix.arch }} dev --rest.address 0.0.0.0
+          docker run -d --name "lodestar-sanity-${ARCH}" -p 9596:9596 "chainsafe/lodestar:${IMAGE_TAG}-${ARCH}" dev --rest.address 0.0.0.0
           sleep 30
-          curl -f http://127.0.0.1:9596/eth/v1/node/version || (docker logs lodestar-sanity-${{ matrix.arch }} && exit 1)
-          docker stop lodestar-sanity-${{ matrix.arch }}
+          curl -f http://127.0.0.1:9596/eth/v1/node/version || (docker logs "lodestar-sanity-${ARCH}" && exit 1)
+          docker stop "lodestar-sanity-${ARCH}"
 
       - name: Build and push custom Grafana
+        env:
+          IMAGE_TAG: ${{ inputs.tag }}
+          ARCH: ${{ matrix.arch }}
         run: >
           docker buildx build ./docker/grafana/ --push
           --file ./docker/grafana/Dockerfile
           --build-context dashboards=./dashboards
-          --tag chainsafe/lodestar-grafana:${{ inputs.tag }}-${{ matrix.arch }}
-          --platform linux/${{ matrix.arch }}
+          --tag "chainsafe/lodestar-grafana:${IMAGE_TAG}-${ARCH}"
+          --platform "linux/${ARCH}"
 
       - name: Build and push custom Prometheus
+        env:
+          IMAGE_TAG: ${{ inputs.tag }}
+          ARCH: ${{ matrix.arch }}
         run: >
           docker buildx build ./docker/prometheus/ --push
           --file ./docker/prometheus/Dockerfile
-          --tag chainsafe/lodestar-prometheus:${{ inputs.tag }}-${{ matrix.arch }}
-          --platform linux/${{ matrix.arch }}
+          --tag "chainsafe/lodestar-prometheus:${IMAGE_TAG}-${ARCH}"
+          --platform "linux/${ARCH}"
 
   docker-manifest:
     name: Create Docker manifest
@@ -82,30 +94,39 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Create and push lodestar manifest
+        env:
+          IMAGE_TAG: ${{ inputs.tag }}
+          EXTRA_TAGS_INPUT: ${{ inputs.extra-tags }}
         run: |
           EXTRA_TAGS=""
-          if [ -n "${{ inputs.extra-tags }}" ]; then
-            for t in $(echo "${{ inputs.extra-tags }}" | tr ',' ' '); do
+          if [ -n "$EXTRA_TAGS_INPUT" ]; then
+            for t in $(echo "$EXTRA_TAGS_INPUT" | tr ',' ' '); do
               EXTRA_TAGS="$EXTRA_TAGS -t chainsafe/lodestar:$t"
             done
           fi
-          docker buildx imagetools create -t chainsafe/lodestar:${{ inputs.tag }} $EXTRA_TAGS \
-            chainsafe/lodestar:${{ inputs.tag }}-amd64 \
-            chainsafe/lodestar:${{ inputs.tag }}-arm64
+          docker buildx imagetools create -t "chainsafe/lodestar:${IMAGE_TAG}" $EXTRA_TAGS \
+            "chainsafe/lodestar:${IMAGE_TAG}-amd64" \
+            "chainsafe/lodestar:${IMAGE_TAG}-arm64"
 
       - name: Create and push grafana manifest
+        env:
+          IMAGE_TAG: ${{ inputs.tag }}
         run: |
-          docker buildx imagetools create -t chainsafe/lodestar-grafana:${{ inputs.tag }} \
-            chainsafe/lodestar-grafana:${{ inputs.tag }}-amd64 \
-            chainsafe/lodestar-grafana:${{ inputs.tag }}-arm64
+          docker buildx imagetools create -t "chainsafe/lodestar-grafana:${IMAGE_TAG}" \
+            "chainsafe/lodestar-grafana:${IMAGE_TAG}-amd64" \
+            "chainsafe/lodestar-grafana:${IMAGE_TAG}-arm64"
 
       - name: Create and push prometheus manifest
+        env:
+          IMAGE_TAG: ${{ inputs.tag }}
         run: |
-          docker buildx imagetools create -t chainsafe/lodestar-prometheus:${{ inputs.tag }} \
-            chainsafe/lodestar-prometheus:${{ inputs.tag }}-amd64 \
-            chainsafe/lodestar-prometheus:${{ inputs.tag }}-arm64
+          docker buildx imagetools create -t "chainsafe/lodestar-prometheus:${IMAGE_TAG}" \
+            "chainsafe/lodestar-prometheus:${IMAGE_TAG}-amd64" \
+            "chainsafe/lodestar-prometheus:${IMAGE_TAG}-arm64"
 
       - name: Verify lodestar manifest
+        env:
+          IMAGE_TAG: ${{ inputs.tag }}
         run: |
-          docker pull chainsafe/lodestar:${{ inputs.tag }}
-          docker image history chainsafe/lodestar:${{ inputs.tag }}
+          docker pull "chainsafe/lodestar:${IMAGE_TAG}"
+          docker image history "chainsafe/lodestar:${IMAGE_TAG}"

--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -29,21 +29,24 @@ jobs:
           fetch-depth: 0
 
       - name: Validate inputs
+        env:
+          TAG: ${{ inputs.tag }}
+          REF: ${{ inputs.ref }}
         run: |
           # Ensure tag doesn't conflict with protected tags
-          if [[ "${{ inputs.tag }}" =~ ^(latest|next|stable|rc)$ ]]; then
-            echo "Error: Cannot use reserved tag '${{ inputs.tag }}'. Use a custom tag name."
+          if [[ "$TAG" =~ ^(latest|next|stable|rc)$ ]]; then
+            echo "Error: Cannot use reserved tag '${TAG}'. Use a custom tag name."
             exit 1
           fi
-          echo "Building from ref: ${{ inputs.ref }}"
+          echo "Building from ref: ${REF}"
           echo "Commit: $(git rev-parse HEAD)"
-          echo "Tag: ${{ inputs.tag }}"
+          echo "Tag: ${TAG}"
 
   docker:
     name: Build and publish Docker
     needs: validate
     uses: ./.github/workflows/docker.yml
     with:
-      tag: ${{ inputs.tag }}
-      ref: ${{ inputs.ref }}
+      tag: ${TAG}
+      ref: ${REF}
     secrets: inherit

--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -47,6 +47,6 @@ jobs:
     needs: validate
     uses: ./.github/workflows/docker.yml
     with:
-      tag: ${TAG}
-      ref: ${REF}
+      tag: ${{ inputs.tag }}
+      ref: ${{ inputs.ref }}
     secrets: inherit

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -51,10 +51,11 @@ jobs:
           docker pull ${{env.LIGHTHOUSE_DOCKER_IMAGE}}
           docker pull ${{env.NETHERMIND_DOCKER_IMAGE}}
       - name: Sim tests multifork
-        run: DEBUG='${{github.event.inputs.debug}}' pnpm test:sim:multifork
         working-directory: packages/cli
         env:
+          DEBUG: ${{ github.event.inputs.debug }}
           GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
+        run: DEBUG="$DEBUG" pnpm test:sim:multifork
       - name: Upload debug log test files for "packages/cli"
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -80,10 +81,11 @@ jobs:
           docker pull ${{env.LIGHTHOUSE_DOCKER_IMAGE}}
           docker pull ${{env.NETHERMIND_DOCKER_IMAGE}}
       - name: Sim tests endpoints
-        run: DEBUG='${{github.event.inputs.debug}}'  pnpm test:sim:endpoints
         working-directory: packages/cli
         env:
+          DEBUG: ${{ github.event.inputs.debug }}
           GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
+        run: DEBUG="$DEBUG" pnpm test:sim:endpoints
       - name: Upload debug log test files for "packages/cli"
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -109,10 +111,11 @@ jobs:
           docker pull ${{env.LIGHTHOUSE_DOCKER_IMAGE}}
           docker pull ${{env.NETHERMIND_DOCKER_IMAGE}}
       - name: Sim tests backup eth provider
-        run: DEBUG='${{github.event.inputs.debug}}' pnpm test:sim:backup_eth_provider
         working-directory: packages/cli
         env:
+          DEBUG: ${{ github.event.inputs.debug }}
           GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
+        run: DEBUG="$DEBUG" pnpm test:sim:backup_eth_provider
       - name: Upload debug log test files for "packages/cli"
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -138,10 +141,11 @@ jobs:
           docker pull ${{env.LIGHTHOUSE_DOCKER_IMAGE}}
           # docker pull ${{env.NETHERMIND_DOCKER_IMAGE}}
       - name: Sim tests mixed client
-        run: DEBUG='${{github.event.inputs.debug}}' pnpm test:sim:mixedclient
         working-directory: packages/cli
         env:
+          DEBUG: ${{ github.event.inputs.debug }}
           GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
+        run: DEBUG="$DEBUG" pnpm test:sim:mixedclient
       - name: Upload debug log test files for "packages/cli"
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary
`docker.yml` interpolated `inputs.tag` / `inputs.extra-tags` (and matrix arch) directly into `docker buildx` / `docker run` / `imagetools` `run:` scripts. Move those values into `env:` and expand quoted shell variables instead.

## Test plan
- [ ] Manual/publish workflow still builds and pushes arch-specific tags
- [ ] Manifest creation still applies optional extra-tags
- [ ] Sanity-check container still starts against the built tag


Made with [Cursor](https://cursor.com)