### PR TITLE
test: dedupe builder/validator apiStub helpers into @lodestar/test-utils

### DIFF
--- a/packages/builder/test/unit/utils/apiStub.ts
+++ b/packages/builder/test/unit/utils/apiStub.ts
@@ -1,9 +1,7 @@
-import {Mocked, vi} from "vitest";
-import {ApiClientMethods, ApiResponse, Endpoint, Endpoints, HttpStatusCode, IHttpClient} from "@lodestar/api";
+import {vi} from "vitest";
+import {ApiClientStub} from "@lodestar/test-utils/apiStub";
 
-export type ApiClientStub = {[K in keyof Endpoints]: Mocked<ApiClientMethods<Endpoints[K]>>} & {
-  httpClient: Mocked<IHttpClient>;
-};
+export {type ApiClientStub, mockApiErrorResponse, mockApiResponse} from "@lodestar/test-utils/apiStub";
 
 export function getApiClientStub(): ApiClientStub {
   return {
@@ -14,22 +12,4 @@ export function getApiClientStub(): ApiClientStub {
       getSyncingStatus: vi.fn(),
     },
   } as unknown as ApiClientStub;
-}
-
-export function mockApiResponse<T, M, E extends Endpoint<any, any, any, T, M>>({
-  data,
-  meta,
-}: (E["return"] extends void ? {data?: never} : {data: E["return"]}) &
-  (E["meta"] extends void ? {meta?: never} : {meta: E["meta"]})): ApiResponse<E> {
-  const response = new Response(null, {status: HttpStatusCode.OK});
-  const apiResponse = new ApiResponse<E>({} as any, null, response);
-  apiResponse.value = () => data as T;
-  apiResponse.meta = () => meta as M;
-  return apiResponse;
-}
-
-export async function mockApiErrorResponse<E extends Endpoint>(status: HttpStatusCode): Promise<ApiResponse<E>> {
-  const res = new ApiResponse<E>({} as any, null, new Response(null, {status}));
-  await res.errorBody();
-  return res;
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -16,6 +16,11 @@
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js"
     },
