### PR TITLE
perf: implement appendBuilderToRegistry()

### DIFF
--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -17,7 +17,7 @@ import {isValidDepositSignature} from "../block/processDeposit.js";
 import {getCachedBeaconState} from "../cache/stateCache.js";
 import type {BeaconStateTransitionMetrics} from "../metrics.js";
 import {CachedBeaconStateFulu, CachedBeaconStateGloas} from "../types.js";
-import {addBuilderToRegistry, initializePtcWindow, isBuilderWithdrawalCredential} from "../util/gloas.js";
+import {appendBuilderToRegistry, initializePtcWindow, isBuilderWithdrawalCredential} from "../util/gloas.js";
 import {isValidatorKnown} from "../util/index.js";
 import {PendingDepositsLookup} from "../util/pendingDepositsLookup.js";
 import {progressiveListRootNode} from "../util/ssz.js";
@@ -264,7 +264,7 @@ function onboardBuildersFromPendingDeposits(
       continue;
     }
 
-    addBuilderToRegistry(
+    appendBuilderToRegistry(
       state,
       deposit.pubkey,
       PAYLOAD_BUILDER_VERSION,

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -273,7 +273,44 @@ export function addBuilderToRegistry(
     }
   }
 
-  const newBuilder = ssz.gloas.Builder.toViewDU({
+  const newBuilder = createBuilderView(pubkey, version, executionAddress, amount, depositEpoch);
+
+  if (builderIndex < state.builders.length) {
+    state.builders.set(builderIndex, newBuilder);
+  } else {
+    state.builders.push(newBuilder);
+  }
+}
+
+/**
+ * Append a new builder to the registry without scanning for a reusable slot.
+ *
+ * This is only safe to be used at the gloas fork transition.
+ */
+export function appendBuilderToRegistry(
+  state: CachedBeaconStateGloas,
+  pubkey: Uint8Array,
+  version: number,
+  executionAddress: Uint8Array,
+  amount: number,
+  slot: number
+): void {
+  const depositEpoch = computeEpochAtSlot(slot);
+  state.builders.push(createBuilderView(pubkey, version, executionAddress, amount, depositEpoch));
+}
+
+/**
+ * Build a Builder view for registry insertion. Shared by the scan-based {@link addBuilderToRegistry}
+ * and the append-only {@link appendBuilderToRegistry} so both paths produce an identical view.
+ */
+function createBuilderView(
+  pubkey: Uint8Array,
+  version: number,
+  executionAddress: Uint8Array,
+  amount: number,
+  depositEpoch: Epoch
+) {
+  return ssz.gloas.Builder.toViewDU({
     pubkey,
     version,
     executionAddress,
@@ -281,12 +318,6 @@ export function addBuilderToRegistry(
     depositEpoch,
     withdrawableEpoch: FAR_FUTURE_EPOCH,
   });
-
-  if (builderIndex < state.builders.length) {
-    state.builders.set(builderIndex, newBuilder);
-  } else {
-    state.builders.push(newBuilder);
-  }
 }
 
 /**

--- a/packages/state-transition/test/unit/util/gloas.test.ts
+++ b/packages/state-transition/test/unit/util/gloas.test.ts
@@ -1,5 +1,35 @@
 import {describe, expect, it} from "vitest";
-import {getExpectedGasLimit, isGasLimitTargetCompatible} from "../../../src/util/gloas.js";
+import {createBeaconConfig} from "@lodestar/config";
+import {getConfig} from "@lodestar/config/test-utils";
+import {FAR_FUTURE_EPOCH, ForkName, MIN_DEPOSIT_AMOUNT, PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
+import {createCachedBeaconState, createPubkeyCache} from "../../../src/index.js";
+import {CachedBeaconStateGloas} from "../../../src/types.js";
+import {
+  addBuilderToRegistry,
+  appendBuilderToRegistry,
+  getExpectedGasLimit,
+  isGasLimitTargetCompatible,
+} from "../../../src/util/gloas.js";
+
+function buildGloasState(slot = 0): CachedBeaconStateGloas {
+  const config = getConfig(ForkName.gloas);
+  const view = ssz.gloas.BeaconState.defaultViewDU();
+  view.slot = slot;
+  view.fork = ssz.phase0.Fork.toViewDU({
+    previousVersion: config.GENESIS_FORK_VERSION,
+    currentVersion: config.GLOAS_FORK_VERSION,
+    epoch: 0,
+  });
+  return createCachedBeaconState(
+    view,
+    {
+      config: createBeaconConfig(config, view.genesisValidatorsRoot),
+      pubkeyCache: createPubkeyCache(),
+    },
+    {skipSyncCommitteeCache: true}
+  ) as CachedBeaconStateGloas;
+}
 
 describe("util / gloas", () => {
   describe("getExpectedGasLimit", () => {
@@ -72,6 +102,35 @@ describe("util / gloas", () => {
 
       expect(isGasLimitTargetCompatible(parentGasLimit, expectedGasLimit, expectedGasLimit)).toBe(true);
       expect(isGasLimitTargetCompatible(parentGasLimit, roundedGasLimit, expectedGasLimit)).toBe(false);
+    });
+  });
+
+  describe("appendBuilderToRegistry", () => {
+    // At the fork transition the builders registry is append-only (no reusable slot exists), so the
+    // scan-free appendBuilderToRegistry must produce a byte-identical registry to the scan-based
+    // addBuilderToRegistry. addBuilderToRegistry is the oracle here.
+    it("matches addBuilderToRegistry for append-only onboarding", () => {
+      const slot = 0; // any slot; both paths compute depositEpoch identically
+      const scanState = buildGloasState(slot);
+      const appendState = buildGloasState(slot);
+
+      const n = 256;
+      for (let i = 0; i < n; i++) {
+        const pubkey = new Uint8Array(48).fill(i & 0xff);
+        const execAddr = new Uint8Array(20).fill(i & 0xff);
+        const amount = MIN_DEPOSIT_AMOUNT + i; // balance > 0, as for a fresh builder at the fork
+
+        addBuilderToRegistry(scanState, pubkey, PAYLOAD_BUILDER_VERSION, execAddr, amount, slot);
+        appendBuilderToRegistry(appendState, pubkey, PAYLOAD_BUILDER_VERSION, execAddr, amount, slot);
+
+        // byte-for-byte registry equivalence after every onboard
+        expect(appendState.builders.hashTreeRoot()).toEqual(scanState.builders.hashTreeRoot());
+      }
+
+      expect(appendState.builders.length).toBe(n);
+      const builder = appendState.builders.getReadonly(n - 1);
+      expect(builder.withdrawableEpoch).toBe(FAR_FUTURE_EPOCH);
+      expect(builder.version).toBe(PAYLOAD_BUILDER_VERSION);
     });
   });
 });


### PR DESCRIPTION
**Motivation**

- I was able to test onboarding 1000 builder deposits at fork transition (all signature verification comes from the cache), but not with 262k. It turns out the O(n²) scan of `addBuilderToRegistry()` was the cause but we don't have to call it at all

**Description**

- write a new `appendBuilderToRegistry()` to be used specifically at the fork transition without having to loop throuh `state.builders`

**AI Assistance Disclosure**

- created with the help of Claude