### PR TITLE
fix: use progressive payload attestation pool response

### DIFF
--- a/packages/api/src/beacon/routes/beacon/pool.ts
+++ b/packages/api/src/beacon/routes/beacon/pool.ts
@@ -51,6 +51,7 @@ type ProposerSlashingList = ValueOf<typeof ProposerSlashingListType>;
 type SignedVoluntaryExitList = ValueOf<typeof SignedVoluntaryExitListType>;
 type SignedBLSToExecutionChangeList = ValueOf<typeof SignedBLSToExecutionChangeListType>;
 type SyncCommitteeMessageList = ValueOf<typeof SyncCommitteeMessageListType>;
+type PayloadAttestationList = ValueOf<typeof ssz.gloas.PayloadAttestations>;
 type PayloadAttestationMessageList = ValueOf<typeof PayloadAttestationMessageListType>;
 
 export type Endpoints = {
@@ -74,7 +75,7 @@ export type Endpoints = {
     "GET",
     {slot?: Slot},
     {query: {slot?: number}},
-    ValueOf<typeof ssz.gloas.PayloadAttestations>,
+    PayloadAttestationList,
     VersionMeta
   >;
 

--- a/packages/api/src/beacon/routes/beacon/pool.ts
+++ b/packages/api/src/beacon/routes/beacon/pool.ts
@@ -51,7 +51,6 @@ type ProposerSlashingList = ValueOf<typeof ProposerSlashingListType>;
 type SignedVoluntaryExitList = ValueOf<typeof SignedVoluntaryExitListType>;
 type SignedBLSToExecutionChangeList = ValueOf<typeof SignedBLSToExecutionChangeListType>;
 type SyncCommitteeMessageList = ValueOf<typeof SyncCommitteeMessageListType>;
-type PayloadAttestationList = ValueOf<typeof ssz.gloas.PayloadAttestations>;
 type PayloadAttestationMessageList = ValueOf<typeof PayloadAttestationMessageListType>;
 
 export type Endpoints = {
@@ -75,7 +74,7 @@ export type Endpoints = {
     "GET",
     {slot?: Slot},
     {query: {slot?: number}},
-    PayloadAttestationList,
+    ValueOf<typeof ssz.gloas.PayloadAttestations>,
     VersionMeta
   >;
 

--- a/packages/api/src/beacon/routes/beacon/pool.ts
+++ b/packages/api/src/beacon/routes/beacon/pool.ts
@@ -37,7 +37,6 @@ const ProposerSlashingListType = ArrayOf(ssz.phase0.ProposerSlashing);
 const SignedVoluntaryExitListType = ArrayOf(ssz.phase0.SignedVoluntaryExit);
 const SignedBLSToExecutionChangeListType = ArrayOf(ssz.capella.SignedBLSToExecutionChange);
 const SyncCommitteeMessageListType = ArrayOf(ssz.altair.SyncCommitteeMessage);
-const PayloadAttestationListType = ssz.gloas.PayloadAttestations;
 const PayloadAttestationMessageListType = ArrayOf(ssz.gloas.PayloadAttestationMessage, PTC_SIZE);
 
 type AttestationListPhase0 = ValueOf<typeof AttestationListTypePhase0>;
@@ -52,7 +51,7 @@ type ProposerSlashingList = ValueOf<typeof ProposerSlashingListType>;
 type SignedVoluntaryExitList = ValueOf<typeof SignedVoluntaryExitListType>;
 type SignedBLSToExecutionChangeList = ValueOf<typeof SignedBLSToExecutionChangeListType>;
 type SyncCommitteeMessageList = ValueOf<typeof SyncCommitteeMessageListType>;
-type PayloadAttestationList = ValueOf<typeof PayloadAttestationListType>;
+type PayloadAttestationList = ValueOf<typeof ssz.gloas.PayloadAttestations>;
 type PayloadAttestationMessageList = ValueOf<typeof PayloadAttestationMessageListType>;
 
 export type Endpoints = {
@@ -245,7 +244,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         schema: {query: {slot: Schema.Uint}},
       },
       resp: {
-        data: PayloadAttestationListType,
+        data: ssz.gloas.PayloadAttestations,
         meta: VersionCodec,
       },
     },

--- a/packages/api/src/beacon/routes/beacon/pool.ts
+++ b/packages/api/src/beacon/routes/beacon/pool.ts
@@ -1,13 +1,6 @@
 import {ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {
-  ForkName,
-  ForkPostElectra,
-  ForkPreElectra,
-  MAX_PAYLOAD_ATTESTATIONS,
-  PTC_SIZE,
-  isForkPostElectra,
-} from "@lodestar/params";
+import {ForkName, ForkPostElectra, ForkPreElectra, PTC_SIZE, isForkPostElectra} from "@lodestar/params";
 import {
   ArrayOf,
   AttesterSlashing,
@@ -44,7 +37,7 @@ const ProposerSlashingListType = ArrayOf(ssz.phase0.ProposerSlashing);
 const SignedVoluntaryExitListType = ArrayOf(ssz.phase0.SignedVoluntaryExit);
 const SignedBLSToExecutionChangeListType = ArrayOf(ssz.capella.SignedBLSToExecutionChange);
 const SyncCommitteeMessageListType = ArrayOf(ssz.altair.SyncCommitteeMessage);
-const PayloadAttestationListType = ArrayOf(ssz.gloas.PayloadAttestation, MAX_PAYLOAD_ATTESTATIONS);
+const PayloadAttestationListType = ssz.gloas.PayloadAttestations;
 const PayloadAttestationMessageListType = ArrayOf(ssz.gloas.PayloadAttestationMessage, PTC_SIZE);
 
 type AttestationListPhase0 = ValueOf<typeof AttestationListTypePhase0>;

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -120,7 +120,10 @@ export const testData: GenericServerTestCases<Endpoints> = {
   },
   getPoolPayloadAttestations: {
     args: {slot: 1},
-    res: {data: [ssz.gloas.PayloadAttestation.defaultValue()], meta: {version: ForkName.gloas}},
+    res: {
+      data: Array.from({length: 5}, () => ssz.gloas.PayloadAttestation.defaultValue()),
+      meta: {version: ForkName.gloas},
+    },
   },
   getPoolAttesterSlashingsV2: {
     args: undefined,


### PR DESCRIPTION
`getPoolPayloadAttestations` may return aggregates for multiple block roots or slots and exceed the 4 payload attestations allowed in one block. Its SSZ codec reused `MAX_PAYLOAD_ATTESTATIONS`, so larger pool responses could not be decoded.

Use the Gloas progressive `PayloadAttestations` type and cover JSON and SSZ responses with 5 entries

see https://github.com/ethereum/beacon-APIs/pull/635
