### PR TITLE
fix: handle attributable peers on range sync

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
+++ b/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
@@ -58,11 +58,12 @@ export type PayloadErrorType =
     };
 
 export class PayloadError extends Error {
-  type: PayloadErrorType;
-
-  constructor(type: PayloadErrorType, message?: string) {
+  constructor(
+    readonly payloadInput: PayloadEnvelopeInput,
+    readonly type: PayloadErrorType,
+    message?: string
+  ) {
     super(message ?? type.code);
-    this.type = type;
   }
 }
 
@@ -125,7 +126,7 @@ export async function importExecutionPayload(
   // 2. Get ProtoBlock for parent root lookup
   const protoBlock = this.forkChoice.getBlockHexDefaultStatus(blockRootHex);
   if (!protoBlock) {
-    throw new PayloadError({
+    throw new PayloadError(payloadInput, {
       code: PayloadErrorCode.BLOCK_NOT_IN_FORK_CHOICE,
       blockRootHex,
     });
@@ -140,13 +141,13 @@ export async function importExecutionPayload(
     );
 
   if (blockState == null) {
-    throw new PayloadError({
+    throw new PayloadError(payloadInput, {
       code: PayloadErrorCode.MISS_BLOCK_STATE,
       blockRootHex: protoBlock.blockRoot,
     });
   }
   if (!isStatePostGloas(blockState)) {
-    throw new PayloadError({
+    throw new PayloadError(payloadInput, {
       code: PayloadErrorCode.ENVELOPE_VERIFICATION_ERROR,
       message: `Expected gloas+ state for payload import, got fork=${blockState.forkName}`,
     });
@@ -161,6 +162,7 @@ export async function importExecutionPayload(
     });
   } catch (e) {
     throw new PayloadError(
+      payloadInput,
       {
         code: PayloadErrorCode.ENVELOPE_VERIFICATION_ERROR,
         message: (e as Error).message,
@@ -193,7 +195,7 @@ export async function importExecutionPayload(
 
   // 4b. Check signature verification result
   if (!signatureValid) {
-    throw new PayloadError({code: PayloadErrorCode.INVALID_SIGNATURE});
+    throw new PayloadError(payloadInput, {code: PayloadErrorCode.INVALID_SIGNATURE});
   }
 
   // 4c. Handle EL response
@@ -202,7 +204,7 @@ export async function importExecutionPayload(
       break;
 
     case ExecutionPayloadStatus.INVALID:
-      throw new PayloadError({
+      throw new PayloadError(payloadInput, {
         code: PayloadErrorCode.EXECUTION_ENGINE_INVALID,
         execStatus: execResult.status,
         errorMessage: execResult.validationError ?? "",
@@ -215,7 +217,7 @@ export async function importExecutionPayload(
     case ExecutionPayloadStatus.INVALID_BLOCK_HASH:
     case ExecutionPayloadStatus.ELERROR:
     case ExecutionPayloadStatus.UNAVAILABLE:
-      throw new PayloadError({
+      throw new PayloadError(payloadInput, {
         code: PayloadErrorCode.EXECUTION_ENGINE_ERROR,
         execStatus: execResult.status,
         errorMessage: execResult.validationError ?? "",

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -64,8 +64,6 @@ export async function processBlocks(
     return; // TODO: or throw?
   }
 
-  let importingPayload: PayloadEnvelopeInput | undefined;
-
   try {
     const {relevantBlocks, parentSlots, parentBlock} = verifyBlocksSanityChecks(this, blocks, payloadEnvelopes, opts);
 
@@ -156,9 +154,7 @@ export async function processBlocks(
         if (payloadDA === undefined) {
           throw new Error(`Missing payload DA status for slot ${slot}`);
         }
-        importingPayload = payloadInput;
         await importExecutionPayload.call(this, payloadInput, payloadDA, {validSignature: false});
-        importingPayload = undefined;
       }
 
       await nextEventLoop();
@@ -179,7 +175,7 @@ export async function processBlocks(
       if (!opts.disableOnBlockError) {
         this.logger.debug(
           "Payload error",
-          {slot: importingPayload?.slot ?? null, blockRoot: importingPayload?.blockRootHex ?? null},
+          {slot: err.payloadInput.slot, blockRoot: err.payloadInput.blockRootHex},
           err
         );
       }

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -8,7 +8,7 @@ import {BlockError, BlockErrorCode, isBlockErrorAborted} from "../errors/index.j
 import {BlockProcessOpts} from "../options.js";
 import {IBlockInput} from "./blockInput/types.js";
 import {importBlock} from "./importBlock.js";
-import {importExecutionPayload} from "./importExecutionPayload.js";
+import {PayloadError, importExecutionPayload} from "./importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {FullyVerifiedBlock, ImportBlockOpts} from "./types.js";
 import {assertLinearChainSegment} from "./utils/chainSegment.js";
@@ -63,6 +63,8 @@ export async function processBlocks(
   if (blocks.length === 0) {
     return; // TODO: or throw?
   }
+
+  let importingPayload: PayloadEnvelopeInput | undefined;
 
   try {
     const {relevantBlocks, parentSlots, parentBlock} = verifyBlocksSanityChecks(this, blocks, payloadEnvelopes, opts);
@@ -154,7 +156,9 @@ export async function processBlocks(
         if (payloadDA === undefined) {
           throw new Error(`Missing payload DA status for slot ${slot}`);
         }
+        importingPayload = payloadInput;
         await importExecutionPayload.call(this, payloadInput, payloadDA, {validSignature: false});
+        importingPayload = undefined;
       }
 
       await nextEventLoop();
@@ -164,13 +168,21 @@ export async function processBlocks(
       return; // Ignore
     }
 
-    // above functions should only throw BlockError
-    const err = getBlockError(e, blocks[0].getBlock());
+    // above functions should only throw BlockError, or PayloadError from the gloas payload import
+    const err = getBlockOrPayloadError(e, blocks[0].getBlock());
 
     // TODO: De-duplicate with logic above
     // ChainEvent.errorBlock
-    if (!(err instanceof BlockError)) {
+    if (!(err instanceof BlockError) && !(err instanceof PayloadError)) {
       this.logger.debug("Non BlockError received", {}, err);
+    } else if (err instanceof PayloadError) {
+      if (!opts.disableOnBlockError) {
+        this.logger.debug(
+          "Payload error",
+          {slot: importingPayload?.slot ?? null, blockRoot: importingPayload?.blockRootHex ?? null},
+          err
+        );
+      }
     } else if (!opts.disableOnBlockError) {
       this.logger.debug("Block error", {slot: err.signedBlock.message.slot}, err);
 
@@ -201,8 +213,14 @@ export async function processBlocks(
   }
 }
 
-function getBlockError(e: unknown, block: SignedBeaconBlock): BlockError {
+function getBlockOrPayloadError(e: unknown, block: SignedBeaconBlock): BlockError | PayloadError {
   if (e instanceof BlockError) {
+    return e;
+  }
+
+  // Pass PayloadError through UNWRAPPED instead of flattening into BEACON_CHAIN_ERROR, which would lose
+  // the INVALID/ERROR distinction and the correct slot. Range sync's routeProcessingFailure reads its code.
+  if (e instanceof PayloadError) {
     return e;
   }
 

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -174,7 +174,7 @@ export async function processBlocks(
     // TODO: De-duplicate with logic above
     // ChainEvent.errorBlock
     if (!(err instanceof BlockError) && !(err instanceof PayloadError)) {
-      this.logger.debug("Non BlockError received", {}, err);
+      this.logger.debug("Neither BlockError nor PayloadError received", {}, err);
     } else if (err instanceof PayloadError) {
       if (!opts.disableOnBlockError) {
         this.logger.debug(
@@ -218,8 +218,6 @@ function getBlockOrPayloadError(e: unknown, block: SignedBeaconBlock): BlockErro
     return e;
   }
 
-  // Pass PayloadError through UNWRAPPED instead of flattening into BEACON_CHAIN_ERROR, which would lose
-  // the INVALID/ERROR distinction and the correct slot. Range sync's routeProcessingFailure reads its code.
   if (e instanceof PayloadError) {
     return e;
   }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -44,22 +44,31 @@ export async function verifyBlocksStateTransitionOnly(
     // STFN - per_slot_processing() + per_block_processing()
     // NOTE: `regen.getPreState()` should have dialed forward the state already caching checkpoint states
     const useBlsBatchVerify = !opts?.disableBlsBatchVerify;
-    const postState = preState.stateTransition(
-      block,
-      {
-        // NOTE: Assume valid for now while sending payload to execution engine in parallel
-        // Latter verifyBlocksInEpoch() will make sure that payload is indeed valid
-        executionPayloadStatus: ExecutionPayloadStatus.valid,
-        dataAvailabilityStatus,
-        // false because it's verified below with better error typing
-        verifyStateRoot: false,
-        // if block is trusted don't verify proposer or op signature
-        verifyProposer: !useBlsBatchVerify && !validSignatures && !validProposerSignature,
-        verifySignatures: !useBlsBatchVerify && !validSignatures,
-        dontTransferCache: false,
-      },
-      {metrics, validatorMonitor}
-    );
+    let postState: IBeaconStateView;
+    try {
+      postState = preState.stateTransition(
+        block,
+        {
+          // NOTE: Assume valid for now while sending payload to execution engine in parallel
+          // Latter verifyBlocksInEpoch() will make sure that payload is indeed valid
+          executionPayloadStatus: ExecutionPayloadStatus.valid,
+          dataAvailabilityStatus,
+          // false because it's verified below with better error typing
+          verifyStateRoot: false,
+          // if block is trusted don't verify proposer or op signature
+          verifyProposer: !useBlsBatchVerify && !validSignatures && !validProposerSignature,
+          verifySignatures: !useBlsBatchVerify && !validSignatures,
+          dontTransferCache: false,
+        },
+        {metrics, validatorMonitor}
+      );
+    } catch (e) {
+      throw new BlockError(block, {
+        code: BlockErrorCode.PER_BLOCK_PROCESSING_ERROR,
+        blockRoot: blocks[i].blockRootHex,
+        error: e as Error,
+      });
+    }
 
     const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
       source: StateHashTreeRootSource.blockTransition,

--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -136,7 +136,7 @@ export type BlockErrorType =
   | {code: BlockErrorCode.NON_LINEAR_PARENT_ROOTS}
   | {code: BlockErrorCode.NON_LINEAR_SLOTS}
   | {code: BlockErrorCode.ENVELOPE_BLOCK_ROOT_MISMATCH; envelopeBlockRoot: RootHex; blockRoot: RootHex}
-  | {code: BlockErrorCode.PER_BLOCK_PROCESSING_ERROR; error: Error}
+  | {code: BlockErrorCode.PER_BLOCK_PROCESSING_ERROR; blockRoot: RootHex; error: Error}
   | {code: BlockErrorCode.BEACON_CHAIN_ERROR; error: Error}
   | {code: BlockErrorCode.KNOWN_BAD_BLOCK}
   | {code: BlockErrorCode.BLACKLISTED_BLOCK}

--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -184,10 +184,16 @@ export function isBlockErrorAborted(e: unknown): e is BlockError {
 export function renderBlockErrorType(type: BlockErrorType): Record<string, string | number | null> {
   switch (type.code) {
     case BlockErrorCode.PRESTATE_MISSING:
-    case BlockErrorCode.PER_BLOCK_PROCESSING_ERROR:
     case BlockErrorCode.BEACON_CHAIN_ERROR:
       return {
         code: type.code,
+        error: type.error.message,
+      };
+
+    case BlockErrorCode.PER_BLOCK_PROCESSING_ERROR:
+      return {
+        code: type.code,
+        blockRoot: type.blockRoot,
         error: type.error.message,
       };
 

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -39,11 +39,22 @@ export enum BatchStatus {
   AwaitingValidation = "AwaitingValidation",
 }
 
+/** Identity of one download attempt*/
 export type Attempt = {
   /** The peer that made the attempt */
   peers: PeerIdStr[];
   /** The hash of the blocks of the attempt */
   hash: RootHex;
+};
+
+/**
+ * A failed attempt that has been classified for blame.
+ */
+export type FailedAttempt = Attempt & {
+  /**
+   * True when the failure is evidence the peers served bad data, so they may be downscored..
+   */
+  peerAttributable: boolean;
 };
 
 type TrackedRequest = {
@@ -108,10 +119,12 @@ export type BatchMetadata = {
   // Retry counters
   downloadAttempts: number;
   processingAttempts: number;
+  executionErrorAttempts: number;
 
   // Cumulative peer attribution for failed attempts (only present when non-empty)
   failedDownloadPeers?: string;
   failedProcessingPeers?: string;
+  executionErrorPeers?: string;
 };
 
 function formatRangeReq(req: {startSlot: Slot; count: number}): string {
@@ -152,10 +165,10 @@ export class Batch {
   state: BatchState = {status: BatchStatus.AwaitingDownload, blocks: [], payloadEnvelopes: null};
   /** Peers that provided good data, with column coverage for by_range requests */
   private readonly successfulDownloads = new Map<PeerIdStr, TrackedRequest>();
-  /** The `Attempts` that have been made and failed to send us this batch. */
-  readonly failedProcessingAttempts: Attempt[] = [];
-  /** The `Attempts` that have been made and failed because of execution malfunction. */
-  readonly executionErrorAttempts: Attempt[] = [];
+  /** The attempts that have been made and failed to send us this batch. */
+  readonly failedProcessingAttempts: FailedAttempt[] = [];
+  /** The attempts that have been made and failed because of execution malfunction. */
+  readonly executionErrorAttempts: FailedAttempt[] = [];
   /** The number of download retries this batch has undergone due to a failed request. */
   private readonly failedDownloadAttempts: PeerIdStr[] = [];
   private readonly config: ChainForkConfig;
@@ -419,10 +432,18 @@ export class Batch {
   }
 
   /**
-   * Gives a list of peers from which this batch has had a failed download or processing attempt.
+   * Gives a list of peers from which this batch has had a failed download attempt, or a
+   * peer-attributable failed processing/execution attempt.
    */
   getFailedPeers(): PeerIdStr[] {
-    return [...this.failedDownloadAttempts, ...this.failedProcessingAttempts.flatMap((a) => a.peers)];
+    return [...this.failedDownloadAttempts, ...this.getPeerAttributableAttempts().flatMap((a) => a.peers)];
+  }
+
+  /**
+   * Attempts whose failure is peer-attributable, across both the processing and execution error
+   */
+  getPeerAttributableAttempts(): FailedAttempt[] {
+    return [...this.failedProcessingAttempts, ...this.executionErrorAttempts].filter((a) => a.peerAttributable);
   }
 
   /**
@@ -457,6 +478,7 @@ export class Batch {
   getMetadata(): BatchMetadata {
     const {blocksRequest, blobsRequest, columnsRequest, envelopesRequest} = this.requests;
     const failedProcessingPeerList = this.failedProcessingAttempts.flatMap((a) => a.peers);
+    const executionErrorPeerList = this.executionErrorAttempts.flatMap((a) => a.peers);
     return {
       startEpoch: this.startEpoch,
       startSlot: this.startSlot,
@@ -468,11 +490,15 @@ export class Batch {
       ...(envelopesRequest && {envelopesReq: formatRangeReq(envelopesRequest)}),
       downloadAttempts: this.failedDownloadAttempts.length,
       processingAttempts: this.failedProcessingAttempts.length,
+      executionErrorAttempts: this.executionErrorAttempts.length,
       ...(this.failedDownloadAttempts.length > 0 && {
         failedDownloadPeers: this.failedDownloadAttempts.join(","),
       }),
       ...(failedProcessingPeerList.length > 0 && {
         failedProcessingPeers: failedProcessingPeerList.join(","),
+      }),
+      ...(executionErrorPeerList.length > 0 && {
+        executionErrorPeers: executionErrorPeerList.join(","),
       }),
     };
   }
@@ -703,11 +729,7 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.Processing));
     }
 
-    if (isExecutionEngineError(err)) {
-      this.onExecutionEngineError(this.state.attempt);
-    } else {
-      this.onProcessingError(this.state.attempt);
-    }
+    this.routeProcessingFailure(err, this.state.attempt);
   }
 
   /**
@@ -718,10 +740,17 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.AwaitingValidation));
     }
 
-    if (isExecutionEngineError(err)) {
-      this.onExecutionEngineError(this.state.attempt);
+    this.routeProcessingFailure(err, this.state.attempt);
+  }
+
+  private routeProcessingFailure(err: Error, attempt: Attempt): void {
+    const code = err instanceof BlockError || err instanceof PayloadError ? err.type.code : null;
+    const failedAttempt: FailedAttempt = {...attempt, peerAttributable: isPeerAttributableFailure(code)};
+
+    if (isExecutionEngineFailure(code)) {
+      this.onExecutionEngineError(failedAttempt);
     } else {
-      this.onProcessingError(this.state.attempt);
+      this.onProcessingError(failedAttempt);
     }
   }
 
@@ -735,7 +764,7 @@ export class Batch {
     return this.state.attempt;
   }
 
-  private onExecutionEngineError(attempt: Attempt): void {
+  private onExecutionEngineError(attempt: FailedAttempt): void {
     this.executionErrorAttempts.push(attempt);
     if (this.executionErrorAttempts.length > MAX_BATCH_PROCESSING_ATTEMPTS) {
       throw new BatchError(this.errorType({code: BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS}));
@@ -746,7 +775,7 @@ export class Batch {
     this.state = {status: BatchStatus.AwaitingDownload, blocks: [], payloadEnvelopes: null};
   }
 
-  private onProcessingError(attempt: Attempt): void {
+  private onProcessingError(attempt: FailedAttempt): void {
     this.failedProcessingAttempts.push(attempt);
     if (this.failedProcessingAttempts.length > MAX_BATCH_PROCESSING_ATTEMPTS) {
       throw new BatchError(this.errorType({code: BatchErrorCode.MAX_PROCESSING_ATTEMPTS}));
@@ -789,18 +818,44 @@ type BatchErrorMetadata = {
 
 export class BatchError extends LodestarError<BatchErrorType & BatchErrorMetadata> {}
 
-function isExecutionEngineError(err: Error): boolean {
-  if (!(err instanceof BlockError)) {
-    return false;
-  }
-
-  if (err.type.code === BlockErrorCode.EXECUTION_ENGINE_ERROR) {
-    return true;
-  }
-
+/**
+ * Whether a processing failure is an execution-engine failure. INVALID and local ERROR share one
+ * retry budget (executionErrorAttempts) — the remedy is the same, re-download from another peer —
+ * so this only selects the bucket, not blame. Everything else is a plain processing failure.
+ */
+function isExecutionEngineFailure(code: BlockErrorCode | PayloadErrorCode | null): boolean {
   return (
-    err.type.code === BlockErrorCode.BEACON_CHAIN_ERROR &&
-    err.type.error instanceof PayloadError &&
-    err.type.error.type.code === PayloadErrorCode.EXECUTION_ENGINE_ERROR
+    code === BlockErrorCode.EXECUTION_ENGINE_INVALID ||
+    code === BlockErrorCode.EXECUTION_ENGINE_ERROR ||
+    code === PayloadErrorCode.EXECUTION_ENGINE_INVALID ||
+    code === PayloadErrorCode.EXECUTION_ENGINE_ERROR
   );
+}
+
+/**
+ * Based on an error code, return if peer is attributable for FailedAttempt.
+ */
+function isPeerAttributableFailure(code: BlockErrorCode | PayloadErrorCode | null): boolean {
+  switch (code) {
+    // EL returned a definitive INVALID verdict on the payload
+    case BlockErrorCode.EXECUTION_ENGINE_INVALID:
+    case PayloadErrorCode.EXECUTION_ENGINE_INVALID:
+    // a block or envelope signature is invalid
+    case BlockErrorCode.INVALID_SIGNATURE:
+    case PayloadErrorCode.INVALID_SIGNATURE:
+    // the block's state transition produced an invalid state root
+    case BlockErrorCode.INVALID_STATE_ROOT:
+    // the segment this peer served is internally inconsistent (in-segment link breaks, see PR #9684)
+    case BlockErrorCode.NON_LINEAR_SLOTS:
+    case BlockErrorCode.NON_LINEAR_PARENT_ROOTS:
+    case BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS:
+    // the envelope references a mismatched block root, or fails field verification
+    case BlockErrorCode.ENVELOPE_BLOCK_ROOT_MISMATCH:
+    case PayloadErrorCode.ENVELOPE_VERIFICATION_ERROR:
+    // the peer served a block we have explicitly blacklisted
+    case BlockErrorCode.BLACKLISTED_BLOCK:
+      return true;
+    default:
+      return false;
+  }
 }

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -842,8 +842,9 @@ function isPeerAttributableFailure(code: BlockErrorCode | PayloadErrorCode | nul
     // a block or envelope signature is invalid
     case BlockErrorCode.INVALID_SIGNATURE:
     case PayloadErrorCode.INVALID_SIGNATURE:
-    // the block's state transition produced an invalid state root
+    // the block's state transition produced an invalid state root, or failed per_slot/per_block processing
     case BlockErrorCode.INVALID_STATE_ROOT:
+    case BlockErrorCode.PER_BLOCK_PROCESSING_ERROR:
     // the segment this peer served is internally inconsistent (in-segment link breaks, see PR #9684)
     case BlockErrorCode.NON_LINEAR_SLOTS:
     case BlockErrorCode.NON_LINEAR_PARENT_ROOTS:

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -819,9 +819,8 @@ type BatchErrorMetadata = {
 export class BatchError extends LodestarError<BatchErrorType & BatchErrorMetadata> {}
 
 /**
- * Whether a processing failure is an execution-engine failure. INVALID and local ERROR share one
- * retry budget (executionErrorAttempts) — the remedy is the same, re-download from another peer —
- * so this only selects the bucket, not blame. Everything else is a plain processing failure.
+ * Whether a processing failure is an execution-engine failure. Pre-gloas, all EL errors stay in
+ * BlockErrorCode, post-gloas, they stay in PayloadErrorCode.
  */
 function isExecutionEngineFailure(code: BlockErrorCode | PayloadErrorCode | null): boolean {
   return (

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -358,9 +358,10 @@ export class SyncChain {
       // If a batch exceeds it's retry limit, maybe downscore peers.
       // shouldDownscoreOnBatchError() functions enforces that all BatchErrorCode values are covered
       if (e instanceof BatchError) {
-        const shouldReportPeer = shouldReportPeerOnBatchError(e.type.code);
+        const shouldReportPeer = shouldReportPeerOnBatchError(e.type.code, this.batches.get(e.type.startEpoch));
         if (shouldReportPeer) {
-          for (const peer of this.peerset.keys()) {
+          // Only the peers actually at fault are reported, never the whole peerset.
+          for (const peer of shouldReportPeer.peers) {
             this.reportPeer(peer, shouldReportPeer.action, shouldReportPeer.reason);
           }
         }
@@ -768,7 +769,7 @@ export class SyncChain {
 
         // The last batch attempt is right, all others are wrong. Penalize other peers
         const attemptOk = batch.validationSuccess();
-        for (const attempt of batch.failedProcessingAttempts) {
+        for (const attempt of batch.getPeerAttributableAttempts()) {
           if (attempt.hash !== attemptOk.hash) {
             for (const badAttemptPeer of attempt.peers) {
               if (attemptOk.peers.find((goodPeer) => goodPeer === badAttemptPeer)) {
@@ -830,21 +831,29 @@ export class SyncChain {
  * If peer should not be downscored, returns null.
  */
 export function shouldReportPeerOnBatchError(
-  code: BatchErrorCode
-): {action: PeerAction.LowToleranceError; reason: string} | null {
+  code: BatchErrorCode,
+  batch: Batch | undefined
+): {action: PeerAction.LowToleranceError; reason: string; peers: PeerIdStr[]} | null {
   switch (code) {
-    // A batch could not be processed after max retry limit. It's likely that all peers
-    // in this chain are sending invalid batches repeatedly so are either malicious or faulty.
-    // We drop the chain and report all peers.
-    // There are some edge cases with forks that could cause this situation, but it's unlikely.
+    //  A batch could not be processed after max retry limit. Report
+    // only the peers that served a peer-attributable failed attempt.
     case BatchErrorCode.MAX_PROCESSING_ATTEMPTS:
-      return {action: PeerAction.LowToleranceError, reason: "SyncChainMaxProcessingAttempts"};
+    case BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS: {
+      const peers = [...new Set(batch?.getPeerAttributableAttempts().flatMap((attempt) => attempt.peers) ?? [])];
+      if (peers.length === 0) {
+        return null;
+      }
+      const reason =
+        code === BatchErrorCode.MAX_PROCESSING_ATTEMPTS
+          ? "SyncChainMaxProcessingAttempts"
+          : "SyncChainMaxExecutionEngineInvalid";
+      return {action: PeerAction.LowToleranceError, reason, peers};
+    }
 
     // TODO: Should peers be reported for MAX_DOWNLOAD_ATTEMPTS?
     case BatchErrorCode.MAX_DOWNLOAD_ATTEMPTS:
     case BatchErrorCode.INVALID_COUNT:
     case BatchErrorCode.WRONG_STATUS:
-    case BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS:
       return null;
   }
 }

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -771,6 +771,9 @@ export class SyncChain {
         const attemptOk = batch.validationSuccess();
         for (const attempt of batch.getPeerAttributableAttempts()) {
           if (attempt.hash !== attemptOk.hash) {
+            // attempt.peers contains block/column/envelope peers.
+            // And if there is one bad envelope we will downscore block and column peers to
+            // TODO: resolve this
             for (const badAttemptPeer of attempt.peers) {
               if (attemptOk.peers.find((goodPeer) => goodPeer === badAttemptPeer)) {
                 // The same peer corrected its previous attempt
@@ -839,15 +842,18 @@ export function shouldReportPeerOnBatchError(
     // only the peers that served a peer-attributable failed attempt.
     case BatchErrorCode.MAX_PROCESSING_ATTEMPTS:
     case BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS: {
-      const peers = [...new Set(batch?.getPeerAttributableAttempts().flatMap((attempt) => attempt.peers) ?? [])];
-      if (peers.length === 0) {
+      // penalize both the processing-error and execution-error peers
+      const attributablePeers = [
+        ...new Set(batch?.getPeerAttributableAttempts().flatMap((attempt) => attempt.peers) ?? []),
+      ];
+      if (attributablePeers.length === 0) {
         return null;
       }
       const reason =
         code === BatchErrorCode.MAX_PROCESSING_ATTEMPTS
           ? "SyncChainMaxProcessingAttempts"
-          : "SyncChainMaxExecutionEngineInvalid";
-      return {action: PeerAction.LowToleranceError, reason, peers};
+          : "SyncChainMaxExecutionEngineErrorAttempts";
+      return {action: PeerAction.LowToleranceError, reason, peers: attributablePeers};
     }
 
     // TODO: Should peers be reported for MAX_DOWNLOAD_ATTEMPTS?

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -7,6 +7,7 @@ import {DataAvailabilityStatus, IBeaconStateView} from "@lodestar/state-transiti
 import {ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {importBlock} from "../../../../src/chain/blocks/importBlock.js";
+import {PayloadError, PayloadErrorCode} from "../../../../src/chain/blocks/importExecutionPayload.js";
 import {processBlocks} from "../../../../src/chain/blocks/index.js";
 import {assertLinearChainSegment} from "../../../../src/chain/blocks/utils/chainSegment.js";
 import {verifyBlocksInEpoch} from "../../../../src/chain/blocks/verifyBlock.js";
@@ -117,5 +118,34 @@ describe("chain / blocks / processBlocks", () => {
 
     expect(seenBlockProposers.isKnown(slot, proposerIndex)).toBe(true);
     expect(importBlock).toHaveBeenCalledOnce();
+  });
+
+  // The gloas payload import throws a PayloadError. Range sync relies on it arriving intact so it can
+  // read the INVALID/ERROR code and decide peer attribution — getBlockOrPayloadError must pass it
+  // through, not flatten it into a generic BEACON_CHAIN_ERROR. (The origin is mocked here; what matters
+  // is that a PayloadError raised anywhere in the pipeline is re-thrown unwrapped.)
+  it("re-throws a PayloadError unwrapped, without flattening it into BEACON_CHAIN_ERROR", async () => {
+    const payloadError = new PayloadError({
+      code: PayloadErrorCode.EXECUTION_ENGINE_INVALID,
+      execStatus: ExecutionPayloadStatus.INVALID,
+      errorMessage: "bad payload",
+    });
+    vi.mocked(verifyBlocksInEpoch).mockRejectedValue(payloadError);
+
+    await expect(processBlocks.call(chain, [blockInput], null, {})).rejects.toBe(payloadError);
+  });
+
+  // Contrast: a plain error (not a Block/Payload error) IS wrapped, which is why the passthrough above
+  // has to be selective.
+  it("wraps a non-Block/Payload error into BEACON_CHAIN_ERROR", async () => {
+    const internalError = new Error("regen boom");
+    vi.mocked(verifyBlocksInEpoch).mockRejectedValue(internalError);
+
+    const err = await processBlocks.call(chain, [blockInput], null, {}).then(
+      () => null,
+      (e) => e
+    );
+    expect(err).toBeInstanceOf(BlockError);
+    expect((err as BlockError).type.code).toBe(BlockErrorCode.BEACON_CHAIN_ERROR);
   });
 });

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -9,6 +9,7 @@ import {toRootHex} from "@lodestar/utils";
 import {importBlock} from "../../../../src/chain/blocks/importBlock.js";
 import {PayloadError, PayloadErrorCode} from "../../../../src/chain/blocks/importExecutionPayload.js";
 import {processBlocks} from "../../../../src/chain/blocks/index.js";
+import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {assertLinearChainSegment} from "../../../../src/chain/blocks/utils/chainSegment.js";
 import {verifyBlocksInEpoch} from "../../../../src/chain/blocks/verifyBlock.js";
 import {verifyBlocksSanityChecks} from "../../../../src/chain/blocks/verifyBlocksSanityChecks.js";
@@ -125,7 +126,8 @@ describe("chain / blocks / processBlocks", () => {
   // through, not flatten it into a generic BEACON_CHAIN_ERROR. (The origin is mocked here; what matters
   // is that a PayloadError raised anywhere in the pipeline is re-thrown unwrapped.)
   it("re-throws a PayloadError unwrapped, without flattening it into BEACON_CHAIN_ERROR", async () => {
-    const payloadError = new PayloadError({
+    const payloadInput = {slot: 1, blockRootHex: "0x1234"} as unknown as PayloadEnvelopeInput;
+    const payloadError = new PayloadError(payloadInput, {
       code: PayloadErrorCode.EXECUTION_ENGINE_INVALID,
       execStatus: ExecutionPayloadStatus.INVALID,
       errorMessage: "bad payload",

--- a/packages/beacon-node/test/unit/chain/blocks/verifyBlocksStateTransitionOnly.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyBlocksStateTransitionOnly.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from "vitest";
+import {testLogger} from "@lodestar/logger/test-utils";
+import {ForkName} from "@lodestar/params";
+import {DataAvailabilityStatus, IBeaconStateView} from "@lodestar/state-transition";
+import {ssz} from "@lodestar/types";
+import {verifyBlocksStateTransitionOnly} from "../../../../src/chain/blocks/verifyBlocksStateTransitionOnly.js";
+import {BlockError, BlockErrorCode} from "../../../../src/chain/errors/index.js";
+import {MockBlockInput} from "../../../utils/blockInput.js";
+
+describe("chain / blocks / verifyBlocksStateTransitionOnly", () => {
+  // A block with an invalid deposit/attestation/operation makes preState.stateTransition() throw a
+  // plain Error. It must surface as a specific, peer-attributable PER_BLOCK_PROCESSING_ERROR (carrying
+  // the block root) rather than a generic BEACON_CHAIN_ERROR — otherwise range sync never blames the
+  // peer that served the invalid block.
+  it("wraps a state-transition failure as PER_BLOCK_PROCESSING_ERROR with the block root", async () => {
+    const blockRootHex = "0x1234";
+    const preState = {
+      stateTransition: () => {
+        throw new Error("invalid attestation");
+      },
+    } as unknown as IBeaconStateView;
+
+    const blockInput = new MockBlockInput({forkName: ForkName.deneb, slot: 1, blockRootHex});
+    blockInput._block = ssz.deneb.SignedBeaconBlock.defaultValue();
+
+    const err = await verifyBlocksStateTransitionOnly(
+      preState,
+      [blockInput],
+      [DataAvailabilityStatus.Available],
+      testLogger(),
+      null,
+      null,
+      new AbortController().signal,
+      {}
+    ).then(
+      () => null,
+      (e) => e
+    );
+
+    expect(err).toBeInstanceOf(BlockError);
+    const {type} = err as BlockError;
+    expect(type.code).toBe(BlockErrorCode.PER_BLOCK_PROCESSING_ERROR);
+    if (type.code === BlockErrorCode.PER_BLOCK_PROCESSING_ERROR) {
+      expect(type.blockRoot).toBe(blockRootHex);
+      expect(type.error.message).toBe("invalid attestation");
+    }
+  });
+});

--- a/packages/beacon-node/test/unit/chain/errors/blockError.test.ts
+++ b/packages/beacon-node/test/unit/chain/errors/blockError.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, it} from "vitest";
+import {BlockErrorCode, renderBlockErrorType} from "../../../../src/chain/errors/blockError.js";
+
+describe("chain / errors / renderBlockErrorType", () => {
+  // Guards against re-lumping PER_BLOCK_PROCESSING_ERROR back with the {code, error}-only cases, which
+  // would silently drop the blockRoot from logs.
+  it("includes blockRoot for PER_BLOCK_PROCESSING_ERROR", () => {
+    const metadata = renderBlockErrorType({
+      code: BlockErrorCode.PER_BLOCK_PROCESSING_ERROR,
+      blockRoot: "0x1234",
+      error: new Error("invalid attestation"),
+    });
+
+    expect(metadata).toEqual({
+      code: BlockErrorCode.PER_BLOCK_PROCESSING_ERROR,
+      blockRoot: "0x1234",
+      error: "invalid attestation",
+    });
+  });
+});

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -15,7 +15,6 @@ import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEn
 import {BlockError, BlockErrorCode} from "../../../../src/chain/errors/index.js";
 import {ExecutionPayloadStatus} from "../../../../src/execution/index.js";
 import {computeNodeIdFromPrivateKey} from "../../../../src/network/subnets/index.js";
-import {MAX_BATCH_PROCESSING_ATTEMPTS} from "../../../../src/sync/constants.js";
 import {Batch, BatchError, BatchErrorCode, BatchStatus} from "../../../../src/sync/range/batch.js";
 import {getBatchSlotRange} from "../../../../src/sync/range/utils/index.js";
 import {CustodyConfig} from "../../../../src/util/dataColumns.js";
@@ -623,50 +622,301 @@ describe("sync / range / batch", async () => {
     );
   });
 
-  describe("processingError", () => {
+  describe("processing failure routing", () => {
     const startEpoch = 0;
 
-    it("treats wrapped payload execution engine errors as local execution failures", () => {
-      const batch = batchInProcessing(startEpoch);
-      const error = new BlockError(ssz.phase0.SignedBeaconBlock.defaultValue(), {
-        code: BlockErrorCode.BEACON_CHAIN_ERROR,
-        error: new PayloadError({
-          code: PayloadErrorCode.EXECUTION_ENGINE_ERROR,
-          execStatus: ExecutionPayloadStatus.ELERROR,
-          errorMessage: "execution engine unavailable",
-        }),
+    function downloadedBatch(): Batch {
+      const batch = new Batch(startEpoch, config, clock, custodyConfig, false, undefined, Number.MAX_SAFE_INTEGER);
+      batch.startDownloading(peerSyncMeta);
+      batch.downloadingSuccess(
+        peer,
+        [
+          BlockInputPreData.createFromBlock({
+            block: ssz.capella.SignedBeaconBlock.defaultValue(),
+            blockRootHex: "0x1234",
+            source: BlockInputSource.byRoot,
+            seenTimestampSec: Date.now() / 1000,
+            forkName: ForkName.capella,
+            daOutOfRange: false,
+          }),
+        ],
+        null
+      );
+      return batch;
+    }
+
+    function blockError(type: ConstructorParameters<typeof BlockError>[1]): BlockError {
+      return new BlockError(ssz.phase0.SignedBeaconBlock.defaultValue(), type);
+    }
+
+    const executionInvalidBlockError = (): BlockError =>
+      blockError({
+        code: BlockErrorCode.EXECUTION_ENGINE_INVALID,
+        execStatus: ExecutionPayloadStatus.INVALID,
+        errorMessage: "bal is empty",
       });
 
-      for (let i = 0; i < MAX_BATCH_PROCESSING_ATTEMPTS; i++) {
-        const attempt = i + 1;
+    type ExecutionEngineErrorStatus =
+      | ExecutionPayloadStatus.ELERROR
+      | ExecutionPayloadStatus.UNAVAILABLE
+      | ExecutionPayloadStatus.INVALID_BLOCK_HASH;
 
-        batch.processingError(error);
+    const executionErrorBlockError = (execStatus: ExecutionEngineErrorStatus): BlockError =>
+      blockError({code: BlockErrorCode.EXECUTION_ENGINE_ERROR, execStatus, errorMessage: "el is down"});
 
-        expect(batch.state.status, `attempt ${attempt}: batch should await redownload`).toBe(
-          BatchStatus.AwaitingDownload
-        );
-        expect(
-          batch.failedProcessingAttempts,
-          `attempt ${attempt}: local execution errors should not count as peer-attributable failures`
-        ).toHaveLength(0);
-        expect(
-          batch.executionErrorAttempts,
-          `attempt ${attempt}: local execution errors should be tracked`
-        ).toHaveLength(attempt);
+    describe("processingError", () => {
+      const executionEngineErrorStatuses: ExecutionEngineErrorStatus[] = [
+        ExecutionPayloadStatus.ELERROR,
+        ExecutionPayloadStatus.UNAVAILABLE,
+        ExecutionPayloadStatus.INVALID_BLOCK_HASH,
+      ];
 
-        downloadBlock(batch);
+      it.each(executionEngineErrorStatuses)(
+        "EXECUTION_ENGINE_ERROR (%s) => executionErrorAttempts, not peer attributable",
+        (execStatus) => {
+          const batch = downloadedBatch();
+          batch.startProcessing();
+          batch.processingError(executionErrorBlockError(execStatus));
+
+          expect(batch.failedProcessingAttempts.length).toBe(0);
+          expect(batch.executionErrorAttempts.length).toBe(1);
+          expect(batch.executionErrorAttempts[0].peerAttributable).toBe(false);
+          expect(batch.getPeerAttributableAttempts()).toEqual([]);
+          expect(batch.state.status).toBe(BatchStatus.AwaitingDownload);
+        }
+      );
+
+      it("EXECUTION_ENGINE_INVALID => executionErrorAttempts, peer attributable", () => {
+        const batch = downloadedBatch();
         batch.startProcessing();
+        batch.processingError(executionInvalidBlockError());
+
+        // shares the EL budget rather than the processing budget
+        expect(batch.failedProcessingAttempts.length).toBe(0);
+        expect(batch.executionErrorAttempts.length).toBe(1);
+        expect(batch.executionErrorAttempts[0].peerAttributable).toBe(true);
+        expect(batch.getPeerAttributableAttempts().flatMap((a) => a.peers)).toEqual([peer]);
+      });
+
+      // Under this PR, processBlocks passes PayloadError through UNWRAPPED, so range sync sees it
+      // directly (no BEACON_CHAIN_ERROR wrapper). A local EL ERROR must not be peer-attributable.
+      it("PayloadError EXECUTION_ENGINE_ERROR => executionErrorAttempts, not peer attributable", () => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(
+          new PayloadError({
+            code: PayloadErrorCode.EXECUTION_ENGINE_ERROR,
+            execStatus: ExecutionPayloadStatus.ELERROR,
+            errorMessage: "el is down",
+          })
+        );
+
+        expect(batch.failedProcessingAttempts.length).toBe(0);
+        expect(batch.executionErrorAttempts.length).toBe(1);
+        expect(batch.executionErrorAttempts[0].peerAttributable).toBe(false);
+      });
+
+      it("PayloadError EXECUTION_ENGINE_INVALID => executionErrorAttempts, peer attributable", () => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(
+          new PayloadError({
+            code: PayloadErrorCode.EXECUTION_ENGINE_INVALID,
+            execStatus: ExecutionPayloadStatus.INVALID,
+            errorMessage: "bal is empty",
+          })
+        );
+
+        expect(batch.executionErrorAttempts.length).toBe(1);
+        expect(batch.executionErrorAttempts[0].peerAttributable).toBe(true);
+      });
+
+      it("non execution error => failedProcessingAttempts, peer attributable", () => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(blockError({code: BlockErrorCode.NON_LINEAR_SLOTS}));
+
+        expect(batch.executionErrorAttempts.length).toBe(0);
+        expect(batch.failedProcessingAttempts.length).toBe(1);
+        expect(batch.failedProcessingAttempts[0].peerAttributable).toBe(true);
+        expect(batch.getFailedPeers()).toContain(peer);
+      });
+
+      it("BEACON_CHAIN_ERROR (our internal fault) => failedProcessingAttempts, NOT peer attributable", () => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(blockError({code: BlockErrorCode.BEACON_CHAIN_ERROR, error: new Error("regen boom")}));
+
+        // still counts toward the processing retry budget, but blaming a peer for our own bug would
+        // risk self-isolation, so it must not be peer-attributable
+        expect(batch.failedProcessingAttempts.length).toBe(1);
+        expect(batch.failedProcessingAttempts[0].peerAttributable).toBe(false);
+        expect(batch.getPeerAttributableAttempts()).toEqual([]);
+        expect(batch.getFailedPeers()).not.toContain(peer);
+      });
+
+      it("PARENT_BLOCK_UNKNOWN (segment-boundary gap) => failedProcessingAttempts, NOT peer attributable", () => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(blockError({code: BlockErrorCode.PARENT_BLOCK_UNKNOWN, parentRoot: "0x1234"}));
+
+        // a missing parent at a segment boundary implicates a previous batch / a gap / a reorg, not
+        // the peer that served this batch — so it must not be peer-attributable
+        expect(batch.failedProcessingAttempts.length).toBe(1);
+        expect(batch.failedProcessingAttempts[0].peerAttributable).toBe(false);
+        expect(batch.getPeerAttributableAttempts()).toEqual([]);
+        expect(batch.getFailedPeers()).not.toContain(peer);
+      });
+
+      it("PayloadError BLOCK_NOT_IN_FORK_CHOICE (local precondition) => failedProcessingAttempts, NOT peer attributable", () => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(
+          new PayloadError({code: PayloadErrorCode.BLOCK_NOT_IN_FORK_CHOICE, blockRootHex: "0x1234"})
+        );
+
+        expect(batch.failedProcessingAttempts.length).toBe(1);
+        expect(batch.failedProcessingAttempts[0].peerAttributable).toBe(false);
+        expect(batch.getPeerAttributableAttempts()).toEqual([]);
+        expect(batch.getFailedPeers()).not.toContain(peer);
+      });
+
+      it("PayloadError MISS_BLOCK_STATE (local precondition) => failedProcessingAttempts, NOT peer attributable", () => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(new PayloadError({code: PayloadErrorCode.MISS_BLOCK_STATE, blockRootHex: "0x1234"}));
+
+        expect(batch.failedProcessingAttempts.length).toBe(1);
+        expect(batch.failedProcessingAttempts[0].peerAttributable).toBe(false);
+        expect(batch.getPeerAttributableAttempts()).toEqual([]);
+        expect(batch.getFailedPeers()).not.toContain(peer);
+      });
+
+      it("mixed EL statuses share one budget and trip MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS", () => {
+        const errors = [
+          executionErrorBlockError(ExecutionPayloadStatus.ELERROR),
+          executionInvalidBlockError(),
+          executionErrorBlockError(ExecutionPayloadStatus.UNAVAILABLE),
+        ];
+
+        const batch = downloadedBatch();
+        for (const err of errors) {
+          batch.startProcessing();
+          batch.processingError(err);
+          // re-download so the batch can be processed again
+          batch.startDownloading(peerSyncMeta);
+          batch.downloadingSuccess(
+            peer,
+            [
+              BlockInputPreData.createFromBlock({
+                block: ssz.capella.SignedBeaconBlock.defaultValue(),
+                blockRootHex: "0x1234",
+                source: BlockInputSource.byRoot,
+                seenTimestampSec: Date.now() / 1000,
+                forkName: ForkName.capella,
+                daOutOfRange: false,
+              }),
+            ],
+            null
+          );
+        }
+        expect(batch.executionErrorAttempts.length).toBe(3);
+
+        // the 4th EL failure exceeds MAX_BATCH_PROCESSING_ATTEMPTS
+        batch.startProcessing();
+        expectThrowsLodestarError(
+          () => batch.processingError(executionErrorBlockError(ExecutionPayloadStatus.ELERROR)),
+          new BatchError({
+            code: BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS,
+            startEpoch,
+            status: BatchStatus.Processing,
+          })
+        );
+      });
+    });
+
+    describe("validationError", () => {
+      function batchAwaitingValidation(): Batch {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingSuccess();
+        return batch;
       }
 
-      expectThrowsLodestarError(
-        () => batch.processingError(error),
-        new BatchError({
-          code: BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS,
-          startEpoch,
-          status: BatchStatus.Processing,
+      it("EXECUTION_ENGINE_ERROR => executionErrorAttempts, not peer attributable", () => {
+        const batch = batchAwaitingValidation();
+        batch.validationError(executionErrorBlockError(ExecutionPayloadStatus.ELERROR));
+
+        expect(batch.failedProcessingAttempts.length).toBe(0);
+        expect(batch.executionErrorAttempts.length).toBe(1);
+        expect(batch.executionErrorAttempts[0].peerAttributable).toBe(false);
+        expect(batch.getPeerAttributableAttempts()).toEqual([]);
+      });
+
+      it("EXECUTION_ENGINE_INVALID => executionErrorAttempts, peer attributable", () => {
+        const batch = batchAwaitingValidation();
+        batch.validationError(executionInvalidBlockError());
+
+        expect(batch.executionErrorAttempts.length).toBe(1);
+        expect(batch.executionErrorAttempts[0].peerAttributable).toBe(true);
+        expect(batch.getPeerAttributableAttempts().length).toBe(1);
+      });
+
+      it("PayloadError EXECUTION_ENGINE_ERROR => executionErrorAttempts, not peer attributable", () => {
+        const batch = batchAwaitingValidation();
+        batch.validationError(
+          new PayloadError({
+            code: PayloadErrorCode.EXECUTION_ENGINE_ERROR,
+            execStatus: ExecutionPayloadStatus.UNAVAILABLE,
+            errorMessage: "el is down",
+          })
+        );
+
+        expect(batch.failedProcessingAttempts.length).toBe(0);
+        expect(batch.executionErrorAttempts.length).toBe(1);
+        expect(batch.executionErrorAttempts[0].peerAttributable).toBe(false);
+      });
+
+      it("non execution error => failedProcessingAttempts, peer attributable", () => {
+        const batch = batchAwaitingValidation();
+        batch.validationError(blockError({code: BlockErrorCode.NON_LINEAR_SLOTS}));
+
+        expect(batch.executionErrorAttempts.length).toBe(0);
+        expect(batch.failedProcessingAttempts.length).toBe(1);
+        expect(batch.failedProcessingAttempts[0].peerAttributable).toBe(true);
+      });
+    });
+
+    it("getFailedPeers excludes a peer whose only failure was a local execution engine error", () => {
+      const batch = downloadedBatch();
+      batch.startProcessing();
+      batch.processingError(executionErrorBlockError(ExecutionPayloadStatus.ELERROR));
+
+      // local EL error is blameless => peer stays retryable
+      expect(batch.getFailedPeers()).not.toContain(peer);
+    });
+
+    it("getFailedPeers includes a peer that served a definitively invalid payload (BlockError)", () => {
+      const batch = downloadedBatch();
+      batch.startProcessing();
+      batch.processingError(executionInvalidBlockError());
+
+      // stored in executionErrorAttempts but peer-attributable => must not be retried
+      expect(batch.getFailedPeers()).toContain(peer);
+    });
+
+    it("getFailedPeers includes a peer that served a definitively invalid payload (PayloadError)", () => {
+      const batch = downloadedBatch();
+      batch.startProcessing();
+      batch.processingError(
+        new PayloadError({
+          code: PayloadErrorCode.EXECUTION_ENGINE_INVALID,
+          execStatus: ExecutionPayloadStatus.INVALID,
+          errorMessage: "bal is empty",
         })
       );
-      expect(batch.failedProcessingAttempts).toHaveLength(0);
+
+      expect(batch.getFailedPeers()).toContain(peer);
     });
   });
 
@@ -709,6 +959,25 @@ describe("sync / range / batch", async () => {
 
       expect(batch.failedProcessingAttempts).toHaveLength(1);
       expect(batch.failedProcessingAttempts[0].peers).toEqual([peer]);
+    });
+
+    it("preserves the original peer across retain: an EL INVALID on reprocess is attributable", () => {
+      const batch = batchInProcessing();
+      batch.retainForReprocessing();
+      batch.startProcessing();
+      batch.processingError(
+        new BlockError(ssz.phase0.SignedBeaconBlock.defaultValue(), {
+          code: BlockErrorCode.EXECUTION_ENGINE_INVALID,
+          execStatus: ExecutionPayloadStatus.INVALID,
+          errorMessage: "bal is empty",
+        })
+      );
+
+      expect(batch.executionErrorAttempts).toHaveLength(1);
+      expect(batch.executionErrorAttempts[0].peerAttributable).toBe(true);
+      expect(batch.executionErrorAttempts[0].peers).toEqual([peer]);
+      // and it must be excluded from the next retry
+      expect(batch.getFailedPeers()).toContain(peer);
     });
   });
 });

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -135,6 +135,8 @@ describe("sync / range / batch", async () => {
   const custodyConfig = new CustodyConfig({config, nodeId});
   const peer = validPeerIdStr;
   const peerSyncMeta = {peerId: peer, client: "lodestar", custodyColumns: custodyConfig.sampledColumns};
+  // Minimal PayloadError context; these tests only read err.type, not the payloadInput.
+  const payloadInput = {slot: 1, blockRootHex: "0x1234"} as unknown as PayloadEnvelopeInput;
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -704,7 +706,7 @@ describe("sync / range / batch", async () => {
         const batch = downloadedBatch();
         batch.startProcessing();
         batch.processingError(
-          new PayloadError({
+          new PayloadError(payloadInput, {
             code: PayloadErrorCode.EXECUTION_ENGINE_ERROR,
             execStatus: ExecutionPayloadStatus.ELERROR,
             errorMessage: "el is down",
@@ -720,7 +722,7 @@ describe("sync / range / batch", async () => {
         const batch = downloadedBatch();
         batch.startProcessing();
         batch.processingError(
-          new PayloadError({
+          new PayloadError(payloadInput, {
             code: PayloadErrorCode.EXECUTION_ENGINE_INVALID,
             execStatus: ExecutionPayloadStatus.INVALID,
             errorMessage: "bal is empty",
@@ -785,7 +787,7 @@ describe("sync / range / batch", async () => {
         const batch = downloadedBatch();
         batch.startProcessing();
         batch.processingError(
-          new PayloadError({code: PayloadErrorCode.BLOCK_NOT_IN_FORK_CHOICE, blockRootHex: "0x1234"})
+          new PayloadError(payloadInput, {code: PayloadErrorCode.BLOCK_NOT_IN_FORK_CHOICE, blockRootHex: "0x1234"})
         );
 
         expect(batch.failedProcessingAttempts.length).toBe(1);
@@ -797,7 +799,9 @@ describe("sync / range / batch", async () => {
       it("PayloadError MISS_BLOCK_STATE (local precondition) => failedProcessingAttempts, NOT peer attributable", () => {
         const batch = downloadedBatch();
         batch.startProcessing();
-        batch.processingError(new PayloadError({code: PayloadErrorCode.MISS_BLOCK_STATE, blockRootHex: "0x1234"}));
+        batch.processingError(
+          new PayloadError(payloadInput, {code: PayloadErrorCode.MISS_BLOCK_STATE, blockRootHex: "0x1234"})
+        );
 
         expect(batch.failedProcessingAttempts.length).toBe(1);
         expect(batch.failedProcessingAttempts[0].peerAttributable).toBe(false);
@@ -878,7 +882,7 @@ describe("sync / range / batch", async () => {
       it("PayloadError EXECUTION_ENGINE_ERROR => executionErrorAttempts, not peer attributable", () => {
         const batch = batchAwaitingValidation();
         batch.validationError(
-          new PayloadError({
+          new PayloadError(payloadInput, {
             code: PayloadErrorCode.EXECUTION_ENGINE_ERROR,
             execStatus: ExecutionPayloadStatus.UNAVAILABLE,
             errorMessage: "el is down",
@@ -922,7 +926,7 @@ describe("sync / range / batch", async () => {
       const batch = downloadedBatch();
       batch.startProcessing();
       batch.processingError(
-        new PayloadError({
+        new PayloadError(payloadInput, {
           code: PayloadErrorCode.EXECUTION_ENGINE_INVALID,
           execStatus: ExecutionPayloadStatus.INVALID,
           errorMessage: "bal is empty",

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -742,6 +742,19 @@ describe("sync / range / batch", async () => {
         expect(batch.getFailedPeers()).toContain(peer);
       });
 
+      it("PER_BLOCK_PROCESSING_ERROR (invalid block) => failedProcessingAttempts, peer attributable", () => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(
+          blockError({code: BlockErrorCode.PER_BLOCK_PROCESSING_ERROR, blockRoot: "0x1234", error: new Error("bad op")})
+        );
+
+        // a block that fails per_slot/per_block processing is the peer's bad data
+        expect(batch.failedProcessingAttempts.length).toBe(1);
+        expect(batch.failedProcessingAttempts[0].peerAttributable).toBe(true);
+        expect(batch.getFailedPeers()).toContain(peer);
+      });
+
       it("BEACON_CHAIN_ERROR (our internal fault) => failedProcessingAttempts, NOT peer attributable", () => {
         const batch = downloadedBatch();
         batch.startProcessing();

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -10,6 +10,7 @@ import {BlockInputPreData} from "../../../../src/chain/blocks/blockInput/blockIn
 import {BlockInputSource, IBlockInput} from "../../../../src/chain/blocks/blockInput/types.js";
 import {BlockError, BlockErrorCode} from "../../../../src/chain/errors/index.js";
 import {ZERO_HASH} from "../../../../src/constants/index.js";
+import {ExecutionPayloadStatus} from "../../../../src/execution/index.js";
 import type {Metrics} from "../../../../src/metrics/metrics.js";
 import {BatchError, BatchErrorCode} from "../../../../src/sync/range/batch.js";
 import {ChainTarget, SyncChain, SyncChainFns} from "../../../../src/sync/range/chain.js";
@@ -399,8 +400,10 @@ describe("sync / range / chain", () => {
   describe("batch teardown peer reporting", () => {
     async function runToTeardown(
       syncType: RangeSyncType,
-      processChainSegment: SyncChainFns["processChainSegment"] = async () => {
-        throw Error("always reject to force teardown");
+      // Default: a peer-attributable processing failure (the batch's own blocks are bad), so teardown
+      // trips MAX_PROCESSING_ATTEMPTS and reports the offending peers.
+      processChainSegment: SyncChainFns["processChainSegment"] = async (blocks) => {
+        throw new BlockError(blocks[0].getBlock(), {code: BlockErrorCode.NON_LINEAR_SLOTS});
       }
     ): Promise<{reportPeerSpy: ReturnType<typeof vi.fn>; err: Error | null}> {
       const reportPeerSpy = vi.fn();
@@ -477,6 +480,73 @@ describe("sync / range / chain", () => {
 
       expect(err).toBeInstanceOf(BatchError);
       expect((err as BatchError).type.code).toBe(BatchErrorCode.MAX_PROCESSING_ATTEMPTS);
+    });
+
+    it("does not report peers when teardown is caused by execution engine errors", async () => {
+      const processChainSegment: SyncChainFns["processChainSegment"] = async (blocks) => {
+        throw new BlockError(blocks[0].getBlock(), {
+          code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
+          execStatus: ExecutionPayloadStatus.ELERROR,
+          errorMessage: "el is down",
+        });
+      };
+
+      const {reportPeerSpy, err} = await runToTeardown(RangeSyncType.Finalized, processChainSegment);
+
+      expect((err as BatchError).type.code).toBe(BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS);
+      // our EL malfunctioning is not evidence against any peer
+      expect(reportPeerSpy).not.toHaveBeenCalled();
+    });
+
+    it("reports only the offending peers when teardown is caused by INVALID payloads", async () => {
+      const processChainSegment: SyncChainFns["processChainSegment"] = async (blocks) => {
+        throw new BlockError(blocks[0].getBlock(), {
+          code: BlockErrorCode.EXECUTION_ENGINE_INVALID,
+          execStatus: ExecutionPayloadStatus.INVALID,
+          errorMessage: "bal is empty",
+        });
+      };
+
+      const {reportPeerSpy, err} = await runToTeardown(RangeSyncType.Finalized, processChainSegment);
+
+      expect((err as BatchError).type.code).toBe(BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS);
+      expect(reportPeerSpy).toHaveBeenCalled();
+
+      const reportedPeers = reportPeerSpy.mock.calls.map(([peerId]) => peerId);
+      // only the peers that actually served an INVALID attempt, each reported once
+      expect(new Set(reportedPeers).size).toBe(reportedPeers.length);
+      expect(reportedPeers.length).toBeLessThan(6);
+      for (const call of reportPeerSpy.mock.calls) {
+        expect(call[2]).toBe("SyncChainMaxExecutionEngineInvalid");
+      }
+    });
+
+    it("reports only the offending peers when teardown trips MAX_PROCESSING_ATTEMPTS", async () => {
+      // default processChainSegment throws a peer-attributable NON_LINEAR_SLOTS
+      const {reportPeerSpy, err} = await runToTeardown(RangeSyncType.Finalized);
+
+      expect((err as BatchError).type.code).toBe(BatchErrorCode.MAX_PROCESSING_ATTEMPTS);
+      expect(reportPeerSpy).toHaveBeenCalled();
+
+      const reportedPeers = reportPeerSpy.mock.calls.map(([peerId]) => peerId);
+      // only the peers that served a bad attempt, each reported once — not the whole peerset
+      expect(new Set(reportedPeers).size).toBe(reportedPeers.length);
+      expect(reportedPeers.length).toBeLessThan(6);
+      for (const call of reportPeerSpy.mock.calls) {
+        expect(call[2]).toBe("SyncChainMaxProcessingAttempts");
+      }
+    });
+
+    it("does not report peers when teardown is caused by our own internal error", async () => {
+      const processChainSegment: SyncChainFns["processChainSegment"] = async (blocks) => {
+        throw new BlockError(blocks[0].getBlock(), {code: BlockErrorCode.BEACON_CHAIN_ERROR, error: new Error("boom")});
+      };
+
+      const {reportPeerSpy, err} = await runToTeardown(RangeSyncType.Finalized, processChainSegment);
+
+      expect((err as BatchError).type.code).toBe(BatchErrorCode.MAX_PROCESSING_ATTEMPTS);
+      // repeated internal errors tear the chain down, but blaming a peer for our own bug would risk self-isolation
+      expect(reportPeerSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -517,7 +517,7 @@ describe("sync / range / chain", () => {
       expect(new Set(reportedPeers).size).toBe(reportedPeers.length);
       expect(reportedPeers.length).toBeLessThan(6);
       for (const call of reportPeerSpy.mock.calls) {
-        expect(call[2]).toBe("SyncChainMaxExecutionEngineInvalid");
+        expect(call[2]).toBe("SyncChainMaxExecutionEngineErrorAttempts");
       }
     });
 

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -1193,7 +1193,7 @@ describe("UnknownBlockSync", () => {
       const processExecutionPayload = vi
         .fn()
         .mockRejectedValueOnce(
-          new PayloadError({
+          new PayloadError({slot: 1, blockRootHex: "0x1234"} as unknown as PayloadEnvelopeInput, {
             code: PayloadErrorCode.BLOCK_NOT_IN_FORK_CHOICE,
             blockRootHex,
           })
@@ -1290,7 +1290,7 @@ describe("UnknownBlockSync", () => {
       const processExecutionPayload = vi
         .fn()
         .mockRejectedValueOnce(
-          new PayloadError({
+          new PayloadError({slot: 1, blockRootHex: "0x1234"} as unknown as PayloadEnvelopeInput, {
             code: PayloadErrorCode.EXECUTION_ENGINE_ERROR,
             execStatus: ExecutionPayloadStatus.ELERROR,
             errorMessage: "execution engine offline",
@@ -1609,9 +1609,11 @@ describe("UnknownBlockSync", () => {
       });
 
       const sendExecutionPayloadEnvelopesByRoot = vi.fn().mockResolvedValue([envelope]);
-      const processExecutionPayload = vi
-        .fn()
-        .mockRejectedValue(new PayloadError({code: PayloadErrorCode.INVALID_SIGNATURE}));
+      const processExecutionPayload = vi.fn().mockRejectedValue(
+        new PayloadError({slot: 1, blockRootHex: "0x1234"} as unknown as PayloadEnvelopeInput, {
+          code: PayloadErrorCode.INVALID_SIGNATURE,
+        })
+      );
       const processBlock = vi.fn().mockResolvedValue(undefined);
       const seenPayloadPrune = vi.fn();
       const {emitter} = setupPayloadSyncTest({


### PR DESCRIPTION
**Motivation**

- we don't differentiate different errors after processing a batch, and always penalize peers, for example `EXECUTION_ENGINE_INVALID` is different from `EXECUTION_ENGINE_ERROR`
- post-gloas, we also have PayloadError, need to also handle it in range sync

**Description**
- throw PayloadError in block processor instead of wrapping it inside BlockError
- track `FailedAttempt` with `perAttributable`, derived from error code
- later on, only penalize peers with `peerAttributable = true`
- also `getFailedPeers` should only include failed attempt with `peerAttributable = true`


part of #9667

**AI Assistance Disclosure**

- created with the help of Claude