### PR TITLE
test: update fast confirmation spec tests to v1.7.0-alpha.13

### DIFF
--- a/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
+++ b/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
@@ -881,15 +881,5 @@ specTestIterator(
   {
     fast_confirmation: {type: RunnerType.default, fn: fastConfirmationTest({onlyPredefinedResponses: false})},
   },
-  {
-    ...defaultSkipOpts,
-    skippedTestSuites: [
-      ...(defaultSkipOpts.skippedTestSuites ?? []),
-      // TODO GLOAS: unskip with the v1.7.0-alpha.13 gloas implementation. The alpha.13 gloas
-      // vectors require beacon-chain changes not yet on unstable (blocks fail state transition),
-      // and the gloas-modified `get_safe_execution_block_hash` (parent payload block hash) is not
-      // implemented yet.
-      /^gloas\/fast_confirmation\/.*/,
-    ],
-  }
+  defaultSkipOpts
 );

--- a/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
+++ b/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
@@ -721,15 +721,12 @@ const fastConfirmationTest =
           // real, or if full bls_setting=2 support is ever added.
           name.includes("is_one_confirmed_fails_recently_activated_validator_voting_in_empty_slot") ||
           name.includes("is_one_confirmed_passes_with_new_validator_activated_in_head_state") ||
-          // Upstream test-encoding artifact: `on_fast_confirmation` runs are implicit in the
-          // format ("once per slot at slot start"), but the generator deviates in these vectors —
-          // `fcr_no_restart_if_head_gu_is_stale` runs the handler TWICE in one slot (two
-          // consecutive FCR checks steps at the same time, violating the spec's once-per-slot
-          // MUST), and `..._two_consecutive_slots_2` SKIPS the run for an epoch-start slot (tick
-          // without an FCR checks step, so no rotation). A client running the handler once per
-          // slot cannot reproduce the expected FCR-store variables. Unskip once the format
-          // declares the schedule (explicit on_fast_confirmation step) or generation is
-          // constrained to once per slot.
+          // These vectors run `on_fast_confirmation` twice in one slot (stale GU test) or skip an
+          // epoch-boundary run (consecutive slots test), so a client running the handler once per
+          // slot cannot reproduce the expected FCR-store variables. Fixed upstream, unskip when
+          // the next spec-tests release (> v1.7.0-alpha.13) is picked up:
+          // - https://github.com/ethereum/consensus-specs/pull/5499
+          // - https://github.com/ethereum/consensus-specs/pull/5498
           name.includes("fcr_no_restart_if_head_gu_is_stale") ||
           name.includes("is_one_confirmed_passes_with_empty_slot_and_attester_in_two_consecutive_slots_2"),
       },

--- a/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
+++ b/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
@@ -4,7 +4,7 @@ import {expect} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
 import {createBeaconConfig} from "@lodestar/config";
 import {getConfig} from "@lodestar/config/test-utils";
-import {CheckpointWithHex, ExecutionStatus, ForkChoice} from "@lodestar/fork-choice";
+import {CheckpointWithHex, ExecutionStatus, ForkChoice, getSafeExecutionBlockHash} from "@lodestar/fork-choice";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {
   ACTIVE_PRESET,
@@ -71,7 +71,7 @@ import {ClockStopped} from "../../mocks/clock.js";
 import {getMockedBeaconDb} from "../../mocks/mockedBeaconDb.js";
 import {assertCorrectProgressiveBalances} from "../config.js";
 import {ethereumConsensusSpecsTests} from "../specTestVersioning.js";
-import {specTestIterator} from "../utils/specTestIterator.js";
+import {defaultSkipOpts, specTestIterator} from "../utils/specTestIterator.js";
 import {RunnerType, TestRunnerFn} from "../utils/types.js";
 
 const ANCHOR_STATE_FILE_NAME = "anchor_state";
@@ -556,26 +556,54 @@ const fastConfirmationTest =
                 );
               }
 
-              // TODO: Expose this value to to spec tests
-              // if (step.checks.previous_epoch_observed_justified_checkpoint) {
-              // }
+              const fcrStore = chain.forkChoice.getFastConfirmationStore();
 
