### PR TITLE
fix: quiesce peer discovery before shutdown

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -285,6 +285,9 @@ export class NetworkCore implements INetworkCore {
 
     this.clock.off(ClockEvent.epoch, this.onEpoch);
 
+    await this.peerManager.quiesce();
+    this.logger.debug("network peerManager quiesced");
+
     // Must goodbye and disconnect before stopping libp2p
     await this.peerManager.goodbyeAndDisconnectAllPeers();
     this.logger.debug("network sent goodbye to all peers");

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -305,6 +305,10 @@ export class NetworkCore implements INetworkCore {
     // a handle that never closes and `Worker.terminate()` then never resolves. Diffing this list
     // between a clean and a stuck shutdown should narrow down which handle it is
     this.logger.debug("network lib2p closed", {activeResources: formatActiveResources()});
+    const processReport = process.report.getReport() as {libuv: Array<{type: string}>};
+    this.logger.debug("network lib2p tcp handles", {
+      handles: JSON.stringify(processReport.libuv.filter((handle) => handle.type === "tcp")),
+    });
 
     this.closed = true;
   }

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -164,6 +164,7 @@ export class PeerManager {
   private connectedPeers: Map<PeerIdStr, PeerData>;
   private opts: PeerManagerOpts;
   private intervals: NodeJS.Timeout[] = [];
+  private quiesced = false;
 
   constructor(modules: PeerManagerModules, opts: PeerManagerOpts, discovery: PeerDiscovery | null) {
     const {networkConfig} = modules;
@@ -228,15 +229,23 @@ export class PeerManager {
     return new PeerManager(modules, opts, discovery);
   }
 
-  async close(): Promise<void> {
+  async quiesce(): Promise<void> {
+    if (this.quiesced) return;
+
+    for (const interval of this.intervals) clearInterval(interval);
+    this.intervals = [];
     await this.discovery?.stop();
+    this.quiesced = true;
+  }
+
+  async close(): Promise<void> {
+    await this.quiesce();
     this.libp2p.services.components.events.removeEventListener(Libp2pEvent.connectionOpen, this.onLibp2pPeerConnect);
     this.libp2p.services.components.events.removeEventListener(
       Libp2pEvent.connectionClose,
       this.onLibp2pPeerDisconnect
     );
     this.networkEventBus.off(NetworkEvent.reqRespRequest, this.onRequest);
-    for (const interval of this.intervals) clearInterval(interval);
   }
 
   /**

--- a/packages/beacon-node/test/unit/network/core/networkCore.test.ts
+++ b/packages/beacon-node/test/unit/network/core/networkCore.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, it, vi} from "vitest";
+import {NetworkCore} from "../../../../src/network/core/networkCore.js";
+
+describe("network / core / NetworkCore", () => {
+  it("quiesces peer management before disconnecting peers", async () => {
+    const calls: string[] = [];
+    const modules = {
+      libp2p: {stop: vi.fn(async () => calls.push("libp2p.stop"))},
+      gossip: {stop: vi.fn(async () => calls.push("gossip.stop"))},
+      reqResp: {
+        stop: vi.fn(async () => calls.push("reqResp.stop")),
+        unregisterAllProtocols: vi.fn(async () => calls.push("reqResp.unregister")),
+      },
+      attnetsService: {close: vi.fn(() => calls.push("attnets.close"))},
+      syncnetsService: {close: vi.fn(() => calls.push("syncnets.close"))},
+      peerManager: {
+        quiesce: vi.fn(async () => calls.push("peerManager.quiesce")),
+        goodbyeAndDisconnectAllPeers: vi.fn(async () => calls.push("peerManager.goodbye")),
+        close: vi.fn(async () => calls.push("peerManager.close")),
+      },
+      networkConfig: {},
+      peersData: {},
+      metadata: {},
+      logger: {debug: vi.fn()},
+      config: {},
+      clock: {
+        on: vi.fn(),
+        off: vi.fn(() => calls.push("clock.off")),
+      },
+      statusCache: {},
+      metrics: null,
+      opts: {},
+    } as unknown as ConstructorParameters<typeof NetworkCore>[0];
+
+    const network = new NetworkCore(modules);
+    await network.close();
+
+    expect(calls).toEqual([
+      "clock.off",
+      "peerManager.quiesce",
+      "peerManager.goodbye",
+      "peerManager.close",
+      "gossip.stop",
+      "reqResp.stop",
+      "reqResp.unregister",
+      "attnets.close",
+      "syncnets.close",
+      "libp2p.stop",
+    ]);
+  });
+});


### PR DESCRIPTION
**Motivation**

Lodestar can hang during shutdown when new peer discovery or dial work overlaps libp2p connection teardown. This change quiesces peer management before sending goodbye messages and closing libp2p.

Issue reproduction: https://gist.github.com/nflaig/5f41cfc50f38baf5046a034162943dc3

**Description**

- Add an idempotent `PeerManager.quiesce()` that clears peer-management intervals and stops discovery.
- Call `quiesce()` before taking the goodbye peer snapshot and disconnecting peers.
- Keep `PeerManager.close()` responsible for calling `quiesce()` so direct close callers retain the same cleanup.
- Add a shutdown-order unit test.
- Log remaining TCP handles after libp2p shutdown. This diagnostic is intentionally included because it is part of the exact version under mainnet soak testing.

The direct socket reset/shutdown race is addressed by libp2p/js-libp2p#3596. Both draft PR heads correspond exactly to the image currently under test.

**Validation**

- Tested Lodestar commit: `d8ab5dbb3eb8623ed0d12319b77d75b707cce490`
- Tested js-libp2p commit: `c20c70314f5328ef240f6b061242a313eb38d860`
- Image: `lodestar:shutdown-fix-v6-reset-close-race`
- Image ID: `sha256:2c2bcfbe1a9adf72cb9f73dfc605fb3a149e283d8aeae6b0325bbefd5e1b13f9`
- Mainnet reproduction loop uses the same container with `docker stop -t 60` followed by `docker start`, with about six minutes of synced soak before shutdown.
- At PR creation: 45 effective shutdowns completed cleanly, 0 hangs; round 46 is in progress toward 50.
- `pnpm lint`
- `pnpm check-types`
- `pnpm test:unit` (339 files passed, 1 skipped; 3487 tests passed, 9 skipped, 1 todo)

Local checks ran under Node.js 25.2.1 and emitted the repository engine warning requesting Node.js `^24.13.0`.

**AI Assistance Disclosure**

- [x] External Contributors: I have read the contributor guidelines and disclosed my usage of AI below.

> This PR was written primarily by Codex.
