### PR TITLE
chore(builder): abort signal in while loop + logging nits

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -49,7 +49,7 @@ export class Builder {
 
     this.executionFeeRecipient = opts.executionFeeRecipient;
 
-    this.clock.runEveryEpoch(() => this.builderStatusTracker.poll());
+    this.clock.runEveryEpoch(() => this.builderStatusTracker.poll(this.clock.getCurrentSlot()));
     this.clock.start(this.controller.signal);
 
     this.logger.info("Builder client initialized", {
@@ -75,9 +75,15 @@ export class Builder {
     await waitForNodeReady(api, logger, opts.abortController.signal);
     await logNodeVersion(api, logger);
 
-    const index = await resolveBuilderIdentity(api, logger, builderSigner.getPubkeyHex(), opts.abortController.signal);
-
     const clock = new Clock(config, logger, {genesisTime: Number(genesis.genesisTime), ...opts.clock});
+
+    const index = await resolveBuilderIdentity(
+      api,
+      logger,
+      builderSigner.getPubkeyHex(),
+      opts.abortController.signal,
+      () => clock.getCurrentSlot()
+    );
 
     const builderStatusTracker = new BuilderStatusTracker(api, logger, index);
 

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -49,7 +49,7 @@ export class Builder {
 
     this.executionFeeRecipient = opts.executionFeeRecipient;
 
-    this.clock.runEveryEpoch(this.builderStatusTracker.poll);
+    this.clock.runEveryEpoch((epoch) => this.builderStatusTracker.poll(epoch));
     this.clock.start(this.controller.signal);
 
     this.logger.info("Builder client initialized", {

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -82,7 +82,7 @@ export class Builder {
       logger,
       builderSigner.getPubkeyHex(),
       opts.abortController.signal,
-      () => clock.getCurrentSlot()
+      clock
     );
 
     const builderStatusTracker = new BuilderStatusTracker(api, logger, index);

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -49,7 +49,7 @@ export class Builder {
 
     this.executionFeeRecipient = opts.executionFeeRecipient;
 
-    this.clock.runEveryEpoch(() => this.builderStatusTracker.poll(this.clock.getCurrentSlot()));
+    this.clock.runEveryEpoch(this.builderStatusTracker.poll);
     this.clock.start(this.controller.signal);
 
     this.logger.info("Builder client initialized", {

--- a/packages/builder/src/genesis.ts
+++ b/packages/builder/src/genesis.ts
@@ -1,12 +1,12 @@
 import {ApiClient, ApiError, HttpStatusCode} from "@lodestar/api";
 import {Genesis} from "@lodestar/types/phase0";
-import {Logger, sleep} from "@lodestar/utils";
+import {ErrorAborted, Logger, sleep} from "@lodestar/utils";
 
 /** The time between polls when waiting for genesis */
 const WAITING_FOR_GENESIS_POLL_MS = 12 * 1000;
 
 export async function waitForGenesis(api: ApiClient, logger: Logger, signal: AbortSignal): Promise<Genesis> {
-  while (true) {
+  while (!signal.aborted) {
     try {
       return (await api.beacon.getGenesis()).value();
     } catch (e) {
@@ -18,4 +18,5 @@ export async function waitForGenesis(api: ApiClient, logger: Logger, signal: Abo
       await sleep(WAITING_FOR_GENESIS_POLL_MS, signal);
     }
   }
+  throw new ErrorAborted("waitForGenesis");
 }

--- a/packages/builder/src/identity.ts
+++ b/packages/builder/src/identity.ts
@@ -1,7 +1,7 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
 import {BuilderIndex, BuilderStatus} from "@lodestar/types";
-import {Logger, sleep, toHex} from "@lodestar/utils";
+import {ErrorAborted, Logger, sleep, toHex} from "@lodestar/utils";
 
 export const WAITING_FOR_BUILDER_POLL_MS = 10 * 1000;
 
@@ -54,7 +54,7 @@ async function waitForBuilder(
   id: routes.beacon.BuilderId,
   signal: AbortSignal
 ): Promise<routes.beacon.BuilderResponse> {
-  while (true) {
+  while (!signal.aborted) {
     const builder = await fetchBuilder(api, id);
     if (builder?.status === "active") {
       return builder;
@@ -69,6 +69,7 @@ async function waitForBuilder(
     }
     await sleep(WAITING_FOR_BUILDER_POLL_MS, signal);
   }
+  throw new ErrorAborted("waitForBuilder");
 }
 
 async function fetchBuilder(

--- a/packages/builder/src/identity.ts
+++ b/packages/builder/src/identity.ts
@@ -1,6 +1,7 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
-import {BuilderIndex, BuilderStatus, Slot} from "@lodestar/types";
+import {IClock} from "@lodestar/state-transition";
+import {BuilderIndex, BuilderStatus} from "@lodestar/types";
 import {ErrorAborted, Logger, sleep, toHex} from "@lodestar/utils";
 
 export const WAITING_FOR_BUILDER_POLL_MS = 10 * 1000;
@@ -10,9 +11,9 @@ export async function resolveBuilderIdentity(
   logger: Logger,
   id: routes.beacon.BuilderId,
   signal: AbortSignal,
-  getCurrentSlot: () => Slot
+  clock: IClock
 ): Promise<BuilderIndex> {
-  const builderEntry = await waitForBuilder(api, logger, id, signal, getCurrentSlot);
+  const builderEntry = await waitForBuilder(api, logger, id, signal, clock);
 
   if (builderEntry.builder.version !== PAYLOAD_BUILDER_VERSION) {
     throw Error(`Builder version mismatch: got ${builderEntry.builder.version}, expected ${PAYLOAD_BUILDER_VERSION}`);
@@ -23,7 +24,7 @@ export async function resolveBuilderIdentity(
     status: builderEntry.status,
     balanceGwei: builderEntry.builder.balance,
     executionAddress: toHex(builderEntry.builder.executionAddress),
-    slot: getCurrentSlot(),
+    slot: clock.getCurrentSlot(),
   });
 
   return builderEntry.index;
@@ -55,7 +56,7 @@ async function waitForBuilder(
   logger: Logger,
   id: routes.beacon.BuilderId,
   signal: AbortSignal,
-  getCurrentSlot: () => Slot
+  clock: IClock
 ): Promise<routes.beacon.BuilderResponse> {
   while (!signal.aborted) {
     const builder = await fetchBuilder(api, id);
@@ -66,9 +67,9 @@ async function waitForBuilder(
       throw Error(`Builder exited: id=${id}`);
     }
     if (builder?.status === "pending") {
-      logger.info("Waiting for builder deposit to be finalized", {id, slot: getCurrentSlot()});
+      logger.info("Waiting for builder deposit to be finalized", {id, slot: clock.getCurrentSlot()});
     } else {
-      logger.info("Waiting for builder to be known to the beacon node", {id, slot: getCurrentSlot()});
+      logger.info("Waiting for builder to be known to the beacon node", {id, slot: clock.getCurrentSlot()});
     }
     await sleep(WAITING_FOR_BUILDER_POLL_MS, signal);
   }

--- a/packages/builder/src/identity.ts
+++ b/packages/builder/src/identity.ts
@@ -1,6 +1,6 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
-import {BuilderIndex, BuilderStatus} from "@lodestar/types";
+import {BuilderIndex, BuilderStatus, Slot} from "@lodestar/types";
 import {ErrorAborted, Logger, sleep, toHex} from "@lodestar/utils";
 
 export const WAITING_FOR_BUILDER_POLL_MS = 10 * 1000;
@@ -9,9 +9,10 @@ export async function resolveBuilderIdentity(
   api: ApiClient,
   logger: Logger,
   id: routes.beacon.BuilderId,
-  signal: AbortSignal
+  signal: AbortSignal,
+  getCurrentSlot: () => Slot
 ): Promise<BuilderIndex> {
-  const builderEntry = await waitForBuilder(api, logger, id, signal);
+  const builderEntry = await waitForBuilder(api, logger, id, signal, getCurrentSlot);
 
   if (builderEntry.builder.version !== PAYLOAD_BUILDER_VERSION) {
     throw Error(`Builder version mismatch: got ${builderEntry.builder.version}, expected ${PAYLOAD_BUILDER_VERSION}`);
@@ -22,6 +23,7 @@ export async function resolveBuilderIdentity(
     status: builderEntry.status,
     balanceGwei: builderEntry.builder.balance,
     executionAddress: toHex(builderEntry.builder.executionAddress),
+    slot: getCurrentSlot(),
   });
 
   return builderEntry.index;
@@ -52,7 +54,8 @@ async function waitForBuilder(
   api: ApiClient,
   logger: Logger,
   id: routes.beacon.BuilderId,
-  signal: AbortSignal
+  signal: AbortSignal,
+  getCurrentSlot: () => Slot
 ): Promise<routes.beacon.BuilderResponse> {
   while (!signal.aborted) {
     const builder = await fetchBuilder(api, id);
@@ -63,9 +66,9 @@ async function waitForBuilder(
       throw Error(`Builder exited: id=${id}`);
     }
     if (builder?.status === "pending") {
-      logger.info("Waiting for builder deposit to be finalized", {id});
+      logger.info("Waiting for builder deposit to be finalized", {id, slot: getCurrentSlot()});
     } else {
-      logger.info("Waiting for builder to be known to the beacon node", {id});
+      logger.info("Waiting for builder to be known to the beacon node", {id, slot: getCurrentSlot()});
     }
     await sleep(WAITING_FOR_BUILDER_POLL_MS, signal);
   }

--- a/packages/builder/src/readiness.ts
+++ b/packages/builder/src/readiness.ts
@@ -45,7 +45,7 @@ async function isNodeReady(api: ApiClient, logger: Logger): Promise<boolean> {
 
     return true;
   } catch (e) {
-    logger.warn("Cannot reach the beacon node", {}, e as Error);
+    logger.error("Cannot reach the beacon node", {}, e as Error);
     return false;
   }
 }

--- a/packages/builder/src/readiness.ts
+++ b/packages/builder/src/readiness.ts
@@ -37,7 +37,10 @@ async function isNodeReady(api: ApiClient, logger: Logger): Promise<boolean> {
     }
 
     if (syncingStatus.isOptimistic) {
-      logger.warn("Beacon node head is optimistic, execution payloads are not yet verified - unable to submit bids");
+      logger.warn("Beacon node head is optimistic, execution payloads are not yet verified - unable to submit bids", {
+        headSlot: syncingStatus.headSlot,
+        syncDistance: syncingStatus.syncDistance,
+      });
       return false;
     }
 

--- a/packages/builder/src/services/builderStatusTracker.ts
+++ b/packages/builder/src/services/builderStatusTracker.ts
@@ -29,7 +29,11 @@ export class BuilderStatusTracker {
       }
       this.status = builderStatus.status;
       this.balanceGwei = builderStatus.balance;
-      this.logger.info("Builder status", {status: builderStatus.status, balance: builderStatus.balance, epoch: currentEpoch});
+      this.logger.info("Builder status", {
+        status: builderStatus.status,
+        balance: builderStatus.balance,
+        epoch: currentEpoch,
+      });
     }
   }
 

--- a/packages/builder/src/services/builderStatusTracker.ts
+++ b/packages/builder/src/services/builderStatusTracker.ts
@@ -1,5 +1,5 @@
 import {ApiClient} from "@lodestar/api";
-import {BuilderIndex, BuilderStatus} from "@lodestar/types";
+import {BuilderIndex, BuilderStatus, Slot} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {getBuilderStatus} from "../identity.js";
 
@@ -21,15 +21,15 @@ export class BuilderStatusTracker {
     this.index = index;
   }
 
-  async poll() {
+  async poll(slot: Slot) {
     const builderStatus = await getBuilderStatus(this.api, this.logger, this.index);
     if (builderStatus !== null) {
       if (this.status !== undefined && this.status !== builderStatus.status) {
-        this.logger.info("Builder status changed", {from: this.status, to: builderStatus.status});
+        this.logger.info("Builder status changed", {from: this.status, to: builderStatus.status, slot});
       }
       this.status = builderStatus.status;
       this.balanceGwei = builderStatus.balance;
-      this.logger.info("Builder status", {status: builderStatus.status, balance: builderStatus.balance});
+      this.logger.debug("Builder status", {status: builderStatus.status, balance: builderStatus.balance, slot});
     }
   }
 

--- a/packages/builder/src/services/builderStatusTracker.ts
+++ b/packages/builder/src/services/builderStatusTracker.ts
@@ -1,5 +1,5 @@
 import {ApiClient} from "@lodestar/api";
-import {BuilderIndex, BuilderStatus, Slot} from "@lodestar/types";
+import {BuilderIndex, BuilderStatus, Epoch} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {getBuilderStatus} from "../identity.js";
 
@@ -21,15 +21,15 @@ export class BuilderStatusTracker {
     this.index = index;
   }
 
-  async poll(slot: Slot) {
+  async poll(currentEpoch: Epoch) {
     const builderStatus = await getBuilderStatus(this.api, this.logger, this.index);
     if (builderStatus !== null) {
       if (this.status !== undefined && this.status !== builderStatus.status) {
-        this.logger.info("Builder status changed", {from: this.status, to: builderStatus.status, slot});
+        this.logger.info("Builder status changed", {from: this.status, to: builderStatus.status, epoch: currentEpoch});
       }
       this.status = builderStatus.status;
       this.balanceGwei = builderStatus.balance;
-      this.logger.info("Builder status", {status: builderStatus.status, balance: builderStatus.balance, slot});
+      this.logger.info("Builder status", {status: builderStatus.status, balance: builderStatus.balance, epoch: currentEpoch});
     }
   }
 

--- a/packages/builder/src/services/builderStatusTracker.ts
+++ b/packages/builder/src/services/builderStatusTracker.ts
@@ -29,7 +29,7 @@ export class BuilderStatusTracker {
       }
       this.status = builderStatus.status;
       this.balanceGwei = builderStatus.balance;
-      this.logger.debug("Builder status", {status: builderStatus.status, balance: builderStatus.balance, slot});
+      this.logger.info("Builder status", {status: builderStatus.status, balance: builderStatus.balance, slot});
     }
   }
 

--- a/packages/builder/test/unit/identity.test.ts
+++ b/packages/builder/test/unit/identity.test.ts
@@ -3,11 +3,13 @@ import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
 import {ErrorAborted, toHex} from "@lodestar/utils";
 import {WAITING_FOR_BUILDER_POLL_MS, getBuilderStatus, resolveBuilderIdentity} from "../../src/identity.js";
 import {getApiClientStub, mockApiErrorResponse, mockApiResponse} from "./utils/apiStub.js";
+import {ClockMock} from "./utils/clock.js";
 import {getMockedLogger} from "./utils/logger.js";
 import {mockGetStateBuildersResponse} from "./utils/mocks.js";
 
 describe("Identity", () => {
   const logger = getMockedLogger();
+  const clock = new ClockMock();
   const api = getApiClientStub();
   const index = 1;
   const status = "active";
@@ -15,7 +17,6 @@ describe("Identity", () => {
   const pubkeyString = toHex(pubkey);
   const balance = 1;
   const version = PAYLOAD_BUILDER_VERSION;
-  const getSlot = () => 1;
 
   let abortController: AbortController;
 
@@ -51,7 +52,7 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
 
-    const builderIndex = await resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot);
+    const builderIndex = await resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock);
     expect(builderIndex).toEqual(index);
   });
 
@@ -60,7 +61,7 @@ describe("Identity", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version: newVersion})
     );
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot)).rejects.toThrow(
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock)).rejects.toThrow(
       `Builder version mismatch: got ${newVersion}, expected ${version}`
     );
     expect(api.beacon.getStateBuilders).toHaveBeenCalledWith(expect.objectContaining({builderIds: [pubkeyString]}));
@@ -69,7 +70,7 @@ describe("Identity", () => {
   it("throws on pubkey mismatch", async () => {
     const invalidPubkey = Buffer.alloc(48, 2);
     api.beacon.getStateBuilders.mockResolvedValue(mockGetStateBuildersResponse(index, {pubkey: invalidPubkey}));
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot)).rejects.toThrow(
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock)).rejects.toThrow(
       `Pubkey mismatch: got=${toHex(invalidPubkey)} expected=${pubkeyString}`
     );
     expect(api.beacon.getStateBuilders).toHaveBeenCalledWith(expect.objectContaining({builderIds: [pubkeyString]}));
@@ -77,7 +78,7 @@ describe("Identity", () => {
 
   it("throws on builder status exited", async () => {
     api.beacon.getStateBuilders.mockResolvedValue(mockGetStateBuildersResponse(index, {status: "exited", pubkey}));
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot)).rejects.toThrow(
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock)).rejects.toThrow(
       `Builder exited: id=${pubkeyString}`
     );
     expect(api.beacon.getStateBuilders).toHaveBeenCalledWith(expect.objectContaining({builderIds: [pubkeyString]}));
@@ -91,7 +92,7 @@ describe("Identity", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
-    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot);
+    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock);
     await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
@@ -105,7 +106,7 @@ describe("Identity", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
-    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot);
+    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock);
     await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
@@ -113,14 +114,14 @@ describe("Identity", () => {
 
   it("rejects without querying the beacon node when the signal is already aborted", async () => {
     const abortSignal = AbortSignal.abort();
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortSignal, getSlot)).rejects.toThrow(ErrorAborted);
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortSignal, clock)).rejects.toThrow(ErrorAborted);
     expect(api.beacon.getStateBuilders).not.toHaveBeenCalled();
   });
 
   it("throws on beacon node 500", async () => {
     const resStatus = 500;
     api.beacon.getStateBuilders.mockResolvedValue(await mockApiErrorResponse(resStatus));
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot)).rejects.toThrow(
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock)).rejects.toThrow(
       /status 500/
     );
   });

--- a/packages/builder/test/unit/identity.test.ts
+++ b/packages/builder/test/unit/identity.test.ts
@@ -15,6 +15,7 @@ describe("Identity", () => {
   const pubkeyString = toHex(pubkey);
   const balance = 1;
   const version = PAYLOAD_BUILDER_VERSION;
+  const getSlot = () => 1;
 
   let abortController: AbortController;
 
@@ -50,7 +51,7 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
 
-    const builderIndex = await resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal);
+    const builderIndex = await resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot);
     expect(builderIndex).toEqual(index);
   });
 
@@ -59,7 +60,7 @@ describe("Identity", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version: newVersion})
     );
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal)).rejects.toThrow(
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot)).rejects.toThrow(
       `Builder version mismatch: got ${newVersion}, expected ${version}`
     );
     expect(api.beacon.getStateBuilders).toHaveBeenCalledWith(expect.objectContaining({builderIds: [pubkeyString]}));
