### PR TITLE
docs: explain why gloas ExecutionPayloadBid.value stays UintNum64

### DIFF
--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -332,6 +332,8 @@ export const ExecutionPayloadBid = new ProgressiveContainerType(
     gasLimit: UintBn64,
     builderIndex: BuilderIndex,
     slot: Slot,
+    // Unlike the unbounded gasLimit/executionPayment, value is capped by the builder's balance
+    // (can_builder_cover_bid REJECT + gossip IGNORE), itself UintNum64, so a number is safe here.
     value: UintNum64,
     // executionPayment is a uint64 with no bound in process_execution_payload_bid, so a block can
     // carry any value; use UintBn64 so the hashTreeRoot matches exact-uint64 clients for values > 2**53.

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -332,8 +332,12 @@ export const ExecutionPayloadBid = new ProgressiveContainerType(
     gasLimit: UintBn64,
     builderIndex: BuilderIndex,
     slot: Slot,
-    // Unlike the unbounded gasLimit/executionPayment, value is capped by the builder's balance
-    // (can_builder_cover_bid REJECT + gossip IGNORE), itself UintNum64, so a number is safe here.
+    // Unlike gasLimit/executionPayment (gossip-checked only, so a valid block can still carry any
+    // uint64), a non-self-build value is rejected during processing unless covered by the builder's
+    // balance (can_builder_cover_bid), and self-build bids are forced to 0. Balance itself isn't
+    // structurally bounded, but reaching 2**53 gwei would need ~9M ETH deposited, which is
+    // economically infeasible, so a number is safe here in practice — an economic bound, not a
+    // type-level guarantee.
     value: UintNum64,
     // executionPayment is a uint64 with no bound in process_execution_payload_bid, so a block can
     // carry any value; use UintBn64 so the hashTreeRoot matches exact-uint64 clients for values > 2**53.


### PR DESCRIPTION
Follow-up to #9749 / #9750 / #9751, which converted the unbounded `ExecutionPayloadBid` fields (`executionPayment`, `gasLimit`) and `ProposerPreferences.targetGasLimit` to `UintBn64` for exact `hashTreeRoot` parity above `2**53`.

`value` sits directly between `gasLimit` and `executionPayment` but was left as `UintNum64` with no comment, so it reads like an oversight. It isn't: unlike its neighbors, `value` is bounded by the builder's balance —

- state transition: `can_builder_cover_bid` → hard **REJECT** (`processExecutionPayloadBid.ts`)
- gossip: `[IGNORE] bid.value <= builder's excess balance` (`gloas/p2p-interface.md`)

That bound is itself `UintNum64`, and the whole builder-payment subsystem is number-based (`Builder.balance`, `BuilderPendingWithdrawal.amount`), so `value` can never exceed what a valid block's number-typed balance holds. Reaching `> 2**53` gwei would require a builder actually holding `> 9M` ETH — not reachable at mainnet scale.

This is a **comment-only** change documenting that rationale so the field isn't re-flagged. No functional change. Gloas-only.