-              // TODO: Expose this value to to spec tests
-              // if (step.checks.current_epoch_observed_justified_checkpoint) {
-              // }
+              if (step.checks.previous_epoch_observed_justified_checkpoint) {
+                expect(toSpecTestCheckpoint(fcrStore.previousEpochObservedJustifiedCheckpoint)).toEqualWithMessage(
+                  step.checks.previous_epoch_observed_justified_checkpoint,
+                  `Invalid previous epoch observed justified checkpoint at step ${i}`
+                );
+              }
 
-              // TODO: Expose this value to to spec tests
-              // if (step.checks.previous_slot_head) {
-              // }
+              if (step.checks.current_epoch_observed_justified_checkpoint) {
+                expect(toSpecTestCheckpoint(fcrStore.currentEpochObservedJustifiedCheckpoint)).toEqualWithMessage(
+                  step.checks.current_epoch_observed_justified_checkpoint,
+                  `Invalid current epoch observed justified checkpoint at step ${i}`
+                );
+              }
 
-              // TODO: Expose this value to to spec tests
-              // if (step.checks.current_slot_head) {
-              // }
+              if (step.checks.previous_epoch_greatest_unrealized_checkpoint) {
+                expect(toSpecTestCheckpoint(fcrStore.previousEpochGreatestUnrealizedCheckpoint)).toEqualWithMessage(
+                  step.checks.previous_epoch_greatest_unrealized_checkpoint,
+                  `Invalid previous epoch greatest unrealized checkpoint at step ${i}`
+                );
+              }
+
+              if (step.checks.previous_slot_head) {
+                expect(fcrStore.previousSlotHead).toEqualWithMessage(
+                  step.checks.previous_slot_head,
+                  `Invalid previous slot head at step ${i}`
+                );
+              }
+
+              if (step.checks.current_slot_head) {
+                expect(fcrStore.currentSlotHead).toEqualWithMessage(
+                  step.checks.current_slot_head,
+                  `Invalid current slot head at step ${i}`
+                );
+              }
 
               if (step.checks.confirmed_root) {
                 expect(confirmedRoot).toEqualWithMessage(
                   step.checks.confirmed_root,
                   `Invalid confirmed root at step: ${i}, time: ${step.checks.time}, head_slot: ${step.checks.head?.slot}`
+                );
+              }
+
+              if (step.checks.safe_execution_block_hash !== undefined) {
+                expect(getSafeExecutionBlockHash(chain.forkChoice)).toEqualWithMessage(
+                  step.checks.safe_execution_block_hash,
+                  `Invalid safe execution block hash at step ${i}`
                 );
               }
 
@@ -687,17 +715,25 @@ const fastConfirmationTest =
           name.includes("voting_source_beyond_two_epoch") ||
           name.includes("justified_update_always_if_better") ||
           name.includes("justified_update_not_realized_finality") ||
-          // TODO: lodestar's fast-confirmation rule (FCR) needs a broader overhaul. These two
-          // is_one_confirmed cases (new in v1.7.0-alpha.12, present in electra + fulu) currently
-          // fail. Unskip once the FCR is reworked.
-          name.includes("is_one_confirmed_fails_large_validator_slashed") ||
+          // Upstream test-generation artifact: bls_setting=2 vectors carry STUB deposit request
+          // signatures which the generator (BLS verification disabled) accepts, adding the
+          // validator to the registry. Deposit signature validity determines state contents, so it
+          // must be real in vectors regardless of bls_setting — same principle as the aggregate
+          // pubkey fix in consensus-specs #5489. Unskip once deposits are signed for real during
+          // generation and a new spec-tests release is picked up.
           name.includes("is_one_confirmed_fails_recently_activated_validator_voting_in_empty_slot") ||
