### PR TITLE
fix: trigger getBlobs in Unknown block sync

### DIFF
--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkSeq} from "@lodestar/params";
+import {ForkSeq, isForkPostGloas} from "@lodestar/params";
 import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
 import {computeTimeAtSlot} from "@lodestar/state-transition";
 import {RootHex, Slot, gloas} from "@lodestar/types";
@@ -764,9 +764,10 @@ export class BlockInputSync {
     // this prevents unbundling attack
     // see https://lighthouse-blog.sigmaprime.io/mev-unbundling-rpc.html
     const {slot: blockSlot, proposerIndex} = pendingBlock.blockInput.getBlock().message;
+    const blockRootHex = pendingBlock.blockInput.blockRootHex;
     const logCtx = {
       slot: blockSlot,
-      root: pendingBlock.blockInput.blockRootHex,
+      root: blockRootHex,
       delaySec: this.chain.clock.secFromSlot(blockSlot),
     };
     this.logger.verbose("Processing downloaded block", logCtx);
@@ -780,7 +781,7 @@ export class BlockInputSync {
       // eligible for proposer boost to prevent unbundling attack
       this.logger.verbose("Avoid proposer boost for this block of known proposer", {
         slot: blockSlot,
-        root: pendingBlock.blockInput.blockRootHex,
+        root: blockRootHex,
         proposerIndex,
       });
       await sleep(proposerBoostWindowMs);
@@ -807,12 +808,24 @@ export class BlockInputSync {
     if (!res.err) {
       this.logger.verbose("Processed block from unknown sync", logCtx);
       // no need to update status to "processed", delete anyway
-      this.pendingBlocks.delete(pendingBlock.blockInput.blockRootHex);
+      this.pendingBlocks.delete(blockRootHex);
+
+      if (isForkPostGloas(fork)) {
+        const payloadInput = this.chain.seenPayloadEnvelopeInputCache.get(blockRootHex);
+        if (!payloadInput) {
+          this.logger.warn("PayloadEnvelopeInput not seeded during unknown sync processReadyBlock()", logCtx);
+        } else {
+          // Similar to the gossip path: immediately attempt fetch of data columns from the execution engine.
+          // The bid already carries the kzg commitments, so there is no reason to wait for the payload to arrive.
+          this.chain.getBlobsTracker.triggerGetBlobs(payloadInput);
+        }
+      }
+
       // Re-enter the scheduler so descendants blocked on either parent blocks or parent payloads
       // are advanced through the same dependency checks as every other pending item.
       this.triggerUnknownBlockSearch();
     } else {
-      const errorData = {slot: pendingBlock.blockInput.slot, root: pendingBlock.blockInput.blockRootHex};
+      const errorData = {slot: pendingBlock.blockInput.slot, root: blockRootHex};
       if (res.err instanceof BlockError) {
         switch (res.err.type.code) {
           // This cases are already handled with `{ignoreIfKnown: true}`


### PR DESCRIPTION
**Motivation**
- we processed block through `BlockInputSync` but did not trigger "getBlobs()" while peers did not provide enough column, that's why we got this [error](https://github.com/ChainSafe/lodestar/issues/9799#issuecomment-5248783285)
```
Aug-08 20:25:01.093[chain]           ^[[31merror^[[39m: Error processing execution payload from gossip slot=182523, peer=16Uiu2HAkxyPDfQ1bUTKbR5pQ55GNVtzZThBUpBDoj9xcDWHdW33o, root=0xb849ac92f071346feb5d6380191b681a6b236d532bfeb4daf7b0bab7313cad2b - Timeout Error: Timeout
    at timeoutPromise (file:///usr/app/packages/utils/src/timeout.ts:19:11)    at withTimeout (file:///usr/app/packages/utils/src/timeout.ts:23:12)
    at async Promise.all (index 0)
    at verifyPayloadsDataAvailability (file:///usr/app/packages/beacon-node/src/chain/blocks/verifyPayloadsDataAvailability.ts:28:3)
    at BeaconChain.processExecutionPayload (file:///usr/app/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts:301:38)    at JobItemQueue.runJob (file:///usr/app/packages/beacon-node/src/util/queue/itemQueue.ts:149:22)Aug-08 20:25:01.100[network]         ^[[34mdebug^[[39m: Req  received method=execution_payload_envelopes_by_root, version=1, client=Lodestar, peer=16...ok7RnP, requestId=12929200
```
**Description**

- similar to gossip path, we should trigger getBlobs once we successfully process a block in `BlockInputSync`

part of #9799

**AI Assistance Disclosure**

- created with the help of Claude