### PR TITLE
chore: update changelog authors mapping

### DIFF
--- a/scripts/generate_changelog.mjs
+++ b/scripts/generate_changelog.mjs
@@ -34,7 +34,11 @@ const knownAuthors = {
   "nflaig@protonmail.com": "nflaig",
   "nazarhussain@gmail.com": "nazarhussain",
   "me@matthewkeil.com": "matthewkeil",
+  "github@mail.matthewkeil.com": "matthewkeil",
   "17676176+ensi321@users.noreply.github.com": "ensi321",
+  "258435968+lodekeeper@users.noreply.github.com": "lodekeeper",
+  "markolazic01@gmail.com": "markolazic01",
+  "56925051+Alleysira@users.noreply.github.com": "Alleysira",
 };
 
 const fromTag = process.argv[2];
@@ -147,7 +151,7 @@ fs.writeFileSync(outpath, changelog);
  * @returns {string}
  */
 function shell(cmd) {
-  return execSync(cmd, {encoding: "utf8"}).trim();
+  return execSync(cmd, {encoding: "utf8", maxBuffer: 10 * 1024 * 1024}).trim();
 }
 
 /**

--- a/scripts/generate_changelog.mjs
+++ b/scripts/generate_changelog.mjs
@@ -39,6 +39,7 @@ const knownAuthors = {
   "258435968+lodekeeper@users.noreply.github.com": "lodekeeper",
   "markolazic01@gmail.com": "markolazic01",
   "56925051+Alleysira@users.noreply.github.com": "Alleysira",
+  "spiralladder@fastmail.com": "spiral-ladder",
 };
 
 const fromTag = process.argv[2];


### PR DESCRIPTION
## Motivation

The v1.46.0 release changelog generated by the `Publish` action used raw
commit author names for several entries instead of GitHub handles:

- `@Marko Lazic`
- `@Jie Ma`
- `@Matthew Keil`
- `@Lodekeeper`
- `@bing` should be `@spiral-ladder`

Action run checked: https://github.com/ChainSafe/lodestar/actions/runs/31577999599

## Description

- Add the missing commit-author email mappings observed in the v1.46.0
  release range.
- Increase the `execSync` buffer used by the changelog helper so GitHub commit
  lookups for large merge commits, such as the v1.46.0 release merge, do not
  fail with `ENOBUFS` and fall back to the raw author name.

## Verification

- `node scripts/generate_changelog.mjs v1.45.0 v1.46.0 /tmp/changelog-v1460.md`
- `git diff --check`
- `pnpm lint`

## AI Assistance Disclosure

This PR was prepared with AI assistance from Lodekeeper / Codex.
