### PR TITLE
chore: address BLS integration review feedback

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -114,6 +114,7 @@ VM
 Vitalik
 Vitest
 Wagyu
+Zig
 addons
 api
 args

--- a/docs/pages/contribution/depgraph.md
+++ b/docs/pages/contribution/depgraph.md
@@ -26,7 +26,7 @@ graph TD
     validator["validator"]:::nodemodule
     state-transition["state-transition"]:::nodemodule
     ssz["ssz"]:::nodemodule
-    blst["blst"]:::nodemodule
+    lodestar-z["lodestar-z"]:::nodemodule
     discv5["discv5"]:::nodemodule
     libp2p["libp2p"]:::nodemodule
     libp2p-gossipsub["libp2p-gossipsub"]:::nodemodule
@@ -40,8 +40,8 @@ graph TD
     ssz-->validator
     ssz-->state-transition
 
-    blst-->beacon-node
-    blst-->state-transition
+    lodestar-z-->beacon-node
+    lodestar-z-->state-transition
 
     discv5-->beacon-node
 
@@ -114,7 +114,7 @@ graph TD
     click utils "https://github.com/ChainSafe/lodestar/tree/unstable/packages/utils"
     click config "https://github.com/ChainSafe/lodestar/tree/unstable/packages/config"
     click ssz "https://github.com/ChainSafe/ssz"
-    click blst "https://github.com/ChainSafe/blst-ts"
+    click lodestar-z "https://github.com/ChainSafe/lodestar-z"
     click discv5 "https://github.com/ChainSafe/discv5"
     click libp2p "https://github.com/libp2p/js-libp2p"
     click libp2p-gossipsub "https://github.com/ChainSafe/js-libp2p-gossipsub"
