### PR TITLE
feat: expose fast confirmation store variables via lodestar API

### DIFF
--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -136,6 +136,11 @@ export type CustodyInfo = {
   custodyColumns: number[];
 };
 
+export type CheckpointHex = {
+  rootHex: RootHex;
+  epoch: Epoch;
+};
+
 export type FastConfirmationInfo = {
   confirmed: {
     rootHex: RootHex | null;
@@ -145,14 +150,14 @@ export type FastConfirmationInfo = {
     rootHex: RootHex;
     slot: Slot;
   };
-  justifiedCheckpoint: {
-    rootHex: RootHex;
-    epoch: Epoch;
-  };
-  finalizedCheckpoint: {
-    rootHex: RootHex;
-    epoch: Epoch;
-  };
+  justifiedCheckpoint: CheckpointHex;
+  finalizedCheckpoint: CheckpointHex;
+  // Spec `FastConfirmationStore` variables, as maintained by `update_fast_confirmation_variables`
+  previousEpochObservedJustifiedCheckpoint: CheckpointHex;
+  currentEpochObservedJustifiedCheckpoint: CheckpointHex;
+  previousEpochGreatestUnrealizedCheckpoint: CheckpointHex;
+  previousSlotHead: RootHex;
+  currentSlotHead: RootHex;
 };
 
 export type Endpoints = {

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -15,6 +15,7 @@ import {
 import {
   EmptyArgs,
   EmptyMeta,
+  EmptyMetaCodec,
   EmptyRequest,
   EmptyRequestCodec,
   EmptyResponseCodec,
@@ -136,29 +137,25 @@ export type CustodyInfo = {
   custodyColumns: number[];
 };
 
-export type Checkpoint = {
-  root: RootHex;
-  epoch: Epoch;
-};
+const BlockInfoType = new ContainerType({root: ssz.Root, slot: ssz.Slot});
 
-export type FastConfirmationInfo = {
-  confirmed: {
-    root: RootHex | null;
-    slot: Slot | null;
-  };
-  head: {
-    root: RootHex;
-    slot: Slot;
-  };
-  justifiedCheckpoint: Checkpoint;
-  finalizedCheckpoint: Checkpoint;
-  // Spec `FastConfirmationStore` variables, as maintained by `update_fast_confirmation_variables`
-  previousEpochObservedJustifiedCheckpoint: Checkpoint;
-  currentEpochObservedJustifiedCheckpoint: Checkpoint;
-  previousEpochGreatestUnrealizedCheckpoint: Checkpoint;
-  previousSlotHead: RootHex;
-  currentSlotHead: RootHex;
-};
+export const FastConfirmationInfoType = new ContainerType(
+  {
+    confirmed: BlockInfoType,
+    head: BlockInfoType,
+    justifiedCheckpoint: ssz.phase0.Checkpoint,
+    finalizedCheckpoint: ssz.phase0.Checkpoint,
+    // Spec `FastConfirmationStore` variables, as maintained by `update_fast_confirmation_variables`
+    previousEpochObservedJustifiedCheckpoint: ssz.phase0.Checkpoint,
+    currentEpochObservedJustifiedCheckpoint: ssz.phase0.Checkpoint,
+    previousEpochGreatestUnrealizedCheckpoint: ssz.phase0.Checkpoint,
+    previousSlotHead: ssz.Root,
+    currentSlotHead: ssz.Root,
+  },
+  {jsonCase: "eth2"}
+);
+
+export type FastConfirmationInfo = ValueOf<typeof FastConfirmationInfoType>;
 
 export type Endpoints = {
   /** Trigger to write a heapdump to disk at `dirpath`. May take > 1min */
@@ -662,7 +659,10 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       url: "/eth/v1/lodestar/fast_confirmation",
       method: "GET",
       req: EmptyRequestCodec,
-      resp: JsonOnlyResponseCodec,
+      resp: {
+        data: FastConfirmationInfoType,
+        meta: EmptyMetaCodec,
+      },
     },
     getAttesterSlashingsFromBlocks: {
       url: "/eth/v1/lodestar/blocks/attester_slashings",

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -136,26 +136,26 @@ export type CustodyInfo = {
   custodyColumns: number[];
 };
 
-export type CheckpointHex = {
-  rootHex: RootHex;
+export type Checkpoint = {
+  root: RootHex;
   epoch: Epoch;
 };
 
 export type FastConfirmationInfo = {
   confirmed: {
-    rootHex: RootHex | null;
+    root: RootHex | null;
     slot: Slot | null;
   };
   head: {
-    rootHex: RootHex;
+    root: RootHex;
     slot: Slot;
   };
-  justifiedCheckpoint: CheckpointHex;
-  finalizedCheckpoint: CheckpointHex;
+  justifiedCheckpoint: Checkpoint;
+  finalizedCheckpoint: Checkpoint;
   // Spec `FastConfirmationStore` variables, as maintained by `update_fast_confirmation_variables`
-  previousEpochObservedJustifiedCheckpoint: CheckpointHex;
-  currentEpochObservedJustifiedCheckpoint: CheckpointHex;
-  previousEpochGreatestUnrealizedCheckpoint: CheckpointHex;
+  previousEpochObservedJustifiedCheckpoint: Checkpoint;
+  currentEpochObservedJustifiedCheckpoint: Checkpoint;
+  previousEpochGreatestUnrealizedCheckpoint: Checkpoint;
   previousSlotHead: RootHex;
   currentSlotHead: RootHex;
 };

--- a/packages/api/test/unit/beacon/genericServerTest/lodestar.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/lodestar.test.ts
@@ -33,13 +33,13 @@ describe("beacon / lodestar", () => {
     it("getFastConfirmationInfo", async () => {
       mockApi.getFastConfirmationInfo.mockResolvedValue({
         data: {
-          confirmed: {rootHex: "0xaa", slot: 100},
-          head: {rootHex: "0xbb", slot: 102},
-          justifiedCheckpoint: {rootHex: "0xcc", epoch: 3},
-          finalizedCheckpoint: {rootHex: "0xdd", epoch: 2},
-          previousEpochObservedJustifiedCheckpoint: {rootHex: "0xee", epoch: 2},
-          currentEpochObservedJustifiedCheckpoint: {rootHex: "0xff", epoch: 3},
-          previousEpochGreatestUnrealizedCheckpoint: {rootHex: "0x11", epoch: 2},
+          confirmed: {root: "0xaa", slot: 100},
+          head: {root: "0xbb", slot: 102},
+          justifiedCheckpoint: {root: "0xcc", epoch: 3},
+          finalizedCheckpoint: {root: "0xdd", epoch: 2},
+          previousEpochObservedJustifiedCheckpoint: {root: "0xee", epoch: 2},
+          currentEpochObservedJustifiedCheckpoint: {root: "0xff", epoch: 3},
+          previousEpochGreatestUnrealizedCheckpoint: {root: "0x11", epoch: 2},
           previousSlotHead: "0x22",
           currentSlotHead: "0x33",
         },
@@ -53,13 +53,13 @@ describe("beacon / lodestar", () => {
       expect(res.ok).toBe(true);
       expect(res.wireFormat()).toBe(WireFormat.json);
       expect(res.json().data).toStrictEqual({
-        confirmed: {root_hex: "0xaa", slot: 100},
-        head: {root_hex: "0xbb", slot: 102},
-        justified_checkpoint: {root_hex: "0xcc", epoch: 3},
-        finalized_checkpoint: {root_hex: "0xdd", epoch: 2},
-        previous_epoch_observed_justified_checkpoint: {root_hex: "0xee", epoch: 2},
-        current_epoch_observed_justified_checkpoint: {root_hex: "0xff", epoch: 3},
-        previous_epoch_greatest_unrealized_checkpoint: {root_hex: "0x11", epoch: 2},
+        confirmed: {root: "0xaa", slot: 100},
+        head: {root: "0xbb", slot: 102},
+        justified_checkpoint: {root: "0xcc", epoch: 3},
+        finalized_checkpoint: {root: "0xdd", epoch: 2},
+        previous_epoch_observed_justified_checkpoint: {root: "0xee", epoch: 2},
+        current_epoch_observed_justified_checkpoint: {root: "0xff", epoch: 3},
+        previous_epoch_greatest_unrealized_checkpoint: {root: "0x11", epoch: 2},
         previous_slot_head: "0x22",
         current_slot_head: "0x33",
       });

--- a/packages/api/test/unit/beacon/genericServerTest/lodestar.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/lodestar.test.ts
@@ -1,9 +1,10 @@
 import {FastifyInstance} from "fastify";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
+import {toHexString} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
 import {getClient} from "../../../../src/beacon/client/lodestar.js";
-import {Endpoints, getDefinitions} from "../../../../src/beacon/routes/lodestar.js";
+import {Endpoints, FastConfirmationInfoType, getDefinitions} from "../../../../src/beacon/routes/lodestar.js";
 import {getRoutes} from "../../../../src/beacon/server/lodestar.js";
 import {HttpClient} from "../../../../src/utils/client/httpClient.js";
 import {AnyEndpoint} from "../../../../src/utils/codecs.js";
@@ -12,7 +13,7 @@ import {WireFormat} from "../../../../src/utils/wireFormat.js";
 import {getMockApi, getTestServer} from "../../../utils/utils.js";
 
 describe("beacon / lodestar", () => {
-  describe("json only endpoints", () => {
+  describe("route responses", () => {
     const mockApi = getMockApi<Endpoints>(getDefinitions(config));
     let baseUrl: string;
     let server: FastifyInstance;
@@ -31,38 +32,44 @@ describe("beacon / lodestar", () => {
     });
 
     it("getFastConfirmationInfo", async () => {
-      mockApi.getFastConfirmationInfo.mockResolvedValue({
-        data: {
-          confirmed: {root: "0xaa", slot: 100},
-          head: {root: "0xbb", slot: 102},
-          justifiedCheckpoint: {root: "0xcc", epoch: 3},
-          finalizedCheckpoint: {root: "0xdd", epoch: 2},
-          previousEpochObservedJustifiedCheckpoint: {root: "0xee", epoch: 2},
-          currentEpochObservedJustifiedCheckpoint: {root: "0xff", epoch: 3},
-          previousEpochGreatestUnrealizedCheckpoint: {root: "0x11", epoch: 2},
-          previousSlotHead: "0x22",
-          currentSlotHead: "0x33",
-        },
-      });
+      const root = (fill: number): Uint8Array => new Uint8Array(32).fill(fill);
+      const data = {
+        confirmed: {root: root(0xaa), slot: 100},
+        head: {root: root(0xbb), slot: 102},
+        justifiedCheckpoint: {root: root(0xcc), epoch: 3},
+        finalizedCheckpoint: {root: root(0xdd), epoch: 2},
+        previousEpochObservedJustifiedCheckpoint: {root: root(0xee), epoch: 2},
+        currentEpochObservedJustifiedCheckpoint: {root: root(0xff), epoch: 3},
+        previousEpochGreatestUnrealizedCheckpoint: {root: root(0x11), epoch: 2},
+        previousSlotHead: root(0x22),
+        currentSlotHead: root(0x33),
+      };
+      mockApi.getFastConfirmationInfo.mockResolvedValue({data});
 
       const httpClient = new HttpClient({baseUrl});
       const client = getClient(config, httpClient);
 
-      const res = await client.getFastConfirmationInfo();
+      const resJson = await client.getFastConfirmationInfo({responseWireFormat: WireFormat.json});
 
-      expect(res.ok).toBe(true);
-      expect(res.wireFormat()).toBe(WireFormat.json);
-      expect(res.json().data).toStrictEqual({
-        confirmed: {root: "0xaa", slot: 100},
-        head: {root: "0xbb", slot: 102},
-        justified_checkpoint: {root: "0xcc", epoch: 3},
-        finalized_checkpoint: {root: "0xdd", epoch: 2},
-        previous_epoch_observed_justified_checkpoint: {root: "0xee", epoch: 2},
-        current_epoch_observed_justified_checkpoint: {root: "0xff", epoch: 3},
-        previous_epoch_greatest_unrealized_checkpoint: {root: "0x11", epoch: 2},
-        previous_slot_head: "0x22",
-        current_slot_head: "0x33",
+      expect(resJson.ok).toBe(true);
+      expect(resJson.wireFormat()).toBe(WireFormat.json);
+      expect(resJson.json().data).toStrictEqual({
+        confirmed: {root: toHexString(root(0xaa)), slot: "100"},
+        head: {root: toHexString(root(0xbb)), slot: "102"},
+        justified_checkpoint: {root: toHexString(root(0xcc)), epoch: "3"},
+        finalized_checkpoint: {root: toHexString(root(0xdd)), epoch: "2"},
+        previous_epoch_observed_justified_checkpoint: {root: toHexString(root(0xee)), epoch: "2"},
+        current_epoch_observed_justified_checkpoint: {root: toHexString(root(0xff)), epoch: "3"},
+        previous_epoch_greatest_unrealized_checkpoint: {root: toHexString(root(0x11)), epoch: "2"},
+        previous_slot_head: toHexString(root(0x22)),
+        current_slot_head: toHexString(root(0x33)),
       });
+
+      const resSsz = await client.getFastConfirmationInfo({responseWireFormat: WireFormat.ssz});
+
+      expect(resSsz.ok).toBe(true);
+      expect(resSsz.wireFormat()).toBe(WireFormat.ssz);
+      expect(toHexString(resSsz.ssz())).toBe(toHexString(FastConfirmationInfoType.serialize(data)));
     });
 
     it("getHistoricalSummaries", async () => {

--- a/packages/api/test/unit/beacon/genericServerTest/lodestar.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/lodestar.test.ts
@@ -12,7 +12,7 @@ import {WireFormat} from "../../../../src/utils/wireFormat.js";
 import {getMockApi, getTestServer} from "../../../utils/utils.js";
 
 describe("beacon / lodestar", () => {
-  describe("get HistoricalSummaries as json", () => {
+  describe("json only endpoints", () => {
     const mockApi = getMockApi<Endpoints>(getDefinitions(config));
     let baseUrl: string;
     let server: FastifyInstance;
@@ -28,6 +28,41 @@ describe("beacon / lodestar", () => {
 
     afterAll(async () => {
       if (server !== undefined) await server.close();
+    });
+
+    it("getFastConfirmationInfo", async () => {
+      mockApi.getFastConfirmationInfo.mockResolvedValue({
+        data: {
+          confirmed: {rootHex: "0xaa", slot: 100},
+          head: {rootHex: "0xbb", slot: 102},
+          justifiedCheckpoint: {rootHex: "0xcc", epoch: 3},
+          finalizedCheckpoint: {rootHex: "0xdd", epoch: 2},
+          previousEpochObservedJustifiedCheckpoint: {rootHex: "0xee", epoch: 2},
+          currentEpochObservedJustifiedCheckpoint: {rootHex: "0xff", epoch: 3},
+          previousEpochGreatestUnrealizedCheckpoint: {rootHex: "0x11", epoch: 2},
+          previousSlotHead: "0x22",
+          currentSlotHead: "0x33",
+        },
+      });
+
+      const httpClient = new HttpClient({baseUrl});
+      const client = getClient(config, httpClient);
+
+      const res = await client.getFastConfirmationInfo();
+
+      expect(res.ok).toBe(true);
+      expect(res.wireFormat()).toBe(WireFormat.json);
+      expect(res.json().data).toStrictEqual({
+        confirmed: {root_hex: "0xaa", slot: 100},
+        head: {root_hex: "0xbb", slot: 102},
+        justified_checkpoint: {root_hex: "0xcc", epoch: 3},
+        finalized_checkpoint: {root_hex: "0xdd", epoch: 2},
+        previous_epoch_observed_justified_checkpoint: {root_hex: "0xee", epoch: 2},
+        current_epoch_observed_justified_checkpoint: {root_hex: "0xff", epoch: 3},
+        previous_epoch_greatest_unrealized_checkpoint: {root_hex: "0x11", epoch: 2},
+        previous_slot_head: "0x22",
+        current_slot_head: "0x33",
+      });
     });
 
     it("getHistoricalSummaries", async () => {

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -21,7 +21,6 @@ import {ProfileThread, profileThread, writeHeapSnapshot} from "../../../util/pro
 import {getStateResponseWithRegen} from "../beacon/state/utils.js";
 import {ApiError} from "../errors.js";
 import {ApiModules} from "../types.js";
-import {toCheckpoint} from "../utils.js";
 import {getAttesterSlashingsFromIndexedAttestations} from "./attesterSlashing.js";
 
 export function getLodestarApi({
@@ -291,20 +290,20 @@ export function getLodestarApi({
       return {
         data: {
           confirmed: {
-            root: fcrStore.confirmedRoot,
-            slot: confirmedBlock?.slot ?? null,
+            root: fromHex(fcrStore.confirmedRoot),
+            slot: confirmedBlock?.slot ?? 0,
           },
           head: {
-            root: headRoot,
+            root: fromHex(headRoot),
             slot: head.slot,
           },
-          justifiedCheckpoint: toCheckpoint(justifiedCheckpoint),
-          finalizedCheckpoint: toCheckpoint(finalizedCheckpoint),
-          previousEpochObservedJustifiedCheckpoint: toCheckpoint(fcrStore.previousEpochObservedJustifiedCheckpoint),
-          currentEpochObservedJustifiedCheckpoint: toCheckpoint(fcrStore.currentEpochObservedJustifiedCheckpoint),
-          previousEpochGreatestUnrealizedCheckpoint: toCheckpoint(fcrStore.previousEpochGreatestUnrealizedCheckpoint),
-          previousSlotHead: fcrStore.previousSlotHead,
-          currentSlotHead: fcrStore.currentSlotHead,
+          justifiedCheckpoint,
+          finalizedCheckpoint,
+          previousEpochObservedJustifiedCheckpoint: fcrStore.previousEpochObservedJustifiedCheckpoint,
+          currentEpochObservedJustifiedCheckpoint: fcrStore.currentEpochObservedJustifiedCheckpoint,
+          previousEpochGreatestUnrealizedCheckpoint: fcrStore.previousEpochGreatestUnrealizedCheckpoint,
+          previousSlotHead: fromHex(fcrStore.previousSlotHead),
+          currentSlotHead: fromHex(fcrStore.currentSlotHead),
         },
       };
     },

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -21,6 +21,7 @@ import {ProfileThread, profileThread, writeHeapSnapshot} from "../../../util/pro
 import {getStateResponseWithRegen} from "../beacon/state/utils.js";
 import {ApiError} from "../errors.js";
 import {ApiModules} from "../types.js";
+import {toCheckpointHex} from "../utils.js";
 import {getAttesterSlashingsFromIndexedAttestations} from "./attesterSlashing.js";
 
 export function getLodestarApi({
@@ -280,7 +281,7 @@ export function getLodestarApi({
     },
 
     async getFastConfirmationInfo() {
-      const confirmedRoot = chain.forkChoice.getConfirmedRoot();
+      const fcrStore = chain.forkChoice.getFastConfirmationStore();
       const confirmedBlock = chain.forkChoice.getConfirmedBlock();
       const justifiedCheckpoint = chain.forkChoice.getJustifiedCheckpoint();
       const finalizedCheckpoint = chain.forkChoice.getFinalizedCheckpoint();
@@ -290,21 +291,22 @@ export function getLodestarApi({
       return {
         data: {
           confirmed: {
-            rootHex: confirmedRoot,
+            rootHex: fcrStore.confirmedRoot,
             slot: confirmedBlock?.slot ?? null,
           },
           head: {
             rootHex: headRoot,
             slot: head.slot,
           },
-          justifiedCheckpoint: {
-            rootHex: justifiedCheckpoint.rootHex,
-            epoch: justifiedCheckpoint.epoch,
-          },
-          finalizedCheckpoint: {
-            rootHex: finalizedCheckpoint.rootHex,
-            epoch: finalizedCheckpoint.epoch,
-          },
+          justifiedCheckpoint: toCheckpointHex(justifiedCheckpoint),
+          finalizedCheckpoint: toCheckpointHex(finalizedCheckpoint),
+          previousEpochObservedJustifiedCheckpoint: toCheckpointHex(fcrStore.previousEpochObservedJustifiedCheckpoint),
+          currentEpochObservedJustifiedCheckpoint: toCheckpointHex(fcrStore.currentEpochObservedJustifiedCheckpoint),
+          previousEpochGreatestUnrealizedCheckpoint: toCheckpointHex(
+            fcrStore.previousEpochGreatestUnrealizedCheckpoint
+          ),
+          previousSlotHead: fcrStore.previousSlotHead,
+          currentSlotHead: fcrStore.currentSlotHead,
         },
       };
     },

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -21,7 +21,7 @@ import {ProfileThread, profileThread, writeHeapSnapshot} from "../../../util/pro
 import {getStateResponseWithRegen} from "../beacon/state/utils.js";
 import {ApiError} from "../errors.js";
 import {ApiModules} from "../types.js";
-import {toApiCheckpointHex} from "../utils.js";
+import {toCheckpoint} from "../utils.js";
 import {getAttesterSlashingsFromIndexedAttestations} from "./attesterSlashing.js";
 
 export function getLodestarApi({
@@ -291,22 +291,18 @@ export function getLodestarApi({
       return {
         data: {
           confirmed: {
-            rootHex: fcrStore.confirmedRoot,
+            root: fcrStore.confirmedRoot,
             slot: confirmedBlock?.slot ?? null,
           },
           head: {
-            rootHex: headRoot,
+            root: headRoot,
             slot: head.slot,
           },
-          justifiedCheckpoint: toApiCheckpointHex(justifiedCheckpoint),
-          finalizedCheckpoint: toApiCheckpointHex(finalizedCheckpoint),
-          previousEpochObservedJustifiedCheckpoint: toApiCheckpointHex(
-            fcrStore.previousEpochObservedJustifiedCheckpoint
-          ),
-          currentEpochObservedJustifiedCheckpoint: toApiCheckpointHex(fcrStore.currentEpochObservedJustifiedCheckpoint),
-          previousEpochGreatestUnrealizedCheckpoint: toApiCheckpointHex(
-            fcrStore.previousEpochGreatestUnrealizedCheckpoint
-          ),
+          justifiedCheckpoint: toCheckpoint(justifiedCheckpoint),
+          finalizedCheckpoint: toCheckpoint(finalizedCheckpoint),
+          previousEpochObservedJustifiedCheckpoint: toCheckpoint(fcrStore.previousEpochObservedJustifiedCheckpoint),
+          currentEpochObservedJustifiedCheckpoint: toCheckpoint(fcrStore.currentEpochObservedJustifiedCheckpoint),
+          previousEpochGreatestUnrealizedCheckpoint: toCheckpoint(fcrStore.previousEpochGreatestUnrealizedCheckpoint),
           previousSlotHead: fcrStore.previousSlotHead,
           currentSlotHead: fcrStore.currentSlotHead,
         },

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -21,7 +21,7 @@ import {ProfileThread, profileThread, writeHeapSnapshot} from "../../../util/pro
 import {getStateResponseWithRegen} from "../beacon/state/utils.js";
 import {ApiError} from "../errors.js";
 import {ApiModules} from "../types.js";
-import {toCheckpointHex} from "../utils.js";
+import {toApiCheckpointHex} from "../utils.js";
 import {getAttesterSlashingsFromIndexedAttestations} from "./attesterSlashing.js";
 
 export function getLodestarApi({
@@ -298,11 +298,13 @@ export function getLodestarApi({
             rootHex: headRoot,
             slot: head.slot,
           },
-          justifiedCheckpoint: toCheckpointHex(justifiedCheckpoint),
-          finalizedCheckpoint: toCheckpointHex(finalizedCheckpoint),
-          previousEpochObservedJustifiedCheckpoint: toCheckpointHex(fcrStore.previousEpochObservedJustifiedCheckpoint),
-          currentEpochObservedJustifiedCheckpoint: toCheckpointHex(fcrStore.currentEpochObservedJustifiedCheckpoint),
-          previousEpochGreatestUnrealizedCheckpoint: toCheckpointHex(
+          justifiedCheckpoint: toApiCheckpointHex(justifiedCheckpoint),
+          finalizedCheckpoint: toApiCheckpointHex(finalizedCheckpoint),
+          previousEpochObservedJustifiedCheckpoint: toApiCheckpointHex(
+            fcrStore.previousEpochObservedJustifiedCheckpoint
+          ),
+          currentEpochObservedJustifiedCheckpoint: toApiCheckpointHex(fcrStore.currentEpochObservedJustifiedCheckpoint),
+          previousEpochGreatestUnrealizedCheckpoint: toApiCheckpointHex(
             fcrStore.previousEpochGreatestUnrealizedCheckpoint
           ),
           previousSlotHead: fcrStore.previousSlotHead,

--- a/packages/beacon-node/src/api/impl/utils.ts
+++ b/packages/beacon-node/src/api/impl/utils.ts
@@ -1,5 +1,3 @@
-import {routes} from "@lodestar/api";
-import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import type {IBeaconChain} from "../../chain/index.js";
 import {SyncState} from "../../sync/index.js";
@@ -74,8 +72,4 @@ export function assertUniqueItems(array: unknown[] | undefined, message: string)
   if (duplicateItems.length) {
     throw new ApiError(400, `${message}: ${duplicateItems.join(", ")}`);
   }
-}
-
-export function toCheckpoint({rootHex, epoch}: CheckpointWithHex): routes.lodestar.Checkpoint {
-  return {root: rootHex, epoch};
 }

--- a/packages/beacon-node/src/api/impl/utils.ts
+++ b/packages/beacon-node/src/api/impl/utils.ts
@@ -76,6 +76,6 @@ export function assertUniqueItems(array: unknown[] | undefined, message: string)
   }
 }
 
-export function toCheckpointHex({rootHex, epoch}: CheckpointWithHex): routes.lodestar.CheckpointHex {
+export function toApiCheckpointHex({rootHex, epoch}: CheckpointWithHex): routes.lodestar.CheckpointHex {
   return {rootHex, epoch};
 }

--- a/packages/beacon-node/src/api/impl/utils.ts
+++ b/packages/beacon-node/src/api/impl/utils.ts
@@ -76,6 +76,6 @@ export function assertUniqueItems(array: unknown[] | undefined, message: string)
   }
 }
 
-export function toApiCheckpointHex({rootHex, epoch}: CheckpointWithHex): routes.lodestar.CheckpointHex {
-  return {rootHex, epoch};
+export function toCheckpoint({rootHex, epoch}: CheckpointWithHex): routes.lodestar.Checkpoint {
+  return {root: rootHex, epoch};
 }

--- a/packages/beacon-node/src/api/impl/utils.ts
+++ b/packages/beacon-node/src/api/impl/utils.ts
@@ -1,3 +1,5 @@
+import {routes} from "@lodestar/api";
+import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import type {IBeaconChain} from "../../chain/index.js";
 import {SyncState} from "../../sync/index.js";
@@ -72,4 +74,8 @@ export function assertUniqueItems(array: unknown[] | undefined, message: string)
   if (duplicateItems.length) {
     throw new ApiError(400, `${message}: ${duplicateItems.join(", ")}`);
   }
+}
+
+export function toCheckpointHex({rootHex, epoch}: CheckpointWithHex): routes.lodestar.CheckpointHex {
+  return {rootHex, epoch};
 }


### PR DESCRIPTION
**Motivation**

https://github.com/ChainSafe/lodestar/pull/9778 added `IForkChoice.getFastConfirmationStore()` for the spec-test runner; this adds its production consumer by exposing the spec `FastConfirmationStore` variables for debugging fast confirmation on live nodes.

**Description**

- Add `CheckpointHex` type to lodestar routes and reuse it for existing checkpoint fields
- Extend `GET /eth/v1/lodestar/fast_confirmation` with `previousEpochObservedJustifiedCheckpoint`, `currentEpochObservedJustifiedCheckpoint`, `previousEpochGreatestUnrealizedCheckpoint`, `previousSlotHead`, `currentSlotHead`
- Populate them from `forkChoice.getFastConfirmationStore()`; shared `toCheckpointHex()` helper in api impl utils

Verified: check-types, biome, api + beacon-node unit tests pass; smoke-tested against a live mainnet node with `--chain.fastConfirmation`.

Refs:
- https://github.com/ChainSafe/lodestar/issues/9690
- https://github.com/ChainSafe/lodestar/pull/9778

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Implemented and verified with Claude Code (Claude Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)