### PR TITLE
fix: handle 1st orphaned payload of blocks[0] in range sync

### DIFF
--- a/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
+++ b/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
@@ -31,23 +31,40 @@ export function assertLinearChainSegment(
   payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
   parentBlock: ProtoBlock | null
 ): ChainSegmentResult {
+  if (blocks.length === 0) {
+    return {warnings: null};
+  }
+
   const warnings: OrphanedPayloadEnvelope[] = [];
 
-  // Track the expected execution payload block hash through the segment.
-  // Starts from the known forkchoice parent's execution hash.
-  // - FULL variant (envelope present for slot): advances to envelope.payload.blockHash
-  // - EMPTY variant (no envelope for slot): execution hash is unchanged
-  let currentExecHash: string | null = parentBlock?.executionPayloadBlockHash ?? null;
-  // Checkpoint sync first batch: parent is the anchor PENDING whose executionPayloadBlockHash
-  // is the inherited parentBlockHash semantic (= grandparent's payload), not its own payload.
-  // If parent's own payload envelope arrives in this batch, advance currentExecHash to that
-  // payload's blockHash so the segment validation sees the true EL chain head.
+  let parentExecHash: string | null = parentBlock?.executionPayloadBlockHash ?? null;
   if (parentBlock !== null) {
     const parentPayloadInput = payloadEnvelopes?.get(parentBlock.slot);
     if (parentPayloadInput?.hasPayloadEnvelope()) {
-      currentExecHash = parentPayloadInput.getBlockHashHex();
+      // Checkpoint-sync first batch: the anchor is stored PENDING with the inherited (grandparent)
+      // hash, not its own payload. Its payload envelope is in this batch, so use that blockHash as
+      // the real parent EL head.
+      parentExecHash = parentPayloadInput.getBlockHashHex();
     }
   }
+
+  // Track the expected execution payload block hash through the segment, seeded from the FIRST
+  // block's own bid
+  const firstBlockMessage = blocks[0].getBlock().message;
+  let currentExecHash: string | null = isGloasBeaconBlock(firstBlockMessage)
+    ? toRootHex(firstBlockMessage.body.signedExecutionPayloadBid.message.parentBlockHash)
+    : null;
+
+  // First block must build on the parent's EL head. PARENT_PAYLOAD_UNKNOWN (vs the in-segment
+  // NON_LINEAR_PAYLOAD_ROOTS below) tells range sync this is a parent-link problem, not an in-batch one.
+  if (parentExecHash !== null && currentExecHash !== null && currentExecHash !== parentExecHash) {
+    throw new BlockError(blocks[0].getBlock(), {
+      code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
+      parentRoot: toRootHex(firstBlockMessage.parentRoot),
+      parentBlockHash: currentExecHash,
+    });
+  }
+
   // Track the execution hash before the last FULL advancement so we can recover
   // if the next block reveals that envelope was orphaned.
   let prevExecHash: string | null = currentExecHash;
@@ -76,8 +93,7 @@ export function assertLinearChainSegment(
     }
 
     if (isGloasBeaconBlock(block.message)) {
-      // Bid check fires only when we have a seeded execution hash. With parentBlock=null the
-      // chain is seeded mid-segment by the first FULL envelope.
+      // currentExecHash and prevExecHash are only null for a pre-gloas first block (fork-transition segment); always set post-gloas.
       if (currentExecHash !== null) {
         // Verify the bid's parentBlockHash matches the tracked execution hash.
         // This ensures the block was built on the correct FULL or EMPTY variant of its parent.
@@ -86,22 +102,13 @@ export function assertLinearChainSegment(
           // Maybe the previous slot's FULL envelope was orphaned — try falling back.
           // If even prevExecHash doesn't match, the segment is non-linear.
           if (bidParentHash !== prevExecHash) {
-            // i === 0 compares against the seeded fork-choice parent (segment boundary); i > 0
-            // compares against the in-segment predecessor's payload (broken link inside the segment).
-            throw new BlockError(
-              block,
-              i === 0
-                ? {
-                    code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN,
-                    parentRoot: toRootHex(block.message.parentRoot),
-                    parentBlockHash: bidParentHash,
-                  }
-                : {
-                    code: BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS,
-                    parentBlockHash: bidParentHash,
-                    expectedBlockHash: currentExecHash,
-                  }
-            );
+            // Broken link inside the segment: throw NON_LINEAR_PAYLOAD_ROOTS instead of PARENT_PAYLOAD_UNKNOWN
+            // this is important for range sync to handle accordingly
+            throw new BlockError(block, {
+              code: BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS,
+              parentBlockHash: bidParentHash,
+              expectedBlockHash: currentExecHash,
+            });
           }
           if (lastFullSlot !== null && payloadEnvelopes !== null) {
             const orphanedInput = payloadEnvelopes.get(lastFullSlot);

--- a/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
@@ -17,11 +17,20 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment with 
   const config = createChainForkConfig({...chainConfig, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
   const seenTimestampSec = Date.now() / 1000;
 
-  function gloasBlockInput(slot: Slot, parentRoot: Uint8Array, bidParentBlockHash: Uint8Array): BlockInputNoData {
+  function gloasBlockInput(
+    slot: Slot,
+    parentRoot: Uint8Array,
+    bidParentBlockHash: Uint8Array,
+    bidBlockHash?: Uint8Array
+  ): BlockInputNoData {
     const block = ssz.gloas.SignedBeaconBlock.defaultValue();
     block.message.slot = slot;
     block.message.parentRoot = parentRoot;
     block.message.body.signedExecutionPayloadBid.message.parentBlockHash = bidParentBlockHash;
+    // The bid commits to its own payload's block hash; PayloadEnvelopeInput.getBlockHashHex() reads it.
+    if (bidBlockHash !== undefined) {
+      block.message.body.signedExecutionPayloadBid.message.blockHash = bidBlockHash;
+    }
     const blockRootHex = toRootHex(ssz.gloas.BeaconBlock.hashTreeRoot(block.message));
     return BlockInputNoData.createFromBlock({
       block: block as SignedBeaconBlock<typeof ForkName.gloas>,
@@ -57,6 +66,11 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment with 
     });
     return payloadInput;
   }
+
+  it("returns no warnings for an empty segment", () => {
+    const {warnings} = assertLinearChainSegment(config, [], null, null);
+    expect(warnings).toBe(null);
+  });
 
   it("passes for a single-block segment with parentBlock=null (no checks fire)", () => {
     const bi = gloasBlockInput(10, Buffer.alloc(32, 0xaa), Buffer.alloc(32, 0xbb));
@@ -102,11 +116,11 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment with 
   });
 
   it("passes for an EMPTY→EMPTY segment (no envelopes) without a parent", () => {
-    // First block's bid check is skipped (currentExecHash starts null); from there no envelopes,
-    // so chain stays "unseeded" — no further checks can fire.
+    // currentExecHash seeds from bi1's bid; with no envelopes it never advances, so bi2 must
+    // build on that same EL head (an EMPTY block does not advance the execution chain).
     const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), Buffer.alloc(32, 0xbb));
     const b1Root = ssz.gloas.BeaconBlock.hashTreeRoot(bi1.getBlock().message as gloas.BeaconBlock);
-    const bi2 = gloasBlockInput(11, b1Root, Buffer.alloc(32, 0xcc));
+    const bi2 = gloasBlockInput(11, b1Root, Buffer.alloc(32, 0xbb));
 
     const {warnings} = assertLinearChainSegment(config, [bi1, bi2], null, null);
     expect(warnings).toBe(null);
@@ -130,17 +144,45 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment with 
     const {warnings} = assertLinearChainSegment(config, [bi1, bi2], envelopes, null);
     expect(warnings).toBe(null);
   });
+
+  it("passes when the FIRST block's payload is orphaned by the next block (range batch boundary)", () => {
+    // Regression for the range-sync wedge: a batch starts at the block whose payload is orphaned.
+    // bi1 builds on grandparent G and reveals payload P; bi2 builds on G again (skipping P),
+    // revealing bi1's payload as orphaned. Pre-fix this threw NON_LINEAR_PAYLOAD_ROOTS because
+    // prevExecHash was seeded null; seeding from bi1's bid lets the fallback recover.
+    const grandparentHash = Buffer.alloc(32, 0x4d); // G — the EL head bi1 (and bi2) build on
+    const bi1PayloadHash = Buffer.alloc(32, 0x66); // P — bi1's revealed (but orphaned) payload
+
+    const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), grandparentHash);
+    const b1Root = ssz.gloas.BeaconBlock.hashTreeRoot(bi1.getBlock().message as gloas.BeaconBlock);
+    const bi2 = gloasBlockInput(11, b1Root, grandparentHash);
+
+    const pi1 = payloadInputFor(bi1, bi1PayloadHash);
+    const envelopes = new Map<Slot, PayloadEnvelopeInput>([[10, pi1]]);
+
+    const {warnings} = assertLinearChainSegment(config, [bi1, bi2], envelopes, null);
+    expect(warnings?.map((w) => w.slot)).toEqual([10]);
+  });
 });
 
 describe("chain / blocks / utils / chainSegment / assertLinearChainSegment boundary (parentBlock provided)", () => {
   const config = createChainForkConfig({...chainConfig, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
   const seenTimestampSec = Date.now() / 1000;
 
-  function gloasBlockInput(slot: Slot, parentRoot: Uint8Array, bidParentBlockHash: Uint8Array): BlockInputNoData {
+  function gloasBlockInput(
+    slot: Slot,
+    parentRoot: Uint8Array,
+    bidParentBlockHash: Uint8Array,
+    bidBlockHash?: Uint8Array
+  ): BlockInputNoData {
     const block = ssz.gloas.SignedBeaconBlock.defaultValue();
     block.message.slot = slot;
     block.message.parentRoot = parentRoot;
     block.message.body.signedExecutionPayloadBid.message.parentBlockHash = bidParentBlockHash;
+    // The bid commits to its own payload's block hash; PayloadEnvelopeInput.getBlockHashHex() reads it.
+    if (bidBlockHash !== undefined) {
+      block.message.body.signedExecutionPayloadBid.message.blockHash = bidBlockHash;
+    }
     const blockRootHex = toRootHex(ssz.gloas.BeaconBlock.hashTreeRoot(block.message));
     return BlockInputNoData.createFromBlock({
       block: block as SignedBeaconBlock<typeof ForkName.gloas>,
@@ -153,6 +195,30 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment bound
     });
   }
 
+  function payloadInputFor(blockInput: BlockInputNoData, payloadBlockHash: Uint8Array): PayloadEnvelopeInput {
+    const block = blockInput.getBlock();
+    const payloadInput = PayloadEnvelopeInput.createFromBlock({
+      blockRootHex: blockInput.blockRootHex,
+      block: block as SignedBeaconBlock<typeof ForkName.gloas>,
+      forkName: ForkName.gloas,
+      sampledColumns: [],
+      custodyColumns: [],
+      timeCreatedSec: seenTimestampSec,
+      daOutOfRange: false,
+    });
+    const envelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    envelope.message.beaconBlockRoot = ssz.gloas.BeaconBlock.hashTreeRoot(block.message as gloas.BeaconBlock);
+    envelope.message.payload.slotNumber = block.message.slot;
+    envelope.message.payload.blockHash = payloadBlockHash;
+    payloadInput.addPayloadEnvelope({
+      envelope,
+      source: PayloadEnvelopeInputSource.byRange,
+      seenTimestampSec,
+      peerIdStr: "peer",
+    });
+    return payloadInput;
+  }
+
   it("throws PARENT_PAYLOAD_UNKNOWN when the first block's bid parentBlockHash mismatches the fork-choice parent (i === 0)", () => {
     const parentExecHash = Buffer.alloc(32, 0x11);
     const mismatchedBidHash = Buffer.alloc(32, 0x22);
@@ -163,5 +229,31 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment bound
       () => assertLinearChainSegment(config, [bi1], null, parentBlock),
       BlockErrorCode.PARENT_PAYLOAD_UNKNOWN
     );
+  });
+
+  it("does not throw PARENT_PAYLOAD_UNKNOWN when the parent has no EL head (pre-merge parent)", () => {
+    // parentExecHash is null → nothing to compare the first block's bid against.
+    const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), Buffer.alloc(32, 0x22));
+    const parentBlock = {slot: 9, executionPayloadBlockHash: null} as unknown as ProtoBlock;
+
+    const {warnings} = assertLinearChainSegment(config, [bi1], null, parentBlock);
+    expect(warnings).toBe(null);
+  });
+
+  it("validates a checkpoint-sync anchor: first block builds on the anchor's own (advanced) payload", () => {
+    // The anchor is stored PENDING with the inherited/grandparent hash; its own payload arrives in
+    // this batch. The first block (slots 10-11 skipped) builds on the anchor's own payload. The
+    // parent reference must advance from the envelope so the first-block check passes.
+    const grandparentHash = Buffer.alloc(32, 0x11); // anchor's stored (inherited) hash
+    const anchorPayloadHash = Buffer.alloc(32, 0x22); // anchor's own revealed payload
+    const parentBlock = {slot: 9, executionPayloadBlockHash: toRootHex(grandparentHash)} as unknown as ProtoBlock;
+
+    const anchorInput = gloasBlockInput(9, Buffer.alloc(32, 0xdd), Buffer.alloc(32, 0x00), anchorPayloadHash);
+    const anchorPayload = payloadInputFor(anchorInput, anchorPayloadHash);
+    const bi1 = gloasBlockInput(12, Buffer.alloc(32, 0xaa), anchorPayloadHash);
+
+    const envelopes = new Map<Slot, PayloadEnvelopeInput>([[9, anchorPayload]]);
+    const {warnings} = assertLinearChainSegment(config, [bi1], envelopes, parentBlock);
+    expect(warnings).toBe(null);
   });
 });


### PR DESCRIPTION
**Motivation**

- lodestar was forgiven enough to handle single orphaned payload in `assertLinearChainSegment()`, but it did not do it right if orphaned block is of 1st block, got

```
DOWNLOAD_BY_RANGE_ERROR_INVALID_CHAIN_SEGMENT
BLOCK_ERROR_NON_LINEAR_PAYLOAD_ROOTS
slot 164001
parentBlockHash=0x4de15c9a...23c0e74
expectedBlockHash=0x669c9e1d...3786cbf24
```

note that payload of slot 16400 is orphaned https://dora.glamsterdam-devnet-7.ethpandaops.io/slot/164000
<img width="1203" height="407" alt="Screenshot 2026-08-07 at 18 15 20" src="https://github.com/user-attachments/assets/eeea9de5-6e10-41f0-a6cf-c3d22eb3be3d" />

how it happened:
- `prevExecHash` and `currentExecHash` are initialized as null in range sync
- after block 164000, `currentExecHash` is updated, `prevExecHash` is null. Note that peer returned the orphaned payload 164000
- error thrown at block 164001, the comparison against `currentExechash` failed, fallback logic to compare to `prevExecHash` also did not work because it's null

**Description**

- initialize `prevExecHash` and `currentExecHash` as always not null for gloas, and it's the parent block hash of 1st block
- also detect `PARENT_PAYLOAD_UNKNOWN` error before the loop

more context: https://discord.com/channels/593655374469660673/1534846703008616498/1534851299126808626

**AI Assistance Disclosure**

- created with the help of Claude