@@ -193,9 +193,9 @@ For a good explanation on how the fork choice itself works, see the [annotated f
 
 Below is a brief summary, listed alphabetically, of each of our main external dependencies managed externally from our monorepo.
 
-### `@chainsafe/blst-ts`
+### `@chainsafe/lodestar-z`
 
-[@chainsafe/blst-ts`](https://github.com/ChainSafe/blst-ts) is our TypeScript wrapper for [@supranational/blst](https://github.com/supranational/blst) native bindings, a highly performant BLS12-381 signature library.
+[`@chainsafe/lodestar-z`](https://github.com/ChainSafe/lodestar-z) provides Lodestar's Zig implementations, including BLS12-381 signature verification backed by [supranational/blst](https://github.com/supranational/blst).
 
 ### `@chainsafe/discv5`
 

--- a/docs/pages/supporting-libraries/index.md
+++ b/docs/pages/supporting-libraries/index.md
@@ -21,7 +21,7 @@
 ## BLS
 
 - [`@chainsafe/bls`](https://github.com/ChainSafe/bls) - Isomorphic Ethereum Consensus BLS sign / verify / aggregate
-- [`@chainsafe/blst-ts`](https://github.com/ChainSafe/blst-ts) - Node specific Ethereum Consensus BLS sign / verify / aggregate
+- [`@chainsafe/lodestar-z`](https://github.com/ChainSafe/lodestar-z) - Zig implementations for Lodestar, including BLS sign / verify / aggregate
 - [`@chainsafe/bls-keystore`](https://github.com/ChainSafe/bls-keystore) - store / retrieve a BLS secret key from an [EIP-2335](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2335.md) JSON keystore
 - [`@chainsafe/bls-keygen`](https://github.com/ChainSafe/bls-keygen) - utility functions to generate BLS secret keys, following [EIP-2333](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2333.md) and [EIP-2334](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2334.md)
 - [`@chainsafe/bls-hd-key`](https://github.com/ChainSafe/bls-hd-key) - low level [EIP-2333](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2333.md) and [EIP-2334](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2334.md) functionality

--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -13,11 +13,7 @@ import {LinkedList} from "../../../util/array.js";
 import {callInNextEventLoop} from "../../../util/eventLoop.js";
 import {QueueError, QueueErrorCode} from "../../../util/queue/index.js";
 import {IBlsVerifier, SameMessageSignatureSet, VerifySignatureOpts} from "../interface.js";
-import {
-  chunkSameMessageSignatureSets,
-  getAggregatedPubkeysCount,
-  verifySignatureSetsInNativeBatches,
-} from "../utils.js";
+import {chunkSameMessageSignatureSets, getAggregatedPubkeysCount, verifySignatureSetsInBatches} from "../utils.js";
 import {JobQueueItem, jobItemSigSets, jobItemWorkReq} from "./jobItem.js";
 import {defaultPoolSize} from "./poolSize.js";
 import {BlsWorkReq, BlsWorkResult, JobQueueItemType, WorkResultCode, WorkResultError, WorkerData} from "./types.js";
@@ -159,7 +155,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
     if (opts.verifyOnMainThread && !this.blsVerifyAllMultiThread) {
       const timer = this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.startTimer();
       try {
-        return verifySignatureSetsInNativeBatches(sets);
+        return verifySignatureSetsInBatches(sets);
       } finally {
         if (timer) timer();
       }

--- a/packages/beacon-node/src/chain/bls/multithread/worker.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/worker.ts
@@ -1,8 +1,8 @@
 import worker from "node:worker_threads";
 import {
   type BlsSignatureSet,
-  verifySignatureSets as verifySignatureSetsNative,
-  verifySignatureSetsSameMessage as verifySignatureSetsSameMessageNative,
+  verifySignatureSets,
+  verifySignatureSetsSameMessage,
 } from "@chainsafe/lodestar-z/bls-verifier";
 import {expose} from "@chainsafe/threads/worker";
 import {BlsWorkReq, BlsWorkResult, JobQueueItemType, WorkResult, WorkResultCode, WorkerData} from "./types.js";
@@ -53,7 +53,7 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
       }
       case JobQueueItemType.sameMessage:
         try {
-          const result = verifySignatureSetsSameMessageNative(workReq.sets, workReq.message);
+          const result = verifySignatureSetsSameMessage(workReq.sets, workReq.message);
           results[i] = {code: WorkResultCode.success, result};
         } catch (e) {
           results[i] = {code: WorkResultCode.error, error: e as Error};
@@ -76,7 +76,7 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
 
       try {
         // Attempt to verify multiple sets at once
-        const isValid = verifySignatureSetsNative(allSets);
+        const isValid = verifySignatureSets(allSets);
 
         if (isValid) {
           // The entire batch is valid, return success to all
@@ -101,7 +101,7 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
 
   for (const {idx, sets} of nonBatchableSets) {
     try {
-      const isValid = verifySignatureSetsNative(sets);
+      const isValid = verifySignatureSets(sets);
       results[idx] = {code: WorkResultCode.success, result: [isValid]};
     } catch (e) {
       results[idx] = {code: WorkResultCode.error, error: e as Error};

--- a/packages/beacon-node/src/chain/bls/singleThread.ts
+++ b/packages/beacon-node/src/chain/bls/singleThread.ts
@@ -1,8 +1,8 @@
-import {verifySignatureSetsSameMessage as verifySignatureSetsSameMessageNative} from "@chainsafe/lodestar-z/bls-verifier";
+import {verifySignatureSetsSameMessage} from "@chainsafe/lodestar-z/bls-verifier";
 import {ISignatureSet} from "@lodestar/state-transition";
 import {Metrics} from "../../metrics/index.js";
 import {IBlsVerifier, SameMessageSignatureSet} from "./interface.js";
-import {chunkSameMessageSignatureSets, getAggregatedPubkeysCount, verifySignatureSetsInNativeBatches} from "./utils.js";
+import {chunkSameMessageSignatureSets, getAggregatedPubkeysCount, verifySignatureSetsInBatches} from "./utils.js";
 
 export class BlsSingleThreadVerifier implements IBlsVerifier {
   private readonly metrics: Metrics | null;
@@ -14,7 +14,7 @@ export class BlsSingleThreadVerifier implements IBlsVerifier {
     this.metrics?.bls.aggregatedPubkeys.inc(getAggregatedPubkeysCount(sets));
 
     const timer = this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.startTimer();
-    const isValid = verifySignatureSetsInNativeBatches(sets);
+    const isValid = verifySignatureSetsInBatches(sets);
 
     // Don't use a try/catch, only count run without exceptions
     if (timer) {
@@ -28,7 +28,7 @@ export class BlsSingleThreadVerifier implements IBlsVerifier {
     const timer = this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.startTimer();
     const result: boolean[] = [];
     for (const setsChunk of chunkSameMessageSignatureSets(sets)) {
-      result.push(...verifySignatureSetsSameMessageNative(setsChunk, message));
+      result.push(...verifySignatureSetsSameMessage(setsChunk, message));
     }
     timer?.();
     return result;

--- a/packages/beacon-node/src/chain/bls/utils.ts
+++ b/packages/beacon-node/src/chain/bls/utils.ts
@@ -3,7 +3,7 @@ import {
   BLS_VERIFIER_MAX_SAME_MESSAGE_BATCH_SIZE,
   BLS_VERIFIER_SET_TYPE,
   type BlsSignatureSet,
-  verifySignatureSets as verifySignatureSetsNative,
+  verifySignatureSets,
 } from "@chainsafe/lodestar-z/bls-verifier";
 import {ISignatureSet, SignatureSetType} from "@lodestar/state-transition";
 import {SameMessageSignatureSet} from "./interface.js";
@@ -48,14 +48,14 @@ export function toBlsSignatureSet(signatureSet: ISignatureSet): BlsSignatureSet 
   }
 }
 
-export function verifySignatureSetsInNativeBatches(signatureSets: ISignatureSet[]): boolean {
+export function verifySignatureSetsInBatches(signatureSets: ISignatureSet[]): boolean {
   if (signatureSets.length === 0) {
     return false;
   }
 
   for (let start = 0; start < signatureSets.length; start += BLS_VERIFIER_MAX_BATCH_SIZE) {
     const sets = signatureSets.slice(start, start + BLS_VERIFIER_MAX_BATCH_SIZE).map(toBlsSignatureSet);
-    if (!verifySignatureSetsNative(sets)) {
+    if (!verifySignatureSets(sets)) {
       return false;
     }
   }

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -69,7 +69,6 @@
     "@chainsafe/bls": "8.2.0",
     "@chainsafe/lodestar-z": "catalog:",
     "@chainsafe/persistent-merkle-tree": "^1.3.0",
-    "@chainsafe/pubkey-index-map": "^3.0.0",
     "@chainsafe/ssz": "^1.6.2",
     "@chainsafe/swap-or-not-shuffle": "^1.2.1",
     "@lodestar/config": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,9 +776,6 @@ importers:
       '@chainsafe/persistent-merkle-tree':
         specifier: ^1.3.0
         version: 1.3.0
-      '@chainsafe/pubkey-index-map':
-        specifier: ^3.0.0
-        version: 3.0.0
       '@chainsafe/ssz':
         specifier: ^1.6.2
         version: 1.6.2
@@ -1256,62 +1253,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       prom-client: '>= 10'
-
-  '@chainsafe/pubkey-index-map-darwin-arm64@3.0.0':
-    resolution: {integrity: sha512-gM/wwA6bpfeZm80aSoH2c3ddbPeZho73TUUprUFlHQNLldGzZ293yFQgj2Ontp1fMf9AI0w+F0uEN2qC6v7g9A==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@chainsafe/pubkey-index-map-darwin-x64@3.0.0':
-    resolution: {integrity: sha512-zy4dH//kLXfQHHFVp1Pcz4HQgSh/uUKWt219hlrb5Fi+xVESVmTnLPjHmL1KtGs/R5W0XcuBrTuBHiq+zMU7lQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@chainsafe/pubkey-index-map-linux-arm64-gnu@3.0.0':
-    resolution: {integrity: sha512-M/HODHZcKDuoRFlx+Ka4NgyFSQvOECyIg/2pCQcgfCozR7rRx7VuOJ0ZSgU+BEhuY+fpaRSTesOlDIIY0ornWQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@chainsafe/pubkey-index-map-linux-arm64-musl@3.0.0':
-    resolution: {integrity: sha512-Sdm15mFsKiz5ndFfhcTjEl4i8TK0+gM1SEmYzmGUgnflrcvPc+US3qsMKyCqorDkHqYAYFFutQXz9QxjOMkIwg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@chainsafe/pubkey-index-map-linux-x64-gnu@3.0.0':
-    resolution: {integrity: sha512-+4h995h2xEBmYdr9Tw05uYvFmMSELyaJagJ2KsFohkRjqiUyB76l8zR8aUKx7lwLXXHxWjHMYyWKHF3tTKRFNQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@chainsafe/pubkey-index-map-linux-x64-musl@3.0.0':
-    resolution: {integrity: sha512-qwFuygeutP4o9J/8ylD+ZrqkqeyytMl9E38ucIWpbiPYXDiJxpRN148v4Ah+NWwz6PqCROVyTxEyZklzy0AxUA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@chainsafe/pubkey-index-map-win32-arm64-msvc@3.0.0':
-    resolution: {integrity: sha512-2t01rQAdiM5KPM7XLsZDtMhWAXz/YKY20H1N4jvaWURjaLm+S0j9X/Mt0xOjJ5SC++1g64LXjV+wnXO5j1S8Nw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@chainsafe/pubkey-index-map-win32-x64-msvc@3.0.0':
-    resolution: {integrity: sha512-QemArQbgsLJ4eaM9S0Kdr3ucJUpZXTDfh3wTNp9eh7G3o1Y9O2Hp7G7BlEkF0cWU9ZsWe9YSzmeX24Uo5DNo4g==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@chainsafe/pubkey-index-map@3.0.0':
-    resolution: {integrity: sha512-KvWmKOG8WiVePHQDGyz+xo+RpsrmPEeipF8boqmXNYCLOGyVpkEXQk0IDVpnxngZziY6d97F9sml2vliDoyYyQ==}
-    engines: {node: '>= 10'}
 
   '@chainsafe/snappy-wasm@0.5.0':
     resolution: {integrity: sha512-ydXvhr9p+JjvzSSEyi6XExq8pHugFnrk70mk17T6mhDsklPvaXc+8K90G7TJF+u51lxI/fpv7MahrA5ayjFcSA==}
@@ -6939,41 +6880,6 @@ snapshots:
   '@chainsafe/prometheus-gc-stats@1.0.2(prom-client@15.1.3)':
     dependencies:
       prom-client: 15.1.3
-
-  '@chainsafe/pubkey-index-map-darwin-arm64@3.0.0':
-    optional: true
-
-  '@chainsafe/pubkey-index-map-darwin-x64@3.0.0':
-    optional: true
-
-  '@chainsafe/pubkey-index-map-linux-arm64-gnu@3.0.0':
-    optional: true
-
-  '@chainsafe/pubkey-index-map-linux-arm64-musl@3.0.0':
-    optional: true
-
-  '@chainsafe/pubkey-index-map-linux-x64-gnu@3.0.0':
-    optional: true
-
-  '@chainsafe/pubkey-index-map-linux-x64-musl@3.0.0':
-    optional: true
-
-  '@chainsafe/pubkey-index-map-win32-arm64-msvc@3.0.0':
-    optional: true
-
-  '@chainsafe/pubkey-index-map-win32-x64-msvc@3.0.0':
-    optional: true
-
-  '@chainsafe/pubkey-index-map@3.0.0':
-    optionalDependencies:
-      '@chainsafe/pubkey-index-map-darwin-arm64': 3.0.0
-      '@chainsafe/pubkey-index-map-darwin-x64': 3.0.0
-      '@chainsafe/pubkey-index-map-linux-arm64-gnu': 3.0.0
-      '@chainsafe/pubkey-index-map-linux-arm64-musl': 3.0.0
-      '@chainsafe/pubkey-index-map-linux-x64-gnu': 3.0.0
-      '@chainsafe/pubkey-index-map-linux-x64-musl': 3.0.0
-      '@chainsafe/pubkey-index-map-win32-arm64-msvc': 3.0.0
-      '@chainsafe/pubkey-index-map-win32-x64-msvc': 3.0.0
 
   '@chainsafe/snappy-wasm@0.5.0': {}
 


### PR DESCRIPTION
Follow-up to #9820 addressing the latest review feedback:

- remove native-only naming from BLS verifier wrappers
- remove the unused `@chainsafe/pubkey-index-map` dependency and lock entries
- update stale `blst-ts` documentation references to Lodestar-Z

Verification:
- `pnpm build`
- `pnpm lint`
- `pnpm check-types`
- `pnpm test:unit` (342 passed, 1 skipped; 3522 tests passed)
- `pnpm docs:lint`