### PR TITLE
test: mimic http client error body in mockApiErrorResponse

### DIFF
--- a/packages/validator/test/utils/apiStub.ts
+++ b/packages/validator/test/utils/apiStub.ts
@@ -64,6 +64,9 @@ export function mockApiResponse<T, M, E extends Endpoint<any, any, any, T, M>>({
   return apiResponse;
 }
 
-export function mockApiErrorResponse<E extends Endpoint>(status: HttpStatusCode): ApiResponse<E> {
-  return new ApiResponse<E>({} as any, null, new Response(null, {status}));
+export async function mockApiErrorResponse<E extends Endpoint>(status: HttpStatusCode): Promise<ApiResponse<E>> {
+  const res = new ApiResponse<E>({} as any, null, new Response(null, {status}));
+  // Mimic the http client which populates the error body before returning the response
+  await res.errorBody();
+  return res;
 }

--- a/packages/validator/test/utils/apiStub.ts
+++ b/packages/validator/test/utils/apiStub.ts
@@ -66,7 +66,6 @@ export function mockApiResponse<T, M, E extends Endpoint<any, any, any, T, M>>({
 
 export async function mockApiErrorResponse<E extends Endpoint>(status: HttpStatusCode): Promise<ApiResponse<E>> {
   const res = new ApiResponse<E>({} as any, null, new Response(null, {status}));
-  // Mimic the http client which populates the error body before returning the response
   await res.errorBody();
   return res;
 }


### PR DESCRIPTION
## Motivation

The real http client calls `await apiResponse.errorBody()` on every non-ok response before returning it ([`httpClient.ts`](https://github.com/ChainSafe/lodestar/blob/unstable/packages/api/src/utils/client/httpClient.ts)), which populates the internal `_errorBody` cache. Downstream, the **synchronous** accessors `error()` → `getErrorMessage()` → `resolvedErrorBody()` rely on that cache and throw `"errorBody() must be called first"` when it is empty.

The validator test helper `mockApiErrorResponse` skipped this step, so a mocked error response did not faithfully mimic the client — calling `.error()` / `.assertOk()` on it would throw that guard error instead of the real `ApiError`.

This went unnoticed because `mockApiErrorResponse` is currently **unused** in the validator package (only `mockApiResponse` is referenced by the tests).

## Description

Make `mockApiErrorResponse` `async` and `await res.errorBody()` before returning, so the helper matches real client behavior. Aligns it with the corrected copy of this helper being added in the new `@lodestar/builder` package.

Spotted by @markolazic01 while porting the helper into the builder package.

🤖 Generated with AI assistance
