### PR TITLE
chore: add debug log when proposer slashing production is skipped

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1179,7 +1179,7 @@ export class BeaconChain implements IBeaconChain {
     }
 
     if (this.opPool.hasSeenProposerSlashing(proposerIndex)) {
-      this.logger.debug("Not producing proposer slashing, slashing for proposer is already known", {
+      this.logger.debug("Not producing proposer slashing, one is already known for the proposer", {
         slot: blockSlot,
         proposerIndex,
       });

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1179,7 +1179,7 @@ export class BeaconChain implements IBeaconChain {
     }
 
     if (this.opPool.hasSeenProposerSlashing(proposerIndex)) {
-      this.logger.debug("Not producing proposer slashing, one is already known for the proposer", {
+      this.logger.debug("Not producing proposer slashing, already in the op pool", {
         slot: blockSlot,
         proposerIndex,
       });

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1174,11 +1174,15 @@ export class BeaconChain implements IBeaconChain {
 
   /** Produce a proposer slashing from two conflicting signed block headers observed for the same slot and proposer */
   private async produceProposerSlashing(blockSlot: Slot, proposerIndex: ValidatorIndex): Promise<void> {
-    if (
-      this.opts.disableProposerSlashings === true ||
-      this.opPool.hasSeenProposerSlashing(proposerIndex) ||
-      this.producingProposerSlashing.has(proposerIndex)
-    ) {
+    if (this.opts.disableProposerSlashings === true || this.producingProposerSlashing.has(proposerIndex)) {
+      return;
+    }
+
+    if (this.opPool.hasSeenProposerSlashing(proposerIndex)) {
+      this.logger.debug("Not producing proposer slashing, slashing for proposer is already known", {
+        slot: blockSlot,
+        proposerIndex,
+      });
       return;
     }
 


### PR DESCRIPTION
Follow-up to #9787 that adds a debug log when proposer slashing production is skipped because a slashing for the proposer is already known

Without this the skip is silent and it is not possible to tell from logs whether a node observed an equivocation and lost the production race to another node or never detected it at all
