### PR TITLE
fix: force process exit when a worker thread can not be terminated

### DIFF
--- a/packages/beacon-node/src/index.ts
+++ b/packages/beacon-node/src/index.ts
@@ -19,5 +19,4 @@ export {type NodeJsLibp2pOpts, createNodeJsLibp2p} from "./network/index.js";
 export * from "./node/index.js";
 // Export type util for CLI - TEMP move to lodestar-types eventually
 export {getStateSlotFromBytes, getStateTypeFromBytes} from "./util/multifork.js";
-
 export {hasWorkerTerminationFailed} from "./util/workerEvents.js";

--- a/packages/beacon-node/src/index.ts
+++ b/packages/beacon-node/src/index.ts
@@ -19,3 +19,5 @@ export {type NodeJsLibp2pOpts, createNodeJsLibp2p} from "./network/index.js";
 export * from "./node/index.js";
 // Export type util for CLI - TEMP move to lodestar-types eventually
 export {getStateSlotFromBytes, getStateTypeFromBytes} from "./util/multifork.js";
+
+export {hasWorkerTerminationFailed} from "./util/workerEvents.js";

--- a/packages/beacon-node/src/util/workerEvents.ts
+++ b/packages/beacon-node/src/util/workerEvents.ts
@@ -117,6 +117,17 @@ export function wireEventsOnMainThread<EventData>(
  * @returns `false` if it could not be terminated, the worker thread is then still running and the
  * caller has to decide how to proceed without it.
  */
+/**
+ * Process-wide record that some worker thread could not be terminated. It is a property of the
+ * process, not of any one instance, and `process.exit()` joins every worker regardless of which
+ * one is stuck, so the caller only needs to know that it happened at all.
+ */
+let someWorkerTerminationFailed = false;
+
+export function hasWorkerTerminationFailed(): boolean {
+  return someWorkerTerminationFailed;
+}
+
 export async function terminateWorkerThread({
   worker,
   retryMs,
@@ -151,5 +162,6 @@ export async function terminateWorkerThread({
   }
 
   logger?.debug(`Worker thread failed to terminate in ${retryCount * retryMs}ms`);
+  someWorkerTerminationFailed = true;
   return false;
 }

--- a/packages/beacon-node/src/util/workerEvents.ts
+++ b/packages/beacon-node/src/util/workerEvents.ts
@@ -118,14 +118,18 @@ export function wireEventsOnMainThread<EventData>(
  * caller has to decide how to proceed without it.
  */
 /**
- * Process-wide record that some worker thread could not be terminated. It is a property of the
- * process, not of any one instance, and `process.exit()` joins every worker regardless of which
- * one is stuck, so the caller only needs to know that it happened at all.
+ * How many worker threads are believed to be still running after termination failed. It is a
+ * property of the process, not of any one instance, since `process.exit()` joins every worker
+ * regardless of which one is stuck.
+ *
+ * A count rather than a flag so that a worker terminating late, after its own attempt gave up but
+ * while the rest of the shutdown is still running, does not clear the record for a different
+ * worker that really is stuck.
  */
-let someWorkerTerminationFailed = false;
+let unterminatedWorkers = 0;
 
 export function hasWorkerTerminationFailed(): boolean {
-  return someWorkerTerminationFailed;
+  return unterminatedWorkers > 0;
 }
 
 export async function terminateWorkerThread({
@@ -162,6 +166,12 @@ export async function terminateWorkerThread({
   }
 
   logger?.debug(`Worker thread failed to terminate in ${retryCount * retryMs}ms`);
-  someWorkerTerminationFailed = true;
+  unterminatedWorkers++;
+  // It may still terminate while the rest of the shutdown runs, in which case it can no longer
+  // block `process.exit()` and there is nothing to force
+  void terminated.then(() => {
+    unterminatedWorkers--;
+    logger?.debug("Worker thread terminated after the deadline");
+  });
   return false;
 }

--- a/packages/beacon-node/test/unit/util/workerEvents.test.ts
+++ b/packages/beacon-node/test/unit/util/workerEvents.test.ts
@@ -51,4 +51,33 @@ describe("util / workerEvents / terminateWorkerThread", () => {
     await expect(promise).resolves.toBe(false);
     expect(Thread.terminate).toHaveBeenCalledTimes(retryCount);
   });
+
+  it("stops reporting a failure once the worker terminates after the deadline", async () => {
+    // `unterminatedWorkers` is module state and the test above leaves a worker permanently
+    // unterminated on purpose, so take a fresh module instance to isolate the count
+    vi.resetModules();
+    const {terminateWorkerThread: terminate, hasWorkerTerminationFailed: hasFailed} = await import(
+      "../../../src/util/workerEvents.js"
+    );
+
+    // no termination event during the retries, so it gives up and records the worker as running
+    let emit: ((event: {type: string}) => void) | undefined;
+    vi.mocked(Thread.events).mockReturnValue({
+      subscribe: (cb: (event: {type: string}) => void) => {
+        emit = cb;
+        return {unsubscribe: () => {}};
+      },
+    } as unknown as ReturnType<typeof Thread.events>);
+    vi.mocked(Thread.terminate).mockReturnValue(new Promise<void>(() => {}) as never);
+
+    const promise = terminate({worker, retryMs, retryCount});
+    await vi.advanceTimersByTimeAsync(retryMs * retryCount);
+    await expect(promise).resolves.toBe(false);
+    expect(hasFailed()).toBe(true);
+
+    // the worker terminates late, while the rest of the shutdown is still running
+    emit?.({type: "termination"});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(hasFailed()).toBe(false);
+  });
 });

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -159,10 +159,9 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
             // pid 1 that have no handler installed, including SIGKILL, so this is expected when
             // running as pid 1 in a container without an init. `process.exit()` below then still
             // blocks on the join, which is no worse than before this branch existed.
-            logger.error(
-              "Could not force exit, run with an init (docker --init, tini) so the process is not pid 1",
-              {pid: process.pid}
-            );
+            logger.error("Could not force exit, run with an init (docker --init, tini) so the process is not pid 1", {
+              pid: process.pid,
+            });
           }
           // Explicitly exit until active handles issue is resolved
           // See https://github.com/ChainSafe/lodestar/issues/5642

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import {getHeapStatistics} from "node:v8";
 import {SignableENR} from "@chainsafe/enr";
 import {hasher} from "@chainsafe/persistent-merkle-tree";
-import {BeaconDb, BeaconNode} from "@lodestar/beacon-node";
+import {BeaconDb, BeaconNode, hasWorkerTerminationFailed} from "@lodestar/beacon-node";
 import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {LoggerNode, getNodeLogger} from "@lodestar/logger/node";
@@ -146,6 +146,24 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
         try {
           await node.close();
           logger.debug("Beacon node closed");
+          if (hasWorkerTerminationFailed()) {
+            // The state is archived and the db is closed by now, but `process.exit()` joins every
+            // worker via `stop_sub_worker_contexts()`, so a worker that could not be terminated
+            // blocks it until the process manager gives up. Leave on our own terms instead.
+            logger.warn("Worker thread still running, forcing process exit");
+            // A signal always reports 128+signum, the code can not be chosen, but SIGTERM (143) is
+            // what a container reports for a normal stop while SIGKILL (137) reads as a crash
+            process.removeAllListeners("SIGTERM");
+            process.kill(process.pid, "SIGTERM");
+            // Only reached if the signal was not delivered. The kernel discards signals sent to
+            // pid 1 that have no handler installed, including SIGKILL, so this is expected when
+            // running as pid 1 in a container without an init. `process.exit()` below then still
+            // blocks on the join, which is no worse than before this branch existed.
+            logger.error(
+              "Could not force exit, run with an init (docker --init, tini) so the process is not pid 1",
+              {pid: process.pid}
+            );
+          }
           // Explicitly exit until active handles issue is resolved
           // See https://github.com/ChainSafe/lodestar/issues/5642
           process.exit(0);


### PR DESCRIPTION
Follow up to #9790. That one keeps a stuck network worker from costing us the state archive, this one keeps it from costing us a 60s shutdown.

`process.exit()` joins every worker thread via `stop_sub_worker_contexts()` -> `uv_thread_join()`, so a worker that can not be terminated blocks the exit until the process manager gives up. Nothing in JS can preempt that, the main thread is inside C++ and the event loop is dead, so no timer runs. Captured live from a wedged process:

```
Thread 1 "MainThread":
#2  uv_thread_join                    deps/uv/src/unix/thread.c:295
#3  node::worker::Worker::JoinThread()
#4  node::Environment::stop_sub_worker_contexts()
#5  node::DefaultProcessExitHandlerInternal(...)
```

A signal is the only lever. `terminateWorkerThread` now records the failure process wide, and once `BeaconNode.close()` has returned, the CLI leaves on its own terms. That point is safe, the finalized state is archived and the db is closed.

- 20/20 mainnet shutdowns already archive state (#9790), this only changes when the process goes away
- clean shutdowns are untouched, they still `process.exit(0)`
- a stuck worker exits with 143 in ~7s instead of 137 after 60s

**This only works if the process is not pid 1**

The kernel discards signals sent to pid 1 that have no handler installed, **including SIGKILL**. A container running the node directly as pid 1 therefore can not signal itself at all. Verified:

| | result |
|---|---|
| `docker run node -e 'process.kill(process.pid,"SIGKILL")'` | pid=1, **survives**, exit 0 |
| same with `docker run --init` | pid=7, killed immediately |

Measured end to end on a mainnet node, with an init so the node is not pid 1, and the failed-termination path forced:

```
stopSeconds=6.7  exit=143  dockerd force-kill: 0
warn: Worker thread still running, forcing process exit
```

and without an init the same build survives its own SIGTERM *and* SIGKILL.

So when the signal is not deliverable this logs an actionable error naming the requirement and falls through to the blocking `process.exit()`, which is no worse than today's behaviour. Deployments that want the fast exit need `docker --init`, `init: true` in compose, tini, or systemd (where the node is never pid 1).

Worth considering as a follow up: warn at startup when `process.pid === 1`, so operators learn about it before it matters rather than during a shutdown.

**Testing**

3 clean shutdowns on the final build: exit 0 in 6.0-7.7s, force-exit branch correctly not taken. Forced-failure path: exit 143 in 6.7s with zero force kills. The stuck worker itself is intermittent (~10% of shutdowns) and unrelated to this change, root cause notes at https://gist.github.com/nflaig/5f41cfc50f38baf5046a034162943dc3

**AI Assistance Disclosure**

Investigation and patch developed with Claude Code, validated on a mainnet node as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
