### PR TITLE
style(fork-choice): use .js extensions in relative imports

### DIFF
--- a/packages/fork-choice/src/forkChoice/fastConfirmation/data.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/data.ts
@@ -4,8 +4,8 @@ import {
   FastConfirmationContext,
   FastConfirmationSnapshot,
   IFastConfirmationStore,
-} from "./types.ts";
-import {getBlock, getUnrealizedJustification} from "./utils.ts";
+} from "./types.js";
+import {getBlock, getUnrealizedJustification} from "./utils.js";
 
 export function createFastConfirmationCache(): FastConfirmationCache {
   return {

--- a/packages/fork-choice/src/forkChoice/fastConfirmation/fastConfirmationRule.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/fastConfirmationRule.ts
@@ -1,19 +1,19 @@
 import {computeEpochAtSlot, isStartSlotOfEpoch} from "@lodestar/state-transition";
 import {RootHex} from "@lodestar/types";
 import {Logger, withObservedDuration} from "@lodestar/utils";
-import {buildFastConfirmationSnapshot, createFastConfirmationCache} from "./data.ts";
-import {FastConfirmationMetrics, FastConfirmationSteps} from "./metrics.ts";
-import {runFastConfirmationRules} from "./rules.ts";
+import {buildFastConfirmationSnapshot, createFastConfirmationCache} from "./data.js";
+import {FastConfirmationMetrics, FastConfirmationSteps} from "./metrics.js";
+import {runFastConfirmationRules} from "./rules.js";
 import {
   FastConfirmationContext,
   FastConfirmationResult,
   FastConfirmationRunResult,
   IFastConfirmationRule,
   IFastConfirmationStore,
-} from "./types.ts";
+} from "./types.js";
 
-export * from "./metrics.ts";
-export * from "./types.ts";
+export * from "./metrics.js";
+export * from "./types.js";
 
 export class FastConfirmationRule implements IFastConfirmationRule {
   constructor(

--- a/packages/fork-choice/src/forkChoice/fastConfirmation/index.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/index.ts
@@ -1,3 +1,3 @@
-export * from "./fastConfirmationRule.ts";
-export * from "./metrics.ts";
-export * from "./types.ts";
+export * from "./fastConfirmationRule.js";
+export * from "./metrics.js";
+export * from "./types.js";

--- a/packages/fork-choice/src/forkChoice/fastConfirmation/rules.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/rules.ts
@@ -1,6 +1,6 @@
 import {computeEpochAtSlot, isStartSlotOfEpoch} from "@lodestar/state-transition";
 import {Logger} from "@lodestar/utils";
-import {equalCheckpointWithHex} from "../store.ts";
+import {equalCheckpointWithHex} from "../store.js";
 import {
   FastConfirmationCache,
   FastConfirmationContext,
@@ -11,8 +11,8 @@ import {
   FastConfirmationSnapshot,
   IFastConfirmationStore,
   isResetReason,
-} from "./types.ts";
-import {findLatestConfirmedDescendant, getBlock, isAncestor, isConfirmedChainSafe} from "./utils.ts";
+} from "./types.js";
+import {findLatestConfirmedDescendant, getBlock, isAncestor, isConfirmedChainSafe} from "./utils.js";
 
 export const resetIfConfirmedUnavailable: FastConfirmationRule = (snapshot, ctx, _store, cache, decision) => {
   const confirmedBlock = getBlock(ctx, cache, decision.confirmedRoot);

--- a/packages/fork-choice/src/forkChoice/fastConfirmation/types.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/types.ts
@@ -1,8 +1,8 @@
 import {EffectiveBalanceIncrements, IBeaconStateView} from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot, ValidatorIndex} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
-import {ProtoBlock} from "../../protoArray/interface.ts";
-import {CheckpointWithHex} from "../store.ts";
+import {ProtoBlock} from "../../protoArray/interface.js";
+import {CheckpointWithHex} from "../store.js";
 
 export type FastConfirmationBalanceSource = {
   state: IBeaconStateView | null;

--- a/packages/fork-choice/src/forkChoice/fastConfirmation/utils.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/utils.ts
@@ -9,8 +9,8 @@ import {
 } from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot, ValidatorIndex} from "@lodestar/types";
 import {Logger, fromHex} from "@lodestar/utils";
-import {ExecutionStatus, ProtoBlock} from "../../protoArray/interface.ts";
-import {CheckpointWithHex, computeTotalBalance, equalCheckpointWithHex} from "../store.ts";
+import {ExecutionStatus, ProtoBlock} from "../../protoArray/interface.js";
+import {CheckpointWithHex, computeTotalBalance, equalCheckpointWithHex} from "../store.js";
 import {
   type BalanceSourceKey,
   FastConfirmationBalanceSource,
@@ -19,7 +19,7 @@ import {
   FastConfirmationSnapshot,
   IFastConfirmationStore,
   type TotalActiveBalanceCacheKey,
-} from "./types.ts";
+} from "./types.js";
 
 // Spec: adjust_committee_weight_estimate_to_ensure_safety
 // https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/fast-confirmation.md#adjust_committee_weight_estimate_to_ensure_safety

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -50,7 +50,7 @@ import {
   FastConfirmationSteps,
   type IFastConfirmationRule,
   type IFastConfirmationSpecStore,
-} from "./fastConfirmation/fastConfirmationRule.ts";
+} from "./fastConfirmation/fastConfirmationRule.js";
 import {
   AncestorResult,
   AncestorStatus,

--- a/packages/fork-choice/src/forkChoice/store.ts
+++ b/packages/fork-choice/src/forkChoice/store.ts
@@ -1,7 +1,7 @@
 import {EffectiveBalanceIncrements, IBeaconStateView} from "@lodestar/state-transition";
 import {RootHex, Slot, ValidatorIndex, phase0} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
-import {ForkChoiceStateGetter, IFastConfirmationStore} from "./fastConfirmation/types.ts";
+import {ForkChoiceStateGetter, IFastConfirmationStore} from "./fastConfirmation/types.js";
 import {CheckpointWithBalance, CheckpointWithTotalBalance} from "./interface.js";
 
 /**

--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -16,7 +16,7 @@ export {
   type IFastConfirmationRule,
   type IFastConfirmationStore,
   getFastConfirmationMetrics,
-} from "./forkChoice/fastConfirmation/fastConfirmationRule.ts";
+} from "./forkChoice/fastConfirmation/fastConfirmationRule.js";
 export {ForkChoice, type ForkChoiceOpts, UpdateHeadOpt, getCommitteeFraction} from "./forkChoice/forkChoice.js";
 export {
   type AncestorResult,

--- a/packages/fork-choice/src/metrics.ts
+++ b/packages/fork-choice/src/metrics.ts
@@ -1,5 +1,5 @@
 import {MetricsRegisterExtra} from "@lodestar/utils";
-import {FastConfirmationMetrics, getFastConfirmationMetrics} from "./forkChoice/fastConfirmation/metrics.ts";
+import {FastConfirmationMetrics, getFastConfirmationMetrics} from "./forkChoice/fastConfirmation/metrics.js";
 import {UpdateHeadOpt} from "./forkChoice/forkChoice.js";
 import {NotReorgedReason} from "./forkChoice/interface.js";
 


### PR DESCRIPTION
**Motivation**

Repo convention is `.js` extensions for relative imports. The fast confirmation rule module was the last code using `.ts` specifiers, compiling only via `rewriteRelativeImportExtensions`. The same fix already landed for the FCR spec test in https://github.com/ChainSafe/lodestar/pull/9704.

**Description**

- Rewrite 23 `.ts` relative import specifiers to `.js` across 10 files in `packages/fork-choice/src` — no functional change.
- Possible follow-up (not bundled): with zero `.ts` specifiers left repo-wide, `rewriteRelativeImportExtensions` could be dropped from `tsconfig.common.json` to prevent recurrence.

Verified: fork-choice build, check-types, biome, 229 unit tests; beacon-node check-types.

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Mechanical rewrite and verification done with Claude Code, reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)