### PR TITLE
fix(builder): wait for Gloas fork and improve startup logging

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -83,7 +83,7 @@ export class Builder {
       builderSigner.getPubkeyHex(),
       opts.abortController.signal,
       clock,
-      config.GLOAS_FORK_EPOCH
+      config
     );
 
     const builderStatusTracker = new BuilderStatusTracker(api, logger, index);

--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -82,7 +82,8 @@ export class Builder {
       logger,
       builderSigner.getPubkeyHex(),
       opts.abortController.signal,
-      clock
+      clock,
+      config.GLOAS_FORK_EPOCH
     );
 
     const builderStatusTracker = new BuilderStatusTracker(api, logger, index);

--- a/packages/builder/src/identity.ts
+++ b/packages/builder/src/identity.ts
@@ -79,10 +79,12 @@ async function waitForBuilder(
     try {
       builder = await fetchBuilder(api, id);
     } catch (e) {
-      // The clock gate above uses wall-clock epoch, but getStateBuilders reads the head block's state
-      // which is not advanced to the current slot. Right after the fork epoch the head can still be the
-      // last pre-gloas block until the first gloas block is imported; treat a bad-request here as that
-      // transient and keep polling (avoids differentiating on client-specific error text).
+      // The clock gate above uses wall-clock epoch, but getStateBuilders reads the head block's post-state
+      // (by root, not advanced to the current slot), so its fork follows the head block's slot rather than
+      // wall-clock. Right at the boundary, while the head block is still in the last fulu epoch, that state
+      // is pre-gloas and the endpoint returns a bad request even though wall-clock is already in gloas; it
+      // only becomes gloas once a gloas-epoch block is head. Treat that as the transient and keep polling
+      // (avoids differentiating on client-specific error text).
       if (e instanceof ApiError && e.status === HttpStatusCode.BAD_REQUEST) {
         logger.info("Waiting for Gloas state to be available at head", {
           gloasForkEpoch,

--- a/packages/builder/src/identity.ts
+++ b/packages/builder/src/identity.ts
@@ -1,7 +1,7 @@
-import {ApiClient, routes} from "@lodestar/api";
+import {ApiClient, ApiError, HttpStatusCode, routes} from "@lodestar/api";
 import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
 import {IClock} from "@lodestar/state-transition";
-import {BuilderIndex, BuilderStatus} from "@lodestar/types";
+import {BuilderIndex, BuilderStatus, Epoch} from "@lodestar/types";
 import {ErrorAborted, Logger, sleep, toHex} from "@lodestar/utils";
 
 export const WAITING_FOR_BUILDER_POLL_MS = 10 * 1000;
@@ -11,9 +11,10 @@ export async function resolveBuilderIdentity(
   logger: Logger,
   id: routes.beacon.BuilderId,
   signal: AbortSignal,
-  clock: IClock
+  clock: IClock,
+  gloasForkEpoch: Epoch
 ): Promise<BuilderIndex> {
-  const builderEntry = await waitForBuilder(api, logger, id, signal, clock);
+  const builderEntry = await waitForBuilder(api, logger, id, signal, clock, gloasForkEpoch);
 
   if (builderEntry.builder.version !== PAYLOAD_BUILDER_VERSION) {
     throw Error(`Builder version mismatch: got ${builderEntry.builder.version}, expected ${PAYLOAD_BUILDER_VERSION}`);
@@ -56,10 +57,40 @@ async function waitForBuilder(
   logger: Logger,
   id: routes.beacon.BuilderId,
   signal: AbortSignal,
-  clock: IClock
+  clock: IClock,
+  gloasForkEpoch: Epoch
 ): Promise<routes.beacon.BuilderResponse> {
   while (!signal.aborted) {
-    const builder = await fetchBuilder(api, id);
+    const currentEpoch = clock.getCurrentEpoch();
+    if (currentEpoch < gloasForkEpoch) {
+      // Builders only exist post-gloas, the beacon node returns an error for pre-gloas state
+      logger.info("Waiting for Gloas fork before resolving builder identity", {
+        gloasForkEpoch,
+        currentEpoch,
+        slot: clock.getCurrentSlot(),
+      });
+      await sleep(WAITING_FOR_BUILDER_POLL_MS, signal);
+      continue;
+    }
+
+    let builder: routes.beacon.BuilderResponse | null = null;
+    try {
+      builder = await fetchBuilder(api, id);
+    } catch (e) {
+      // At the fork boundary the head state may still be pre-gloas for a brief window until
+      // the first post-fork state is available, keep polling instead of exiting
+      if (e instanceof ApiError && e.status === HttpStatusCode.BAD_REQUEST && e.message.includes("pre-gloas")) {
+        logger.info("Waiting for Gloas state to be available at head", {
+          gloasForkEpoch,
+          currentEpoch,
+          slot: clock.getCurrentSlot(),
+        });
+        await sleep(WAITING_FOR_BUILDER_POLL_MS, signal);
+        continue;
+      }
+      throw e;
+    }
+
     if (builder?.status === "active") {
       return builder;
     }

--- a/packages/builder/src/identity.ts
+++ b/packages/builder/src/identity.ts
@@ -77,8 +77,9 @@ async function waitForBuilder(
     try {
       builder = await fetchBuilder(api, id);
     } catch (e) {
-      // At the fork boundary the head state may still be pre-gloas for a brief window until
-      // the first post-fork state is available, keep polling instead of exiting
+      // The clock gate above uses wall-clock epoch, but getStateBuilders reads the head block's
+      // state which is not advanced to the current slot. At the fork boundary the head is still the
+      // last pre-gloas block until the first gloas block is imported, so tolerate that transient 400.
       if (e instanceof ApiError && e.status === HttpStatusCode.BAD_REQUEST && e.message.includes("pre-gloas")) {
         logger.info("Waiting for Gloas state to be available at head", {
           gloasForkEpoch,

--- a/packages/builder/src/identity.ts
+++ b/packages/builder/src/identity.ts
@@ -1,7 +1,8 @@
 import {ApiClient, ApiError, HttpStatusCode, routes} from "@lodestar/api";
+import {ChainForkConfig} from "@lodestar/config";
 import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
 import {IClock} from "@lodestar/state-transition";
-import {BuilderIndex, BuilderStatus, Epoch} from "@lodestar/types";
+import {BuilderIndex, BuilderStatus} from "@lodestar/types";
 import {ErrorAborted, Logger, sleep, toHex} from "@lodestar/utils";
 
 export const WAITING_FOR_BUILDER_POLL_MS = 10 * 1000;
@@ -12,9 +13,9 @@ export async function resolveBuilderIdentity(
   id: routes.beacon.BuilderId,
   signal: AbortSignal,
   clock: IClock,
-  gloasForkEpoch: Epoch
+  config: ChainForkConfig
 ): Promise<BuilderIndex> {
-  const builderEntry = await waitForBuilder(api, logger, id, signal, clock, gloasForkEpoch);
+  const builderEntry = await waitForBuilder(api, logger, id, signal, clock, config);
 
   if (builderEntry.builder.version !== PAYLOAD_BUILDER_VERSION) {
     throw Error(`Builder version mismatch: got ${builderEntry.builder.version}, expected ${PAYLOAD_BUILDER_VERSION}`);
@@ -58,8 +59,9 @@ async function waitForBuilder(
   id: routes.beacon.BuilderId,
   signal: AbortSignal,
   clock: IClock,
-  gloasForkEpoch: Epoch
+  config: ChainForkConfig
 ): Promise<routes.beacon.BuilderResponse> {
+  const gloasForkEpoch = config.GLOAS_FORK_EPOCH;
   while (!signal.aborted) {
     const currentEpoch = clock.getCurrentEpoch();
     if (currentEpoch < gloasForkEpoch) {
@@ -77,10 +79,11 @@ async function waitForBuilder(
     try {
       builder = await fetchBuilder(api, id);
     } catch (e) {
-      // The clock gate above uses wall-clock epoch, but getStateBuilders reads the head block's
-      // state which is not advanced to the current slot. At the fork boundary the head is still the
-      // last pre-gloas block until the first gloas block is imported, so tolerate that transient 400.
-      if (e instanceof ApiError && e.status === HttpStatusCode.BAD_REQUEST && e.message.includes("pre-gloas")) {
+      // The clock gate above uses wall-clock epoch, but getStateBuilders reads the head block's state
+      // which is not advanced to the current slot. Right after the fork epoch the head can still be the
+      // last pre-gloas block until the first gloas block is imported; treat a bad-request here as that
+      // transient and keep polling (avoids differentiating on client-specific error text).
+      if (e instanceof ApiError && e.status === HttpStatusCode.BAD_REQUEST) {
         logger.info("Waiting for Gloas state to be available at head", {
           gloasForkEpoch,
           currentEpoch,

--- a/packages/builder/src/identity.ts
+++ b/packages/builder/src/identity.ts
@@ -79,12 +79,8 @@ async function waitForBuilder(
     try {
       builder = await fetchBuilder(api, id);
     } catch (e) {
-      // The clock gate above uses wall-clock epoch, but getStateBuilders reads the head block's post-state
-      // (by root, not advanced to the current slot), so its fork follows the head block's slot rather than
-      // wall-clock. Right at the boundary, while the head block is still in the last fulu epoch, that state
-      // is pre-gloas and the endpoint returns a bad request even though wall-clock is already in gloas; it
-      // only becomes gloas once a gloas-epoch block is head. Treat that as the transient and keep polling
-      // (avoids differentiating on client-specific error text).
+      // At the fork boundary getStateBuilders("head") can still 400: it serves the head block's
+      // post-state, which stays pre-gloas until a gloas-epoch block is head. Keep polling on the transient.
       if (e instanceof ApiError && e.status === HttpStatusCode.BAD_REQUEST) {
         logger.info("Waiting for Gloas state to be available at head", {
           gloasForkEpoch,

--- a/packages/builder/test/unit/identity.test.ts
+++ b/packages/builder/test/unit/identity.test.ts
@@ -144,6 +144,26 @@ describe("Identity", () => {
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
   });
 
+  it("resolves once the Gloas fork is reached", async () => {
+    vi.useFakeTimers();
+    const forkClock = new ClockMock();
+    const forkConfig = {GLOAS_FORK_EPOCH: 1} as unknown as ChainForkConfig;
+    api.beacon.getStateBuilders.mockResolvedValue(
+      mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
+    );
+    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, forkClock, forkConfig);
+
+    // Pre-fork: the builder waits without querying the beacon node
+    await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
+    expect(api.beacon.getStateBuilders).not.toHaveBeenCalled();
+
+    // Gloas fork reached: the builder queries the beacon node and resolves
+    forkClock.currentEpoch = 1;
+    await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
+    expect(await promise).toEqual(index);
+    expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects without querying the beacon node when the signal is already aborted", async () => {
     const abortSignal = AbortSignal.abort();
     await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortSignal, clock, config)).rejects.toThrow(

--- a/packages/builder/test/unit/identity.test.ts
+++ b/packages/builder/test/unit/identity.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
-import {ChainForkConfig} from "@lodestar/config";
+import {createChainForkConfig} from "@lodestar/config";
 import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
 import {ErrorAborted, toHex} from "@lodestar/utils";
 import {WAITING_FOR_BUILDER_POLL_MS, getBuilderStatus, resolveBuilderIdentity} from "../../src/identity.js";
@@ -19,7 +19,7 @@ describe("Identity", () => {
   const balance = 1;
   const version = PAYLOAD_BUILDER_VERSION;
   // ClockMock reports currentEpoch=0, use GLOAS_FORK_EPOCH=0 so tests query the beacon node without waiting for the fork
-  const config = {GLOAS_FORK_EPOCH: 0} as unknown as ChainForkConfig;
+  const config = createChainForkConfig({GLOAS_FORK_EPOCH: 0});
 
   let abortController: AbortController;
 
@@ -118,7 +118,7 @@ describe("Identity", () => {
   it("waits for the Gloas fork before querying the beacon node", async () => {
     vi.useFakeTimers();
     // ClockMock reports currentEpoch=0, so a future fork epoch keeps the builder in the pre-fork wait loop
-    const futureForkConfig = {GLOAS_FORK_EPOCH: 1} as unknown as ChainForkConfig;
+    const futureForkConfig = createChainForkConfig({GLOAS_FORK_EPOCH: 1});
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, futureForkConfig);
     await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
 
@@ -147,7 +147,7 @@ describe("Identity", () => {
   it("resolves once the Gloas fork is reached", async () => {
     vi.useFakeTimers();
     const forkClock = new ClockMock();
-    const forkConfig = {GLOAS_FORK_EPOCH: 1} as unknown as ChainForkConfig;
+    const forkConfig = createChainForkConfig({GLOAS_FORK_EPOCH: 1});
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );

--- a/packages/builder/test/unit/identity.test.ts
+++ b/packages/builder/test/unit/identity.test.ts
@@ -1,4 +1,5 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {ChainForkConfig} from "@lodestar/config";
 import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
 import {ErrorAborted, toHex} from "@lodestar/utils";
 import {WAITING_FOR_BUILDER_POLL_MS, getBuilderStatus, resolveBuilderIdentity} from "../../src/identity.js";
@@ -17,8 +18,8 @@ describe("Identity", () => {
   const pubkeyString = toHex(pubkey);
   const balance = 1;
   const version = PAYLOAD_BUILDER_VERSION;
-  // ClockMock reports currentEpoch=0, use 0 so tests query the beacon node without waiting for the fork
-  const gloasForkEpoch = 0;
+  // ClockMock reports currentEpoch=0, use GLOAS_FORK_EPOCH=0 so tests query the beacon node without waiting for the fork
+  const config = {GLOAS_FORK_EPOCH: 0} as unknown as ChainForkConfig;
 
   let abortController: AbortController;
 
@@ -54,14 +55,7 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
 
-    const builderIndex = await resolveBuilderIdentity(
-      api,
-      logger,
-      pubkeyString,
-      abortController.signal,
-      clock,
-      gloasForkEpoch
-    );
+    const builderIndex = await resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
     expect(builderIndex).toEqual(index);
   });
 
@@ -71,7 +65,7 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version: newVersion})
     );
     await expect(
-      resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, gloasForkEpoch)
+      resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config)
     ).rejects.toThrow(`Builder version mismatch: got ${newVersion}, expected ${version}`);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledWith(expect.objectContaining({builderIds: [pubkeyString]}));
   });
@@ -80,7 +74,7 @@ describe("Identity", () => {
     const invalidPubkey = Buffer.alloc(48, 2);
     api.beacon.getStateBuilders.mockResolvedValue(mockGetStateBuildersResponse(index, {pubkey: invalidPubkey}));
     await expect(
-      resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, gloasForkEpoch)
+      resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config)
     ).rejects.toThrow(`Pubkey mismatch: got=${toHex(invalidPubkey)} expected=${pubkeyString}`);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledWith(expect.objectContaining({builderIds: [pubkeyString]}));
   });
@@ -88,7 +82,7 @@ describe("Identity", () => {
   it("throws on builder status exited", async () => {
     api.beacon.getStateBuilders.mockResolvedValue(mockGetStateBuildersResponse(index, {status: "exited", pubkey}));
     await expect(
-      resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, gloasForkEpoch)
+      resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config)
     ).rejects.toThrow(`Builder exited: id=${pubkeyString}`);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledWith(expect.objectContaining({builderIds: [pubkeyString]}));
   });
@@ -101,7 +95,7 @@ describe("Identity", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
-    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, gloasForkEpoch);
+    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
     await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
@@ -115,7 +109,7 @@ describe("Identity", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
-    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, gloasForkEpoch);
+    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
     await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
@@ -124,30 +118,35 @@ describe("Identity", () => {
   it("waits for the Gloas fork before querying the beacon node", async () => {
     vi.useFakeTimers();
     // ClockMock reports currentEpoch=0, so a future fork epoch keeps the builder in the pre-fork wait loop
-    const futureGloasForkEpoch = 1;
-    const promise = resolveBuilderIdentity(
-      api,
-      logger,
-      pubkeyString,
-      abortController.signal,
-      clock,
-      futureGloasForkEpoch
-    );
+    const futureForkConfig = {GLOAS_FORK_EPOCH: 1} as unknown as ChainForkConfig;
+    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, futureForkConfig);
     await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
 
     expect(api.beacon.getStateBuilders).not.toHaveBeenCalled();
     expect(logger.info).toHaveBeenCalledWith(
       "Waiting for Gloas fork before resolving builder identity",
-      expect.objectContaining({gloasForkEpoch: futureGloasForkEpoch, currentEpoch: 0})
+      expect.objectContaining({gloasForkEpoch: 1, currentEpoch: 0})
     );
 
     abortController.abort();
     await expect(promise).rejects.toThrow(ErrorAborted);
   });
 
+  it("keeps polling on a transient pre-gloas 400 at the fork boundary", async () => {
+    vi.useFakeTimers();
+    api.beacon.getStateBuilders.mockResolvedValueOnce(await mockApiErrorResponse(400));
+    api.beacon.getStateBuilders.mockResolvedValue(
+      mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
+    );
+    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
+    await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
+    expect(await promise).toEqual(index);
+    expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
+  });
+
   it("rejects without querying the beacon node when the signal is already aborted", async () => {
     const abortSignal = AbortSignal.abort();
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortSignal, clock, gloasForkEpoch)).rejects.toThrow(
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortSignal, clock, config)).rejects.toThrow(
       ErrorAborted
     );
     expect(api.beacon.getStateBuilders).not.toHaveBeenCalled();
@@ -157,7 +156,7 @@ describe("Identity", () => {
     const resStatus = 500;
     api.beacon.getStateBuilders.mockResolvedValue(await mockApiErrorResponse(resStatus));
     await expect(
-      resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, gloasForkEpoch)
+      resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config)
     ).rejects.toThrow(/status 500/);
   });
 });

--- a/packages/builder/test/unit/identity.test.ts
+++ b/packages/builder/test/unit/identity.test.ts
@@ -17,6 +17,8 @@ describe("Identity", () => {
   const pubkeyString = toHex(pubkey);
   const balance = 1;
   const version = PAYLOAD_BUILDER_VERSION;
+  // ClockMock reports currentEpoch=0, use 0 so tests query the beacon node without waiting for the fork
+  const gloasForkEpoch = 0;
 
   let abortController: AbortController;
 
@@ -52,7 +54,14 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
 
-    const builderIndex = await resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock);
+    const builderIndex = await resolveBuilderIdentity(
+      api,
+      logger,
+      pubkeyString,
+      abortController.signal,
+      clock,
+      gloasForkEpoch
+    );
     expect(builderIndex).toEqual(index);
   });
 
@@ -61,26 +70,26 @@ describe("Identity", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version: newVersion})
     );
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock)).rejects.toThrow(
-      `Builder version mismatch: got ${newVersion}, expected ${version}`
-    );
+    await expect(
+      resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, gloasForkEpoch)
+    ).rejects.toThrow(`Builder version mismatch: got ${newVersion}, expected ${version}`);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledWith(expect.objectContaining({builderIds: [pubkeyString]}));
   });
 
   it("throws on pubkey mismatch", async () => {
     const invalidPubkey = Buffer.alloc(48, 2);
     api.beacon.getStateBuilders.mockResolvedValue(mockGetStateBuildersResponse(index, {pubkey: invalidPubkey}));
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock)).rejects.toThrow(
-      `Pubkey mismatch: got=${toHex(invalidPubkey)} expected=${pubkeyString}`
-    );
+    await expect(
+      resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, gloasForkEpoch)
+    ).rejects.toThrow(`Pubkey mismatch: got=${toHex(invalidPubkey)} expected=${pubkeyString}`);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledWith(expect.objectContaining({builderIds: [pubkeyString]}));
   });
 
   it("throws on builder status exited", async () => {
     api.beacon.getStateBuilders.mockResolvedValue(mockGetStateBuildersResponse(index, {status: "exited", pubkey}));
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock)).rejects.toThrow(
-      `Builder exited: id=${pubkeyString}`
-    );
+    await expect(
+      resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, gloasForkEpoch)
+    ).rejects.toThrow(`Builder exited: id=${pubkeyString}`);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledWith(expect.objectContaining({builderIds: [pubkeyString]}));
   });
 
@@ -92,7 +101,7 @@ describe("Identity", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
-    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock);
+    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, gloasForkEpoch);
     await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
@@ -106,23 +115,49 @@ describe("Identity", () => {
     api.beacon.getStateBuilders.mockResolvedValue(
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
-    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock);
+    const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, gloasForkEpoch);
     await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
   });
 
+  it("waits for the Gloas fork before querying the beacon node", async () => {
+    vi.useFakeTimers();
+    // ClockMock reports currentEpoch=0, so a future fork epoch keeps the builder in the pre-fork wait loop
+    const futureGloasForkEpoch = 1;
+    const promise = resolveBuilderIdentity(
+      api,
+      logger,
+      pubkeyString,
+      abortController.signal,
+      clock,
+      futureGloasForkEpoch
+    );
+    await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
+
+    expect(api.beacon.getStateBuilders).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      "Waiting for Gloas fork before resolving builder identity",
+      expect.objectContaining({gloasForkEpoch: futureGloasForkEpoch, currentEpoch: 0})
+    );
+
+    abortController.abort();
+    await expect(promise).rejects.toThrow(ErrorAborted);
+  });
+
   it("rejects without querying the beacon node when the signal is already aborted", async () => {
     const abortSignal = AbortSignal.abort();
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortSignal, clock)).rejects.toThrow(ErrorAborted);
+    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortSignal, clock, gloasForkEpoch)).rejects.toThrow(
+      ErrorAborted
+    );
     expect(api.beacon.getStateBuilders).not.toHaveBeenCalled();
   });
 
   it("throws on beacon node 500", async () => {
     const resStatus = 500;
     api.beacon.getStateBuilders.mockResolvedValue(await mockApiErrorResponse(resStatus));
-    await expect(resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock)).rejects.toThrow(
-      /status 500/
-    );
+    await expect(
+      resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, gloasForkEpoch)
+    ).rejects.toThrow(/status 500/);
   });
 });

