### PR TITLE
fix: harden safe execution block hash handling

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -445,7 +445,7 @@ export async function importBlock(
      * zero block hash (pre TTD)
      */
     const safeBlockHash = getSafeExecutionBlockHash(this.forkChoice, this.logger);
-    const finalizedBlockHash = getFinalizedExecutionBlockHash(this.forkChoice, this.logger);
+    const finalizedBlockHash = getFinalizedExecutionBlockHash(this.forkChoice);
     if (headBlockHash !== ZERO_HASH_HEX) {
       this.executionEngine
         .notifyForkchoiceUpdate(

--- a/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
+++ b/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
@@ -250,7 +250,7 @@ export async function importExecutionPayload(
   const head = this.forkChoice.getHead();
   if (!this.opts.disableImportExecutionFcU && blockRootHex === head.blockRoot) {
     const safeBlockHash = getSafeExecutionBlockHash(this.forkChoice, this.logger);
-    const finalizedBlockHash = getFinalizedExecutionBlockHash(this.forkChoice, this.logger);
+    const finalizedBlockHash = getFinalizedExecutionBlockHash(this.forkChoice);
     this.executionEngine.notifyForkchoiceUpdate(fork, blockHashHex, safeBlockHash, finalizedBlockHash).catch((e) => {
       if (!isErrorAborted(e) && !isQueueErrorAborted(e)) {
         this.logger.error("Error pushing notifyForkchoiceUpdate()", {blockHashHex, finalizedBlockHash}, e);

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -224,7 +224,7 @@ export class PrepareNextSlotScheduler {
           this.metrics?.blockPayload.payloadAdvancePrepTime.observe(preparationTime);
 
           const safeBlockHash = getSafeExecutionBlockHash(this.chain.forkChoice, this.logger);
-          const finalizedBlockHash = getFinalizedExecutionBlockHash(this.chain.forkChoice, this.logger);
+          const finalizedBlockHash = getFinalizedExecutionBlockHash(this.chain.forkChoice);
 
           // awaiting here instead of throwing an async call because there is no other task
           // left for scheduler and this gives nice semantics to catch and log errors in the

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -271,7 +271,7 @@ export async function produceBlockBody<T extends BlockType>(
     // full and blinded no longer makes sense in gloas, it might be a good idea to move
     // this into a completely separate function and have pre/post gloas more separated
     const safeBlockHash = getSafeExecutionBlockHash(this.forkChoice, this.logger);
-    const finalizedBlockHash = getFinalizedExecutionBlockHash(this.forkChoice, this.logger);
+    const finalizedBlockHash = getFinalizedExecutionBlockHash(this.forkChoice);
     // TODO GLOAS: post-Gloas, proposer feeRecipient is also carried (signed) in
     // ProposerPreferencesPool. Consider using this unified cache instead
     // see https://github.com/ChainSafe/lodestar/issues/9379
@@ -417,7 +417,7 @@ export async function produceBlockBody<T extends BlockType>(
     }
 
     const safeBlockHash = getSafeExecutionBlockHash(this.forkChoice, this.logger);
-    const finalizedBlockHash = getFinalizedExecutionBlockHash(this.forkChoice, this.logger);
+    const finalizedBlockHash = getFinalizedExecutionBlockHash(this.forkChoice);
     const feeRecipient = requestedFeeRecipient ?? this.beaconProposerCache.getOrDefault(proposerIndex);
     const feeRecipientType = requestedFeeRecipient
       ? "requested"

--- a/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
+++ b/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
@@ -139,7 +139,7 @@ describe("PrepareNextSlot scheduler", () => {
     expect(chainStub.recomputeForkChoiceHead).toHaveBeenCalledOnce();
     expect(regenStub.getBlockSlotState).toHaveBeenCalledOnce();
     expect(updateBuilderStatus).toHaveBeenCalledOnce();
-    expect(forkChoiceStub.getFinalizedBlock).toHaveBeenCalledOnce();
+    expect(forkChoiceStub.getFinalizedBlock).toHaveBeenCalledTimes(2);
     expect(executionEngineStub.notifyForkchoiceUpdate).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledTimes(1);
   });

--- a/packages/fork-choice/src/forkChoice/errors.ts
+++ b/packages/fork-choice/src/forkChoice/errors.ts
@@ -89,6 +89,7 @@ export enum ForkChoiceErrorCode {
   FORK_CHOICE_STORE_ERROR = "FORKCHOICE_ERROR_FORK_CHOICE_STORE_ERROR",
   UNABLE_TO_SET_JUSTIFIED_CHECKPOINT = "FORKCHOICE_ERROR_UNABLE_TO_SET_JUSTIFIED_CHECKPOINT",
   AFTER_BLOCK_FAILED = "FORKCHOICE_ERROR_AFTER_BLOCK_FAILED",
+  MISSING_EXECUTION_PAYLOAD_BLOCK_HASH = "FORKCHOICE_ERROR_MISSING_EXECUTION_PAYLOAD_BLOCK_HASH",
 }
 
 export type ForkChoiceErrorType =
@@ -103,6 +104,7 @@ export type ForkChoiceErrorType =
   | {code: ForkChoiceErrorCode.ATTEMPT_TO_REVERT_JUSTIFICATION; store: Slot; state: Slot}
   | {code: ForkChoiceErrorCode.FORK_CHOICE_STORE_ERROR; error: Error}
   | {code: ForkChoiceErrorCode.UNABLE_TO_SET_JUSTIFIED_CHECKPOINT; error: Error}
-  | {code: ForkChoiceErrorCode.AFTER_BLOCK_FAILED; error: Error};
+  | {code: ForkChoiceErrorCode.AFTER_BLOCK_FAILED; error: Error}
+  | {code: ForkChoiceErrorCode.MISSING_EXECUTION_PAYLOAD_BLOCK_HASH; root: RootHex; slot: Slot};
 
 export class ForkChoiceError extends LodestarError<ForkChoiceErrorType> {}

--- a/packages/fork-choice/src/forkChoice/safeBlocks.ts
+++ b/packages/fork-choice/src/forkChoice/safeBlocks.ts
@@ -1,23 +1,9 @@
-import {GENESIS_SLOT, ZERO_HASH_HEX} from "@lodestar/params";
-import {Root, RootHex} from "@lodestar/types";
-import {LogLevel, Logger, fromHex} from "@lodestar/utils";
-import {HEX_ZERO_HASH, ProtoBlock, isGloasBlock} from "../protoArray/interface.js";
+import {GENESIS_SLOT} from "@lodestar/params";
+import {RootHex} from "@lodestar/types";
+import {LogLevel, Logger} from "@lodestar/utils";
+import {ExecutionStatus, HEX_ZERO_HASH, ProtoBlock, isGloasBlock} from "../protoArray/interface.js";
+import {ForkChoiceError, ForkChoiceErrorCode} from "./errors.js";
 import {IForkChoice} from "./interface.js";
-
-/**
- * Under honest majority and certain network synchronicity assumptions there exists a block
- * that is safe from re-orgs. Normally this block is pretty close to the head of canonical
- * chain which makes it valuable to expose a safe block to users.
- *
- * @deprecated The merged fast-confirmation spec only defines `get_safe_execution_block_hash`.
- */
-export function getSafeBeaconBlockRoot(fc: IForkChoice): Root {
-  const confirmedRoot = fc.getConfirmedRoot();
-  if (confirmedRoot && fc.hasBlockHex(confirmedRoot)) {
-    return fromHex(confirmedRoot);
-  }
-  return fc.getJustifiedCheckpoint().root;
-}
 
 /**
  * Get execution payload hash to report as `safeBlockHash` in `engine_forkchoiceUpdated`.
@@ -29,16 +15,21 @@ export function getSafeBeaconBlockRoot(fc: IForkChoice): Root {
  *
  * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/bellatrix/fast-confirmation.md#new-get_safe_execution_block_hash
  */
-export function getSafeExecutionBlockHash(forkChoice: IForkChoice, logger?: Pick<Logger, LogLevel.warn>): RootHex {
+export function getSafeExecutionBlockHash(forkChoice: IForkChoice, logger?: Pick<Logger, LogLevel.debug>): RootHex {
+  const confirmedRoot = forkChoice.getConfirmedRoot();
   const confirmedBlock = forkChoice.getConfirmedBlock();
   if (confirmedBlock === null) {
-    logger?.warn("Confirmed block not found, using zero safe execution block hash", {
-      confirmedRoot: forkChoice.getConfirmedRoot(),
-    });
-    return ZERO_HASH_HEX;
+    throw new ForkChoiceError({code: ForkChoiceErrorCode.MISSING_PROTO_ARRAY_BLOCK, root: confirmedRoot});
   }
 
-  return getExecutionBlockHash(confirmedBlock, logger);
+  if (confirmedBlock.blockRoot === forkChoice.getFinalizedBlock().blockRoot) {
+    logger?.debug("Confirmed block is the finalized block", {
+      blockRoot: confirmedBlock.blockRoot,
+      slot: confirmedBlock.slot,
+    });
+  }
+
+  return getExecutionBlockHash(confirmedBlock);
 }
 
 /**
@@ -47,11 +38,11 @@ export function getSafeExecutionBlockHash(forkChoice: IForkChoice, logger?: Pick
  *
  * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/gloas/fork-choice.md#notify_forkchoice_updated
  */
-export function getFinalizedExecutionBlockHash(forkChoice: IForkChoice, logger?: Pick<Logger, LogLevel.warn>): RootHex {
-  return getExecutionBlockHash(forkChoice.getFinalizedBlock(), logger);
+export function getFinalizedExecutionBlockHash(forkChoice: IForkChoice): RootHex {
+  return getExecutionBlockHash(forkChoice.getFinalizedBlock());
 }
 
-function getExecutionBlockHash(block: ProtoBlock, logger?: Pick<Logger, LogLevel.warn>): RootHex {
+function getExecutionBlockHash(block: ProtoBlock): RootHex {
   if (isGloasBlock(block)) {
     return block.parentBlockHash;
   }
@@ -63,13 +54,19 @@ function getExecutionBlockHash(block: ProtoBlock, logger?: Pick<Logger, LogLevel
     return HEX_ZERO_HASH;
   }
 
-  if (block.executionPayloadBlockHash === null) {
-    logger?.warn("Execution payload block hash not found, using zero hash", {
-      blockRoot: block.blockRoot,
-      slot: block.slot,
-    });
+  // Widen the correlated fields so the runtime invariant is still checked for malformed input.
+  const executionPayloadBlockHash: RootHex | null = block.executionPayloadBlockHash;
+  const executionStatus: ExecutionStatus = block.executionStatus;
+  if (executionPayloadBlockHash === null) {
+    if (executionStatus !== ExecutionStatus.PreMerge) {
+      throw new ForkChoiceError({
+        code: ForkChoiceErrorCode.MISSING_EXECUTION_PAYLOAD_BLOCK_HASH,
+        root: block.blockRoot,
+        slot: block.slot,
+      });
+    }
     return HEX_ZERO_HASH;
   }
 
-  return block.executionPayloadBlockHash;
+  return executionPayloadBlockHash;
 }

--- a/packages/fork-choice/src/forkChoice/safeBlocks.ts
+++ b/packages/fork-choice/src/forkChoice/safeBlocks.ts
@@ -54,19 +54,14 @@ function getExecutionBlockHash(block: ProtoBlock): RootHex {
     return HEX_ZERO_HASH;
   }
 
-  // Widen the correlated fields so the runtime invariant is still checked for malformed input.
-  const executionPayloadBlockHash: RootHex | null = block.executionPayloadBlockHash;
-  const executionStatus: ExecutionStatus = block.executionStatus;
-  if (executionPayloadBlockHash === null) {
-    if (executionStatus !== ExecutionStatus.PreMerge) {
-      throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.MISSING_EXECUTION_PAYLOAD_BLOCK_HASH,
-        root: block.blockRoot,
-        slot: block.slot,
-      });
-    }
-    return HEX_ZERO_HASH;
+  const {blockRoot, slot} = block;
+  if (block.executionPayloadBlockHash === null && block.executionStatus !== ExecutionStatus.PreMerge) {
+    throw new ForkChoiceError({
+      code: ForkChoiceErrorCode.MISSING_EXECUTION_PAYLOAD_BLOCK_HASH,
+      root: blockRoot,
+      slot,
+    });
   }
 
-  return executionPayloadBlockHash;
+  return block.executionPayloadBlockHash ?? HEX_ZERO_HASH;
 }

--- a/packages/fork-choice/test/unit/forkChoice/safeBlocks.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/safeBlocks.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it, vi} from "vitest";
 import {GENESIS_SLOT} from "@lodestar/params";
 import {DataAvailabilityStatus} from "@lodestar/state-transition";
 import {RootHex, Slot} from "@lodestar/types";
+import {ForkChoiceError, ForkChoiceErrorCode} from "../../../src/forkChoice/errors.js";
 import {IForkChoice} from "../../../src/forkChoice/interface.js";
 import {getFinalizedExecutionBlockHash, getSafeExecutionBlockHash} from "../../../src/forkChoice/safeBlocks.js";
 import {ExecutionStatus, HEX_ZERO_HASH, PayloadStatus, ProtoBlock} from "../../../src/protoArray/interface.js";
@@ -67,19 +68,30 @@ describe("safeBlocks - getSafeExecutionBlockHash", () => {
     expect(getSafeExecutionBlockHash(fc)).toBe("0xpayloadA");
   });
 
+  it("logs when the confirmed block is the finalized block", () => {
+    const debug = vi.fn();
+    const confirmed = buildBlock({
+      blockRoot: "0xaa",
+      executionPayloadBlockHash: "0xpayloadA",
+      parentBlockHash: null,
+    });
+    const fc = mockForkChoice(confirmed, confirmed);
+
+    expect(getSafeExecutionBlockHash(fc, {debug})).toBe("0xpayloadA");
+    expect(debug).toHaveBeenCalledWith("Confirmed block is the finalized block", {
+      blockRoot: confirmed.blockRoot,
+      slot: confirmed.slot,
+    });
+  });
+
   it("pre-Bellatrix: returns ZERO_HASH_HEX when executionPayloadBlockHash is null", () => {
-    const warn = vi.fn();
     const confirmed = buildBlock({
       blockRoot: "0xaa",
       executionPayloadBlockHash: null,
       parentBlockHash: null,
     });
     const fc = mockForkChoice(confirmed, confirmed);
-    expect(getSafeExecutionBlockHash(fc, {warn})).toBe(HEX_ZERO_HASH);
-    expect(warn).toHaveBeenCalledWith("Execution payload block hash not found, using zero hash", {
-      blockRoot: confirmed.blockRoot,
-      slot: confirmed.slot,
-    });
+    expect(getSafeExecutionBlockHash(fc)).toBe(HEX_ZERO_HASH);
   });
 
   it("post-Gloas: returns the confirmed block's bid.parent_block_hash, not its own payload hash", () => {
@@ -92,8 +104,7 @@ describe("safeBlocks - getSafeExecutionBlockHash", () => {
     expect(getSafeExecutionBlockHash(fc)).toBe("0xparentEL");
   });
 
-  it("returns ZERO_HASH_HEX and logs when the confirmed block is not found", () => {
-    const warn = vi.fn();
+  it("throws when the confirmed block is not found", () => {
     const finalized = buildBlock({
       blockRoot: "0xbb",
       executionPayloadBlockHash: "0xpayloadF",
@@ -101,10 +112,29 @@ describe("safeBlocks - getSafeExecutionBlockHash", () => {
     });
     const fc = mockForkChoice(null, finalized);
 
-    expect(getSafeExecutionBlockHash(fc, {warn})).toBe(HEX_ZERO_HASH);
-    expect(warn).toHaveBeenCalledWith("Confirmed block not found, using zero safe execution block hash", {
-      confirmedRoot: "0xconfirmed",
-    });
+    expect(() => getSafeExecutionBlockHash(fc)).toThrowError(
+      new ForkChoiceError({code: ForkChoiceErrorCode.MISSING_PROTO_ARRAY_BLOCK, root: "0xconfirmed"})
+    );
+  });
+
+  it("throws when a post-Merge block is missing its execution payload block hash", () => {
+    const confirmed = {
+      ...buildBlock({
+        blockRoot: "0xaa",
+        executionPayloadBlockHash: null,
+        parentBlockHash: null,
+      }),
+      executionStatus: ExecutionStatus.Valid,
+    } as unknown as ProtoBlock;
+    const fc = mockForkChoice(confirmed, confirmed);
+
+    expect(() => getSafeExecutionBlockHash(fc)).toThrowError(
+      new ForkChoiceError({
+        code: ForkChoiceErrorCode.MISSING_EXECUTION_PAYLOAD_BLOCK_HASH,
+        root: confirmed.blockRoot,
+        slot: confirmed.slot,
+      })
+    );
   });
 
   it("pre-Gloas genesis anchor: returns ZERO_HASH_HEX, not the state's payload header hash", () => {
@@ -142,18 +172,13 @@ describe("safeBlocks - getFinalizedExecutionBlockHash", () => {
   });
 
   it("pre-Bellatrix: returns ZERO_HASH_HEX when executionPayloadBlockHash is null", () => {
-    const warn = vi.fn();
     const finalized = buildBlock({
       blockRoot: "0xbb",
       executionPayloadBlockHash: null,
       parentBlockHash: null,
     });
     const fc = mockForkChoice(finalized, finalized);
-    expect(getFinalizedExecutionBlockHash(fc, {warn})).toBe(HEX_ZERO_HASH);
-    expect(warn).toHaveBeenCalledWith("Execution payload block hash not found, using zero hash", {
-      blockRoot: finalized.blockRoot,
-      slot: finalized.slot,
-    });
+    expect(getFinalizedExecutionBlockHash(fc)).toBe(HEX_ZERO_HASH);
   });
 
   it("post-Gloas: returns the finalized block's bid.parent_block_hash, not its own payload hash", () => {


### PR DESCRIPTION
Follow-up on https://github.com/ChainSafe/lodestar/pull/9393 based on @twoeths' comments
- log when the confirmed block equals the finalized block
- throw typed errors for missing fork-choice execution data
- preserve valid pre-Merge zero-hash behavior
- remove the unused safe beacon block helper