### PR TITLE
feat: instrument builder onboarding at the gloas fork transition

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
@@ -1,3 +1,4 @@
+import {ForkName} from "@lodestar/params";
 import {
   BeaconStateTransitionMetrics,
   EpochTransitionStep,
@@ -44,6 +45,27 @@ export function createHistoricalStateTransitionMetrics(
       help: "Time to call each step of epoch transition in seconds",
       labelNames: ["step"],
       buckets: [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1],
+    }),
+    forkUpgradeTime: metricsRegister.histogram<{fork: ForkName}>({
+      name: "lodestar_historical_state_stfn_fork_upgrade_seconds",
+      help: "Time to upgrade the state at a fork boundary in seconds",
+      labelNames: ["fork"],
+      buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
+    }),
+    onboardBuildersTime: metricsRegister.histogram({
+      name: "lodestar_historical_state_stfn_gloas_onboard_builders_seconds",
+      help: "Time spent in onboardBuildersFromPendingDeposits at the gloas fork transition",
+      buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
+    }),
+    onboardBuildersDeposits: metricsRegister.gauge<{outcome: "onboarded" | "topup" | "kept" | "dropped"}>({
+      name: "lodestar_historical_state_stfn_gloas_onboard_builders_deposits",
+      help: "Pending deposits handled at the gloas fork transition, by outcome",
+      labelNames: ["outcome"],
+    }),
+    onboardBuildersSignatureChecks: metricsRegister.gauge<{source: "cache" | "verified"}>({
+      name: "lodestar_historical_state_stfn_gloas_onboard_builders_signature_checks",
+      help: "Builder deposit signature checks at the gloas fork transition, by whether the pre-verify cache served them",
+      labelNames: ["source"],
     }),
     processBlockTime: metricsRegister.histogram({
       name: "lodestar_historical_state_stfn_process_block_seconds",

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -36,20 +36,20 @@ export function getMetrics(register: MetricsRegister) {
       name: "lodestar_stfn_fork_upgrade_seconds",
       help: "Time to upgrade the state at a fork boundary in seconds",
       labelNames: ["fork"],
-      // The gloas upgrade is unbounded (see gloasOnboardBuildersTime), hence the long tail
+      // The gloas upgrade is unbounded (see onboardBuildersTime), hence the long tail
       buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
     }),
-    gloasOnboardBuildersTime: register.histogram({
+    onboardBuildersTime: register.histogram({
       name: "lodestar_stfn_gloas_onboard_builders_seconds",
       help: "Time spent in onboardBuildersFromPendingDeposits at the gloas fork transition",
       buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
     }),
-    gloasOnboardBuildersDeposits: register.gauge<{outcome: "onboarded" | "topup" | "kept" | "dropped"}>({
+    onboardBuildersDeposits: register.gauge<{outcome: "onboarded" | "topup" | "kept" | "dropped"}>({
       name: "lodestar_stfn_gloas_onboard_builders_deposits",
       help: "Pending deposits handled at the gloas fork transition, by outcome",
       labelNames: ["outcome"],
     }),
-    gloasOnboardBuildersSignatureChecks: register.gauge<{source: "cache" | "verified"}>({
+    onboardBuildersSignatureChecks: register.gauge<{source: "cache" | "verified"}>({
       name: "lodestar_stfn_gloas_onboard_builders_signature_checks",
       help: "Builder deposit signature checks at the gloas fork transition. `verified` means the pre-verify cache missed and BLS ran inline, on the fork transition's critical path",
       labelNames: ["source"],

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -1,3 +1,4 @@
+import {ForkName} from "@lodestar/params";
 import {MetricsRegister} from "@lodestar/utils";
 import {ProposerRewardType} from "./block/types.js";
 import {EpochTransitionStep} from "./epoch/index.js";
@@ -30,6 +31,28 @@ export function getMetrics(register: MetricsRegister) {
       help: "Time to call each step of epoch transition in seconds",
       labelNames: ["step"],
       buckets: [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1],
+    }),
+    forkUpgradeTime: register.histogram<{fork: ForkName}>({
+      name: "lodestar_stfn_fork_upgrade_seconds",
+      help: "Time to upgrade the state at a fork boundary in seconds",
+      labelNames: ["fork"],
+      // The gloas upgrade is unbounded (see gloasOnboardBuildersTime), hence the long tail
+      buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
+    }),
+    gloasOnboardBuildersTime: register.histogram({
+      name: "lodestar_stfn_gloas_onboard_builders_seconds",
+      help: "Time spent in onboardBuildersFromPendingDeposits at the gloas fork transition",
+      buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
+    }),
+    gloasOnboardBuildersDeposits: register.gauge<{outcome: "onboarded" | "topup" | "kept" | "dropped"}>({
+      name: "lodestar_stfn_gloas_onboard_builders_deposits",
+      help: "Pending deposits handled at the gloas fork transition, by outcome",
+      labelNames: ["outcome"],
+    }),
+    gloasOnboardBuildersSignatureChecks: register.gauge<{source: "cache" | "verified"}>({
+      name: "lodestar_stfn_gloas_onboard_builders_signature_checks",
+      help: "Builder deposit signature checks at the gloas fork transition. `verified` means the pre-verify cache missed and BLS ran inline, on the fork transition's critical path",
+      labelNames: ["source"],
     }),
     processBlockTime: register.histogram({
       name: "lodestar_stfn_process_block_seconds",

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -15,6 +15,7 @@ import {ssz} from "@lodestar/types";
 import {toPubkeyHex} from "@lodestar/utils";
 import {isValidDepositSignature} from "../block/processDeposit.js";
 import {getCachedBeaconState} from "../cache/stateCache.js";
+import type {BeaconStateTransitionMetrics} from "../metrics.js";
 import {CachedBeaconStateFulu, CachedBeaconStateGloas} from "../types.js";
 import {addBuilderToRegistry, initializePtcWindow, isBuilderWithdrawalCredential} from "../util/gloas.js";
 import {isValidatorKnown} from "../util/index.js";
@@ -24,7 +25,10 @@ import {progressiveListRootNode} from "../util/ssz.js";
 /**
  * Upgrade a state from Fulu to Gloas.
  */
-export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBeaconStateGloas {
+export function upgradeStateToGloas(
+  stateFulu: CachedBeaconStateFulu,
+  metrics?: BeaconStateTransitionMetrics | null
+): CachedBeaconStateGloas {
   const {config} = stateFulu;
 
   ssz.fulu.BeaconState.commitViewDU(stateFulu);
@@ -106,7 +110,7 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
   const stateGloas = getCachedBeaconState(stateGloasView, stateFulu);
 
   // Process pending builder deposits at the fork boundary
-  onboardBuildersFromPendingDeposits(stateGloas);
+  onboardBuildersFromPendingDeposits(stateGloas, metrics);
 
   stateGloas.commit();
   // Clear cache to ensure the cache of fulu fields is not used by new gloas fields
@@ -164,7 +168,23 @@ function migrateBasicListToGloas<ElementType extends BasicType<unknown>>(
  * Applies any pending deposits for builders to onboard builders during the fork transition
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.8/specs/gloas/fork.md#new-onboard_builders_from_pending_deposits
  */
-function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void {
+function onboardBuildersFromPendingDeposits(
+  state: CachedBeaconStateGloas,
+  metrics?: BeaconStateTransitionMetrics | null
+): void {
+  const timer = metrics?.gloasOnboardBuildersTime.startTimer();
+
+  // Counted so the duration above is interpretable: this loop walks the whole pending
+  // deposit queue, and its cost is dominated by whichever branch the queue happens to
+  // hit. `verified` signature checks are the ones the pre-verify cache missed, i.e. BLS
+  // running inline on the fork transition's critical path.
+  let onboarded = 0;
+  let topups = 0;
+  let kept = 0;
+  let dropped = 0;
+  let sigFromCache = 0;
+  let sigVerified = 0;
+
   // Track pubkeys of new builders added when applying deposits. `state.builders` starts empty
   // at the fork, so every builder pubkey here is one added in an earlier iteration.
   const builderPubkeys = new Set<string>();
@@ -182,6 +202,7 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
     if (isValidatorKnown(state, validatorIndex)) {
       pendingDeposits.push(deposit);
       pendingDepositsLookup.add(depositValue, pubkeyHex);
+      kept++;
       continue;
     }
 
@@ -194,6 +215,7 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
           break;
         }
       }
+      topups++;
       continue;
     }
 
@@ -203,6 +225,7 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
     if (!isBuilderWithdrawalCredential(deposit.withdrawalCredentials)) {
       pendingDeposits.push(deposit);
       pendingDepositsLookup.add(depositValue, pubkeyHex);
+      kept++;
       continue;
     }
     if (
@@ -210,6 +233,7 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
     ) {
       pendingDeposits.push(deposit);
       pendingDepositsLookup.add(depositValue, pubkeyHex);
+      kept++;
       continue;
     }
 
@@ -219,6 +243,11 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
     // The prepareNextSlot scheduler pre-verifies these signatures in the epochs before the fork
     // A cache miss falls back to verifying this one deposit — no worse than pre-cache.
     const cached = state.epochCtx.builderDepositSignatureCache.getSignatureValidity(depositValue);
+    if (cached === null) {
+      sigVerified++;
+    } else {
+      sigFromCache++;
+    }
     const isValid =
       cached ??
       isValidDepositSignature(
@@ -229,6 +258,7 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
         deposit.signature
       );
     if (!isValid) {
+      dropped++;
       continue;
     }
 
@@ -241,7 +271,18 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
       deposit.slot
     );
     builderPubkeys.add(pubkeyHex);
+    onboarded++;
   }
 
   state.pendingDeposits = pendingDeposits;
+
+  timer?.();
+  if (metrics) {
+    metrics.gloasOnboardBuildersDeposits.set({outcome: "onboarded"}, onboarded);
+    metrics.gloasOnboardBuildersDeposits.set({outcome: "topup"}, topups);
+    metrics.gloasOnboardBuildersDeposits.set({outcome: "kept"}, kept);
+    metrics.gloasOnboardBuildersDeposits.set({outcome: "dropped"}, dropped);
+    metrics.gloasOnboardBuildersSignatureChecks.set({source: "cache"}, sigFromCache);
+    metrics.gloasOnboardBuildersSignatureChecks.set({source: "verified"}, sigVerified);
+  }
 }

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -172,12 +172,14 @@ function onboardBuildersFromPendingDeposits(
   state: CachedBeaconStateGloas,
   metrics?: BeaconStateTransitionMetrics | null
 ): void {
-  const timer = metrics?.gloasOnboardBuildersTime.startTimer();
+  const timer = metrics?.onboardBuildersTime.startTimer();
 
   // Counted so the duration above is interpretable: this loop walks the whole pending
   // deposit queue, and its cost is dominated by whichever branch the queue happens to
   // hit. `verified` signature checks are the ones the pre-verify cache missed, i.e. BLS
-  // running inline on the fork transition's critical path.
+  // running inline on the fork transition's critical path. The signature totals include
+  // the checks hasPendingValidator() does internally, which dominate when a builder
+  // deposit is preceded by same-pubkey validator deposits.
   let onboarded = 0;
   let topups = 0;
   let kept = 0;
@@ -278,11 +280,12 @@ function onboardBuildersFromPendingDeposits(
 
   timer?.();
   if (metrics) {
-    metrics.gloasOnboardBuildersDeposits.set({outcome: "onboarded"}, onboarded);
-    metrics.gloasOnboardBuildersDeposits.set({outcome: "topup"}, topups);
-    metrics.gloasOnboardBuildersDeposits.set({outcome: "kept"}, kept);
-    metrics.gloasOnboardBuildersDeposits.set({outcome: "dropped"}, dropped);
-    metrics.gloasOnboardBuildersSignatureChecks.set({source: "cache"}, sigFromCache);
-    metrics.gloasOnboardBuildersSignatureChecks.set({source: "verified"}, sigVerified);
+    metrics.onboardBuildersDeposits.set({outcome: "onboarded"}, onboarded);
+    metrics.onboardBuildersDeposits.set({outcome: "topup"}, topups);
+    metrics.onboardBuildersDeposits.set({outcome: "kept"}, kept);
+    metrics.onboardBuildersDeposits.set({outcome: "dropped"}, dropped);
+    const lookupChecks = pendingDepositsLookup.signatureChecks;
+    metrics.onboardBuildersSignatureChecks.set({source: "cache"}, sigFromCache + lookupChecks.fromCache);
+    metrics.onboardBuildersSignatureChecks.set({source: "verified"}, sigVerified + lookupChecks.verified);
   }
 }

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -1,4 +1,4 @@
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Epoch, SignedBeaconBlock, SignedBlindedBeaconBlock, Slot, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {BlockExternalData, DataAvailabilityStatus, ExecutionPayloadStatus} from "./block/externalData.js";
@@ -278,7 +278,12 @@ function processSlotsWithTransientCache(
         postState = upgradeStateToFulu(postState as CachedBeaconStateElectra) as CachedBeaconStateAllForks;
       }
       if (stateEpoch === config.GLOAS_FORK_EPOCH) {
-        postState = upgradeStateToGloas(postState as CachedBeaconStateFulu) as CachedBeaconStateAllForks;
+        // Timed, unlike the other fork upgrades: this one does unbounded work.
+        // onboardBuildersFromPendingDeposits walks the entire pending deposit queue, so its
+        // cost is set by whatever is sitting in that queue when the fork lands.
+        const timer = metrics?.forkUpgradeTime.startTimer({fork: ForkName.gloas});
+        postState = upgradeStateToGloas(postState as CachedBeaconStateFulu, metrics) as CachedBeaconStateAllForks;
+        timer?.();
       }
       if (stateEpoch === config.HEZE_FORK_EPOCH) {
         postState = upgradeStateToHeze(postState as CachedBeaconStateGloas) as CachedBeaconStateAllForks;

--- a/packages/state-transition/src/util/pendingDepositsLookup.ts
+++ b/packages/state-transition/src/util/pendingDepositsLookup.ts
@@ -22,6 +22,9 @@ type PendingDepositsValidation = {
  * newly-appended tail rather than re-running BLS on previously-invalid entries.
  */
 export class PendingDepositsLookup {
+  private signaturesFromCache = 0;
+  private signaturesVerified = 0;
+
   private constructor(
     private readonly depositsByPubkey: Map<PubkeyHex, electra.PendingDeposit[]>,
     private readonly validationCache: Map<PubkeyHex, PendingDepositsValidation>
@@ -52,6 +55,16 @@ export class PendingDepositsLookup {
    * Most of the time it should hit the BuilderDepositSignatureCache so we don't have to validate
    * signatures here.
    */
+  /**
+   * Signature checks performed inside `hasPendingValidator()`, split by whether the pre-verify
+   * cache served them. These are the scan the caller never sees: when a builder-routed deposit is
+   * preceded by same-pubkey validator deposits this walk dominates, and on a `true` result the
+   * caller skips its own signature check entirely.
+   */
+  get signatureChecks(): {fromCache: number; verified: number} {
+    return {fromCache: this.signaturesFromCache, verified: this.signaturesVerified};
+  }
+
   hasPendingValidator(config: BeaconConfig, pubkeyHex: PubkeyHex, cache: BuilderDepositSignatureCache): boolean {
     const validation = this.validationCache.get(pubkeyHex);
     if (validation?.hasValidSignature === true) {
@@ -73,8 +86,14 @@ export class PendingDepositsLookup {
 
     for (let i = startIndex; i < deposits.length; i++) {
       const deposit = deposits[i];
+      const cached = cache.getSignatureValidity(deposit);
+      if (cached === null) {
+        this.signaturesVerified++;
+      } else {
+        this.signaturesFromCache++;
+      }
       const isValid =
-        cache.getSignatureValidity(deposit) ??
+        cached ??
         isValidDepositSignature(
           config,
           deposit.pubkey,

--- a/packages/state-transition/test/unit/slot/upgradeStateToGloasCacheHit.test.ts
+++ b/packages/state-transition/test/unit/slot/upgradeStateToGloasCacheHit.test.ts
@@ -142,11 +142,11 @@ describe("upgradeStateToGloas - builder-deposit signature cache", () => {
     const outcomes = new Map<string, number>();
     const sigChecks = new Map<string, number>();
     const metrics = {
-      gloasOnboardBuildersTime: {startTimer: () => () => {}},
-      gloasOnboardBuildersDeposits: {
+      onboardBuildersTime: {startTimer: () => () => {}},
+      onboardBuildersDeposits: {
         set: ({outcome}: {outcome: string}, value: number) => outcomes.set(outcome, value),
       },
-      gloasOnboardBuildersSignatureChecks: {
+      onboardBuildersSignatureChecks: {
         set: ({source}: {source: string}, value: number) => sigChecks.set(source, value),
       },
     };
@@ -207,11 +207,25 @@ describe("upgradeStateToGloas - builder-deposit signature cache", () => {
     preVerifyBuilderDepositsPreGloas(fuluState, MAX_BUILDER_DEPOSITS_PER_SLOT, 60_000);
     preVerifyBuilderDepositsPreGloas(fuluState, MAX_BUILDER_DEPOSITS_PER_SLOT, 60_000);
 
-    const gloasState = upgradeStateToGloas(fuluState);
+    const outcomes = new Map<string, number>();
+    const sigChecks = new Map<string, number>();
+    const metrics = {
+      onboardBuildersTime: {startTimer: () => () => {}},
+      onboardBuildersDeposits: {set: ({outcome}: {outcome: string}, value: number) => outcomes.set(outcome, value)},
+      onboardBuildersSignatureChecks: {
+        set: ({source}: {source: string}, value: number) => sigChecks.set(source, value),
+      },
+    };
+
+    const gloasState = upgradeStateToGloas(fuluState, metrics as unknown as Parameters<typeof upgradeStateToGloas>[1]);
 
     // The builder onboards; hasPendingValidator resolved all 40 validator checks from the cache, so
     // isValidDepositSignature (the BLS fallback) is never called on the transition's critical path.
     expect(gloasState.builders.length).toBe(1);
     expect(isValidDepositSignatureSpy).not.toHaveBeenCalled();
+    // The 40 checks hasPendingValidator did internally are counted, not just the builder deposit's
+    // own one — that scan is the dominant cost in this shape and would otherwise be invisible.
+    expect(Object.fromEntries(sigChecks)).toEqual({cache: 41, verified: 0});
+    expect(Object.fromEntries(outcomes)).toEqual({onboarded: 1, topup: 0, kept: 40, dropped: 0});
   });
 });

--- a/packages/state-transition/test/unit/slot/upgradeStateToGloasCacheHit.test.ts
+++ b/packages/state-transition/test/unit/slot/upgradeStateToGloasCacheHit.test.ts
@@ -89,6 +89,80 @@ describe("upgradeStateToGloas - builder-deposit signature cache", () => {
     });
   }
 
+  it("reports deposit outcomes and cache hits through metrics", () => {
+    isValidDepositSignatureSpy.mockClear();
+
+    const deposits = generateBuilderPendingDeposits(config, 3, 3000);
+    // Same pubkey as deposits[0], queued after it, so it lands on the top-up branch rather
+    // than onboarding a second builder.
+    const topup = {...deposits[0], amount: 1_000_000_000};
+
+    const stateView = ssz.fulu.BeaconState.defaultViewDU();
+    for (let i = 0; i < 64; i++) {
+      const validator = ssz.phase0.Validator.defaultValue();
+      validator.pubkey = Buffer.alloc(48, i + 1);
+      validator.withdrawalCredentials = Buffer.alloc(32, i + 1);
+      validator.effectiveBalance = 32e9;
+      validator.activationEligibilityEpoch = 0;
+      validator.activationEpoch = 0;
+      validator.exitEpoch = FAR_FUTURE_EPOCH;
+      validator.withdrawableEpoch = FAR_FUTURE_EPOCH;
+      stateView.validators.push(ssz.phase0.Validator.toViewDU(validator));
+      stateView.balances.push(32e9);
+    }
+    // A deposit for an existing validator: stays in the pending queue → "kept"
+    stateView.pendingDeposits.push(
+      ssz.electra.PendingDeposit.toViewDU({
+        pubkey: Buffer.alloc(48, 1),
+        withdrawalCredentials: Buffer.alloc(32),
+        amount: 32e9,
+        signature: Buffer.alloc(96),
+        slot: 0,
+      })
+    );
+    for (const deposit of deposits) {
+      stateView.pendingDeposits.push(ssz.electra.PendingDeposit.toViewDU(deposit));
+    }
+    stateView.pendingDeposits.push(ssz.electra.PendingDeposit.toViewDU(topup));
+    stateView.commit();
+
+    const fuluState = createCachedBeaconState(
+      stateView,
+      {config, pubkeyCache: createPubkeyCache()},
+      {skipSyncCommitteeCache: true, skipSyncPubkeys: true}
+    ) as CachedBeaconStateFulu;
+
+    // Warm the cache for all three builder deposits, marking the last one invalid so it is dropped.
+    const cache = fuluState.epochCtx.builderDepositSignatureCache;
+    const values = fuluState.pendingDeposits.getAllReadonlyValues();
+    cache.setSignatureValidity(values[1], true);
+    cache.setSignatureValidity(values[2], true);
+    cache.setSignatureValidity(values[3], false);
+
+    const outcomes = new Map<string, number>();
+    const sigChecks = new Map<string, number>();
+    const metrics = {
+      gloasOnboardBuildersTime: {startTimer: () => () => {}},
+      gloasOnboardBuildersDeposits: {
+        set: ({outcome}: {outcome: string}, value: number) => outcomes.set(outcome, value),
+      },
+      gloasOnboardBuildersSignatureChecks: {
+        set: ({source}: {source: string}, value: number) => sigChecks.set(source, value),
+      },
+    };
+
+    const gloasState = upgradeStateToGloas(fuluState, metrics as unknown as Parameters<typeof upgradeStateToGloas>[1]);
+
+    expect(Object.fromEntries(outcomes)).toEqual({onboarded: 2, topup: 1, kept: 1, dropped: 1});
+    // Every signature check was served by the cache; the top-up short-circuits before reaching one.
+    expect(Object.fromEntries(sigChecks)).toEqual({cache: 3, verified: 0});
+    expect(isValidDepositSignatureSpy).not.toHaveBeenCalled();
+    expect(gloasState.builders.length).toBe(2);
+    // The top-up landed on the builder onboarded from deposits[0], not on a new entry.
+    expect(gloasState.builders.getReadonly(0).balance).toBe(deposits[0].amount + topup.amount);
+    expect(gloasState.pendingDeposits.length).toBe(1);
+  });
+
   it("Scenario 5: fork resolves same-pubkey validator deposits from the cache (no BLS fallback)", () => {
     isValidDepositSignatureSpy.mockClear();
 


### PR DESCRIPTION
`upgradeStateToGloas` has no timer or metric, and unlike the other fork upgrades it does unbounded work, `onboardBuildersFromPendingDeposits` walks the entire pending deposit queue, so its cost is set by whatever is queued when the fork lands.

Without this the only signal is a bump in `lodestar_block_processor_queue_job_time_seconds` on the block that crosses the boundary, which conflates the upgrade with the rest of block processing and gives no way to tell whether a slow transition came from the top-up linear scan, `hasPendingValidator`, or deposits the pre-verify cache missed.
Adds a timer for the upgrade and for the onboarding loop, plus counts of deposits by outcome (`onboarded`/`topup`/`kept`/`dropped`) and signature checks by `cache` vs `verified`.