### PR TITLE
refactor: use Wei type for produce block values

### DIFF
--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -88,9 +88,9 @@ export const ProduceBlockV3MetaType = new ContainerType(
     /** Specifies whether the response contains full or blinded block */
     executionPayloadBlinded: ssz.Boolean,
     /** Execution payload value in Wei */
-    executionPayloadValue: ssz.UintBn64,
+    executionPayloadValue: ssz.Wei,
     /** Consensus rewards paid to the proposer for this block, in Wei */
-    consensusBlockValue: ssz.UintBn64,
+    consensusBlockValue: ssz.Wei,
   },
   {jsonCase: "eth2"}
 );
@@ -104,9 +104,9 @@ export const ProduceBlockV4MetaType = new ContainerType(
   {
     ...VersionType.fields,
     /** Consensus rewards paid to the proposer for this block, in Wei */
-    consensusBlockValue: ssz.UintBn64,
+    consensusBlockValue: ssz.Wei,
     /** Local execution payload value when self-building, or builder bid value when committing to a bid, in Wei */
-    executionPayloadValue: ssz.UintBn64,
+    executionPayloadValue: ssz.Wei,
     /** Specifies whether the response contains full block contents or only the beacon block */
     executionPayloadIncluded: ssz.Boolean,
   },

--- a/packages/api/test/unit/beacon/testData/validator.ts
+++ b/packages/api/test/unit/beacon/testData/validator.ts
@@ -9,8 +9,6 @@ const randaoReveal = new Uint8Array(96).fill(1);
 const selectionProof = new Uint8Array(96).fill(1);
 const graffiti = "a".repeat(32);
 const feeRecipient = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-const executionPayloadValue = 2n ** 64n;
-const consensusBlockValue = executionPayloadValue + 1n;
 
 export const testData: GenericServerTestCases<Endpoints> = {
   getAttesterDuties: {
@@ -74,8 +72,8 @@ export const testData: GenericServerTestCases<Endpoints> = {
       data: ssz.electra.BlockContents.defaultValue(),
       meta: {
         version: ForkName.electra,
-        executionPayloadValue,
-        consensusBlockValue,
+        executionPayloadValue: ssz.Wei.defaultValue(),
+        consensusBlockValue: ssz.Wei.defaultValue(),
         executionPayloadBlinded: false,
         executionPayloadSource: ProducedBlockSource.engine,
       },
@@ -96,8 +94,8 @@ export const testData: GenericServerTestCases<Endpoints> = {
       data: ssz.gloas.BlockContents.defaultValue(),
       meta: {
         version: ForkName.gloas,
-        consensusBlockValue,
-        executionPayloadValue,
+        consensusBlockValue: ssz.Wei.defaultValue(),
+        executionPayloadValue: ssz.Wei.defaultValue(),
         executionPayloadIncluded: true,
       },
     },

--- a/packages/api/test/unit/beacon/testData/validator.ts
+++ b/packages/api/test/unit/beacon/testData/validator.ts
@@ -9,6 +9,8 @@ const randaoReveal = new Uint8Array(96).fill(1);
 const selectionProof = new Uint8Array(96).fill(1);
 const graffiti = "a".repeat(32);
 const feeRecipient = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const executionPayloadValue = 2n ** 64n;
+const consensusBlockValue = executionPayloadValue + 1n;
 
 export const testData: GenericServerTestCases<Endpoints> = {
   getAttesterDuties: {
@@ -72,8 +74,8 @@ export const testData: GenericServerTestCases<Endpoints> = {
       data: ssz.electra.BlockContents.defaultValue(),
       meta: {
         version: ForkName.electra,
-        executionPayloadValue: ssz.Wei.defaultValue(),
-        consensusBlockValue: ssz.Wei.defaultValue(),
+        executionPayloadValue,
+        consensusBlockValue,
         executionPayloadBlinded: false,
         executionPayloadSource: ProducedBlockSource.engine,
       },
@@ -94,8 +96,8 @@ export const testData: GenericServerTestCases<Endpoints> = {
       data: ssz.gloas.BlockContents.defaultValue(),
       meta: {
         version: ForkName.gloas,
-        consensusBlockValue: ssz.Wei.defaultValue(),
-        executionPayloadValue: ssz.Wei.defaultValue(),
+        consensusBlockValue,
+        executionPayloadValue,
         executionPayloadIncluded: true,
       },
     },


### PR DESCRIPTION
`produceBlockV3` and `produceBlockV4` return execution and consensus values in Wei, but their metadata codecs used `UintBn64` instead of the canonical `uint256` Wei type