### PR TITLE
chore: copy patches into development image

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -30,6 +30,7 @@ RUN corepack enable
 # Only changes to package.json or lockfile will invalidate the install layer,
 # source code changes will only invalidate the build layer.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches
 COPY packages/api/package.json packages/api/
 COPY packages/beacon-node/package.json packages/beacon-node/
 COPY packages/cli/package.json packages/cli/


### PR DESCRIPTION
**Motivation**

`Dockerfile.dev` runs `pnpm install --frozen-lockfile` before copying the source, but the workspace references `patches/sigstore@4.0.0.patch`. The development image build fails because the patch is not available in the install layer.

**Description**

Copy the `patches` directory before installing dependencies.

Validated the Docker build through the dependency installation layer.

> This PR was written primarily with Codex.