--- a/packages/builder/test/unit/utils/clock.ts
+++ b/packages/builder/test/unit/utils/clock.ts
@@ -4,7 +4,7 @@ import {Epoch, Slot} from "@lodestar/types";
 type RunEveryFn = (slot: Slot, signal: AbortSignal) => Promise<void>;
 
 export class ClockMock implements IClock {
-  readonly currentEpoch: number = 0;
+  currentEpoch = 0;
   readonly genesisTime: number = 0;
   readonly secondsPerSlot: number = 12;
 
@@ -18,7 +18,7 @@ export class ClockMock implements IClock {
   msFromSlot = (): number => 0;
   secFromSlot = (): number => 0;
   getCurrentSlot = (): number => 0;
-  getCurrentEpoch = (): number => 0;
+  getCurrentEpoch = (): number => this.currentEpoch;
 
   async tickSlotFns(slot: Slot, signal: AbortSignal): Promise<void> {
     for (const fn of this.everySlot) await fn(slot, signal);

--- a/packages/cli/src/cmds/builder/handler.ts
+++ b/packages/cli/src/cmds/builder/handler.ts
@@ -40,8 +40,7 @@ export async function builderHandler(args: IBuilderCliArgs & GlobalArgs): Promis
   }
 
   const keypair = await loadBuilderKeypair(args.keystore, args.keystorePassword, args.builderPubkey);
-  logger.info("Builder keystore");
-  logger.info(keypair.publicKey.toHex());
+  logger.info("Loaded builder keystore", {pubkey: keypair.publicKey.toHex()});
 
   const onGracefulShutdownCbs: (() => Promise<void> | void)[] = [];
   onGracefulShutdown(async () => {

--- a/packages/cli/src/cmds/builder/handler.ts
+++ b/packages/cli/src/cmds/builder/handler.ts
@@ -39,8 +39,7 @@ export async function builderHandler(args: IBuilderCliArgs & GlobalArgs): Promis
     throw Error("Cannot put zero address as an executionFeeRecipient");
   }
 
-  const keypair = await loadBuilderKeypair(args.keystore, args.keystorePassword, args.builderPubkey);
-  logger.info("Loaded builder keystore", {pubkey: keypair.publicKey.toHex()});
+  const keypair = await loadBuilderKeypair(logger, args.keystore, args.keystorePassword, args.builderPubkey);
 
   const onGracefulShutdownCbs: (() => Promise<void> | void)[] = [];
   onGracefulShutdown(async () => {

--- a/packages/cli/src/cmds/builder/handler.ts
+++ b/packages/cli/src/cmds/builder/handler.ts
@@ -7,6 +7,7 @@ import {getBeaconConfigFromArgs} from "../../config/beaconParams.js";
 import {GlobalArgs} from "../../options/index.js";
 import {getGlobalPaths} from "../../paths/global.js";
 import {cleanOldLogFiles, onGracefulShutdown, parseFeeRecipient, parseLoggerArgs} from "../../util/index.js";
+import {getVersionData} from "../../util/version.js";
 import {loadBuilderKeypair} from "./loadKeypair.js";
 import {IBuilderCliArgs} from "./options.js";
 
@@ -29,6 +30,9 @@ export async function builderHandler(args: IBuilderCliArgs & GlobalArgs): Promis
     logger.debug("Not able to delete log files", {}, e as Error);
   }
 
+  const {version, commit} = getVersionData();
+  logger.info("Lodestar", {network, version, commit});
+
   const executionFeeRecipient = parseFeeRecipient(args.executionFeeRecipient);
 
   if (executionFeeRecipient === ZERO_ADDRESS) {
@@ -36,6 +40,7 @@ export async function builderHandler(args: IBuilderCliArgs & GlobalArgs): Promis
   }
 
   const keypair = await loadBuilderKeypair(args.keystore, args.keystorePassword, args.builderPubkey);
+  logger.info("Loaded builder keystore", {pubkey: keypair.publicKey.toHex()});
 
   const onGracefulShutdownCbs: (() => Promise<void> | void)[] = [];
   onGracefulShutdown(async () => {

--- a/packages/cli/src/cmds/builder/handler.ts
+++ b/packages/cli/src/cmds/builder/handler.ts
@@ -40,7 +40,8 @@ export async function builderHandler(args: IBuilderCliArgs & GlobalArgs): Promis
   }
 
   const keypair = await loadBuilderKeypair(args.keystore, args.keystorePassword, args.builderPubkey);
-  logger.info("Loaded builder keystore", {pubkey: keypair.publicKey.toHex()});
+  logger.info("Builder keystore");
+  logger.info(keypair.publicKey.toHex());
 
   const onGracefulShutdownCbs: (() => Promise<void> | void)[] = [];
   onGracefulShutdown(async () => {

--- a/packages/cli/src/cmds/builder/loadKeypair.ts
+++ b/packages/cli/src/cmds/builder/loadKeypair.ts
@@ -2,10 +2,12 @@ import fs from "node:fs";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {SecretKey} from "@chainsafe/blst";
 import {Keypair} from "@lodestar/builder";
+import {Logger} from "@lodestar/utils";
 import {ensure0xPrefix} from "../../util/format.js";
 import {readPassphraseFile} from "../../util/passphrase.js";
 
 export async function loadBuilderKeypair(
+  logger: Logger,
   keystorePath: string,
   passwordPath: string,
   expectedPubkey?: string
@@ -27,6 +29,8 @@ export async function loadBuilderKeypair(
   if (expectedPubkey && publicKeyHex !== ensure0xPrefix(expectedPubkey.toLowerCase())) {
     throw Error(`Pubkey mismatch: keystore ${publicKeyHex}, expected ${expectedPubkey}`);
   }
+
+  logger.info("Loaded builder keystore", {pubkey: publicKeyHex});
 
   return {secretKey, publicKey};
 }

--- a/packages/cli/test/unit/cmds/builder/loadKeypair.test.ts
+++ b/packages/cli/test/unit/cmds/builder/loadKeypair.test.ts
@@ -4,9 +4,10 @@ import {afterAll, beforeAll, describe, expect, it} from "vitest";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {SecretKey} from "@chainsafe/blst";
 import {loadBuilderKeypair} from "../../../../src/cmds/builder/loadKeypair.js";
-import {testFilesDir} from "../../../utils.js";
+import {testFilesDir, testLogger} from "../../../utils.js";
 
 describe("Keystore loading", () => {
+  const logger = testLogger();
   const testFilesDirBuilder = path.join(testFilesDir, "builder");
   const keystorePath = path.join(testFilesDirBuilder, "keystore.json");
   const passwordPath = path.join(testFilesDirBuilder, "password.txt");
@@ -30,22 +31,22 @@ describe("Keystore loading", () => {
   });
 
   it("Successful keystore load", async () => {
-    const {secretKey} = await loadBuilderKeypair(keystorePath, passwordPath);
+    const {secretKey} = await loadBuilderKeypair(logger, keystorePath, passwordPath);
     expect(secretKey.toBytes()).toEqual(Uint8Array.from(secretKeyBytes));
   });
 
   it("Successful keystore load with matching pubkey", async () => {
-    const {secretKey} = await loadBuilderKeypair(keystorePath, passwordPath, publicKey.toHex());
+    const {secretKey} = await loadBuilderKeypair(logger, keystorePath, passwordPath, publicKey.toHex());
     expect(secretKey.toBytes()).toEqual(Uint8Array.from(secretKeyBytes));
   });
 
   it("Successful keystore load with matching uppercase pubkey", async () => {
-    const {secretKey} = await loadBuilderKeypair(keystorePath, passwordPath, publicKey.toHex().toUpperCase());
+    const {secretKey} = await loadBuilderKeypair(logger, keystorePath, passwordPath, publicKey.toHex().toUpperCase());
     expect(secretKey.toBytes()).toEqual(Uint8Array.from(secretKeyBytes));
   });
 
   it("Shouldn't load with improper password", async () => {
-    await expect(loadBuilderKeypair(keystorePath, wrongPasswordPath)).rejects.toThrow(
+    await expect(loadBuilderKeypair(logger, keystorePath, wrongPasswordPath)).rejects.toThrow(
       `Invalid password for keystore ${keystorePath}`
     );
   });
@@ -54,7 +55,7 @@ describe("Keystore loading", () => {
     const wrongSecretKey = SecretKey.fromBytes(Buffer.alloc(32, 2));
     const wrongPublicKey = wrongSecretKey.toPublicKey().toHex();
 
-    await expect(loadBuilderKeypair(keystorePath, passwordPath, wrongPublicKey)).rejects.toThrow(
+    await expect(loadBuilderKeypair(logger, keystorePath, passwordPath, wrongPublicKey)).rejects.toThrow(
       `Pubkey mismatch: keystore ${publicKey.toHex()}, expected ${wrongPublicKey}`
     );
   });


### PR DESCRIPTION
**Motivation**

Setting up the Lodestar builder to onboard on a pre-Gloas network surfaced a few startup / operator issues:

1. **The builder exits pre-fork.** `getStateBuilders` returns `400 Builders are not supported for pre-gloas state` and the error propagates out of `Builder.init`, killing the process until an external wrapper restarts it:

```
✖ Error: getStateBuilders failed with status 400: Builders are not supported for pre-gloas state fork=fulu
    at fetchBuilder (packages/builder/src/identity.ts:88:31)
    at waitForBuilder (packages/builder/src/identity.ts:62:21)
    at resolveBuilderIdentity (packages/builder/src/identity.ts:16:24)
    at Builder.init (packages/builder/src/builder.ts:80:19)
```

2. The **imported builder pubkey isn't logged**, so operators can't confirm which key was loaded.
3. The startup **`Lodestar network=… version=… commit=…` banner** (present in the beacon and validator clients) is missing.

**Description**

- Gate builder identity resolution on `GLOAS_FORK_EPOCH`: while `currentEpoch < gloasForkEpoch`, log `Waiting for Gloas fork before resolving builder identity` and keep polling instead of querying — and crashing on — the pre-gloas beacon state.
- Tolerate a transient pre-gloas `400` right at the fork boundary (the head state may briefly still be pre-gloas until the first post-fork state is available); any other error still propagates.
- Log the imported builder pubkey right after loading the keystore.
- Print the `Lodestar` network/version/commit banner on startup, matching the beacon and validator clients.

Added a unit test for the pre-fork wait; existing identity tests updated for the new `gloasForkEpoch` argument.
