### PR TITLE
fix: bound network worker termination so shutdown can complete

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -298,8 +298,9 @@ export class NetworkCore implements INetworkCore {
     this.attnetsService.close();
     this.syncnetsService.close();
     await this.libp2p.stop();
-    // Anything still listed here keeps this thread's event loop from draining, which is what stops
-    // `Worker.terminate()` from ever resolving and hangs shutdown until the process manager steps in
+    // Diagnostic for the shutdown hang, this thread can spin in `Environment::CleanupHandles()` on
+    // a handle that never closes and `Worker.terminate()` then never resolves. Diffing this list
+    // between a clean and a stuck shutdown should narrow down which handle it is
     this.logger.debug("network lib2p closed", {activeResources: formatActiveResources()});
 
     this.closed = true;

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -70,6 +70,15 @@ export type BaseNetworkInit = {
   initialCustodyGroupCount: number;
 };
 
+/** Counts of what is still keeping this thread's event loop alive, e.g. `TCPWrap=3,Timeout=1` */
+function formatActiveResources(): string {
+  const counts = new Map<string, number>();
+  for (const resource of process.getActiveResourcesInfo()) {
+    counts.set(resource, (counts.get(resource) ?? 0) + 1);
+  }
+  return Array.from(counts, ([name, count]) => `${name}=${count}`).join(",");
+}
+
 /**
  * This class is meant to work both:
  * - In a libp2p worker
@@ -289,7 +298,9 @@ export class NetworkCore implements INetworkCore {
     this.attnetsService.close();
     this.syncnetsService.close();
     await this.libp2p.stop();
-    this.logger.debug("network lib2p closed");
+    // Anything still listed here keeps this thread's event loop from draining, which is what stops
+    // `Worker.terminate()` from ever resolving and hangs shutdown until the process manager steps in
+    this.logger.debug("network lib2p closed", {activeResources: formatActiveResources()});
 
     this.closed = true;
   }

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -60,8 +60,9 @@ type WorkerNetworkCoreModules = WorkerNetworkCoreInitModules & {
 const NETWORK_WORKER_EXIT_TIMEOUT_MS = 1000;
 const NETWORK_WORKER_EXIT_RETRY_COUNT = 3;
 /** Unbounded RPC into the worker, and `BeaconNode.close()` archives chain state to disk only after
- * the network is closed. Measured at 2-4s on mainnet, this only caps a pathological close */
-const NETWORK_CORE_CLOSE_TIMEOUT_MS = 5000;
+ * the network is closed. Measured at 2-4s on mainnet, kept well clear of that because cutting the
+ * close short leaves libp2p handles open, which is what stops the worker from exiting */
+const NETWORK_CORE_CLOSE_TIMEOUT_MS = 10_000;
 
 /**
  * NetworkCore implementation using a Worker thread

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -167,13 +167,21 @@ export class WorkerNetworkCore implements INetworkCore {
     this.modules.logger.debug("closing network core running in network worker");
     await this.getApi().close();
     this.modules.logger.debug("terminating network worker");
-    await terminateWorkerThread({
+    const terminated = await terminateWorkerThread({
       worker: this.getApi(),
       retryCount: NETWORK_WORKER_EXIT_RETRY_COUNT,
       retryMs: NETWORK_WORKER_EXIT_TIMEOUT_MS,
       logger: this.modules.logger,
     });
-    this.modules.logger.debug("terminated network worker");
+    if (terminated) {
+      this.modules.logger.debug("terminated network worker");
+    } else {
+      // A forced terminate() can not preempt a worker blocked in a native call, so the worker may
+      // still be running. Unref it so it can not keep the main process alive, otherwise graceful
+      // shutdown would hang until the process is force-killed (see #5775, #6053).
+      (this.modules.worker as unknown as workerThreads.Worker).unref();
+      this.modules.logger.warn("Network worker did not terminate in time, unref-ed it to allow process exit");
+    }
   }
 
   async test(): Promise<void> {

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -172,7 +172,7 @@ export class WorkerNetworkCore implements INetworkCore {
     try {
       await withTimeout(async () => this.getApi().close(), NETWORK_CORE_CLOSE_TIMEOUT_MS);
     } catch (e) {
-      this.modules.logger.debug("Error closing network core, terminating worker anyway", {}, e as Error);
+      this.modules.logger.debug("Error closing network core", {}, e as Error);
     }
     this.modules.logger.debug("terminating network worker");
     const terminated = await terminateWorkerThread({

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -172,7 +172,6 @@ export class WorkerNetworkCore implements INetworkCore {
     try {
       await withTimeout(async () => this.getApi().close(), NETWORK_CORE_CLOSE_TIMEOUT_MS);
     } catch (e) {
-      // Terminating the worker below tears the core down anyway
       this.modules.logger.debug("Error closing network core, terminating worker anyway", {}, e as Error);
     }
     this.modules.logger.debug("terminating network worker");
@@ -185,7 +184,6 @@ export class WorkerNetworkCore implements INetworkCore {
     if (terminated) {
       this.modules.logger.debug("terminated network worker");
     } else {
-      // Worker may still be running, unref it so it can not keep the process alive
       (this.modules.worker as unknown as workerThreads.Worker).unref();
       this.modules.logger.debug("Network worker did not terminate in time, unref-ed it to allow process exit");
     }

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -10,6 +10,7 @@ import {BeaconConfig, chainConfigToJson} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
 import {ResponseIncoming, ResponseOutgoing} from "@lodestar/reqresp";
 import {Status} from "@lodestar/types";
+import {withTimeout} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
 import {AsyncIterableBridgeCaller, AsyncIterableBridgeHandler} from "../../util/asyncIterableToEvents.js";
 import {PeerIdStr, peerIdFromString} from "../../util/peerId.js";
@@ -58,6 +59,12 @@ type WorkerNetworkCoreModules = WorkerNetworkCoreInitModules & {
 
 const NETWORK_WORKER_EXIT_TIMEOUT_MS = 1000;
 const NETWORK_WORKER_EXIT_RETRY_COUNT = 3;
+/**
+ * Closing the network core is an RPC into the worker, so it never settles if the worker is wedged.
+ * Bound it: `BeaconNode.close()` closes the network before archiving chain state to disk, so an
+ * unbounded await here costs that archive and forces a slow replay on the next start.
+ */
+const NETWORK_CORE_CLOSE_TIMEOUT_MS = 3000;
 
 /**
  * NetworkCore implementation using a Worker thread
@@ -165,7 +172,13 @@ export class WorkerNetworkCore implements INetworkCore {
 
   async close(): Promise<void> {
     this.modules.logger.debug("closing network core running in network worker");
-    await this.getApi().close();
+    try {
+      await withTimeout(async () => this.getApi().close(), NETWORK_CORE_CLOSE_TIMEOUT_MS);
+    } catch (e) {
+      // Terminating the worker below tears the core down anyway, and the peers we failed to say
+      // goodbye to will time us out. Neither is worth failing the shutdown over.
+      this.modules.logger.warn("Error closing network core, terminating worker anyway", {}, e as Error);
+    }
     this.modules.logger.debug("terminating network worker");
     const terminated = await terminateWorkerThread({
       worker: this.getApi(),

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -177,7 +177,7 @@ export class WorkerNetworkCore implements INetworkCore {
     } catch (e) {
       // Terminating the worker below tears the core down anyway, and the peers we failed to say
       // goodbye to will time us out. Neither is worth failing the shutdown over.
-      this.modules.logger.warn("Error closing network core, terminating worker anyway", {}, e as Error);
+      this.modules.logger.debug("Error closing network core, terminating worker anyway", {}, e as Error);
     }
     this.modules.logger.debug("terminating network worker");
     const terminated = await terminateWorkerThread({
@@ -193,7 +193,7 @@ export class WorkerNetworkCore implements INetworkCore {
       // still be running. Unref it so it can not keep the main process alive, otherwise graceful
       // shutdown would hang until the process is force-killed (see #5775, #6053).
       (this.modules.worker as unknown as workerThreads.Worker).unref();
-      this.modules.logger.warn("Network worker did not terminate in time, unref-ed it to allow process exit");
+      this.modules.logger.debug("Network worker did not terminate in time, unref-ed it to allow process exit");
     }
   }
 

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -60,8 +60,8 @@ type WorkerNetworkCoreModules = WorkerNetworkCoreInitModules & {
 const NETWORK_WORKER_EXIT_TIMEOUT_MS = 1000;
 const NETWORK_WORKER_EXIT_RETRY_COUNT = 3;
 /** Unbounded RPC into the worker, and `BeaconNode.close()` archives chain state to disk only after
- * the network is closed. Measured at 2.0-4.1s over 20 mainnet shutdowns, kept clear of that because
- * cutting the close short leaves libp2p handles open, which is what stops the worker from exiting */
+ * the network is closed. Measured at 2.0-4.1s over 21 mainnet shutdowns, deliberately kept clear of
+ * that since an unclosed libuv handle is what stops the worker exiting */
 const NETWORK_CORE_CLOSE_TIMEOUT_MS = 5000;
 
 /**

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -60,9 +60,9 @@ type WorkerNetworkCoreModules = WorkerNetworkCoreInitModules & {
 const NETWORK_WORKER_EXIT_TIMEOUT_MS = 1000;
 const NETWORK_WORKER_EXIT_RETRY_COUNT = 3;
 /** Unbounded RPC into the worker, and `BeaconNode.close()` archives chain state to disk only after
- * the network is closed. Measured at 2-4s on mainnet, kept well clear of that because cutting the
- * close short leaves libp2p handles open, which is what stops the worker from exiting */
-const NETWORK_CORE_CLOSE_TIMEOUT_MS = 10_000;
+ * the network is closed. Measured at 2.0-4.1s over 20 mainnet shutdowns, kept clear of that because
+ * cutting the close short leaves libp2p handles open, which is what stops the worker from exiting */
+const NETWORK_CORE_CLOSE_TIMEOUT_MS = 5000;
 
 /**
  * NetworkCore implementation using a Worker thread

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -59,8 +59,8 @@ type WorkerNetworkCoreModules = WorkerNetworkCoreInitModules & {
 
 const NETWORK_WORKER_EXIT_TIMEOUT_MS = 1000;
 const NETWORK_WORKER_EXIT_RETRY_COUNT = 3;
-/** RPC into the worker, never settles if the worker is blocked in a native call, and
- * `BeaconNode.close()` archives chain state to disk only after the network is closed */
+/** Unbounded RPC into the worker, and `BeaconNode.close()` archives chain state to disk only after
+ * the network is closed. Measured at 2-4s on mainnet, this only caps a pathological close */
 const NETWORK_CORE_CLOSE_TIMEOUT_MS = 5000;
 
 /**

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -60,8 +60,8 @@ type WorkerNetworkCoreModules = WorkerNetworkCoreInitModules & {
 const NETWORK_WORKER_EXIT_TIMEOUT_MS = 1000;
 const NETWORK_WORKER_EXIT_RETRY_COUNT = 3;
 /** Unbounded RPC into the worker, and `BeaconNode.close()` archives chain state to disk only after
- * the network is closed. Measured at 2.0-4.1s over 21 mainnet shutdowns, deliberately kept clear of
- * that since an unclosed libuv handle is what stops the worker exiting */
+ * the network is closed. Measured at ~2-4s on mainnet, deliberately kept clear of that since an
+ * unclosed libuv handle is what stops the worker exiting */
 const NETWORK_CORE_CLOSE_TIMEOUT_MS = 5000;
 
 /**

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -59,12 +59,9 @@ type WorkerNetworkCoreModules = WorkerNetworkCoreInitModules & {
 
 const NETWORK_WORKER_EXIT_TIMEOUT_MS = 1000;
 const NETWORK_WORKER_EXIT_RETRY_COUNT = 3;
-/**
- * Closing the network core is an RPC into the worker, so it never settles if the worker is wedged.
- * Bound it: `BeaconNode.close()` closes the network before archiving chain state to disk, so an
- * unbounded await here costs that archive and forces a slow replay on the next start.
- */
-const NETWORK_CORE_CLOSE_TIMEOUT_MS = 3000;
+/** RPC into the worker, never settles if the worker is wedged, and `BeaconNode.close()` archives
+ * chain state to disk only after the network is closed */
+const NETWORK_CORE_CLOSE_TIMEOUT_MS = 5000;
 
 /**
  * NetworkCore implementation using a Worker thread
@@ -175,8 +172,7 @@ export class WorkerNetworkCore implements INetworkCore {
     try {
       await withTimeout(async () => this.getApi().close(), NETWORK_CORE_CLOSE_TIMEOUT_MS);
     } catch (e) {
-      // Terminating the worker below tears the core down anyway, and the peers we failed to say
-      // goodbye to will time us out. Neither is worth failing the shutdown over.
+      // Terminating the worker below tears the core down anyway
       this.modules.logger.debug("Error closing network core, terminating worker anyway", {}, e as Error);
     }
     this.modules.logger.debug("terminating network worker");
@@ -189,9 +185,7 @@ export class WorkerNetworkCore implements INetworkCore {
     if (terminated) {
       this.modules.logger.debug("terminated network worker");
     } else {
-      // A forced terminate() can not preempt a worker blocked in a native call, so the worker may
-      // still be running. Unref it so it can not keep the main process alive, otherwise graceful
-      // shutdown would hang until the process is force-killed (see #5775, #6053).
+      // Worker may still be running, unref it so it can not keep the process alive
       (this.modules.worker as unknown as workerThreads.Worker).unref();
       this.modules.logger.debug("Network worker did not terminate in time, unref-ed it to allow process exit");
     }

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -185,8 +185,8 @@ export class WorkerNetworkCore implements INetworkCore {
     if (terminated) {
       this.modules.logger.debug("terminated network worker");
     } else {
-      // Best effort, `process.exit()` still joins the thread, but it can no longer hold the loop open
-      (this.modules.worker as unknown as workerThreads.Worker).unref();
+      // Nothing more to do, `process.exit()` joins the thread regardless so the process still waits
+      // on it. What matters is returning, so the caller can archive state and close the db
       this.modules.logger.debug("Network worker did not terminate in time, continuing shutdown without it");
     }
   }

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -184,8 +184,9 @@ export class WorkerNetworkCore implements INetworkCore {
     if (terminated) {
       this.modules.logger.debug("terminated network worker");
     } else {
+      // Best effort, `process.exit()` still joins the thread, but it can no longer hold the loop open
       (this.modules.worker as unknown as workerThreads.Worker).unref();
-      this.modules.logger.debug("Network worker did not terminate in time, unref-ed it to allow process exit");
+      this.modules.logger.debug("Network worker did not terminate in time, continuing shutdown without it");
     }
   }
 

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -59,9 +59,9 @@ type WorkerNetworkCoreModules = WorkerNetworkCoreInitModules & {
 
 const NETWORK_WORKER_EXIT_TIMEOUT_MS = 1000;
 const NETWORK_WORKER_EXIT_RETRY_COUNT = 3;
-/** Unbounded RPC into the worker, and `BeaconNode.close()` archives chain state to disk only after
- * the network is closed. Measured at ~2-4s on mainnet, deliberately kept clear of that since an
- * unclosed libuv handle is what stops the worker exiting */
+/** `getApi().close()` is an unbounded RPC into the worker and runs before `BeaconNode.close()`
+ * archives chain state to disk, so it is bounded here. Set well above the ~2-4s a close takes on
+ * mainnet, tripping it leaves libp2p half torn down */
 const NETWORK_CORE_CLOSE_TIMEOUT_MS = 5000;
 
 /**

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -59,8 +59,8 @@ type WorkerNetworkCoreModules = WorkerNetworkCoreInitModules & {
 
 const NETWORK_WORKER_EXIT_TIMEOUT_MS = 1000;
 const NETWORK_WORKER_EXIT_RETRY_COUNT = 3;
-/** RPC into the worker, never settles if the worker is wedged, and `BeaconNode.close()` archives
- * chain state to disk only after the network is closed */
+/** RPC into the worker, never settles if the worker is blocked in a native call, and
+ * `BeaconNode.close()` archives chain state to disk only after the network is closed */
 const NETWORK_CORE_CLOSE_TIMEOUT_MS = 5000;
 
 /**

--- a/packages/beacon-node/src/util/workerEvents.ts
+++ b/packages/beacon-node/src/util/workerEvents.ts
@@ -131,8 +131,16 @@ export async function terminateWorkerThread({
   });
 
   for (let i = 0; i < retryCount; i++) {
-    await Thread.terminate(worker);
-    const result = await Promise.race([terminated, sleep(retryMs).then(() => false)]);
+    // `Thread.terminate()` resolves to `Worker.terminate()`, which cannot preempt a worker that is
+    // stuck inside a synchronous native (napi) call (V8 can only tear down the isolate at a JS
+    // safepoint). If that happens the terminate call itself never resolves, so it must be raced
+    // against the timeout too - otherwise the intended `retryCount * retryMs` budget is unreachable
+    // and shutdown hangs indefinitely instead of failing bounded. See #5775 / the network-worker
+    // shutdown hang.
+    const result = await Promise.race([
+      Thread.terminate(worker).then(() => terminated),
+      sleep(retryMs).then(() => false),
+    ]);
 
     if (result) return;
 

--- a/packages/beacon-node/src/util/workerEvents.ts
+++ b/packages/beacon-node/src/util/workerEvents.ts
@@ -138,7 +138,7 @@ export async function terminateWorkerThread({
 
   for (let i = 0; i < retryCount; i++) {
     // `Worker.terminate()` cannot preempt a worker stuck in a synchronous native (napi) call and
-    // then never resolves, so it has to be raced too, otherwise the budget is unreachable.
+    // then never resolves, so it has to be raced too, otherwise `retryCount * retryMs` never applies.
     const result = await Promise.race([
       Thread.terminate(worker).then(() => terminated),
       sleep(retryMs).then(() => false),

--- a/packages/beacon-node/src/util/workerEvents.ts
+++ b/packages/beacon-node/src/util/workerEvents.ts
@@ -152,9 +152,10 @@ export async function terminateWorkerThread({
 
     if (result) return true;
 
-    logger?.warn("Worker thread failed to terminate, retrying...");
+    logger?.debug("Worker thread failed to terminate, retrying...");
   }
 
-  logger?.error(`Worker thread failed to terminate in ${retryCount * retryMs}ms`);
+  // Logged at debug as the caller owns how severe a failed termination is, it gets `false` back.
+  logger?.debug(`Worker thread failed to terminate in ${retryCount * retryMs}ms`);
   return false;
 }

--- a/packages/beacon-node/src/util/workerEvents.ts
+++ b/packages/beacon-node/src/util/workerEvents.ts
@@ -111,6 +111,14 @@ export function wireEventsOnMainThread<EventData>(
   }
 }
 
+/**
+ * Terminate a worker thread, bounded to `retryCount * retryMs`.
+ *
+ * @returns `true` if the worker terminated in time. Returns `false` if it could not be terminated
+ * (it may be blocked in a native call that a forced `terminate()` can not preempt); in that case the
+ * worker is still running and the caller must ensure it can not keep the process alive (e.g. by
+ * `unref`-ing it). See #5775, #6053.
+ */
 export async function terminateWorkerThread({
   worker,
   retryMs,
@@ -121,7 +129,7 @@ export async function terminateWorkerThread({
   retryMs: number;
   retryCount: number;
   logger?: Logger;
-}): Promise<void> {
+}): Promise<boolean> {
   const terminated = new Promise((resolve) => {
     Thread.events(worker).subscribe((event) => {
       if (event.type === "termination") {
@@ -142,10 +150,11 @@ export async function terminateWorkerThread({
       sleep(retryMs).then(() => false),
     ]);
 
-    if (result) return;
+    if (result) return true;
 
     logger?.warn("Worker thread failed to terminate, retrying...");
   }
 
-  throw new Error(`Worker thread failed to terminate in ${retryCount * retryMs}ms.`);
+  logger?.error(`Worker thread failed to terminate in ${retryCount * retryMs}ms`);
+  return false;
 }

--- a/packages/beacon-node/src/util/workerEvents.ts
+++ b/packages/beacon-node/src/util/workerEvents.ts
@@ -114,10 +114,8 @@ export function wireEventsOnMainThread<EventData>(
 /**
  * Terminate a worker thread, bounded to `retryCount * retryMs`.
  *
- * @returns `true` if the worker terminated in time. Returns `false` if it could not be terminated
- * (it may be blocked in a native call that a forced `terminate()` can not preempt); in that case the
- * worker is still running and the caller must ensure it can not keep the process alive (e.g. by
- * `unref`-ing it). See #5775, #6053.
+ * @returns `false` if it could not be terminated, the worker is then still running and the caller
+ * must ensure it can not keep the process alive (e.g. by `unref`-ing it).
  */
 export async function terminateWorkerThread({
   worker,
@@ -139,12 +137,8 @@ export async function terminateWorkerThread({
   });
 
   for (let i = 0; i < retryCount; i++) {
-    // `Thread.terminate()` resolves to `Worker.terminate()`, which cannot preempt a worker that is
-    // stuck inside a synchronous native (napi) call (V8 can only tear down the isolate at a JS
-    // safepoint). If that happens the terminate call itself never resolves, so it must be raced
-    // against the timeout too - otherwise the intended `retryCount * retryMs` budget is unreachable
-    // and shutdown hangs indefinitely instead of failing bounded. See #5775 / the network-worker
-    // shutdown hang.
+    // `Worker.terminate()` cannot preempt a worker stuck in a synchronous native (napi) call and
+    // then never resolves, so it has to be raced too, otherwise the budget is unreachable.
     const result = await Promise.race([
       Thread.terminate(worker).then(() => terminated),
       sleep(retryMs).then(() => false),
@@ -155,7 +149,6 @@ export async function terminateWorkerThread({
     logger?.debug("Worker thread failed to terminate, retrying...");
   }
 
-  // Logged at debug as the caller owns how severe a failed termination is, it gets `false` back.
   logger?.debug(`Worker thread failed to terminate in ${retryCount * retryMs}ms`);
   return false;
 }

--- a/packages/beacon-node/src/util/workerEvents.ts
+++ b/packages/beacon-node/src/util/workerEvents.ts
@@ -114,8 +114,8 @@ export function wireEventsOnMainThread<EventData>(
 /**
  * Terminate a worker thread, bounded to `retryCount * retryMs`.
  *
- * @returns `false` if it could not be terminated, the worker is then still running and the caller
- * must ensure it can not keep the process alive (e.g. by `unref`-ing it).
+ * @returns `false` if it could not be terminated, the worker thread is then still running and the
+ * caller has to decide how to proceed without it.
  */
 export async function terminateWorkerThread({
   worker,
@@ -137,8 +137,9 @@ export async function terminateWorkerThread({
   });
 
   for (let i = 0; i < retryCount; i++) {
-    // `Worker.terminate()` cannot preempt a worker stuck in a synchronous native (napi) call and
-    // then never resolves, so it has to be raced too, otherwise `retryCount * retryMs` never applies.
+    // `Worker.terminate()` resolves only once the worker thread exits, and the thread can spin
+    // forever in `Environment::CleanupHandles()` when a libuv handle on its loop never closes, so
+    // it has to be raced too, otherwise `retryCount * retryMs` never applies.
     const result = await Promise.race([
       Thread.terminate(worker).then(() => terminated),
       sleep(retryMs).then(() => false),

--- a/packages/beacon-node/test/unit/util/workerEvents.test.ts
+++ b/packages/beacon-node/test/unit/util/workerEvents.test.ts
@@ -12,10 +12,8 @@ vi.mock("@chainsafe/threads", () => ({
 describe("util / workerEvents / terminateWorkerThread", () => {
   const retryMs = 20;
   const retryCount = 3;
-  // A fake Thread handle - the mocked Thread.* statics ignore it.
   const worker = {} as Thread;
 
-  /** Build a Thread.events observable stub that emits the given events on subscribe. */
   function mockEvents(events: Array<{type: string}>): void {
     vi.mocked(Thread.events).mockReturnValue({
       subscribe: (cb: (event: {type: string}) => void) => {
@@ -43,20 +41,14 @@ describe("util / workerEvents / terminateWorkerThread", () => {
   });
 
   it("returns false in bounded time when Thread.terminate() never resolves (does not hang)", async () => {
-    // Simulate a worker stuck in a blocking native call: terminate() never resolves and no
-    // termination event is ever emitted. The old implementation awaited terminate() outside the
-    // race and would hang forever; the fix falls through within the retry budget and returns false
-    // (rather than throwing, which would abort the rest of graceful shutdown).
+    // Worker stuck in a blocking native call, terminate() never resolves
     mockEvents([]);
     vi.mocked(Thread.terminate).mockReturnValue(new Promise<void>(() => {}) as never);
 
     const promise = terminateWorkerThread({worker, retryMs, retryCount});
-    // Drive the per-retry `sleep(retryMs)` timeouts deterministically instead of waiting real time,
-    // so the bound is enforced by controlled timer advancement rather than a wall-clock assertion.
     await vi.advanceTimersByTimeAsync(retryMs * retryCount);
 
     await expect(promise).resolves.toBe(false);
-    // Must have retried the terminate call each iteration (bounded to retryCount attempts).
     expect(Thread.terminate).toHaveBeenCalledTimes(retryCount);
   });
 });

--- a/packages/beacon-node/test/unit/util/workerEvents.test.ts
+++ b/packages/beacon-node/test/unit/util/workerEvents.test.ts
@@ -41,7 +41,7 @@ describe("util / workerEvents / terminateWorkerThread", () => {
   });
 
   it("returns false in bounded time when Thread.terminate() never resolves (does not hang)", async () => {
-    // Worker stuck in a blocking native call, terminate() never resolves
+    // Worker that never exits, terminate() never resolves
     mockEvents([]);
     vi.mocked(Thread.terminate).mockReturnValue(new Promise<void>(() => {}) as never);
 

--- a/packages/beacon-node/test/unit/util/workerEvents.test.ts
+++ b/packages/beacon-node/test/unit/util/workerEvents.test.ts
@@ -1,0 +1,59 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {Thread} from "@chainsafe/threads";
+import {terminateWorkerThread} from "../../../src/util/workerEvents.js";
+
+vi.mock("@chainsafe/threads", () => ({
+  Thread: {
+    terminate: vi.fn(),
+    events: vi.fn(),
+  },
+}));
+
+describe("util / workerEvents / terminateWorkerThread", () => {
+  const retryMs = 20;
+  const retryCount = 3;
+  // A fake Thread handle - the mocked Thread.* statics ignore it.
+  const worker = {} as Thread;
+
+  /** Build a Thread.events observable stub that emits the given events on subscribe. */
+  function mockEvents(events: Array<{type: string}>): void {
+    vi.mocked(Thread.events).mockReturnValue({
+      subscribe: (cb: (event: {type: string}) => void) => {
+        for (const event of events) cb(event);
+        return {unsubscribe: () => {}};
+      },
+    } as unknown as ReturnType<typeof Thread.events>);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves when the worker terminates and emits a termination event", async () => {
+    mockEvents([{type: "termination"}]);
+    vi.mocked(Thread.terminate).mockResolvedValue(undefined as never);
+
+    await expect(terminateWorkerThread({worker, retryMs, retryCount})).resolves.toBeUndefined();
+    expect(Thread.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws bounded instead of hanging when Thread.terminate() never resolves", async () => {
+    // Simulate a worker stuck in a blocking native call: terminate() never resolves and no
+    // termination event is ever emitted. The old implementation awaited terminate() outside the
+    // race and would hang forever; the fix must fall through to the throw within the retry budget.
+    mockEvents([]);
+    vi.mocked(Thread.terminate).mockReturnValue(new Promise<void>(() => {}) as never);
+
+    const start = Date.now();
+    await expect(terminateWorkerThread({worker, retryMs, retryCount})).rejects.toThrow(
+      `Worker thread failed to terminate in ${retryCount * retryMs}ms.`
+    );
+    // Must have retried the terminate call each iteration and stayed bounded (allow generous slack).
+    expect(Thread.terminate).toHaveBeenCalledTimes(retryCount);
+    expect(Date.now() - start).toBeLessThan(retryMs * retryCount * 20);
+  });
+});

--- a/packages/beacon-node/test/unit/util/workerEvents.test.ts
+++ b/packages/beacon-node/test/unit/util/workerEvents.test.ts
@@ -33,25 +33,24 @@ describe("util / workerEvents / terminateWorkerThread", () => {
     vi.useRealTimers();
   });
 
-  it("resolves when the worker terminates and emits a termination event", async () => {
+  it("returns true when the worker terminates and emits a termination event", async () => {
     mockEvents([{type: "termination"}]);
     vi.mocked(Thread.terminate).mockResolvedValue(undefined as never);
 
-    await expect(terminateWorkerThread({worker, retryMs, retryCount})).resolves.toBeUndefined();
+    await expect(terminateWorkerThread({worker, retryMs, retryCount})).resolves.toBe(true);
     expect(Thread.terminate).toHaveBeenCalledTimes(1);
   });
 
-  it("throws bounded instead of hanging when Thread.terminate() never resolves", async () => {
+  it("returns false in bounded time when Thread.terminate() never resolves (does not hang)", async () => {
     // Simulate a worker stuck in a blocking native call: terminate() never resolves and no
     // termination event is ever emitted. The old implementation awaited terminate() outside the
-    // race and would hang forever; the fix must fall through to the throw within the retry budget.
+    // race and would hang forever; the fix falls through within the retry budget and returns false
+    // (rather than throwing, which would abort the rest of graceful shutdown).
     mockEvents([]);
     vi.mocked(Thread.terminate).mockReturnValue(new Promise<void>(() => {}) as never);
 
     const start = Date.now();
-    await expect(terminateWorkerThread({worker, retryMs, retryCount})).rejects.toThrow(
-      `Worker thread failed to terminate in ${retryCount * retryMs}ms.`
-    );
+    await expect(terminateWorkerThread({worker, retryMs, retryCount})).resolves.toBe(false);
     // Must have retried the terminate call each iteration and stayed bounded (allow generous slack).
     expect(Thread.terminate).toHaveBeenCalledTimes(retryCount);
     expect(Date.now() - start).toBeLessThan(retryMs * retryCount * 20);

--- a/packages/beacon-node/test/unit/util/workerEvents.test.ts
+++ b/packages/beacon-node/test/unit/util/workerEvents.test.ts
@@ -27,6 +27,7 @@ describe("util / workerEvents / terminateWorkerThread", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
@@ -49,10 +50,13 @@ describe("util / workerEvents / terminateWorkerThread", () => {
     mockEvents([]);
     vi.mocked(Thread.terminate).mockReturnValue(new Promise<void>(() => {}) as never);
 
-    const start = Date.now();
-    await expect(terminateWorkerThread({worker, retryMs, retryCount})).resolves.toBe(false);
-    // Must have retried the terminate call each iteration and stayed bounded (allow generous slack).
+    const promise = terminateWorkerThread({worker, retryMs, retryCount});
+    // Drive the per-retry `sleep(retryMs)` timeouts deterministically instead of waiting real time,
+    // so the bound is enforced by controlled timer advancement rather than a wall-clock assertion.
+    await vi.advanceTimersByTimeAsync(retryMs * retryCount);
+
+    await expect(promise).resolves.toBe(false);
+    // Must have retried the terminate call each iteration (bounded to retryCount attempts).
     expect(Thread.terminate).toHaveBeenCalledTimes(retryCount);
-    expect(Date.now() - start).toBeLessThan(retryMs * retryCount * 20);
   });
 });


### PR DESCRIPTION
Graceful shutdown hangs and the process has to be force-killed:

```
Aug-07 20:13:03.049 []        info:  Stopping gracefully
Aug-07 20:13:05.065 [network] debug: terminating network worker   <- last shutdown progress
...                                  chain keeps ticking slots for another 54s
dockerd: "Container failed to exit within 1m0s of signal 15 - using the force"
```

`terminateWorkerThread` awaits `Thread.terminate()` outside the timeout race, so the `retryCount * retryMs` budget is unreachable. The budget is 3s, the hang was 56s, and there is no `Worker thread failed to terminate, retrying...` in the logs, i.e. it never returned from the first call.

**Why terminate never resolves.** gdb stacks captured from a live wedged process show the worker is not blocked, it is spinning:

```
Thread 73 (LWP 1524870 "WorkerThread"):     <- state R, on CPU
#2  uv_run (loop=0x7fd473dc6938, mode=UV_RUN_ONCE)   deps/uv/src/unix/core.c:434
#3  node::Environment::CleanupHandles()
#4  node::Environment::RunCleanup()
#5  node::FreeEnvironment(node::Environment*)
#6  node::worker::Worker::Run()
```

`CleanupHandles()` ends in `while (handle_cleanup_waiting_ != 0 || request_waiting_ != 0 || !handle_wrap_queue_.IsEmpty()) uv_run(event_loop(), UV_RUN_ONCE);`. A libuv handle on the worker's loop never closes, so the loop never exits and the thread never dies. Which handle is still open is not identified.

**What it costs.** `BeaconNode.close()` closes the network before `chain.persistToDisk()`, so the hang means the finalized state is never archived and the db is never closed cleanly. On the affected node `checkpoint_states/` was empty for 5 days and a restart fell back to a db state 319 slots behind the head it had at shutdown.

- race `Thread.terminate()` against the timeout so the `retryCount * retryMs` budget is enforced
- return a boolean instead of throwing, so a failed termination does not abort the rest of `BeaconNode.close()`
- bound `getApi().close()`, an unbounded RPC into the same worker that runs before the archive
- log `getActiveResourcesInfo()` when the network core closes, so the next stuck shutdown can be diagnosed from a log line rather than gdb

**Scope.** This keeps a stuck worker from costing us the state archive. It does not stop the worker getting stuck, and it does not make the process exit promptly: `process.exit()` joins every worker via `stop_sub_worker_contexts()`, confirmed in the same capture, so a stuck shutdown still runs to the process manager's stop timeout.

```
Thread 1 (LWP 1524136 "MainThread"):
#2  uv_thread_join                     deps/uv/src/unix/thread.c:295
#3  node::worker::Worker::JoinThread()
#4  node::Environment::stop_sub_worker_contexts()
#5  node::DefaultProcessExitHandlerInternal(...)
```

I tried to fix that here too, by surfacing the failed termination and hard exiting from the CLI. It did not work - on both wedges that occurred during validation the flag read false at the CLI even though the worker had set it, and the process still waited for the docker timeout. That is dropped from this PR rather than shipped unproven, and `unref()` went with it since `process.exit()` joins regardless of refcounting.

**Testing.** 101 mainnet shutdowns on this branch, each after soaking at ~200 peers with 90-160 live inbound QUIC connections for at least 5 minutes:

- **99/101 archived the finalized state and logged `Beacon node closed`**, including all 7 where the worker failed to terminate
- clean shutdowns complete in 5.9-9.1s
- the 7 stuck ones still archived and closed internally in ~9s before being force-killed on the docker timeout

The build without this change hung at `terminating network worker` and lost the archive on all 4 shutdowns observed.

`NETWORK_CORE_CLOSE_TIMEOUT_MS` is 5s. At the original 3s it tripped on 35 of 101 shutdowns, so the measurement was censored. Raising it to 10s temporarily made it uncensored: 21 shutdowns closed the core in 2.0-4.1s and none hit the bound, so 5s clears the observed max with margin while still bounding an `await` that sits in front of the archive. Note the 35 censored runs mean it is not established that this RPC always resolves, which is the argument for bounding it at all.

Root cause notes, gdb captures and the handle-walk tooling: https://gist.github.com/nflaig/b266d89c03cdd2c76338823afed5b2c0

**AI Assistance Disclosure**

Investigation and patch developed with Claude Code. Cause traced from debug logs and gdb captures of a live wedged process, validated on a mainnet node as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