@@ -68,7 +69,7 @@ describe("Identity", () => {
   it("throws on pubkey mismatch", async () => {
     const invalidPubkey = Buffer.alloc(48, 2);
     api.beacon.getStateBuilders.mockResolvedValue(mockGetStateBuildersResponse(index, {pubkey: invalidPubkey}));
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal)).rejects.toThrow(
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot)).rejects.toThrow(
       `Pubkey mismatch: got=${toHex(invalidPubkey)} expected=${pubkeyString}`
     );
     expect(api.beacon.getStateBuilders).toHaveBeenCalledWith(expect.objectContaining({builderIds: [pubkeyString]}));
@@ -76,7 +77,7 @@ describe("Identity", () => {
 
   it("throws on builder status exited", async () => {
     api.beacon.getStateBuilders.mockResolvedValue(mockGetStateBuildersResponse(index, {status: "exited", pubkey}));
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal)).rejects.toThrow(
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot)).rejects.toThrow(
       `Builder exited: id=${pubkeyString}`
     );
     expect(api.beacon.getStateBuilders).toHaveBeenCalledWith(expect.objectContaining({builderIds: [pubkeyString]}));
@@ -90,7 +91,7 @@ describe("Identity", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
-    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal);
+    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot);
     await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
@@ -104,7 +105,7 @@ describe("Identity", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
-    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal);
+    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot);
     await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