-          // This case (new in v1.7.0-alpha.13, consensus-specs #5449) deposits a validator, but the
-          // vectors are generated with bls_setting=2 so the deposit carries a stub signature that
-          // only the pyspec BLS stub accepts. Lodestar verifies the deposit proof of possession
-          // inside processPendingDeposits, so the validator is never onboarded and the state root
-          // diverges once the pending deposit is applied.
-          name.includes("is_one_confirmed_passes_with_new_validator_activated_in_head_state"),
+          name.includes("is_one_confirmed_passes_with_new_validator_activated_in_head_state") ||
+          // Upstream test-encoding artifact: `on_fast_confirmation` runs are implicit in the
+          // format ("once per slot at slot start"), but the generator deviates in these vectors —
+          // `fcr_no_restart_if_head_gu_is_stale` runs the handler TWICE in one slot (two
+          // consecutive FCR checks steps at the same time, violating the spec's once-per-slot
+          // MUST), and `..._two_consecutive_slots_2` SKIPS the run for an epoch-start slot (tick
+          // without an FCR checks step, so no rotation). A client running the handler once per
+          // slot cannot reproduce the expected FCR-store variables. Unskip once the format
+          // declares the schedule (explicit on_fast_confirmation step) or generation is
+          // constrained to once per slot.
+          name.includes("fcr_no_restart_if_head_gu_is_stale") ||
+          name.includes("is_one_confirmed_passes_with_empty_slot_and_attester_in_two_consecutive_slots_2"),
       },
     };
   };
