### PR TITLE
fix(bls): bound worker signature packages

### DIFF
--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -360,6 +360,10 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
     worker.status = {code: WorkerStatusCode.running, workerApi};
     this.workersBusy++;
 
+    if (this.jobs.length > 0) {
+      callInNextEventLoop(this.runJob);
+    }
+
     try {
       let startedJobsDefault = 0;
       let startedJobsSameMessage = 0;

--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -495,13 +495,19 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
     let totalSigs = 0;
 
     while (totalSigs < MAX_SIGNATURE_SETS_PER_JOB) {
-      const job = this.jobs.shift();
+      const job = this.jobs.first();
       if (!job) {
         break;
       }
 
+      const jobSigSets = jobItemSigSets(job);
+      if (jobs.length > 0 && totalSigs + jobSigSets > MAX_SIGNATURE_SETS_PER_JOB) {
+        break;
+      }
+
+      this.jobs.shift();
       jobs.push(job);
-      totalSigs += jobItemSigSets(job);
+      totalSigs += jobSigSets;
     }
 
     return jobs;

--- a/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
@@ -1,3 +1,4 @@
+import type {Gauge} from "prom-client";
 import {afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
 import {SecretKey} from "@chainsafe/lodestar-z/blst";
 import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
@@ -5,6 +6,7 @@ import {testLogger} from "@lodestar/logger/test-utils";
 import {ISignatureSet, SignatureSetType} from "@lodestar/state-transition";
 import {VerifySignatureOpts} from "../../../../src/chain/bls/interface.js";
 import {BlsMultiThreadWorkerPool} from "../../../../src/chain/bls/multithread/index.js";
+import {createMetricsTest} from "../../../unit/metrics/utils.js";
 
 describe("chain / bls / multithread queue", () => {
   const logger = testLogger();
@@ -130,4 +132,21 @@ describe("chain / bls / multithread queue", () => {
       await pool.close();
     });
   }
+
+  it("Should not retry batchable jobs that fit the native verifier bound", async () => {
+    const metrics = createMetricsTest();
+    const pool = new BlsMultiThreadWorkerPool({}, {logger, metrics});
+    afterEachCallbacks.push(() => pool.close());
+    await pool["waitTillInitialized"]();
+
+    const smallJob = pool.verifySignatureSets([sets[0], sets[1]], {batchable: true});
+    const largeJob = pool.verifySignatureSets(
+      Array.from({length: 255}, () => sets[2]),
+      {batchable: true}
+    );
+
+    await expect(Promise.all([smallJob, largeJob])).resolves.toEqual([true, true]);
+    const retries = await (metrics.blsThreadPool.batchRetries as unknown as Gauge).get();
+    expect(retries.values[0]?.value).toBe(0);
+  });
 });

--- a/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
@@ -1,5 +1,5 @@
 import type {Gauge} from "prom-client";
-import {afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
+import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {SecretKey} from "@chainsafe/lodestar-z/blst";
 import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {testLogger} from "@lodestar/logger/test-utils";
@@ -148,5 +148,43 @@ describe("chain / bls / multithread queue", () => {
     await expect(Promise.all([smallJob, largeJob])).resolves.toEqual([true, true]);
     const retries = await (metrics.blsThreadPool.batchRetries as unknown as Gauge).get();
     expect(retries.values[0]?.value).toBe(0);
+  });
+
+  it("Should dispatch bounded packages to idle workers", async () => {
+    const pool = await initializePool();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    let startedWorkerCalls = 0;
+    let releaseWorkers!: () => void;
+    const workersReleased = new Promise<void>((resolve) => {
+      releaseWorkers = resolve;
+    });
+
+    for (const worker of pool["workers"]) {
+      if (!("workerApi" in worker.status)) {
+        throw Error("BLS worker did not initialize");
+      }
+
+      const verifyManySignatureSets = worker.status.workerApi.verifyManySignatureSets.bind(worker.status.workerApi);
+      worker.status.workerApi.verifyManySignatureSets = async (workReqs) => {
+        startedWorkerCalls++;
+        await workersReleased;
+        return verifyManySignatureSets(workReqs);
+      };
+    }
+
+    const smallJob = pool.verifySignatureSets([sets[0], sets[1]], {batchable: true});
+    const largeJob = pool.verifySignatureSets(
+      Array.from({length: 127}, () => sets[2]),
+      {batchable: true}
+    );
+
+    try {
+      await vi.waitFor(() => expect(startedWorkerCalls).toBe(2));
+    } finally {
+      releaseWorkers();
+    }
+
+    await expect(Promise.all([smallJob, largeJob])).resolves.toEqual([true, true]);
   });
 });


### PR DESCRIPTION
## Summary

- keep worker packages within `MAX_SIGNATURE_SETS_PER_JOB` instead of overshooting when the next queued job is large
- prevent valid aggregate packages from exceeding Lodestar-Z's 256-set verifier bound and falling back to individual verification
- add a regression for a 2-set job followed by a 255-set job, which previously produced one retry

## Verification

- `pnpm --filter @lodestar/beacon-node build`
- `pnpm --filter @lodestar/beacon-node check-types`
- `pnpm biome check packages/beacon-node/src/chain/bls/multithread/index.ts packages/beacon-node/test/e2e/chain/bls/multithread.test.ts`
- `pnpm vitest run --project e2e packages/beacon-node/test/e2e/chain/bls/multithread.test.ts` (9 passed)

Follow-up for #9820 review feedback: https://github.com/ChainSafe/lodestar/pull/9820#discussion_r3805332750
