### PR TITLE
feat(bls): update metrics for zig pk cache

### DIFF
--- a/dashboards/lodestar_bls_thread_pool.json
+++ b/dashboards/lodestar_bls_thread_pool.json
@@ -1116,6 +1116,102 @@
       ],
       "title": "BLS worker pool - jobs per worker call",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 520,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le, type) (rate(lodestar_bls_thread_pool_native_verification_time_seconds_bucket[$rate_interval])))",
+          "instant": false,
+          "legendFormat": "p50 {{type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(lodestar_bls_thread_pool_native_verification_time_seconds_bucket[$rate_interval])))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "p95 {{type}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Native BLS verification duration",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/dashboards/lodestar_bls_thread_pool.json
+++ b/dashboards/lodestar_bls_thread_pool.json
@@ -824,7 +824,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Average signatures per set. This number is decided by the time of object submitted to the pool:\n- Sync blocks: 128\n- Aggregates: 3\n- Attestations: 1",
+      "description": "Average signature sets per job, split by job type.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -881,7 +881,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
@@ -895,13 +895,13 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(lodestar_bls_thread_pool_sig_sets_started_total[$rate_interval])/(rate(lodestar_bls_thread_pool_jobs_started_total[$rate_interval])>0)",
+          "expr": "sum by (type) (rate(lodestar_bls_thread_pool_sig_sets_started_total[$rate_interval])) / sum by (type) (rate(lodestar_bls_thread_pool_jobs_started_total[$rate_interval]))",
           "interval": "",
-          "legendFormat": "pool",
+          "legendFormat": "{{type}}",
           "refId": "A"
         }
       ],
-      "title": "BLS worker pool - sigs per set",
+      "title": "BLS worker pool - signature sets per job",
       "type": "timeseries"
     },
     {
@@ -981,38 +981,6 @@
                 "value": "right"
               }
             ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "same_message_job_retries"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "ops"
-              },
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "same_message_set_retries"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "ops"
-              },
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              }
-            ]
           }
         ]
       },
@@ -1059,30 +1027,6 @@
           "interval": "",
           "legendFormat": "batch_retries",
           "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "rate(lodestar_bls_thread_pool_same_message_jobs_retries_total[$rate_interval])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "same_message_job_retries",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "rate(lodestar_bls_thread_pool_same_message_sets_retries_total[$rate_interval])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "same_message_set_retries",
-          "refId": "D"
         }
       ],
       "title": "BLS thread pool - Error rates",
@@ -1093,7 +1037,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Average sets per job. A set may contain +1 signatures. This number should be higher than 1 to reduce communication costs",
+      "description": "Average jobs included in each worker call. Values above 1 show that queue batching amortizes worker communication overhead.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1164,284 +1108,14 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(lodestar_bls_thread_pool_jobs_started_total[$rate_interval])/rate(lodestar_bls_thread_pool_job_groups_started_total[$rate_interval])",
+          "expr": "sum(rate(lodestar_bls_thread_pool_jobs_started_total[$rate_interval])) / sum(rate(lodestar_bls_thread_pool_job_groups_started_total[$rate_interval]))",
           "interval": "",
           "legendFormat": "pool",
           "refId": "A"
         }
       ],
-      "title": "BLS worker pool - sets per job",
+      "title": "BLS worker pool - jobs per worker call",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 42
-      },
-      "id": 520,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "rate(lodestar_bls_thread_pool_aggregate_with_randomness_async_time_seconds_sum[$rate_interval]) * 384",
-          "instant": false,
-          "legendFormat": "aggregate_with_randomness",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "rate(lodestar_bls_thread_pool_pubkeys_aggregation_main_thread_time_seconds_sum[$rate_interval]) * 384",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "pubkey_aggregation",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "BLS jobItemWorkReq cpu time per epoch",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 42
-      },
-      "id": 521,
-      "options": {
-        "calculate": false,
-        "cellGap": 1,
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Magma",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "mode": "single",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "decimals": 3,
-          "reverse": false,
-          "unit": "short"
-        }
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "rate(lodestar_bls_thread_pool_aggregate_with_randomness_async_time_seconds_bucket[$rate_interval])",
-          "format": "heatmap",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "{{le}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Async AggregateWithRandomness Time",
-      "type": "heatmap"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 50
-      },
-      "id": 522,
-      "options": {
-        "calculate": false,
-        "cellGap": 1,
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Magma",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "mode": "single",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "decimals": 3,
-          "reverse": false,
-          "unit": "short"
-        }
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "rate(lodestar_bls_thread_pool_pubkeys_aggregation_main_thread_time_seconds_bucket[$rate_interval])",
-          "format": "heatmap",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "{{le}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Main Thread Public Key Aggregation Time",
-      "type": "heatmap"
     }
   ],
   "refresh": "10s",