@@ -785,9 +821,12 @@ type Checks = {
 
     previous_epoch_observed_justified_checkpoint?: SpecTestCheckpoint;
     current_epoch_observed_justified_checkpoint?: SpecTestCheckpoint;
+    previous_epoch_greatest_unrealized_checkpoint?: SpecTestCheckpoint;
     previous_slot_head?: string;
     current_slot_head?: string;
     confirmed_root?: string;
+    /** Expected response of `get_safe_execution_block_hash()`. New in Bellatrix. */
+    safe_execution_block_hash?: string;
 
     // Custom attributes
     get_proposer_head?: string;
@@ -842,6 +881,20 @@ function isCheck(step: Step): step is Checks {
   return typeof (step as Checks).checks === "object";
 }
 
-specTestIterator(path.join(ethereumConsensusSpecsTests.outputDir, "tests", ACTIVE_PRESET), {
-  fast_confirmation: {type: RunnerType.default, fn: fastConfirmationTest({onlyPredefinedResponses: false})},
-});
+specTestIterator(
+  path.join(ethereumConsensusSpecsTests.outputDir, "tests", ACTIVE_PRESET),
+  {
+    fast_confirmation: {type: RunnerType.default, fn: fastConfirmationTest({onlyPredefinedResponses: false})},
+  },
+  {
+    ...defaultSkipOpts,
+    skippedTestSuites: [
+      ...(defaultSkipOpts.skippedTestSuites ?? []),
+      // TODO GLOAS: unskip with the v1.7.0-alpha.13 gloas implementation. The alpha.13 gloas
+      // vectors require beacon-chain changes not yet on unstable (blocks fail state transition),
+      // and the gloas-modified `get_safe_execution_block_hash` (parent payload block hash) is not
+      // implemented yet.
+      /^gloas\/fast_confirmation\/.*/,
+    ],
+  }
+);

--- a/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
+++ b/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
@@ -715,12 +715,10 @@ const fastConfirmationTest =
           name.includes("voting_source_beyond_two_epoch") ||
           name.includes("justified_update_always_if_better") ||
           name.includes("justified_update_not_realized_finality") ||
-          // Upstream test-generation artifact: bls_setting=2 vectors carry STUB deposit request
-          // signatures which the generator (BLS verification disabled) accepts, adding the
-          // validator to the registry. Deposit signature validity determines state contents, so it
-          // must be real in vectors regardless of bls_setting — same principle as the aggregate
-          // pubkey fix in consensus-specs #5489. Unskip once deposits are signed for real during
-          // generation and a new spec-tests release is picked up.
+          // These vectors carry stub deposit signatures (bls_setting=2) and expect the deposit to
+          // be applied. Passing them requires skipping deposit signature verification inside epoch
+          // processing, which Lodestar does not support. Unskip if upstream signs deposits for
+          // real, or if full bls_setting=2 support is ever added.
           name.includes("is_one_confirmed_fails_recently_activated_validator_voting_in_empty_slot") ||
           name.includes("is_one_confirmed_passes_with_new_validator_activated_in_head_state") ||
           // Upstream test-encoding artifact: `on_fast_confirmation` runs are implicit in the

--- a/packages/fork-choice/src/forkChoice/fastConfirmation/types.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/types.ts
@@ -15,7 +15,7 @@ export type ForkChoiceStateGetter = (
   opts: {stateRoot: RootHex; checkpoint?: never} | {stateRoot?: never; checkpoint: CheckpointWithHex}
 ) => IBeaconStateView | null;
 
-type IFastConfirmationSpecStore = {
+export type IFastConfirmationSpecStore = {
   confirmedRoot: RootHex;
   previousEpochObservedJustifiedCheckpoint: CheckpointWithHex;
   currentEpochObservedJustifiedCheckpoint: CheckpointWithHex;

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -49,6 +49,7 @@ import {
   FastConfirmationRule,
   FastConfirmationSteps,
   type IFastConfirmationRule,
+  type IFastConfirmationSpecStore,
 } from "./fastConfirmation/fastConfirmationRule.ts";
 import {
   AncestorResult,
@@ -226,6 +227,17 @@ export class ForkChoice implements IForkChoice {
 
   getConfirmedRoot(): RootHex {
     return this.fastConfirmationRule?.getConfirmedRoot() ?? this.fcStore.justified.checkpoint.rootHex;
+  }
+
+  getFastConfirmationStore(): IFastConfirmationSpecStore {
+    return {
+      confirmedRoot: this.getConfirmedRoot(),
+      previousEpochObservedJustifiedCheckpoint: this.fcStore.previousEpochObservedJustifiedCheckpoint,
+      currentEpochObservedJustifiedCheckpoint: this.fcStore.currentEpochObservedJustifiedCheckpoint,
+      previousEpochGreatestUnrealizedCheckpoint: this.fcStore.previousEpochGreatestUnrealizedCheckpoint,
+      previousSlotHead: this.fcStore.previousSlotHead,
+      currentSlotHead: this.fcStore.currentSlotHead,
+    };
   }
 
   getConfirmedBlock(): ProtoBlock | null {

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -8,6 +8,7 @@ import {
   ProtoBlock,
   ProtoNode,
 } from "../protoArray/interface.js";
+import {IFastConfirmationSpecStore} from "./fastConfirmation/types.js";
 import {UpdateAndGetHeadOpt} from "./forkChoice.js";
 import {CheckpointWithHex} from "./store.js";
 
@@ -100,6 +101,8 @@ export interface IForkChoice {
   getHead(): ProtoBlock;
   getConfirmedRoot(): RootHex;
   getConfirmedBlock(): ProtoBlock | null;
+  /** Snapshot of the spec `FastConfirmationStore` fields, mirroring `get_fast_confirmation_store` */
+  getFastConfirmationStore(): IFastConfirmationSpecStore;
   /** Resume the fast confirmation rule; restarts from the finalized root on the next slot tick */
   resumeFastConfirmation(): void;
   /** Pause the fast confirmation rule (e.g. while syncing); pins the confirmed root to the finalized root */


### PR DESCRIPTION
**Motivation**

Update spec tests to v1.7.0-alpha.13 FCR fixes proposed from #9690 ([consensus-specs#5489](https://github.com/ethereum/consensus-specs/pull/5489), [consensus-specs#5490](https://github.com/ethereum/consensus-specs/pull/5490)) and complete the missing FCR assertions.

**Description**

- Unskip `is_one_confirmed_fails_large_validator_slashed`, fixed upstream by [consensus-specs#5490](https://github.com/ethereum/consensus-specs/pull/5490)
- Enable the gloas `fast_confirmation` suite — gloas alpha.13 state transition and `get_safe_execution_block_hash` landed via #9393
- Assert `safe_execution_block_hash` ([consensus-specs#5449](https://github.com/ethereum/consensus-specs/pull/5449)) and the `FastConfirmationStore` variables, exposed via `IForkChoice.getFastConfirmationStore()` (debug API endpoint in a follow-up PR)
- Skip vectors blocked on upstream vector artifacts, documented inline; the schedule-related ones are already fixed upstream ([consensus-specs#5498](https://github.com/ethereum/consensus-specs/pull/5498), [consensus-specs#5499](https://github.com/ethereum/consensus-specs/pull/5499)) and unskip on the next spec-tests release

`fast_confirmation` (minimal): 1416 passed / 20 skipped / 0 failed. Full spec suites green: minimal 70,899 passed, mainnet 13,586 passed, 0 failures.

Refs #9690

**AI Assistance Disclosure**

- [x] I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Implemented and verified with AI assistance (Claude Code); all changes reviewed and tests executed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)