@@ -112,14 +113,14 @@ describe("Identity", () => {
 
   it("rejects without querying the beacon node when the signal is already aborted", async () => {
     const abortSignal = AbortSignal.abort();
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortSignal)).rejects.toThrow(ErrorAborted);
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortSignal, getSlot)).rejects.toThrow(ErrorAborted);
     expect(api.beacon.getStateBuilders).not.toHaveBeenCalled();
   });
 
   it("throws on beacon node 500", async () => {
     const resStatus = 500;
     api.beacon.getStateBuilders.mockResolvedValue(await mockApiErrorResponse(resStatus));
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal)).rejects.toThrow(
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, getSlot)).rejects.toThrow(
       /status 500/
     );
   });

--- a/packages/builder/test/unit/identity.test.ts
+++ b/packages/builder/test/unit/identity.test.ts
@@ -1,6 +1,6 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
-import {toHex} from "@lodestar/utils";
+import {ErrorAborted, toHex} from "@lodestar/utils";
 import {WAITING_FOR_BUILDER_POLL_MS, getBuilderStatus, resolveBuilderIdentity} from "../../src/identity.js";
 import {getApiClientStub, mockApiErrorResponse, mockApiResponse} from "./utils/apiStub.js";
 import {getMockedLogger} from "./utils/logger.js";
