### PR TITLE
chore: track elapsed time for ptc and bid

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -1032,6 +1032,7 @@ export function getBeaconBlockApi({
     },
 
     async publishExecutionPayloadBid({signedExecutionPayloadBid}) {
+      const seenTimestampSec = Date.now() / 1000;
       const bid = signedExecutionPayloadBid.message;
       const slot = bid.slot;
       const fork = config.getForkName(slot);
@@ -1041,6 +1042,11 @@ export function getBeaconBlockApi({
       }
 
       await validateApiExecutionPayloadBid(chain, signedExecutionPayloadBid);
+
+      // A bid for `bid.slot` is normally broadcast during the previous slot (`bid.slot - 1`) so the
+      // next-slot proposer can pick it, hence measure elapsed time from the previous slot's start.
+      const delaySec = chain.clock.secFromSlot(slot - 1, seenTimestampSec);
+      metrics?.gossipExecutionPayloadBid.elapsedTimeFromPreviousSlot.observe({source: OpSource.api}, delaySec);
 
       try {
         const insertOutcome = chain.executionPayloadBidPool.add(signedExecutionPayloadBid);

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -1043,10 +1043,8 @@ export function getBeaconBlockApi({
 
       await validateApiExecutionPayloadBid(chain, signedExecutionPayloadBid);
 
-      // A bid for `bid.slot` is normally broadcast during the previous slot (`bid.slot - 1`) so the
-      // next-slot proposer can pick it, hence measure elapsed time from the previous slot's start.
-      const delaySec = chain.clock.secFromSlot(slot - 1, seenTimestampSec);
-      metrics?.gossipExecutionPayloadBid.elapsedTimeFromPreviousSlot.observe({source: OpSource.api}, delaySec);
+      const elapsedSec = chain.clock.secFromSlot(slot, seenTimestampSec);
+      metrics?.gossipExecutionPayloadBid.elapsedTimeTillReceived.observe({source: OpSource.api}, elapsedSec);
 
       try {
         const insertOutcome = chain.executionPayloadBidPool.add(signedExecutionPayloadBid);

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -25,6 +25,7 @@ import {validateApiPayloadAttestationMessage} from "../../../../chain/validation
 import {validateApiProposerSlashing} from "../../../../chain/validation/proposerSlashing.js";
 import {validateApiSyncCommittee} from "../../../../chain/validation/syncCommittee.js";
 import {validateApiVoluntaryExit} from "../../../../chain/validation/voluntaryExit.js";
+import {OpSource} from "../../../../chain/validatorMonitor.js";
 import {validateGossipFnRetryUnknownRoot} from "../../../../network/processor/gossipHandlers.js";
 import {ApiError, FailureList, IndexedError} from "../../errors.js";
 import {ApiModules} from "../../types.js";
@@ -211,6 +212,7 @@ export function getBeaconPoolApi({
     },
 
     async submitPayloadAttestationMessages({payloadAttestationMessages}) {
+      const seenTimestampSec = Date.now() / 1000;
       const failures: FailureList = [];
 
       await Promise.all(
@@ -225,6 +227,9 @@ export function getBeaconPoolApi({
               slot,
               beaconBlockRoot
             );
+
+            const delaySec = chain.clock.secFromSlot(slot, seenTimestampSec);
+            metrics?.gossipPayloadAttestationMessage.elapsedTimeTillReceived.observe({source: OpSource.api}, delaySec);
 
             const insertOutcome = chain.payloadAttestationPool.add(
               payloadAttestationMessage,

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -908,6 +908,24 @@ export function createLodestarMetrics(
         labelNames: ["error"],
       }),
     },
+    gossipExecutionPayloadBid: {
+      // A bid for `bid.slot` is normally broadcast during the previous slot (`bid.slot - 1`) so the
+      // next-slot proposer can pick it, so this measures elapsed time from the previous slot's start.
+      elapsedTimeFromPreviousSlot: register.histogram<{source: OpSource}>({
+        name: "lodestar_gossip_execution_payload_bid_elapsed_time_from_previous_slot_seconds",
+        help: "Time elapsed between the previous slot (bid.slot - 1) start and the time the execution payload bid was received",
+        labelNames: ["source"],
+        buckets: [3, 6, 9, 12],
+      }),
+    },
+    gossipPayloadAttestationMessage: {
+      elapsedTimeTillReceived: register.histogram<{source: OpSource}>({
+        name: "lodestar_gossip_payload_attestation_message_elapsed_time_till_received_seconds",
+        help: "Time elapsed between slot time and the time the payload attestation message was received",
+        labelNames: ["source"],
+        buckets: [3, 6, 9, 12],
+      }),
+    },
     // recovery in the case of specific blob rows required
     recoverBlobSidecars: {
       blobsReconstructed: register.counter({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -909,13 +909,11 @@ export function createLodestarMetrics(
       }),
     },
     gossipExecutionPayloadBid: {
-      // A bid for `bid.slot` is normally broadcast during the previous slot (`bid.slot - 1`) so the
-      // next-slot proposer can pick it, so this measures elapsed time from the previous slot's start.
-      elapsedTimeFromPreviousSlot: register.histogram<{source: OpSource}>({
-        name: "lodestar_gossip_execution_payload_bid_elapsed_time_from_previous_slot_seconds",
-        help: "Time elapsed between the previous slot (bid.slot - 1) start and the time the execution payload bid was received",
+      elapsedTimeTillReceived: register.histogram<{source: OpSource}>({
+        name: "lodestar_gossip_execution_payload_bid_elapsed_time_till_received_seconds",
+        help: "Time elapsed between the bid's slot start and the time the execution payload bid was received (negative = received before its slot, broadcast in the previous slot; positive = received during its own slot, late)",
         labelNames: ["source"],
-        buckets: [3, 6, 9, 12],
+        buckets: [-6, -3, -1, 0, 3],
       }),
     },
     gossipPayloadAttestationMessage: {

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1232,10 +1232,14 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
     [GossipType.payload_attestation_message]: async ({
       gossipData,
       topic,
+      seenTimestampSec,
     }: GossipHandlerParamGeneric<GossipType.payload_attestation_message>) => {
       const {serializedData} = gossipData;
       const payloadAttestationMessage = sszDeserialize(topic, serializedData);
       const validationResult = await validateGossipPayloadAttestationMessage(chain, payloadAttestationMessage);
+
+      const delaySec = chain.clock.secFromSlot(payloadAttestationMessage.data.slot, seenTimestampSec);
+      metrics?.gossipPayloadAttestationMessage.elapsedTimeTillReceived.observe({source: OpSource.gossip}, delaySec);
 
       try {
         const insertOutcome = chain.payloadAttestationPool.add(
@@ -1263,10 +1267,16 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
     [GossipType.execution_payload_bid]: async ({
       gossipData,
       topic,
+      seenTimestampSec,
     }: GossipHandlerParamGeneric<GossipType.execution_payload_bid>) => {
       const {serializedData} = gossipData;
       const executionPayloadBid = sszDeserialize(topic, serializedData);
       const {proposerIndex} = await validateGossipExecutionPayloadBid(chain, executionPayloadBid);
+
+      // A bid for `bid.slot` is normally broadcast during the previous slot (`bid.slot - 1`) so the
+      // next-slot proposer can pick it, hence measure elapsed time from the previous slot's start.
+      const delaySec = chain.clock.secFromSlot(executionPayloadBid.message.slot - 1, seenTimestampSec);
+      metrics?.gossipExecutionPayloadBid.elapsedTimeFromPreviousSlot.observe({source: OpSource.gossip}, delaySec);
 
       // Handle valid payload bid by storing in a bid pool
       try {

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1273,10 +1273,9 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       const executionPayloadBid = sszDeserialize(topic, serializedData);
       const {proposerIndex} = await validateGossipExecutionPayloadBid(chain, executionPayloadBid);
 
-      // A bid for `bid.slot` is normally broadcast during the previous slot (`bid.slot - 1`) so the
-      // next-slot proposer can pick it, hence measure elapsed time from the previous slot's start.
-      const delaySec = chain.clock.secFromSlot(executionPayloadBid.message.slot - 1, seenTimestampSec);
-      metrics?.gossipExecutionPayloadBid.elapsedTimeFromPreviousSlot.observe({source: OpSource.gossip}, delaySec);
+      // this could be negative, because it's most likely the bid of next slot comes at this clock slot
+      const elapsedSec = chain.clock.secFromSlot(executionPayloadBid.message.slot, seenTimestampSec);
+      metrics?.gossipExecutionPayloadBid.elapsedTimeTillReceived.observe({source: OpSource.gossip}, elapsedSec);
 
       // Handle valid payload bid by storing in a bid pool
       try {


### PR DESCRIPTION
**Motivation**

- when investigating #9470, I don't know when do we receive ptc/bid messages which are new to lodestar

**Description**

- track "elapsed time since previous slot" for bid, because the bid is usually published before the bid's slot starts
- track same metric for ptc


**AI Assistance Disclosure**

- create with the help of Claude