### PR TITLE
perf(fork-choice): early-break window walk in getCanonicalPayloadCounts

### DIFF
--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -700,21 +700,36 @@ export class ProtoArray {
     let full = 0;
     let empty = 0;
 
-    for (const node of this.getAllAncestorNodes(headRoot, headPayloadStatus)) {
+    const countNode = (node: ProtoNode): void => {
       if (
         node.slot === GENESIS_SLOT ||
-        node.slot < fromSlot ||
         node.slot > toSlot ||
         !isGloasBlock(node) ||
         node.payloadStatus === PayloadStatus.PENDING
       ) {
-        continue;
+        return;
       }
 
       if (node.payloadStatus === PayloadStatus.FULL) {
         full++;
       } else {
         empty++;
+      }
+    };
+
+    // Walk the canonical chain newest-first: the resolved head, then its ancestors. Ancestors are
+    // strictly slot-descending, so we can stop as soon as a node falls below `fromSlot` instead of
+    // materializing the whole chain back to the anchor as `getAllAncestorNodes` does. This keeps the
+    // scan O(window) rather than O(chain-to-anchor), which matters under prolonged non-finality.
+    const headIndex = this.getNodeIndexByRootAndStatus(headRoot, headPayloadStatus);
+    const head = headIndex !== undefined ? this.nodes[headIndex] : undefined;
+    if (head !== undefined && head.slot >= fromSlot) {
+      countNode(head);
+      for (const node of this.iterateAncestorNodesFromNode(head)) {
+        if (node.slot < fromSlot) {
+          break;
+        }
+        countNode(node);
       }
     }
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -700,37 +700,29 @@ export class ProtoArray {
     let full = 0;
     let empty = 0;
 
-    const countNode = (node: ProtoNode): void => {
-      if (
-        node.slot === GENESIS_SLOT ||
-        node.slot > toSlot ||
-        !isGloasBlock(node) ||
-        node.payloadStatus === PayloadStatus.PENDING
-      ) {
-        return;
-      }
-
-      if (node.payloadStatus === PayloadStatus.FULL) {
-        full++;
-      } else {
-        empty++;
-      }
-    };
-
-    // Walk the canonical chain newest-first: the resolved head, then its ancestors. Ancestors are
-    // strictly slot-descending, so we can stop as soon as a node falls below `fromSlot` instead of
-    // materializing the whole chain back to the anchor as `getAllAncestorNodes` does. This keeps the
-    // scan O(window) rather than O(chain-to-anchor), which matters under prolonged non-finality.
+    // Walk the canonical chain newest-first (resolved head, then ancestors via getParentNodeIndex).
+    // Ancestors are strictly slot-descending, so we stop as soon as a node falls below `fromSlot`
+    // instead of materializing the whole chain back to the anchor as `getAllAncestorNodes` does.
+    // This keeps the scan O(window) rather than O(chain-to-anchor), relevant under prolonged non-finality.
     const headIndex = this.getNodeIndexByRootAndStatus(headRoot, headPayloadStatus);
-    const head = headIndex !== undefined ? this.nodes[headIndex] : undefined;
-    if (head !== undefined && head.slot >= fromSlot) {
-      countNode(head);
-      for (const node of this.iterateAncestorNodesFromNode(head)) {
-        if (node.slot < fromSlot) {
-          break;
+    let node = headIndex !== undefined ? this.nodes[headIndex] : undefined;
+
+    while (node !== undefined && node.slot >= fromSlot) {
+      if (
+        node.slot !== GENESIS_SLOT &&
+        node.slot <= toSlot &&
+        isGloasBlock(node) &&
+        node.payloadStatus !== PayloadStatus.PENDING
+      ) {
+        if (node.payloadStatus === PayloadStatus.FULL) {
+          full++;
+        } else {
+          empty++;
         }
-        countNode(node);
       }
+
+      const parentIndex = this.getParentNodeIndex(node);
+      node = parentIndex === undefined ? undefined : this.nodes[parentIndex];
     }
 
     return {full, empty};


### PR DESCRIPTION
Demo requested in #9815 ([discussion_r3779437582](https://github.com/ChainSafe/lodestar/pull/9815#discussion_r3779437582)) — showing how the O(window) early-break variant of `getCanonicalPayloadCounts` would look. Targets `nflaig/circuit-breaker-canonical-counts`, not `unstable`.

### Approach

Instead of materializing the whole canonical chain via `getAllAncestorNodes()`, walk it newest-first and stop once a node drops below `fromSlot`. Ancestors are strictly slot-descending, so everything past that point is already out of the window — the previous full scan just `continue`d over those.

```ts
const headIndex = this.getNodeIndexByRootAndStatus(headRoot, headPayloadStatus);
const head = headIndex !== undefined ? this.nodes[headIndex] : undefined;
if (head !== undefined && head.slot >= fromSlot) {
  countNode(head);
  for (const node of this.iterateAncestorNodesFromNode(head)) {
    if (node.slot < fromSlot) break;
    countNode(node);
  }
}
```

### The head-inclusion gotcha (your note in r3779406069)

`iterateAncestorNodes()` starts one hop up (`iterateAncestorNodesFromNode` begins at `.parent`), so a direct swap drops the resolved head and undercounts by one. Handled here by counting the head explicitly first, then walking `.parent` via `iterateAncestorNodesFromNode(head)`. A PENDING head is still skipped by `countNode` (same as `getAllAncestorNodes` not pushing a PENDING start node) — it only seeds the ancestor walk.

### Behavior

Identical to the current full-scan: same canonical node sequence (head + ancestors), same filters (genesis / out-of-window / non-gloas / PENDING), same `full`/`empty` counts. Only the traversal is lazy with an early exit. The win (`O(window)` vs `O(chain-to-anchor)`) only shows under prolonged non-finality, when the chain-to-anchor grows well past the fault window.

### Tests

Ran the fork-choice protoArray suite locally against this change — **131/131 pass** (`packages/fork-choice/test/unit/protoArray`, 7 files), including every `getCanonicalPayloadCounts` case: genesis skip, "keeps EMPTY after a late FULL arrives", PENDING head, inclusive bounds, uses-supplied-head-branch. CI here re-runs the full suite.

Not attached to it — happy to close if you'd rather keep the simpler full-scan; just wanted to show the shape as you asked.

🤖 Generated with AI assistance