@@ -108,6 +108,12 @@ describe("Identity", () => {
     await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects without querying the beacon node when the signal is already aborted", async () => {
+    const abortSignal = AbortSignal.abort();
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortSignal)).rejects.toThrow(ErrorAborted);
+    expect(api.beacon.getStateBuilders).not.toHaveBeenCalled();
   });
 
   it("throws on beacon node 500", async () => {

--- a/packages/builder/test/unit/services/builderStatusTracker.test.ts
+++ b/packages/builder/test/unit/services/builderStatusTracker.test.ts
@@ -8,7 +8,7 @@ describe("BuilderStatusTracker", () => {
   const logger = getMockedLogger();
   const api = getApiClientStub();
   const builderIndex = 1;
-  const slot = 1;
+  const epoch = 1;
 
   let builderStatusTracker: BuilderStatusTracker;
 
@@ -28,7 +28,7 @@ describe("BuilderStatusTracker", () => {
   });
 
   it("status and balance should give real values after polling", async () => {
-    await builderStatusTracker.poll(slot);
+    await builderStatusTracker.poll(epoch);
     const {status, balance} = builderStatusTracker.getStatus();
     expect(status).toEqual("active");
     expect(balance).toEqual(1);
@@ -37,7 +37,7 @@ describe("BuilderStatusTracker", () => {
   });
 
   it("updates balance across polls", async () => {
-    await builderStatusTracker.poll(slot);
+    await builderStatusTracker.poll(epoch);
     const {status, balance} = builderStatusTracker.getStatus();
     expect(status).toEqual("active");
     expect(balance).toEqual(1);
@@ -46,7 +46,7 @@ describe("BuilderStatusTracker", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(builderIndex, {status: "active", balance: 2})
     );
-    await builderStatusTracker.poll(slot);
+    await builderStatusTracker.poll(epoch);
     const {status: newStatus, balance: newBalance} = builderStatusTracker.getStatus();
     expect(newStatus).toEqual("active");
     expect(newBalance).toEqual(2);
@@ -55,7 +55,7 @@ describe("BuilderStatusTracker", () => {
   });
 
   it("logs on status change", async () => {
-    await builderStatusTracker.poll(slot);
+    await builderStatusTracker.poll(epoch);
     const {status, balance} = builderStatusTracker.getStatus();
     expect(status).toEqual("active");
     expect(balance).toEqual(1);
@@ -64,16 +64,16 @@ describe("BuilderStatusTracker", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(builderIndex, {status: "exited", balance: 1})
     );
-    await builderStatusTracker.poll(slot);
+    await builderStatusTracker.poll(epoch);
     const {status: newStatus, balance: newBalance} = builderStatusTracker.getStatus();
     expect(newStatus).toEqual("exited");
     expect(newBalance).toEqual(1);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
-    expect(logger.info).toHaveBeenCalledWith("Builder status changed", {from: "active", to: "exited", slot: 1});
+    expect(logger.info).toHaveBeenCalledWith("Builder status changed", {from: "active", to: "exited", epoch: 1});
   });
 
   it("dismisses beacon api 500", async () => {
-    await builderStatusTracker.poll(slot);
+    await builderStatusTracker.poll(epoch);
     const {status, balance} = builderStatusTracker.getStatus();
     expect(status).toEqual("active");
     expect(balance).toEqual(1);
@@ -81,7 +81,7 @@ describe("BuilderStatusTracker", () => {
 
     api.beacon.getStateBuilders.mockResolvedValue(await mockApiErrorResponse(500));
     // poll should resolve when beacon node throws 500
-    await builderStatusTracker.poll(slot);
+    await builderStatusTracker.poll(epoch);
     const {status: newStatus, balance: newBalance} = builderStatusTracker.getStatus();
     expect(newStatus).toEqual("active");
     expect(newBalance).toEqual(1);

--- a/packages/builder/test/unit/services/builderStatusTracker.test.ts
+++ b/packages/builder/test/unit/services/builderStatusTracker.test.ts
@@ -8,6 +8,7 @@ describe("BuilderStatusTracker", () => {
   const logger = getMockedLogger();
   const api = getApiClientStub();
   const builderIndex = 1;
+  const slot = 1;
 
   let builderStatusTracker: BuilderStatusTracker;
 
@@ -27,7 +28,7 @@ describe("BuilderStatusTracker", () => {
   });
 
   it("status and balance should give real values after polling", async () => {
-    await builderStatusTracker.poll();
+    await builderStatusTracker.poll(slot);
     const {status, balance} = builderStatusTracker.getStatus();
     expect(status).toEqual("active");
     expect(balance).toEqual(1);
@@ -36,7 +37,7 @@ describe("BuilderStatusTracker", () => {
   });
 
   it("updates balance across polls", async () => {
-    await builderStatusTracker.poll();
+    await builderStatusTracker.poll(slot);
     const {status, balance} = builderStatusTracker.getStatus();
     expect(status).toEqual("active");
     expect(balance).toEqual(1);
@@ -45,7 +46,7 @@ describe("BuilderStatusTracker", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(builderIndex, {status: "active", balance: 2})
     );
-    await builderStatusTracker.poll();
+    await builderStatusTracker.poll(slot);
     const {status: newStatus, balance: newBalance} = builderStatusTracker.getStatus();
     expect(newStatus).toEqual("active");
     expect(newBalance).toEqual(2);
@@ -54,7 +55,7 @@ describe("BuilderStatusTracker", () => {
   });
 
   it("logs on status change", async () => {
-    await builderStatusTracker.poll();
+    await builderStatusTracker.poll(slot);
     const {status, balance} = builderStatusTracker.getStatus();
     expect(status).toEqual("active");
     expect(balance).toEqual(1);
@@ -63,7 +64,7 @@ describe("BuilderStatusTracker", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(builderIndex, {status: "exited", balance: 1})
     );
-    await builderStatusTracker.poll();
+    await builderStatusTracker.poll(slot);
     const {status: newStatus, balance: newBalance} = builderStatusTracker.getStatus();
     expect(newStatus).toEqual("exited");
     expect(newBalance).toEqual(1);
@@ -72,7 +73,7 @@ describe("BuilderStatusTracker", () => {
   });
 
   it("dismisses beacon api 500", async () => {
-    await builderStatusTracker.poll();
+    await builderStatusTracker.poll(slot);
     const {status, balance} = builderStatusTracker.getStatus();
     expect(status).toEqual("active");
     expect(balance).toEqual(1);
@@ -80,7 +81,7 @@ describe("BuilderStatusTracker", () => {
 
     api.beacon.getStateBuilders.mockResolvedValue(await mockApiErrorResponse(500));
     // poll should resolve when beacon node throws 500
-    await builderStatusTracker.poll();
+    await builderStatusTracker.poll(slot);
     const {status: newStatus, balance: newBalance} = builderStatusTracker.getStatus();
     expect(newStatus).toEqual("active");
     expect(newBalance).toEqual(1);

--- a/packages/builder/test/unit/services/builderStatusTracker.test.ts
+++ b/packages/builder/test/unit/services/builderStatusTracker.test.ts
@@ -69,7 +69,7 @@ describe("BuilderStatusTracker", () => {
     expect(newStatus).toEqual("exited");
     expect(newBalance).toEqual(1);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
-    expect(logger.info).toHaveBeenCalledWith("Builder status changed", {from: "active", to: "exited"});
+    expect(logger.info).toHaveBeenCalledWith("Builder status changed", {from: "active", to: "exited", slot: 1});
   });
 
   it("dismisses beacon api 500", async () => {

--- a/packages/builder/test/unit/utils/clock.ts
+++ b/packages/builder/test/unit/utils/clock.ts
@@ -1,0 +1,29 @@
+import {IClock} from "@lodestar/state-transition";
+import {Epoch, Slot} from "@lodestar/types";
+
+type RunEveryFn = (slot: Slot, signal: AbortSignal) => Promise<void>;
+
+export class ClockMock implements IClock {
+  readonly currentEpoch: number = 0;
+  readonly genesisTime: number = 0;
+  readonly secondsPerSlot: number = 12;
+
+  private readonly everySlot: RunEveryFn[] = [];
+  private readonly everyEpoch: RunEveryFn[] = [];
+
+  start = (): void => {};
+  runEverySlot = (fn: RunEveryFn): number => this.everySlot.push(fn);
+  runEveryEpoch = (fn: RunEveryFn): number => this.everyEpoch.push(fn);
+  msToSlot = (_slot: number): number => 0;
+  msFromSlot = (): number => 0;
+  secFromSlot = (): number => 0;
+  getCurrentSlot = (): number => 0;
+  getCurrentEpoch = (): number => 0;
+
+  async tickSlotFns(slot: Slot, signal: AbortSignal): Promise<void> {
+    for (const fn of this.everySlot) await fn(slot, signal);
+  }
+  async tickEpochFns(epoch: Epoch, signal: AbortSignal): Promise<void> {
+    for (const fn of this.everyEpoch) await fn(epoch, signal);
+  }
+}


### PR DESCRIPTION
**Motivation**

Follow up for leftover comments in: #9781 

**Description**

- Makes `while(true)` loops dependent on `signal.abort` instead.
- Logging improvements.
- Test additions.

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Used Claude to review the changes.
