### PR TITLE
fix: preserve request content length

### DIFF
--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -367,8 +367,8 @@ export class HttpClient implements IHttpClient {
 
     try {
       this.logger?.debug("API request", {routeId, requestWireFormat, responseWireFormat});
-      const request = createApiRequest(definition, args, init);
-      const response = await this.fetch(request.url, request);
+      const {url, requestInit} = createApiRequest(definition, args, init);
+      const response = await this.fetch(url, requestInit);
       const apiResponse = new ApiResponse(definition, response.body, response);
 
       if (!apiResponse.ok) {

--- a/packages/api/src/utils/client/request.ts
+++ b/packages/api/src/utils/client/request.ts
@@ -47,7 +47,7 @@ export function createApiRequest<E extends Endpoint>(
   definition: RouteDefinitionExtra<E>,
   args: E["args"],
   init: ApiRequestInitRequired
-): Request {
+): {url: URL; requestInit: RequestInit} {
   const headers = new Headers();
 
   let req: E["request"];
@@ -104,10 +104,15 @@ export function createApiRequest<E extends Endpoint>(
     }
   }
 
-  return new Request(url, {
-    ...init,
-    method: definition.method,
-    headers: mergeHeaders(headers, req.headers, init.headers),
-    body: req.body as BodyInit,
-  });
+  // Keep the serialized body intact so fetch can determine its length. Passing a `Request`
+  // as `RequestInit` exposes its body as a stream, which Node.js sends with chunked encoding.
+  return {
+    url,
+    requestInit: {
+      ...init,
+      method: definition.method,
+      headers: mergeHeaders(headers, req.headers, init.headers),
+      body: req.body as BodyInit,
+    },
+  };
 }

--- a/packages/api/test/unit/client/httpClient.test.ts
+++ b/packages/api/test/unit/client/httpClient.test.ts
@@ -297,6 +297,8 @@ describe("httpClient json client", () => {
       method: "POST",
       handler: async (req) => {
         expect(req.headers[HttpHeader.ContentType]).toBe(MediaType.ssz);
+        expect(req.headers["content-length"]).toBe(String(container.serialize(payload).byteLength));
+        expect(req.headers["transfer-encoding"]).toBeUndefined();
         expect(req.body).toBeInstanceOf(Uint8Array);
         expect(container.deserialize(req.body as Uint8Array)).toEqual(payload);
       },


### PR DESCRIPTION
keeps serialized request bodies intact when passing them to `fetch`

the API client previously constructed a `Request` and then reused it as `RequestInit`. this exposes the buffered body as a `ReadableStream`, so Node.js sends it with chunked transfer encoding even though its length was originally known.

passing the original string or `Uint8Array` lets `fetch` set `Content-Length`. this does not change serialization or introduce a streaming regression because JSON and SSZ request bodies are already fully materialized before this point.

found while testing the gloas builder API against buildoor with kurtosis