+    "./apiStub": {
+      "typescript": "./src/apiStub.ts",
+      "types": "./lib/apiStub.d.ts",
+      "import": "./lib/apiStub.js"
+    },
     "./doubles": {
       "typescript": "./src/doubles.ts",
       "types": "./lib/doubles.d.ts",
@@ -52,6 +57,7 @@
   "dependencies": {
     "@chainsafe/bls-keystore": "^3.1.0",
     "@chainsafe/blst": "^2.2.0",
+    "@lodestar/api": "workspace:^",
     "@lodestar/params": "workspace:^",
     "@lodestar/utils": "workspace:^",
     "axios": "^1.13.2",

--- a/packages/test-utils/src/apiStub.ts
+++ b/packages/test-utils/src/apiStub.ts
@@ -12,12 +12,14 @@ export const httpClientStub: IHttpClient = {
   urlsScore: [],
 };
 
+// biome-ignore lint/suspicious/noExplicitAny: generic mock over arbitrary endpoints; only the return (T) and meta (M) type params matter here
 export function mockApiResponse<T, M, E extends Endpoint<any, any, any, T, M>>({
   data,
   meta,
 }: (E["return"] extends void ? {data?: never} : {data: E["return"]}) &
   (E["meta"] extends void ? {meta?: never} : {meta: E["meta"]})): ApiResponse<E> {
   const response = new Response(null, {status: HttpStatusCode.OK});
+  // biome-ignore lint/suspicious/noExplicitAny: mock does not use the route definition
   const apiResponse = new ApiResponse<E>({} as any, null, response);
   apiResponse.value = () => data as T;
   apiResponse.meta = () => meta as M;
@@ -25,6 +27,7 @@ export function mockApiResponse<T, M, E extends Endpoint<any, any, any, T, M>>({
 }
 
 export async function mockApiErrorResponse<E extends Endpoint>(status: HttpStatusCode): Promise<ApiResponse<E>> {
+  // biome-ignore lint/suspicious/noExplicitAny: mock does not use the route definition
   const res = new ApiResponse<E>({} as any, null, new Response(null, {status}));
   await res.errorBody();
   return res;

--- a/packages/test-utils/src/apiStub.ts
+++ b/packages/test-utils/src/apiStub.ts
@@ -1,0 +1,31 @@
+import {Mocked, vi} from "vitest";
+import {ApiClientMethods, ApiResponse, Endpoint, Endpoints, HttpStatusCode, IHttpClient} from "@lodestar/api";
+
+export type ApiClientStub = {[K in keyof Endpoints]: Mocked<ApiClientMethods<Endpoints[K]>>} & {
+  httpClient: Mocked<IHttpClient>;
+};
+
+export const httpClientStub: IHttpClient = {
+  baseUrl: "",
+  request: vi.fn(),
+  urlsInits: [],
+  urlsScore: [],
+};
+
+export function mockApiResponse<T, M, E extends Endpoint<any, any, any, T, M>>({
+  data,
+  meta,
+}: (E["return"] extends void ? {data?: never} : {data: E["return"]}) &
+  (E["meta"] extends void ? {meta?: never} : {meta: E["meta"]})): ApiResponse<E> {
+  const response = new Response(null, {status: HttpStatusCode.OK});
+  const apiResponse = new ApiResponse<E>({} as any, null, response);
+  apiResponse.value = () => data as T;
+  apiResponse.meta = () => meta as M;
+  return apiResponse;
+}
+
+export async function mockApiErrorResponse<E extends Endpoint>(status: HttpStatusCode): Promise<ApiResponse<E>> {
+  const res = new ApiResponse<E>({} as any, null, new Response(null, {status}));
+  await res.errorBody();
+  return res;
+}

--- a/packages/validator/test/utils/apiStub.ts
+++ b/packages/validator/test/utils/apiStub.ts
@@ -1,16 +1,7 @@
-import {Mocked, vi} from "vitest";
-import {ApiClientMethods, ApiResponse, Endpoint, Endpoints, HttpStatusCode, IHttpClient} from "@lodestar/api";
+import {vi} from "vitest";
+import {ApiClientStub, httpClientStub} from "@lodestar/test-utils/apiStub";
 
-type ApiClientStub = {[K in keyof Endpoints]: Mocked<ApiClientMethods<Endpoints[K]>>} & {
-  httpClient: Mocked<IHttpClient>;
-};
-
-const httpClientStub: IHttpClient = {
-  baseUrl: "",
-  request: vi.fn(),
-  urlsInits: [],
-  urlsScore: [],
-};
+export {mockApiErrorResponse, mockApiResponse} from "@lodestar/test-utils/apiStub";
 
 export function getApiClientStub(): ApiClientStub {
   return {
@@ -51,22 +42,4 @@ export function getApiClientStub(): ApiClientStub {
     },
     httpClient: httpClientStub,
   } as unknown as ApiClientStub;
-}
-
-export function mockApiResponse<T, M, E extends Endpoint<any, any, any, T, M>>({
-  data,
-  meta,
-}: (E["return"] extends void ? {data?: never} : {data: E["return"]}) &
-  (E["meta"] extends void ? {meta?: never} : {meta: E["meta"]})): ApiResponse<E> {
-  const response = new Response(null, {status: HttpStatusCode.OK});
-  const apiResponse = new ApiResponse<E>({} as any, null, response);
-  apiResponse.value = () => data as T;
-  apiResponse.meta = () => meta as M;
-  return apiResponse;
-}
-
-export async function mockApiErrorResponse<E extends Endpoint>(status: HttpStatusCode): Promise<ApiResponse<E>> {
-  const res = new ApiResponse<E>({} as any, null, new Response(null, {status}));
-  await res.errorBody();
-  return res;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -806,6 +806,9 @@ importers:
       '@chainsafe/blst':
         specifier: ^2.2.0
         version: 2.2.0
+      '@lodestar/api':
+        specifier: workspace:^
+        version: link:../api
       '@lodestar/params':
         specifier: workspace:^
         version: link:../params


### PR DESCRIPTION
## Motivation

Follow-up to #9781, closes #9819.

`packages/builder/test/unit/utils/apiStub.ts` (added in #9781) largely duplicated
`packages/validator/test/utils/apiStub.ts`. The shared pieces — the `ApiClientStub`
type, `httpClientStub`, `mockApiResponse`, and `mockApiErrorResponse` — were
byte-identical in both files, so they were free to drift apart over time (as nearly
happened with the `mockApiErrorResponse` `async`/`errorBody()` change). This moves the
shared bits into `@lodestar/test-utils` so there is a single source of truth.

## Description

- Add `packages/test-utils/src/apiStub.ts` exporting the shared `ApiClientStub` type,
  `httpClientStub`, `mockApiResponse`, and `mockApiErrorResponse` (moved verbatim — no
  behavior change), exposed via a dedicated `@lodestar/test-utils/apiStub` subpath
  export. I used a subpath (mirroring the existing `./doubles` export) rather than the
  main index so the main `@lodestar/test-utils` barrel stays free of eval-time `vi.fn()`
  calls (`httpClientStub`).
- Add `@lodestar/api` as a `workspace:^` dependency of `@lodestar/test-utils` (the
  helpers use `ApiResponse`/`HttpStatusCode` as runtime values). No dependency cycle:
  `@lodestar/api` does not depend on `@lodestar/test-utils`.
- `packages/validator/test/utils/apiStub.ts` and
  `packages/builder/test/unit/utils/apiStub.ts` now import the shared type/helpers from
  `@lodestar/test-utils/apiStub` and keep only their **package-specific**
  `getApiClientStub()` (the two stub different endpoint sets — validator stubs a large
  beacon/node/validator set + `httpClient`, builder stubs `beacon.getStateBuilders` +
  `node.getSyncingStatus`).

Each package's `apiStub.ts` re-exports `mockApiResponse`/`mockApiErrorResponse` so the
~14 existing consumer test files are untouched (minimal diff, and it keeps the ergonomic
local `../utils/apiStub.js` import that every suite already uses). Happy to point the
consumers directly at `@lodestar/test-utils/apiStub` and drop the re-export shims if you
prefer.

## Notes

- No production code touched — only test utilities and the two suites' stub files.
- Verified: `check-types` passes for `@lodestar/test-utils`, `@lodestar/validator`, and
  `@lodestar/builder`; builder unit suite (20/20) and validator unit suite (102/102)
  both pass; biome clean (only the pre-existing `noExplicitAny` warnings that moved with
  the code).

🤖 Generated with AI assistance
