### PR TITLE
deps: bump @chainsafe/libp2p-quic to 2.1.3

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -105,7 +105,7 @@
     "@chainsafe/discv5": "^12.0.1",
     "@chainsafe/enr": "^6.0.1",
     "@chainsafe/libp2p-noise": "^17.0.0",
-    "@chainsafe/libp2p-quic": "^2.1.2",
+    "@chainsafe/libp2p-quic": "^2.1.3",
     "@chainsafe/persistent-merkle-tree": "^1.3.0",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/snappy-wasm": "^0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,8 +195,8 @@ importers:
         specifier: ^17.0.0
         version: 17.0.0
       '@chainsafe/libp2p-quic':
-        specifier: ^2.1.2
-        version: 2.1.2
+        specifier: ^2.1.3
+        version: 2.1.3
       '@chainsafe/persistent-merkle-tree':
         specifier: ^1.3.0
         version: 1.3.0
@@ -1223,54 +1223,54 @@ packages:
   '@chainsafe/libp2p-noise@17.0.0':
     resolution: {integrity: sha512-vwrmY2Y+L1xYhIDiEpl61KHxwrLCZoXzTpwhyk34u+3+6zCAZPL3GxH3i2cs+u5IYNoyLptORdH17RKFXy7upA==}
 
-  '@chainsafe/libp2p-quic-darwin-arm64@2.1.2':
-    resolution: {integrity: sha512-8YwbHgvGqc4Af+r5DiTPOqTTo1o8A6ZnoIOREumF0LBXUcNIm6s2XDJOSM8F+sH4vtC5lQmpxsgQRDVYkj+jpw==}
+  '@chainsafe/libp2p-quic-darwin-arm64@2.1.3':
+    resolution: {integrity: sha512-nJxyHltv7t7BdeqjMAlcX6j+3H9P9YyYoQToIzaXlcphivY02vlHa31SDPA+h978DD0qo6o+yfJ6XjDgud4ZTg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@chainsafe/libp2p-quic-darwin-x64@2.1.2':
-    resolution: {integrity: sha512-JrIDYDB1E15k4/4yMoi0S+mzybIsw/KpOy6EAZFpsaxq/Y1hFHhcjwDq3iK/vyl63GRbbw+ylmLwjP61p/2iAg==}
+  '@chainsafe/libp2p-quic-darwin-x64@2.1.3':
+    resolution: {integrity: sha512-EvihuEoI+1XSTBUac13w3T/A2VySiCYEnminziK0gC2GWJKBxAvi9faWlj3YgZX5WEV4VSsRNnGWQFWlyWlA7A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@chainsafe/libp2p-quic-linux-arm64-gnu@2.1.2':
-    resolution: {integrity: sha512-vE4a/Jq0HNC35CVXE8BG4ZXsyznXrDNFN1VQxM14IG1w7f9hOg9sHlwK3jf5WG4NFeppANHv0e9iGf7/HJbYIw==}
+  '@chainsafe/libp2p-quic-linux-arm64-gnu@2.1.3':
+    resolution: {integrity: sha512-8fuB0EfjMImGLz1p9h0GwURdnX/DtZi+go4MKMml0ZzG7LxfAebh5OOvyprmjxq7d7IY63TtNzEJnRCClpVo0Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@chainsafe/libp2p-quic-linux-arm64-musl@2.1.2':
-    resolution: {integrity: sha512-ZvY7nsyu+o7aOtltkIuoeofipC3SiDHGfiaotMM4cwGG2O90e+JhT6+dIWPaXLEXR9kZf1PLKz4BSuW9vI6MTQ==}
+  '@chainsafe/libp2p-quic-linux-arm64-musl@2.1.3':
+    resolution: {integrity: sha512-4EKUkNDTZdEHCAwUxvm27cV9q6SMv0+CFni3XoPFSm6nIJGtb50RX/YqSqz7/SbnvYsI40sbvt/qXL0KN1TSKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@chainsafe/libp2p-quic-linux-x64-gnu@2.1.2':
-    resolution: {integrity: sha512-n4nAI0wFVKoaFBgcnUpX96VicVlrCJBQsLjE8Lu/JwZDhA9QRfz1cyNAaXJ5PhCXlKtuMOBPrSm5KiQLVU0g+A==}
+  '@chainsafe/libp2p-quic-linux-x64-gnu@2.1.3':
+    resolution: {integrity: sha512-DF+bYVkcDrf1FMVGS4xhqOgQDASIj8p1YzpwJWJ8udIBzMmqXaW/3zoCrzjf8U2Cdnw6mCIUNNFLSNIGhxCALA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@chainsafe/libp2p-quic-linux-x64-musl@2.1.2':
-    resolution: {integrity: sha512-h3aZpzr8iLQLae7JaCUNoGU/2fmeKXRDgef2c5ZQvqwqQMFGUSbyvoO1mhiwlwzOkToQpUPsF86sNP8ygMhCoA==}
+  '@chainsafe/libp2p-quic-linux-x64-musl@2.1.3':
+    resolution: {integrity: sha512-RCd4u87CwwfJDBsJzDQymhDj76vsvz+/+zHR9h5RJXDuqiH7Mr4JLyb8tzeD7pVTRt7MKNSJJFylUl5Tt9pTHQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@chainsafe/libp2p-quic-win32-x64-msvc@2.1.2':
-    resolution: {integrity: sha512-j15rrTscgKxaMw64KElMQudgo/VnktPYcdW7LbW5u8dxKGpm4jcrgsjhCP68BMt04jJJ47lmEdesM0Y9CfoStA==}
+  '@chainsafe/libp2p-quic-win32-x64-msvc@2.1.3':
+    resolution: {integrity: sha512-IjdpofioPIcvht7AtYlLEYEHXB9htg50vSbRfNXcUwlYT+JsIbca7dt63CuAtfHRxIA//zjxzqP/GpxJ2+8aiA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@chainsafe/libp2p-quic@2.1.2':
-    resolution: {integrity: sha512-Xj0gca6+zWAua09ksSHlIhtrU/EqrAkteCZO+0TubevjFy69TD3iTLv3Cww/Sn4yMg3h1I27f+T5fj6NdZraNw==}
+  '@chainsafe/libp2p-quic@2.1.3':
+    resolution: {integrity: sha512-y+diflUZN1hEnGhPnTPk3DUjtPigiGNf6bfXPuRSDwoB2obat0BHW7J2ZncayYTE0TAlel1sr66lLaLEO4VAdQ==}
     engines: {node: '>= 22'}
 
   '@chainsafe/netmask@2.0.0':
@@ -6929,28 +6929,28 @@ snapshots:
       uint8arrays: 5.1.0
       wherearewe: 2.0.1
 
-  '@chainsafe/libp2p-quic-darwin-arm64@2.1.2':
+  '@chainsafe/libp2p-quic-darwin-arm64@2.1.3':
     optional: true
 
-  '@chainsafe/libp2p-quic-darwin-x64@2.1.2':
+  '@chainsafe/libp2p-quic-darwin-x64@2.1.3':
     optional: true
 
-  '@chainsafe/libp2p-quic-linux-arm64-gnu@2.1.2':
+  '@chainsafe/libp2p-quic-linux-arm64-gnu@2.1.3':
     optional: true
 
-  '@chainsafe/libp2p-quic-linux-arm64-musl@2.1.2':
+  '@chainsafe/libp2p-quic-linux-arm64-musl@2.1.3':
     optional: true
 
-  '@chainsafe/libp2p-quic-linux-x64-gnu@2.1.2':
+  '@chainsafe/libp2p-quic-linux-x64-gnu@2.1.3':
     optional: true
 
-  '@chainsafe/libp2p-quic-linux-x64-musl@2.1.2':
+  '@chainsafe/libp2p-quic-linux-x64-musl@2.1.3':
     optional: true
 
-  '@chainsafe/libp2p-quic-win32-x64-msvc@2.1.2':
+  '@chainsafe/libp2p-quic-win32-x64-msvc@2.1.3':
     optional: true
 
-  '@chainsafe/libp2p-quic@2.1.2':
+  '@chainsafe/libp2p-quic@2.1.3':
     dependencies:
       '@libp2p/crypto': 5.1.19
       '@libp2p/interface': 3.2.3
@@ -6961,13 +6961,13 @@ snapshots:
       race-signal: 1.1.3
       uint8arraylist: 2.4.8
     optionalDependencies:
-      '@chainsafe/libp2p-quic-darwin-arm64': 2.1.2
-      '@chainsafe/libp2p-quic-darwin-x64': 2.1.2
-      '@chainsafe/libp2p-quic-linux-arm64-gnu': 2.1.2
-      '@chainsafe/libp2p-quic-linux-arm64-musl': 2.1.2
-      '@chainsafe/libp2p-quic-linux-x64-gnu': 2.1.2
-      '@chainsafe/libp2p-quic-linux-x64-musl': 2.1.2
-      '@chainsafe/libp2p-quic-win32-x64-msvc': 2.1.2
+      '@chainsafe/libp2p-quic-darwin-arm64': 2.1.3
+      '@chainsafe/libp2p-quic-darwin-x64': 2.1.3
+      '@chainsafe/libp2p-quic-linux-arm64-gnu': 2.1.3
+      '@chainsafe/libp2p-quic-linux-arm64-musl': 2.1.3
+      '@chainsafe/libp2p-quic-linux-x64-gnu': 2.1.3
+      '@chainsafe/libp2p-quic-linux-x64-musl': 2.1.3
+      '@chainsafe/libp2p-quic-win32-x64-msvc': 2.1.3
 
   '@chainsafe/netmask@2.0.0':
     dependencies:


### PR DESCRIPTION
Picks up ChainSafe/js-libp2p-quic#66, released as 2.1.3.

`Connection::closed()` only resolves once quinn reports the connection closed, so a stalled connection driver leaves it pending forever, and with it the napi deferred and threadsafe function backing that promise. libp2p will eventually drop such a peer on its own and call `abort()`, but before 2.1.3 the promise stayed pending even then, so each affected connection leaked those resources for the lifetime of the process. 2.1.3 settles it on `abort()` as well, which turns a permanent leak into none.

To be clear about what it does not do: it does not make libp2p notice a dead peer any sooner. By the time `abort()` is called libp2p has already concluded the connection is gone and called `onTransportClosed()` itself. This is resource hygiene, not a peer state fix.

**This is not a fix for the shutdown hang.** I originally wrote that patch believing the pending promises were what kept the network worker from terminating. They are not - gdb stacks from a live wedged worker show it spinning in Node's `Environment::CleanupHandles()` on a libuv handle that never closes, and the wedge rate was identical with and without the patch (4 in 20 shutdowns vs 1 in 5 on 2.1.2). #9790 is the mitigation for that, and the underlying handle is still unidentified.

On the timing of `onTransportClosed()`: `abort()` runs on every locally initiated close, not just at shutdown, so it is worth being precise about what changes. libp2p already calls `onTransportClosed()` itself immediately after `sendClose()` (`abstract-multiaddr-connection.js`), and the method guards every state transition, so it is idempotent. The settled promise therefore produces a redundant call at a moment the framework was transitioning anyway, rather than an genuinely earlier notification. A remote initiated close does not call `abort()` at all and is unaffected. The change only has an observable effect in the stalled driver case it was written for.

**Testing**

2.1.3 is byte-identical in behaviour to the build I ran on a mainnet node for 20 shutdowns at ~200 peers with 90-160 live inbound QUIC connections, no regression observed. Locally, install resolves cleanly, the native addon loads and exposes the unchanged API surface, and typecheck passes.

**AI Assistance Disclosure**

Dependency bump and validation with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


