### PR TITLE
fix: do not produce blocks on top of an optimistic head

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -339,9 +339,9 @@ export function getValidatorApi(
    * Following activities should be skipped on an Optimistic head (with Syncing status):
    * 1. Attestation if targetRoot is optimistic
    * 2. SyncCommitteeContribution if if the root for which to produce contribution is Optimistic.
-   * 3. ProduceBlock if the parentRoot (chain's current head is optimistic). However this doesn't
-   *    need to be checked/aborted here as assembleBody would call EL's api for the latest
-   *    executionStatus of the parentRoot. If still not validated, produceBlock will throw error.
+   * 3. ProduceBlock if the parentRoot (chain's current head) is optimistic. Must be checked
+   *    explicitly as only local payload production consults the EL, blinded blocks from an
+   *    external builder or bid based blocks (gloas) can be produced without a synced EL.
    * 4. SyncCommitteeSignature (base sync committee message) is aborted in the validator client
    *    (see SyncCommitteeService) when the head root it would sign is optimistic, since it is
    *    produced from the head root without a beacon-node produce endpoint to gate here. Spec:
@@ -546,6 +546,12 @@ export function getValidatorApi(
     const parentBlock = chain.getProposerHead(slot);
     const {blockRoot: parentBlockRootHex, slot: parentSlot} = parentBlock;
     const parentBlockRoot = fromHex(parentBlockRootHex);
+    // An optimistic validator MUST NOT produce a block
+    if (parentBlock.executionStatus === ExecutionStatus.Syncing) {
+      throw new NodeIsSyncing(
+        `Parent block's execution payload not yet validated, executionPayloadBlockHash=${parentBlock.executionPayloadBlockHash}`
+      );
+    }
     notOnOutOfRangeData(parentBlockRoot);
     metrics?.blockProductionSlotDelta.set(slot - parentSlot);
 
@@ -871,6 +877,12 @@ export function getValidatorApi(
       const parentBlock = chain.getProposerHead(slot);
       const {blockRoot: parentBlockRootHex, slot: parentSlot} = parentBlock;
       const parentBlockRoot = fromHex(parentBlockRootHex);
+      // An optimistic validator MUST NOT produce a block
+      if (parentBlock.executionStatus === ExecutionStatus.Syncing) {
+        throw new NodeIsSyncing(
+          `Parent block's execution payload not yet validated, executionPayloadBlockHash=${parentBlock.executionPayloadBlockHash}`
+        );
+      }
       notOnOutOfRangeData(parentBlockRoot);
       metrics?.blockProductionSlotDelta.set(slot - parentSlot);
 

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -547,7 +547,7 @@ export function getValidatorApi(
     const {blockRoot: parentBlockRootHex, slot: parentSlot} = parentBlock;
     const parentBlockRoot = fromHex(parentBlockRootHex);
     // An optimistic validator MUST NOT produce a block
-    if (parentBlock.executionStatus === ExecutionStatus.Syncing) {
+    if (isOptimisticBlock(parentBlock)) {
       throw new NodeIsSyncing(
         `Parent block's execution payload not yet validated, executionPayloadBlockHash=${parentBlock.executionPayloadBlockHash}`
       );
@@ -878,7 +878,7 @@ export function getValidatorApi(
       const {blockRoot: parentBlockRootHex, slot: parentSlot} = parentBlock;
       const parentBlockRoot = fromHex(parentBlockRootHex);
       // An optimistic validator MUST NOT produce a block
-      if (parentBlock.executionStatus === ExecutionStatus.Syncing) {
+      if (isOptimisticBlock(parentBlock)) {
         throw new NodeIsSyncing(
           `Parent block's execution payload not yet validated, executionPayloadBlockHash=${parentBlock.executionPayloadBlockHash}`
         );

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {routes} from "@lodestar/api";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
-import {ProtoBlock} from "@lodestar/fork-choice";
+import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName, SLOTS_PER_EPOCH, ZERO_HASH_HEX} from "@lodestar/params";
 import {BeaconStateView, G2_POINT_AT_INFINITY, computeTimeAtSlot} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
@@ -208,6 +208,30 @@ describe("api/validator - produceBlockV3", () => {
     );
     expect(block).toEqual(blindedBlock);
     expect(meta.executionPayloadBlinded).toBe(true);
+  });
+
+  it("rejects block production if parent block is optimistic", async () => {
+    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+    const slot = 1 * SLOTS_PER_EPOCH;
+
+    vi.spyOn(modules.chain.clock, "currentSlot", "get").mockReturnValue(slot);
+    vi.spyOn(modules.sync, "state", "get").mockReturnValue(SyncState.Synced);
+    modules.chain.getProposerHead.mockReturnValue({
+      blockRoot: toRootHex(fullBlock.parentRoot),
+      executionStatus: ExecutionStatus.Syncing,
+    } as ProtoBlock);
+
+    await expect(
+      api.produceBlockV3({
+        slot,
+        randaoReveal: fullBlock.body.randaoReveal,
+        graffiti: "a".repeat(32),
+        skipRandaoVerification: false,
+      })
+    ).rejects.toThrow("Node is syncing");
+
+    expect(modules.chain.produceBlock).not.toHaveBeenCalled();
+    expect(modules.chain.produceBlindedBlock).not.toHaveBeenCalled();
   });
 
   it("correctly pass feeRecipient to produceBlock", async () => {

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV4.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV4.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {routes} from "@lodestar/api";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
-import {ProtoBlock} from "@lodestar/fork-choice";
+import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {getValidatorApi} from "../../../../../src/api/impl/validator/index.js";
@@ -181,5 +181,18 @@ describe("api/validator - produceBlockV4", () => {
     );
     expect(modules.chain.produceBlock).toHaveBeenCalledTimes(2);
     expect(block).toEqual(bidBlock);
+  });
+
+  it("rejects block production if parent block is optimistic", async () => {
+    modules.chain.getProposerHead.mockReturnValue({
+      ...parentBlock,
+      executionStatus: ExecutionStatus.Syncing,
+    } as ProtoBlock);
+
+    await expect(
+      api.produceBlockV4({slot, randaoReveal, graffiti, feeRecipient, includePayload: false})
+    ).rejects.toThrow("Node is syncing");
+
+    expect(modules.chain.produceBlock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
As per [sync/optimistic.md](https://github.com/ethereum/consensus-specs/blob/v1.6.1/sync/optimistic.md#block-production)

> An optimistic validator **MUST NOT** produce a block (i.e., sign across the `DOMAIN_BEACON_PROPOSER` domain).

We only enforced this implicitly via local payload production which fails while the EL is syncing, but blinded blocks from an external builder (pre-gloas) and bid based blocks (gloas) are produced without consulting the EL, meaning a proposer with a syncing EL signs a block on top of an optimistic head. This happened on glamsterdam-devnet-7 where a node proposed a block based on a builder bid while its EL was syncing (https://dora.glamsterdam-devnet-7.ethpandaops.io/slot/165314).

- reject `produceBlockV3` / `produceBlockV4` requests with a 503 if the parent block is optimistic

Note: the check is done on the `ProtoBlock` returned by `getProposerHead` instead of reusing `notOnOptimisticBlockRoot` as the helper resolves the default variant (PENDING post-gloas) which may have a different `executionStatus` than the variant we actually build on.