--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -413,7 +413,15 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
       const [jobStartSec, jobStartNs] = process.hrtime();
       const workResult = await workerApi.verifyManySignatureSets(workReqs);
       const [jobEndSec, jobEndNs] = process.hrtime();
-      const {workerId, batchRetries, batchSigsSuccess, workerStartTime, workerEndTime, results} = workResult;
+      const {
+        workerId,
+        batchRetries,
+        batchSigsSuccess,
+        nativeVerificationTimes,
+        workerStartTime,
+        workerEndTime,
+        results,
+      } = workResult;
 
       const [workerStartSec, workerStartNs] = workerStartTime;
       const [workerEndSec, workerEndNs] = workerEndTime;
@@ -469,6 +477,9 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
       this.metrics?.blsThreadPool.errorJobsSignatureSetsCount.inc(errorCount);
       this.metrics?.blsThreadPool.batchRetries.inc(batchRetries);
       this.metrics?.blsThreadPool.batchSigsSuccess.inc(batchSigsSuccess);
+      for (const {type, duration} of nativeVerificationTimes) {
+        this.metrics?.blsThreadPool.nativeVerificationTime.observe({type}, duration);
+      }
     } catch (e) {
       // Worker communications should never reject
       if (!this.closed) {

--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -243,7 +243,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
     const workers: WorkerDescriptor[] = [];
 
     for (let i = 0; i < poolSize; i++) {
-      const workerData: WorkerData = {workerId: i};
+      const workerData: WorkerData = {workerId: i, metricsEnabled: this.metrics !== null};
       const worker = new Worker(path.join(workerDir, "worker.js"), {
         workerData,
       } as ConstructorParameters<typeof Worker>[1]);
@@ -417,7 +417,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
         workerId,
         batchRetries,
         batchSigsSuccess,
-        nativeVerificationTimes,
+        nativeVerificationTimes = [],
         workerStartTime,
         workerEndTime,
         results,

--- a/packages/beacon-node/src/chain/bls/multithread/types.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/types.ts
@@ -3,6 +3,7 @@ import {SameMessageSignatureSet, VerifySignatureOpts} from "../interface.js";
 
 export type WorkerData = {
   workerId: number;
+  metricsEnabled: boolean;
 };
 
 export enum JobQueueItemType {
@@ -46,8 +47,8 @@ export type BlsWorkResult = {
   batchRetries: number;
   /** Total num of sigs that have been successfully verified with batching */
   batchSigsSuccess: number;
-  /** Native verification call timings */
-  nativeVerificationTimes: NativeVerificationTime[];
+  /** Native verification call timings, only present when metrics are enabled */
+  nativeVerificationTimes?: NativeVerificationTime[];
   /** Time worker function starts - UNIX timestamp in seconds and nanoseconds */
   workerStartTime: [number, number];
   /** Time worker function ends - UNIX timestamp in seconds and nanoseconds */

--- a/packages/beacon-node/src/chain/bls/multithread/types.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/types.ts
@@ -33,6 +33,12 @@ export enum WorkResultCode {
 export type WorkResultError = {code: WorkResultCode.error; error: Error};
 export type WorkResult<R> = {code: WorkResultCode.success; result: R} | WorkResultError;
 
+export type NativeVerificationTime = {
+  type: JobQueueItemType;
+  /** Duration of one native verification call in seconds */
+  duration: number;
+};
+
 export type BlsWorkResult = {
   /** Ascending integer identifying the worker for metrics */
   workerId: number;
@@ -40,6 +46,8 @@ export type BlsWorkResult = {
   batchRetries: number;
   /** Total num of sigs that have been successfully verified with batching */
   batchSigsSuccess: number;
+  /** Native verification call timings */
+  nativeVerificationTimes: NativeVerificationTime[];
   /** Time worker function starts - UNIX timestamp in seconds and nanoseconds */
   workerStartTime: [number, number];
   /** Time worker function ends - UNIX timestamp in seconds and nanoseconds */

--- a/packages/beacon-node/src/chain/bls/multithread/worker.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/worker.ts
@@ -5,7 +5,15 @@ import {
   verifySignatureSetsSameMessage,
 } from "@chainsafe/lodestar-z/bls-verifier";
 import {expose} from "@chainsafe/threads/worker";
-import {BlsWorkReq, BlsWorkResult, JobQueueItemType, WorkResult, WorkResultCode, WorkerData} from "./types.js";
+import {
+  BlsWorkReq,
+  BlsWorkResult,
+  JobQueueItemType,
+  NativeVerificationTime,
+  WorkResult,
+  WorkResultCode,
+  WorkerData,
+} from "./types.js";
 import {chunkifyMaximizeChunkSize} from "./utils.js";
 
 /**
@@ -31,6 +39,7 @@ expose({
 function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
   const [startSec, startNs] = process.hrtime();
   const results: WorkResult<boolean[]>[] = [];
+  const nativeVerificationTimes: NativeVerificationTime[] = [];
   let batchRetries = 0;
   let batchSigsSuccess = 0;
 
@@ -53,7 +62,10 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
       }
       case JobQueueItemType.sameMessage:
         try {
-          const result = verifySignatureSetsSameMessage(workReq.sets, workReq.message);
+          const result = timeNativeVerification(JobQueueItemType.sameMessage, nativeVerificationTimes, () =>
+verifySignatureSetsSameMessage
+            (workReq.sets, workReq.message)
+          );
           results[i] = {code: WorkResultCode.success, result};
         } catch (e) {
           results[i] = {code: WorkResultCode.error, error: e as Error};
@@ -76,7 +88,9 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
 
       try {
         // Attempt to verify multiple sets at once
-        const isValid = verifySignatureSets(allSets);
+        const isValid = timeNativeVerification(JobQueueItemType.default, nativeVerificationTimes, () =>
+          verifySignatureSets(allSets)
+        );
 
         if (isValid) {
           // The entire batch is valid, return success to all
@@ -101,7 +115,9 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
 
   for (const {idx, sets} of nonBatchableSets) {
     try {
-      const isValid = verifySignatureSets(sets);
+      const isValid = timeNativeVerification(JobQueueItemType.default, nativeVerificationTimes, () =>
+        verifySignatureSets(sets)
+      );
       results[idx] = {code: WorkResultCode.success, result: [isValid]};
     } catch (e) {
       results[idx] = {code: WorkResultCode.error, error: e as Error};
@@ -114,8 +130,19 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
     workerId,
     batchRetries,
     batchSigsSuccess,
+    nativeVerificationTimes,
     workerStartTime: [startSec, startNs],
     workerEndTime: [workerEndSec, workerEndNs],
     results,
   };
+}
+
+function timeNativeVerification<T>(type: JobQueueItemType, times: NativeVerificationTime[], verify: () => T): T {
+  const startTime = process.hrtime();
+  try {
+    return verify();
+  } finally {
+    const [seconds, nanoseconds] = process.hrtime(startTime);
+    times.push({type, duration: seconds + nanoseconds / 1e9});
+  }
 }

--- a/packages/beacon-node/src/chain/bls/multithread/worker.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/worker.ts
@@ -28,7 +28,7 @@ const BATCHABLE_MIN_PER_CHUNK = 16;
 // Cloned data from instatiation
 const workerData = worker.workerData as WorkerData;
 if (!workerData) throw Error("workerData must be defined");
-const {workerId} = workerData || {};
+const {workerId, metricsEnabled} = workerData || {};
 
 expose({
   async verifyManySignatureSets(workReqArr: BlsWorkReq[]): Promise<BlsWorkResult> {
@@ -39,7 +39,7 @@ expose({
 function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
   const [startSec, startNs] = process.hrtime();
   const results: WorkResult<boolean[]>[] = [];
-  const nativeVerificationTimes: NativeVerificationTime[] = [];
+  const nativeVerificationTimes: NativeVerificationTime[] | null = metricsEnabled ? [] : null;
   let batchRetries = 0;
   let batchSigsSuccess = 0;
 
@@ -126,18 +126,25 @@ verifySignatureSetsSameMessage
 
   const [workerEndSec, workerEndNs] = process.hrtime();
 
-  return {
+  const workResult: BlsWorkResult = {
     workerId,
     batchRetries,
     batchSigsSuccess,
-    nativeVerificationTimes,
     workerStartTime: [startSec, startNs],
     workerEndTime: [workerEndSec, workerEndNs],
     results,
   };
+  if (nativeVerificationTimes !== null) {
+    workResult.nativeVerificationTimes = nativeVerificationTimes;
+  }
+  return workResult;
 }
 
-function timeNativeVerification<T>(type: JobQueueItemType, times: NativeVerificationTime[], verify: () => T): T {
+function timeNativeVerification<T>(type: JobQueueItemType, times: NativeVerificationTime[] | null, verify: () => T): T {
+  if (times === null) {
+    return verify();
+  }
+
   const startTime = process.hrtime();
   try {
     return verify();

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -476,6 +476,12 @@ export function createLodestarMetrics(
         // Time per sig ~0.9ms on good machines
         buckets: [0.5e-3, 0.75e-3, 1e-3, 1.5e-3, 2e-3, 5e-3],
       }),
+      nativeVerificationTime: register.histogram<{type: JobQueueItemType}>({
+        name: "lodestar_bls_thread_pool_native_verification_time_seconds",
+        help: "Time spent in a native BLS verification call on a worker",
+        labelNames: ["type"],
+        buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.3, 0.5],
+      }),
       totalSigSets: register.gauge({
         name: "lodestar_bls_thread_pool_sig_sets_total",
         help: "Count of total signature sets",

--- a/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
@@ -5,6 +5,7 @@ import {testLogger} from "@lodestar/logger/test-utils";
 import {ISignatureSet, SignatureSetType} from "@lodestar/state-transition";
 import {VerifySignatureOpts} from "../../../../src/chain/bls/interface.js";
 import {BlsMultiThreadWorkerPool} from "../../../../src/chain/bls/multithread/index.js";
+import {createMetrics} from "../../../../src/metrics/index.js";
 
 describe("chain / bls / multithread queue", () => {
   const logger = testLogger();
@@ -108,6 +109,23 @@ describe("chain / bls / multithread queue", () => {
       await testManyValidSignatures({sleep: true}, {batchable: true, priority});
     });
   }
+
+  it("Should record native verification duration by job type", async () => {
+    const metrics = createMetrics({enabled: true, port: 0}, 0);
+    metrics.close();
+    const pool = new BlsMultiThreadWorkerPool({}, {logger, metrics});
+    afterEachCallbacks.push(() => pool.close());
+    await pool["waitTillInitialized"]();
+
+    await pool.verifySignatureSets(sets);
+    await pool.verifySignatureSetsSameMessage(sameMessageSets, sameMessage);
+
+    const metric = await metrics.register.getSingleMetricAsString(
+      "lodestar_bls_thread_pool_native_verification_time_seconds"
+    );
+    expect(metric).toContain('lodestar_bls_thread_pool_native_verification_time_seconds_count{type="default"} 1');
+    expect(metric).toContain('lodestar_bls_thread_pool_native_verification_time_seconds_count{type="same_message"} 1');
+  });
 
   for (const priority of [true, false]) {
     it(`Should verify multiple signatures batched, first is invalid priority=${priority}`, async () => {


### PR DESCRIPTION
**Motivation**

with the new pk cache we need to remove outdated metrics and update with new metrics to track 

**Description**

## Removed

 - BLS jobItemWorkReq CPU time per epoch
 - Async AggregateWithRandomness Time
 - Main Thread Public Key Aggregation Time

These are no longer tracked since we do not do aggregation with the new pk cache. All work is delegated to the zig layer via bindings.

## New

- **jobs per worker call**: This is added to track how many jobs we are queuing per worker clal.
<img width="1477" height="431" alt="Screenshot 2026-08-18 at 11 17 19 PM" src="https://github.com/user-attachments/assets/e8e62f48-051c-415f-9c82-3c87a90c2f45" />

- **native verification duration**: 
<img width="3006" height="615" alt="Screenshot 2026-08-18 at 11 18 45 PM" src="https://github.com/user-attachments/assets/ef54bc73-73e5-4ea0-a5be-82f5a5abc4da" />

**AI Assistance Disclosure**

stale metrics found with codex, code generated with codex
