### PR TITLE
deps: patch @libp2p/tcp to fix network worker shutdown hang

### DIFF
--- a/patches/@libp2p__tcp@11.0.13.patch
+++ b/patches/@libp2p__tcp@11.0.13.patch
@@ -1,0 +1,31 @@
+diff --git a/dist/src/socket-to-conn.js b/dist/src/socket-to-conn.js
+index 2ef149718745e5901cdce459d73dcb3d4b7e596e..a8a2ba0830c4f1cb42bd555112ee01dead908c2f 100644
+--- a/dist/src/socket-to-conn.js
++++ b/dist/src/socket-to-conn.js
+@@ -88,6 +88,10 @@ class TCPSocketMultiaddrConnection extends AbstractMultiaddrConnection {
+         await pEvent(this.socket, 'close', options);
+     }
+     sendReset() {
++        if (this.socket.writableEnded) {
++            this.socket.destroy();
++            return;
++        }
+         this.socket.resetAndDestroy();
+     }
+     sendPause() {
+diff --git a/src/socket-to-conn.ts b/src/socket-to-conn.ts
+index c4a085b17b6326c96b305741af6b1717cd8a2714..4fba3375008e899bb60eef0382cb4d9c6245525f 100644
+--- a/src/socket-to-conn.ts
++++ b/src/socket-to-conn.ts
+@@ -123,6 +123,11 @@ class TCPSocketMultiaddrConnection extends AbstractMultiaddrConnection {
+   }
+ 
+   sendReset (): void {
++    if (this.socket.writableEnded) {
++      this.socket.destroy()
++      return
++    }
++
+     this.socket.resetAndDestroy()
+   }
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ catalogs:
       version: 4.0.7
 
 overrides:
+  '@libp2p/tcp': 11.0.13
   dns-over-http-resolver: ^2.1.1
   elliptic: '>=6.6.1'
   loupe: ^2.3.6
@@ -27,6 +28,7 @@ overrides:
   sigstore: 4.0.0
 
 patchedDependencies:
+  '@libp2p/tcp@11.0.13': 2a9b4f4effc08a7f5869cc5d596c5eea0669ebf22d3c73f48fab474e27c39533
   sigstore@4.0.0: 0d9fa39ff088202d74fca3bec0d7bc1c2822b4bddcab7cd31627235b21b52b32
 
 importers:
@@ -255,8 +257,8 @@ importers:
         specifier: ^5.0.14
         version: 5.0.14
       '@libp2p/tcp':
-        specifier: ^11.0.13
-        version: 11.0.13
+        specifier: 11.0.13
+        version: 11.0.13(patch_hash=2a9b4f4effc08a7f5869cc5d596c5eea0669ebf22d3c73f48fab474e27c39533)
       '@lodestar/api':
         specifier: workspace:^
         version: link:../api
@@ -8020,7 +8022,7 @@ snapshots:
       '@libp2p/interface': 3.2.3
       prom-client: 15.1.3
 
-  '@libp2p/tcp@11.0.13':
+  '@libp2p/tcp@11.0.13(patch_hash=2a9b4f4effc08a7f5869cc5d596c5eea0669ebf22d3c73f48fab474e27c39533)':
     dependencies:
       '@libp2p/interface': 3.2.3
       '@libp2p/utils': 7.2.2
@@ -8029,7 +8031,7 @@ snapshots:
       '@types/sinon': 20.0.0
       main-event: 1.0.1
       p-event: 7.1.0
-      progress-events: 1.0.1
+      progress-events: 1.1.0
       uint8arraylist: 2.4.8
 
   '@libp2p/utils@7.2.2':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,10 @@ allowBuilds:
   ssh2: true
 
 overrides:
+  # Pin exactly while patches/@libp2p__tcp@11.0.13.patch is in place, the patch
+  # only applies to this version. Remove together with the patch once
+  # js-libp2p#3597 is released.
+  "@libp2p/tcp": "11.0.13"
   dns-over-http-resolver: "^2.1.1"
   elliptic: ">=6.6.1"
   loupe: "^2.3.6"
@@ -43,4 +47,5 @@ overrides:
   sigstore: "4.0.0"
 
 patchedDependencies:
+  "@libp2p/tcp@11.0.13": patches/@libp2p__tcp@11.0.13.patch
   sigstore@4.0.0: patches/sigstore@4.0.0.patch


### PR DESCRIPTION
Applies libp2p/js-libp2p#3597 as a local `pnpm patch` until it is released. This fixes the network worker shutdown hang, the underlying handle that #9790 mitigated but did not identify.

## Root cause

`TCPSocketMultiaddrConnection.sendReset()` calls `socket.resetAndDestroy()` unconditionally. When the writable side has already ended that does not tear the handle down, so the socket stays alive as an active `TCPSocketWrap` while libp2p considers it closed. Nothing else holds a reference, so nothing ever closes it.

Node's worker teardown then spins forever, because `Environment::CleanupHandles()` runs until every handle is closed:

```cpp
while (handle_cleanup_waiting_ != 0 || request_waiting_ != 0 || !handle_wrap_queue_.IsEmpty()) {
  uv_run(event_loop(), UV_RUN_ONCE);
}
```

The thread never exits, so `Worker.terminate()` never resolves, so the main thread blocks in `uv_thread_join` from `process.exit()` until the process manager kills it.

The patch guards the case the reset cannot handle:

```js
sendReset (): void {
  if (this.socket.writableEnded) {
    this.socket.destroy()
    return
  }
  this.socket.resetAndDestroy()
}
```

## Why the exact-version pin

`@libp2p/tcp` is declared as `^11.0.13` and `patchedDependencies` keys are version exact, so an 11.0.14 release would resolve past the patch and silently drop the fix. The `overrides` pin prevents that, same as the existing `sigstore` patch. It does mean no `@libp2p/tcp` bump until the patch is dropped.

## Testing

Validated on a mainnet node against a baseline hang rate of 4 in 36 shutdowns (11.1%).

70 consecutive shutdowns, synced with >=200 peers and a 5 minute soak each:

| criterion | result |
| --- | --- |
| hangs | 0 / 70 |
| `TCPSocketWrap` present after `libp2p.stop()` | 0 / 70 |
| worker terminate | 0.027-0.072s, hang signature is 3.000s |
| exit code | 0 on all 70, never SIGKILLed |
| shutdown duration | mean 7.20s, max 9.8s |
| state archived | 70 / 70 |

Plus one shutdown at 9.07h uptime, since orphaned socket counts grew with uptime: terminate 0.180s, no `TCPSocketWrap`, exit 0.

Counted independently from the raw node logs as well as from the test harness. The last unpatched shutdown on the same machine, three minutes before deploying the patched build, hung at 3.001s with `activeResources=MessagePort=1,TCPSocketWrap=6,Timeout=1`.

Observing 70 consecutive clean shutdowns if the bug were still present has probability 0.00026. Fisher exact against the measured baseline gives p = 0.012.

The `activeResources` logging added by #9790 is what made this diagnosable, the presence of `TCPSocketWrap` separated 5 hangs from 32 clean shutdowns perfectly (Fisher p = 0.0000023).

Longest uptime tested was 9.07h. The worst case observed, 28 orphaned sockets, took ~38h to accumulate, so this validates the mechanism rather than proving an upper bound.

Full write-up: https://gist.github.com/nflaig/5f41cfc50f38baf5046a034162943dc3

## When to remove

Drop the patch and the `overrides` pin together once js-libp2p#3597 is released and `@libp2p/tcp` is bumped to a version containing it.

## AI Assistance Disclosure

Investigation, patch and validation with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
