### PR TITLE
fix: fully initialize execution payload bid on gloas upgrade

### DIFF
--- a/packages/beacon-node/src/chain/validation/proposerPreferences.ts
+++ b/packages/beacon-node/src/chain/validation/proposerPreferences.ts
@@ -13,7 +13,7 @@ import {IBeaconChain} from "../index.js";
 
 /**
  * Validates a gossiped `SignedProposerPreferences` per
- * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/gloas/p2p-interface.md#new-proposer_preferences
+ * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.14/specs/gloas/p2p-interface.md#new-proposer_preferences
  */
 export async function validateGossipProposerPreferences(
   chain: IBeaconChain,

--- a/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
+++ b/packages/beacon-node/test/spec/presets/fast_confirmation.test.ts
@@ -720,15 +720,7 @@ const fastConfirmationTest =
           // processing, which Lodestar does not support. Unskip if upstream signs deposits for
           // real, or if full bls_setting=2 support is ever added.
           name.includes("is_one_confirmed_fails_recently_activated_validator_voting_in_empty_slot") ||
-          name.includes("is_one_confirmed_passes_with_new_validator_activated_in_head_state") ||
-          // These vectors run `on_fast_confirmation` twice in one slot (stale GU test) or skip an
-          // epoch-boundary run (consecutive slots test), so a client running the handler once per
-          // slot cannot reproduce the expected FCR-store variables. Fixed upstream, unskip when
-          // the next spec-tests release (> v1.7.0-alpha.13) is picked up:
-          // - https://github.com/ethereum/consensus-specs/pull/5499
-          // - https://github.com/ethereum/consensus-specs/pull/5498
-          name.includes("fcr_no_restart_if_head_gu_is_stale") ||
-          name.includes("is_one_confirmed_passes_with_empty_slot_and_attester_in_two_consecutive_slots_2"),
+          name.includes("is_one_confirmed_passes_with_new_validator_activated_in_head_state"),
       },
     };
   };

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -88,7 +88,7 @@ export const defaultSkipOpts: SkipOpts = {
     /^gloas\/fork_choice\/on_payload_attestation_message\/.*$/,
     /^heze\/fork_choice\/on_payload_attestation_message\/.*$/,
     // TODO-GLOAS: re-enable after the gloas should_apply_proposer_boost rule is implemented.
-    // New test suite added in v1.7.0-alpha.13 (consensus-specs #5441); Lodestar still applies
+    // New test suite added by consensus-specs #5441; Lodestar still applies
     // the pre-gloas proposer boost, so the head weight differs by the boost amount.
     /^gloas\/fork_choice\/should_apply_proposer_boost\/.*$/,
     /^heze\/fork_choice\/should_apply_proposer_boost\/.*$/,

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -1,7 +1,7 @@
 # Lodestar Builder
 
 [![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/aMxzVcr)
-[![Eth Consensus Spec v1.7.0-alpha.13](https://img.shields.io/badge/ETH%20consensus--spec-1.7.0_alpha.13-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.13)
+[![Eth Consensus Spec v1.7.0-alpha.14](https://img.shields.io/badge/ETH%20consensus--spec-1.7.0_alpha.14-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.14)
 ![ES Version](https://img.shields.io/badge/ES-2021-yellow)
 ![Node Version](https://img.shields.io/badge/node-24.x-green)
 

--- a/packages/config/src/chainConfig/configs/mainnet.ts
+++ b/packages/config/src/chainConfig/configs/mainnet.ts
@@ -203,7 +203,7 @@ export const chainConfig: ChainConfig = {
   // 1 slots
   MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS: 1,
   // 2**13 (=8192)
-  MAX_BYTES_PER_INCLUSION_LIST: 8192,
+  MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST: 8192,
 
   // Gloas
   // 2**7 (= 128) payloads

--- a/packages/config/src/chainConfig/configs/minimal.ts
+++ b/packages/config/src/chainConfig/configs/minimal.ts
@@ -208,7 +208,7 @@ export const chainConfig: ChainConfig = {
   // 1 slots
   MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS: 1,
   // 2**13 (=8192)
-  MAX_BYTES_PER_INCLUSION_LIST: 8192,
+  MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST: 8192,
 
   // Fast Confirmation Rule
   // ---------------------------------------------------------------

--- a/packages/config/src/chainConfig/params.ts
+++ b/packages/config/src/chainConfig/params.ts
@@ -344,7 +344,7 @@ function getSpecCriticalParams(localConfig: ChainConfig): Record<keyof ConfigWit
     INCLUSION_LIST_DUE_BPS: hezeForkRelevant,
     MAX_REQUEST_INCLUSION_LIST: hezeForkRelevant,
     MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS: false,
-    MAX_BYTES_PER_INCLUSION_LIST: hezeForkRelevant,
+    MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST: hezeForkRelevant,
     INCLUSION_LIST_COMMITTEE_SIZE: hezeForkRelevant,
     MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE: false,
     MAX_SIGNED_INCLUSION_LIST_SIZE: false,

--- a/packages/config/src/chainConfig/types.ts
+++ b/packages/config/src/chainConfig/types.ts
@@ -145,7 +145,7 @@ export type ChainConfig = {
   // HEZE
   MAX_REQUEST_INCLUSION_LIST: number;
   MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS: number;
-  MAX_BYTES_PER_INCLUSION_LIST: number;
+  MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST: number;
 
   // Fast Confirmation Rule
   CONFIRMATION_BYZANTINE_THRESHOLD: number;
@@ -272,7 +272,7 @@ export const chainConfigTypes: SpecTypes<ChainConfig> = {
   // HEZE
   MAX_REQUEST_INCLUSION_LIST: "number",
   MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS: "number",
-  MAX_BYTES_PER_INCLUSION_LIST: "number",
+  MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST: "number",
 
   // Gloas
   MAX_REQUEST_PAYLOADS: "number",

--- a/packages/config/test/e2e/ensure-config-is-synced.test.ts
+++ b/packages/config/test/e2e/ensure-config-is-synced.test.ts
@@ -13,8 +13,9 @@ import specTestsVersions from "../spec-tests-version.json" with {type: "json"};
  * have special formats that require custom handling, or are not yet implemented.
  */
 const ignoredRemoteConfigFields: (keyof ChainConfig)[] = [
-  // BLOB_SCHEDULE is an array/JSON format that requires special parsing
+  // Schedule fields use array/JSON formats that require special parsing
   "BLOB_SCHEDULE" as keyof ChainConfig,
+  "GAS_LIMIT_SCHEDULE" as keyof ChainConfig,
   // Networking params that may be in presets instead of chainConfig
   "ATTESTATION_SUBNET_COUNT" as keyof ChainConfig,
   "ATTESTATION_SUBNET_EXTRA_BITS" as keyof ChainConfig,

--- a/packages/fork-choice/src/forkChoice/safeBlocks.ts
+++ b/packages/fork-choice/src/forkChoice/safeBlocks.ts
@@ -13,7 +13,7 @@ import {IForkChoice} from "./interface.js";
  * payload may not yet be confirmed canonical, so we report the parent EL block which has
  * been (the bid commits to extending it).
  *
- * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/bellatrix/fast-confirmation.md#new-get_safe_execution_block_hash
+ * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.14/specs/bellatrix/fast-confirmation.md#new-get_safe_execution_block_hash
  */
 export function getSafeExecutionBlockHash(forkChoice: IForkChoice, logger?: Pick<Logger, LogLevel.debug>): RootHex {
   const confirmedRoot = forkChoice.getConfirmedRoot();
@@ -36,7 +36,7 @@ export function getSafeExecutionBlockHash(forkChoice: IForkChoice, logger?: Pick
  * Get execution payload hash to report as `finalizedBlockHash` in `engine_forkchoiceUpdated`.
  * Mirrors `getSafeExecutionBlockHash`: post-Gloas returns the bid `parent_block_hash`.
  *
- * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/gloas/fork-choice.md#notify_forkchoice_updated
+ * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.14/specs/gloas/fork-choice.md#notify_forkchoice_updated
  */
 export function getFinalizedExecutionBlockHash(forkChoice: IForkChoice): RootHex {
   return getExecutionBlockHash(forkChoice.getFinalizedBlock());

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -73,22 +73,20 @@ export function upgradeStateToGloas(
   );
   stateGloasView.currentSyncCommittee = stateGloasCloned.currentSyncCommittee;
   stateGloasView.nextSyncCommittee = stateGloasCloned.nextSyncCommittee;
-  const latestExecutionPayloadBid = ssz.gloas.ExecutionPayloadBid.defaultViewDU();
-  latestExecutionPayloadBid.parentBlockHash = stateFulu.latestExecutionPayloadHeader.parentHash;
-  latestExecutionPayloadBid.parentBlockRoot = stateFulu.latestBlockHeader.parentRoot;
-  latestExecutionPayloadBid.blockHash = stateFulu.latestExecutionPayloadHeader.blockHash;
-  latestExecutionPayloadBid.prevRandao = stateFulu.latestExecutionPayloadHeader.prevRandao;
-  latestExecutionPayloadBid.feeRecipient = ssz.ExecutionAddress.defaultValue();
-  latestExecutionPayloadBid.gasLimit = BigInt(stateFulu.latestExecutionPayloadHeader.gasLimit);
-  latestExecutionPayloadBid.builderIndex = BUILDER_INDEX_SELF_BUILD;
-  latestExecutionPayloadBid.slot = stateFulu.latestBlockHeader.slot;
-  latestExecutionPayloadBid.value = 0;
-  latestExecutionPayloadBid.executionPayment = 0n;
-  latestExecutionPayloadBid.blobKzgCommitments = ssz.gloas.BlobKzgCommitments.defaultViewDU();
-  latestExecutionPayloadBid.executionRequestsRoot = ssz.gloas.ExecutionRequests.hashTreeRoot(
+  stateGloasView.latestExecutionPayloadBid.parentBlockHash = stateFulu.latestExecutionPayloadHeader.parentHash;
+  stateGloasView.latestExecutionPayloadBid.parentBlockRoot = stateFulu.latestBlockHeader.parentRoot;
+  stateGloasView.latestExecutionPayloadBid.blockHash = stateFulu.latestExecutionPayloadHeader.blockHash;
+  stateGloasView.latestExecutionPayloadBid.prevRandao = stateFulu.latestExecutionPayloadHeader.prevRandao;
+  stateGloasView.latestExecutionPayloadBid.feeRecipient = ssz.ExecutionAddress.defaultValue();
+  stateGloasView.latestExecutionPayloadBid.gasLimit = BigInt(stateFulu.latestExecutionPayloadHeader.gasLimit);
+  stateGloasView.latestExecutionPayloadBid.builderIndex = BUILDER_INDEX_SELF_BUILD;
+  stateGloasView.latestExecutionPayloadBid.slot = stateFulu.latestBlockHeader.slot;
+  stateGloasView.latestExecutionPayloadBid.value = 0;
+  stateGloasView.latestExecutionPayloadBid.executionPayment = 0n;
+  stateGloasView.latestExecutionPayloadBid.blobKzgCommitments = ssz.gloas.BlobKzgCommitments.defaultViewDU();
+  stateGloasView.latestExecutionPayloadBid.executionRequestsRoot = ssz.gloas.ExecutionRequests.hashTreeRoot(
     ssz.gloas.ExecutionRequests.defaultValue()
   );
-  stateGloasView.latestExecutionPayloadBid = latestExecutionPayloadBid;
   stateGloasView.nextWithdrawalIndex = stateGloasCloned.nextWithdrawalIndex;
   stateGloasView.nextWithdrawalValidatorIndex = stateGloasCloned.nextWithdrawalValidatorIndex;
   stateGloasView.historicalSummaries = stateGloasCloned.historicalSummaries;

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -73,20 +73,21 @@ export function upgradeStateToGloas(
   );
   stateGloasView.currentSyncCommittee = stateGloasCloned.currentSyncCommittee;
   stateGloasView.nextSyncCommittee = stateGloasCloned.nextSyncCommittee;
-  stateGloasView.latestExecutionPayloadBid.parentBlockHash = stateFulu.latestExecutionPayloadHeader.parentHash;
-  stateGloasView.latestExecutionPayloadBid.parentBlockRoot = stateFulu.latestBlockHeader.parentRoot;
-  stateGloasView.latestExecutionPayloadBid.blockHash = stateFulu.latestExecutionPayloadHeader.blockHash;
-  stateGloasView.latestExecutionPayloadBid.prevRandao = stateFulu.latestExecutionPayloadHeader.prevRandao;
-  stateGloasView.latestExecutionPayloadBid.feeRecipient = ssz.ExecutionAddress.defaultValue();
-  stateGloasView.latestExecutionPayloadBid.gasLimit = BigInt(stateFulu.latestExecutionPayloadHeader.gasLimit);
-  stateGloasView.latestExecutionPayloadBid.builderIndex = BUILDER_INDEX_SELF_BUILD;
-  stateGloasView.latestExecutionPayloadBid.slot = stateFulu.latestBlockHeader.slot;
-  stateGloasView.latestExecutionPayloadBid.value = 0;
-  stateGloasView.latestExecutionPayloadBid.executionPayment = 0n;
-  stateGloasView.latestExecutionPayloadBid.blobKzgCommitments = ssz.gloas.BlobKzgCommitments.defaultViewDU();
-  stateGloasView.latestExecutionPayloadBid.executionRequestsRoot = ssz.gloas.ExecutionRequests.hashTreeRoot(
-    ssz.gloas.ExecutionRequests.defaultValue()
-  );
+  const latestExecutionPayloadBid = ssz.gloas.ExecutionPayloadBid.toViewDU({
+    parentBlockHash: stateFulu.latestExecutionPayloadHeader.parentHash,
+    parentBlockRoot: stateFulu.latestBlockHeader.parentRoot,
+    blockHash: stateFulu.latestExecutionPayloadHeader.blockHash,
+    prevRandao: stateFulu.latestExecutionPayloadHeader.prevRandao,
+    feeRecipient: ssz.ExecutionAddress.defaultValue(),
+    gasLimit: BigInt(stateFulu.latestExecutionPayloadHeader.gasLimit),
+    builderIndex: BUILDER_INDEX_SELF_BUILD,
+    slot: stateFulu.latestBlockHeader.slot,
+    value: 0,
+    executionPayment: 0n,
+    blobKzgCommitments: ssz.gloas.BlobKzgCommitments.defaultValue(),
+    executionRequestsRoot: ssz.gloas.ExecutionRequests.hashTreeRoot(ssz.gloas.ExecutionRequests.defaultValue()),
+  });
+  stateGloasView.latestExecutionPayloadBid = latestExecutionPayloadBid;
   stateGloasView.nextWithdrawalIndex = stateGloasCloned.nextWithdrawalIndex;
   stateGloasView.nextWithdrawalValidatorIndex = stateGloasCloned.nextWithdrawalValidatorIndex;
   stateGloasView.historicalSummaries = stateGloasCloned.historicalSummaries;

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -10,7 +10,7 @@ import {
   ProgressiveListCompositeType,
   ValueOf,
 } from "@chainsafe/ssz";
-import {PAYLOAD_BUILDER_VERSION, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
+import {BUILDER_INDEX_SELF_BUILD, PAYLOAD_BUILDER_VERSION, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {toPubkeyHex} from "@lodestar/utils";
 import {isValidDepositSignature} from "../block/processDeposit.js";
@@ -73,11 +73,22 @@ export function upgradeStateToGloas(
   );
   stateGloasView.currentSyncCommittee = stateGloasCloned.currentSyncCommittee;
   stateGloasView.nextSyncCommittee = stateGloasCloned.nextSyncCommittee;
-  stateGloasView.latestExecutionPayloadBid.blockHash = stateFulu.latestExecutionPayloadHeader.blockHash;
-  stateGloasView.latestExecutionPayloadBid.gasLimit = BigInt(stateFulu.latestExecutionPayloadHeader.gasLimit);
-  stateGloasView.latestExecutionPayloadBid.executionRequestsRoot = ssz.gloas.ExecutionRequests.hashTreeRoot(
+  const latestExecutionPayloadBid = ssz.gloas.ExecutionPayloadBid.defaultViewDU();
+  latestExecutionPayloadBid.parentBlockHash = stateFulu.latestExecutionPayloadHeader.parentHash;
+  latestExecutionPayloadBid.parentBlockRoot = stateFulu.latestBlockHeader.parentRoot;
+  latestExecutionPayloadBid.blockHash = stateFulu.latestExecutionPayloadHeader.blockHash;
+  latestExecutionPayloadBid.prevRandao = stateFulu.latestExecutionPayloadHeader.prevRandao;
+  latestExecutionPayloadBid.feeRecipient = ssz.ExecutionAddress.defaultValue();
+  latestExecutionPayloadBid.gasLimit = BigInt(stateFulu.latestExecutionPayloadHeader.gasLimit);
+  latestExecutionPayloadBid.builderIndex = BUILDER_INDEX_SELF_BUILD;
+  latestExecutionPayloadBid.slot = stateFulu.latestBlockHeader.slot;
+  latestExecutionPayloadBid.value = 0;
+  latestExecutionPayloadBid.executionPayment = 0n;
+  latestExecutionPayloadBid.blobKzgCommitments = ssz.gloas.BlobKzgCommitments.defaultViewDU();
+  latestExecutionPayloadBid.executionRequestsRoot = ssz.gloas.ExecutionRequests.hashTreeRoot(
     ssz.gloas.ExecutionRequests.defaultValue()
   );
+  stateGloasView.latestExecutionPayloadBid = latestExecutionPayloadBid;
   stateGloasView.nextWithdrawalIndex = stateGloasCloned.nextWithdrawalIndex;
   stateGloasView.nextWithdrawalValidatorIndex = stateGloasCloned.nextWithdrawalValidatorIndex;
   stateGloasView.historicalSummaries = stateGloasCloned.historicalSummaries;

--- a/packages/state-transition/test/unit/upgradeState.test.ts
+++ b/packages/state-transition/test/unit/upgradeState.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from "vitest";
 import {ChainForkConfig, createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {config as chainConfig} from "@lodestar/config/default";
-import {FAR_FUTURE_EPOCH, ForkName} from "@lodestar/params";
+import {BUILDER_INDEX_SELF_BUILD, FAR_FUTURE_EPOCH, ForkName} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {createPubkeyCache} from "../../src/cache/pubkeyCache.js";
 import {CachedBeaconStateFulu, createCachedBeaconState} from "../../src/cache/stateCache.js";
@@ -40,13 +40,26 @@ describe("upgradeState", () => {
     expect(() => newState.toValue()).not.toThrow();
   });
 
-  it("upgradeStateToGloas reuses composite-list nodes with identical merkle roots", () => {
+  it("upgradeStateToGloas reuses list nodes and initializes the latest bid", () => {
     // Enough validators to span multiple progressive subtrees (capacities 1, 4, 16, 64, ...) and to
     // populate every slot's committee for the gloas PTC window computed during the upgrade.
     // Not a multiple of itemsPerChunk (4 for uint64, 32 for uint8) so basic-list migration covers
     // a zero-padded partial final chunk.
     const numValidators = 130;
     const fuluStateView = ssz.fulu.BeaconState.defaultViewDU();
+    const latestBlockSlot = 5;
+    const latestBlockParentRoot = new Uint8Array(32).fill(0x11);
+    const latestPayloadParentHash = new Uint8Array(32).fill(0x22);
+    const latestPayloadBlockHash = new Uint8Array(32).fill(0x33);
+    const latestPayloadPrevRandao = new Uint8Array(32).fill(0x44);
+    const latestPayloadGasLimit = 42_000_000;
+    fuluStateView.slot = latestBlockSlot + 3;
+    fuluStateView.latestBlockHeader.slot = latestBlockSlot;
+    fuluStateView.latestBlockHeader.parentRoot = latestBlockParentRoot;
+    fuluStateView.latestExecutionPayloadHeader.parentHash = latestPayloadParentHash;
+    fuluStateView.latestExecutionPayloadHeader.blockHash = latestPayloadBlockHash;
+    fuluStateView.latestExecutionPayloadHeader.prevRandao = latestPayloadPrevRandao;
+    fuluStateView.latestExecutionPayloadHeader.gasLimit = latestPayloadGasLimit;
     for (let i = 0; i < numValidators; i++) {
       const validator = ssz.phase0.Validator.defaultValue();
       // Distinct pubkey/withdrawalCredentials so each validator has a distinct subtree root
@@ -128,6 +141,22 @@ describe("upgradeState", () => {
     expect(gloasState.previousEpochParticipation.hashTreeRoot()).toEqual(expectedPreviousEpochParticipationRoot);
     expect(gloasState.currentEpochParticipation.hashTreeRoot()).toEqual(expectedCurrentEpochParticipationRoot);
     expect(gloasState.inactivityScores.hashTreeRoot()).toEqual(expectedInactivityScoresRoot);
+    const latestBid = gloasState.latestExecutionPayloadBid;
+    expect(latestBid.parentBlockHash).toEqual(latestPayloadParentHash);
+    expect(latestBid.parentBlockRoot).toEqual(latestBlockParentRoot);
+    expect(latestBid.blockHash).toEqual(latestPayloadBlockHash);
+    expect(latestBid.prevRandao).toEqual(latestPayloadPrevRandao);
+    expect(latestBid.feeRecipient).toEqual(ssz.ExecutionAddress.defaultValue());
+    expect(latestBid.gasLimit).toBe(BigInt(latestPayloadGasLimit));
+    expect(latestBid.builderIndex).toBe(BUILDER_INDEX_SELF_BUILD);
+    // Preserve the actual pre-fork block slot when slots were missed before the fork.
+    expect(latestBid.slot).toBe(latestBlockSlot);
+    expect(latestBid.value).toBe(0);
+    expect(latestBid.executionPayment).toBe(0n);
+    expect(latestBid.blobKzgCommitments.length).toBe(0);
+    expect(latestBid.executionRequestsRoot).toEqual(
+      ssz.gloas.ExecutionRequests.hashTreeRoot(ssz.gloas.ExecutionRequests.defaultValue())
+    );
     // Full state still merkleizes and round-trips
     expect(() => gloasState.hashTreeRoot()).not.toThrow();
     expect(() => gloasState.toValue()).not.toThrow();

--- a/packages/types/src/heze/sszTypes.ts
+++ b/packages/types/src/heze/sszTypes.ts
@@ -13,14 +13,12 @@ export const InclusionListCommittee = new VectorBasicType(ValidatorIndex, INCLUS
 
 export const InclusionListBits = new BitVectorType(INCLUSION_LIST_COMMITTEE_SIZE);
 
-export const InclusionListTransactions = gloasSsz.Transactions;
-
 export const InclusionList = new ContainerType(
   {
     slot: Slot,
     validatorIndex: ValidatorIndex,
     dependentRoot: Root,
-    transactions: InclusionListTransactions,
+    transactions: gloasSsz.Transactions,
   },
   {typeName: "InclusionList", jsonCase: "eth2"}
 );
@@ -108,7 +106,7 @@ export const BlockContents = new ContainerType(
 export const PayloadAttributes = new ContainerType(
   {
     ...gloasSsz.PayloadAttributes.fields,
-    inclusionListTransactions: InclusionListTransactions, // [New in Heze:EIP7805]
+    inclusionListTransactions: gloasSsz.Transactions, // [New in Heze:EIP7805]
   },
   {typeName: "PayloadAttributes", jsonCase: "eth2"}
 );

--- a/packages/types/src/heze/sszTypes.ts
+++ b/packages/types/src/heze/sszTypes.ts
@@ -1,10 +1,4 @@
-import {
-  BitVectorType,
-  ContainerType,
-  ProgressiveContainerType,
-  ProgressiveListCompositeType,
-  VectorBasicType,
-} from "@chainsafe/ssz";
+import {BitVectorType, ContainerType, ProgressiveContainerType, VectorBasicType} from "@chainsafe/ssz";
 import {INCLUSION_LIST_COMMITTEE_SIZE} from "@lodestar/params";
 import {ssz as gloasSsz} from "../gloas/index.js";
 import {ssz as primitiveSsz} from "../primitive/index.js";
@@ -17,15 +11,15 @@ function activeFields(count: number): boolean[] {
 
 export const InclusionListCommittee = new VectorBasicType(ValidatorIndex, INCLUSION_LIST_COMMITTEE_SIZE);
 
-export const InclusionListTransactions = new ProgressiveListCompositeType(gloasSsz.Transaction, {
-  typeName: "InclusionListTransactions",
-});
+export const InclusionListBits = new BitVectorType(INCLUSION_LIST_COMMITTEE_SIZE);
+
+export const InclusionListTransactions = gloasSsz.Transactions;
 
 export const InclusionList = new ContainerType(
   {
     slot: Slot,
     validatorIndex: ValidatorIndex,
-    inclusionListCommitteeRoot: Root,
+    dependentRoot: Root,
     transactions: InclusionListTransactions,
   },
   {typeName: "InclusionList", jsonCase: "eth2"}
@@ -42,8 +36,8 @@ export const SignedInclusionList = new ContainerType(
 export const InclusionListsByIndicesRequest = new ContainerType(
   {
     slot: Slot,
-    inclusionListCommitteeRoot: Root,
-    indices: new BitVectorType(INCLUSION_LIST_COMMITTEE_SIZE),
+    dependentRoot: Root,
+    indices: InclusionListBits,
   },
   {typeName: "InclusionListsByIndicesRequest", jsonCase: "eth2"}
 );
@@ -51,7 +45,7 @@ export const InclusionListsByIndicesRequest = new ContainerType(
 export const ExecutionPayloadBid = new ProgressiveContainerType(
   {
     ...gloasSsz.ExecutionPayloadBid.fields,
-    inclusionListBits: new BitVectorType(INCLUSION_LIST_COMMITTEE_SIZE), // [New in Heze:EIP7805]
+    inclusionListBits: InclusionListBits, // [New in Heze:EIP7805]
   },
   activeFields(13),
   {typeName: "ExecutionPayloadBid", jsonCase: "eth2"}

--- a/spec-tests-version.json
+++ b/spec-tests-version.json
@@ -1,6 +1,6 @@
 {
   "ethereumConsensusSpecsTests": {
-    "specVersion": "v1.7.0-alpha.13",
+    "specVersion": "v1.7.0-alpha.14",
     "specTestsRepoUrl": "https://github.com/ethereum/consensus-specs",
     "outputDirBase": "spec-tests",
     "testsToDownload": [

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.7.0-alpha.13
+version: v1.7.0-alpha.14
 style: full
 
 specrefs:

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -46,12 +46,19 @@ exceptions:
 
   containers:
     # gloas
+    - CellsBitList#gloas
     - LightClientHeader#gloas
     - PartialDataColumnGroupID#gloas
     - PartialDataColumnHeader#gloas
+    - PartialDataColumnPartsMetadata#gloas
     - PartialDataColumnSidecar#gloas
 
+    # heze (not implemented)
+    - SignedInclusionLists#heze
+
     # fulu (not implemented yet)
+    - CellsBitList#fulu
+    - OptionalPartialDataColumnHeader#fulu
     - PartialDataColumnGroupID#fulu
     - PartialDataColumnHeader#fulu
     - PartialDataColumnPartsMetadata#fulu
@@ -99,6 +106,7 @@ exceptions:
 
     # heze (not implemented)
     - GetInclusionListResponse#heze
+    - InclusionListEntry#heze
     - InclusionListStore#heze
     - PayloadAttributes#heze
     - Store#heze
@@ -111,7 +119,6 @@ exceptions:
     - compute_merkle_branch_root#phase0
     - compute_time_at_slot_ms#phase0
     - is_non_strict_superset#phase0
-    - is_not_from_future_slot#phase0
     - is_within_slot_range#phase0
     - validate_attester_slashing_gossip#phase0
     - validate_beacon_aggregate_and_proof_gossip#phase0
@@ -294,7 +301,6 @@ exceptions:
     - is_ancestor#gloas
     - is_head_late#gloas
     - is_previous_slot_payload_decision#gloas
-    - is_valid_proposal_slot#gloas
     - notify_ptc_messages#gloas
     - on_block#gloas
     - on_payload_attestation_message#gloas
@@ -314,6 +320,7 @@ exceptions:
     - update_next_withdrawal_builder_index#gloas
     - update_payload_expected_withdrawals#gloas
     - update_proposer_boost_root#gloas
+    - validate_partial_data_column_sidecar_gossip#gloas
     - validate_merge_block#gloas
     - validate_on_attestation#gloas
 
@@ -355,6 +362,7 @@ exceptions:
     - get_inclusion_list_signature#heze
     - get_inclusion_list_store#heze
     - get_inclusion_list_transactions#heze
+    - get_signed_inclusion_list#heze
     - is_inclusion_list_bits_inclusive#heze
     - is_payload_inclusion_list_satisfied#heze
     - is_valid_inclusion_list_signature#heze
@@ -424,5 +432,4 @@ exceptions:
     - CellIndex#fulu
 
     # gloas
-    - ExecutionBranch#gloas
     - PayloadStatus#gloas

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -341,6 +341,16 @@
     FULU_FORK_VERSION: Version = '0x06000000'
     </spec>
 
+- name: GAS_LIMIT_SCHEDULE#gloas
+  sources:
+    - file: packages/config/src/chainConfig/configs/mainnet.ts
+      search: "GAS_LIMIT_SCHEDULE:"
+  spec: |
+    <spec config_var="GAS_LIMIT_SCHEDULE" fork="gloas" hash="28e945d9">
+    GAS_LIMIT_SCHEDULE: tuple[frozendict[str, Any], ...] = (
+    )
+    </spec>
+
 - name: GENESIS_DELAY#phase0
   sources:
     - file: packages/config/src/chainConfig/configs/mainnet.ts
@@ -449,15 +459,6 @@
     MAX_BLOBS_PER_BLOCK_ELECTRA: Uint64 = 9
     </spec>
 
-- name: MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST#heze
-  sources:
-    - file: packages/config/src/chainConfig/configs/mainnet.ts
-      search: "MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST:"
-  spec: |
-    <spec config_var="MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST" fork="heze" hash="5e36c7cc">
-    MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST: Uint64 = 8192
-    </spec>
-
 - name: MAX_PAYLOAD_SIZE#phase0
   sources:
     - file: packages/config/src/chainConfig/configs/mainnet.ts
@@ -528,6 +529,15 @@
   spec: |
     <spec config_var="MAX_REQUEST_PAYLOADS" fork="gloas" hash="cb92d98e">
     MAX_REQUEST_PAYLOADS: Uint64 = 128
+    </spec>
+
+- name: MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST#heze
+  sources:
+    - file: packages/config/src/chainConfig/configs/mainnet.ts
+      search: "MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST:"
+  spec: |
+    <spec config_var="MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST" fork="heze" hash="5e36c7cc">
+    MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST: Uint64 = 8192
     </spec>
 
 - name: MESSAGE_DOMAIN_INVALID_SNAPPY#phase0

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -449,13 +449,13 @@
     MAX_BLOBS_PER_BLOCK_ELECTRA: Uint64 = 9
     </spec>
 
-- name: MAX_BYTES_PER_INCLUSION_LIST#heze
+- name: MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST#heze
   sources:
     - file: packages/config/src/chainConfig/configs/mainnet.ts
-      search: "MAX_BYTES_PER_INCLUSION_LIST:"
+      search: "MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST:"
   spec: |
-    <spec config_var="MAX_BYTES_PER_INCLUSION_LIST" fork="heze" hash="1d503ddc">
-    MAX_BYTES_PER_INCLUSION_LIST: Uint64 = 8192
+    <spec config_var="MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST" fork="heze" hash="5e36c7cc">
+    MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST: Uint64 = 8192
     </spec>
 
 - name: MAX_PAYLOAD_SIZE#phase0

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -23,14 +23,53 @@
         selection_proof: BLSSignature
     </spec>
 
+- name: AggregationBits#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "export const CommitteeBits ="
+  spec: |
+    <spec container="AggregationBits" fork="phase0" hash="0d694176">
+    class AggregationBits(BitList[MAX_VALIDATORS_PER_COMMITTEE]):
+        """
+        The participation bits of a single committee, one bit per member in
+        committee order.
+        """
+    </spec>
+
+- name: AggregationBits#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: export const AggregationBits =
+  spec: |
+    <spec container="AggregationBits" fork="electra" hash="c5f4e568">
+    class AggregationBits(BitList[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]):  # type: ignore
+        """
+        The participation bits of all committees participating in an attestation,
+        concatenated in committee order.
+        """
+    </spec>
+
+- name: AggregationBits#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const AggregationBits =
+  spec: |
+    <spec container="AggregationBits" fork="gloas" hash="f78b17ab">
+    class AggregationBits(ProgressiveBitList):
+        """
+        The participation bits of all committees participating in an attestation,
+        concatenated in committee order.
+        """
+    </spec>
+
 - name: Attestation#phase0
   sources:
     - file: packages/types/src/phase0/sszTypes.ts
       search: export const Attestation =
   spec: |
-    <spec container="Attestation" fork="phase0" hash="d0523528">
+    <spec container="Attestation" fork="phase0" hash="ba57d9f7">
     class Attestation(Container):
-        aggregation_bits: BitList[MAX_VALIDATORS_PER_COMMITTEE]
+        aggregation_bits: AggregationBits
         data: AttestationData
         signature: BLSSignature
     </spec>
@@ -40,14 +79,14 @@
     - file: packages/types/src/electra/sszTypes.ts
       search: export const Attestation =
   spec: |
-    <spec container="Attestation" fork="electra" hash="36145004">
+    <spec container="Attestation" fork="electra" hash="8c85d7c1">
     class Attestation(Container):
         # [Modified in Electra:EIP7549]
         aggregation_bits: AggregationBits
         data: AttestationData
         signature: BLSSignature
         # [New in Electra:EIP7549]
-        committee_bits: BitVector[MAX_COMMITTEES_PER_SLOT]
+        committee_bits: CommitteeBits
     </spec>
 
 - name: Attestation#gloas
@@ -55,12 +94,12 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const Attestation =
   spec: |
-    <spec container="Attestation" fork="gloas" hash="4417e8c7">
+    <spec container="Attestation" fork="gloas" hash="a9dc4cfa">
     class Attestation(ProgressiveContainer(active_fields=[1] * 4)):  # type: ignore
         aggregation_bits: AggregationBits
         data: AttestationData
         signature: BLSSignature
-        committee_bits: BitVector[MAX_COMMITTEES_PER_SLOT]
+        committee_bits: CommitteeBits
     </spec>
 
 - name: AttestationData#phase0
@@ -75,6 +114,42 @@
         beacon_block_root: Root
         source: Checkpoint
         target: Checkpoint
+    </spec>
+
+- name: Attestations#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "attestations: new ListCompositeType(Attestation, MAX_ATTESTATIONS),"
+  spec: |
+    <spec container="Attestations" fork="phase0" hash="7301ff8e">
+    class Attestations(List[Attestation, MAX_ATTESTATIONS]):
+        """
+        The attestations included in a beacon block.
+        """
+    </spec>
+
+- name: Attestations#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: "export const BeaconBlockBody = new ContainerType("
+  spec: |
+    <spec container="Attestations" fork="electra" hash="a7794510">
+    class Attestations(List[Attestation, MAX_ATTESTATIONS_ELECTRA]):
+        """
+        The attestations included in a beacon block.
+        """
+    </spec>
+
+- name: Attestations#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const Attestations =
+  spec: |
+    <spec container="Attestations" fork="gloas" hash="7687a79a">
+    class Attestations(ProgressiveList[Attestation]):
+        """
+        The attestations included in a beacon block.
+        """
     </spec>
 
 - name: AttesterSlashing#phase0
@@ -101,6 +176,92 @@
         attestation_2: IndexedAttestation
     </spec>
 
+- name: AttesterSlashings#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "attesterSlashings: new ListCompositeType(AttesterSlashing, MAX_ATTESTER_SLASHINGS),"
+  spec: |
+    <spec container="AttesterSlashings" fork="phase0" hash="d9a14f15">
+    class AttesterSlashings(List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]):
+        """
+        The attester slashings included in a beacon block.
+        """
+    </spec>
+
+- name: AttesterSlashings#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: "export const BeaconBlockBody = new ContainerType("
+  spec: |
+    <spec container="AttesterSlashings" fork="electra" hash="a6633253">
+    class AttesterSlashings(List[AttesterSlashing, MAX_ATTESTER_SLASHINGS_ELECTRA]):
+        """
+        The attester slashings included in a beacon block.
+        """
+    </spec>
+
+- name: AttesterSlashings#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const AttesterSlashings =
+  spec: |
+    <spec container="AttesterSlashings" fork="gloas" hash="84747a80">
+    class AttesterSlashings(ProgressiveList[AttesterSlashing]):
+        """
+        The attester slashings included in a beacon block.
+        """
+    </spec>
+
+- name: AttestingIndices#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "export const CommitteeIndices ="
+  spec: |
+    <spec container="AttestingIndices" fork="phase0" hash="fd953ae2">
+    class AttestingIndices(List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE]):
+        """
+        The indices of the validators participating in an attestation.
+        """
+    </spec>
+
+- name: AttestingIndices#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: export const AttestingIndices =
+  spec: |
+    <spec container="AttestingIndices" fork="electra" hash="bb457dd4">
+    class AttestingIndices(
+        List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]  # type: ignore
+    ):
+        """
+        The indices of the validators participating in an attestation.
+        """
+    </spec>
+
+- name: AttestingIndices#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const AttestingIndices =
+  spec: |
+    <spec container="AttestingIndices" fork="gloas" hash="42569463">
+    class AttestingIndices(ProgressiveList[ValidatorIndex]):
+        """
+        The indices of the validators participating in an attestation.
+        """
+    </spec>
+
+- name: Attnets#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "export const AttestationSubnets ="
+  spec: |
+    <spec container="Attnets" fork="phase0" hash="a1051379">
+    class Attnets(BitVector[ATTESTATION_SUBNET_COUNT]):  # type: ignore
+        """
+        The attestation subnets a node is subscribed to, one bit per subnet.
+        """
+    </spec>
+
 - name: BLSToExecutionChange#capella
   sources:
     - file: packages/types/src/capella/sszTypes.ts
@@ -111,6 +272,56 @@
         validator_index: ValidatorIndex
         from_bls_pubkey: BLSPubkey
         to_execution_address: ExecutionAddress
+    </spec>
+
+- name: BLSToExecutionChanges#capella
+  sources:
+    - file: packages/types/src/capella/sszTypes.ts
+      search: export const BLSToExecutionChanges =
+  spec: |
+    <spec container="BLSToExecutionChanges" fork="capella" hash="f502a79d">
+    class BLSToExecutionChanges(List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]):
+        """
+        The signed BLS-to-execution credential changes included in a beacon
+        block.
+        """
+    </spec>
+
+- name: BLSToExecutionChanges#gloas
+  sources:
+    - file: packages/types/src/capella/sszTypes.ts
+      search: export const BLSToExecutionChanges =
+  spec: |
+    <spec container="BLSToExecutionChanges" fork="gloas" hash="01736e3a">
+    class BLSToExecutionChanges(ProgressiveList[SignedBLSToExecutionChange]):
+        """
+        The signed BLS-to-execution credential changes included in a beacon
+        block.
+        """
+    </spec>
+
+- name: Balances#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: export const Balances =
+  spec: |
+    <spec container="Balances" fork="phase0" hash="29aef611">
+    class Balances(List[Gwei, VALIDATOR_REGISTRY_LIMIT]):
+        """
+        The balances of all validators.
+        """
+    </spec>
+
+- name: Balances#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const Balances =
+  spec: |
+    <spec container="Balances" fork="gloas" hash="ee949cce">
+    class Balances(ProgressiveList[Gwei]):
+        """
+        The balances of all validators.
+        """
     </spec>
 
 - name: BeaconBlock#phase0
@@ -132,16 +343,16 @@
     - file: packages/types/src/phase0/sszTypes.ts
       search: export const BeaconBlockBody =
   spec: |
-    <spec container="BeaconBlockBody" fork="phase0" hash="e982fea2">
+    <spec container="BeaconBlockBody" fork="phase0" hash="ae856cd4">
     class BeaconBlockBody(Container):
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
-        attestations: List[Attestation, MAX_ATTESTATIONS]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        proposer_slashings: ProposerSlashings
+        attester_slashings: AttesterSlashings
+        attestations: Attestations
+        deposits: Deposits
+        voluntary_exits: VoluntaryExits
     </spec>
 
 - name: BeaconBlockBody#altair
@@ -149,16 +360,16 @@
     - file: packages/types/src/altair/sszTypes.ts
       search: export const BeaconBlockBody =
   spec: |
-    <spec container="BeaconBlockBody" fork="altair" hash="4afb2e64">
+    <spec container="BeaconBlockBody" fork="altair" hash="1a3ef507">
     class BeaconBlockBody(Container):
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
-        attestations: List[Attestation, MAX_ATTESTATIONS]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        proposer_slashings: ProposerSlashings
+        attester_slashings: AttesterSlashings
+        attestations: Attestations
+        deposits: Deposits
+        voluntary_exits: VoluntaryExits
         # [New in Altair]
         sync_aggregate: SyncAggregate
     </spec>
@@ -168,16 +379,16 @@
     - file: packages/types/src/bellatrix/sszTypes.ts
       search: export const BeaconBlockBody =
   spec: |
-    <spec container="BeaconBlockBody" fork="bellatrix" hash="2ba73fc8">
+    <spec container="BeaconBlockBody" fork="bellatrix" hash="0f4ea4d2">
     class BeaconBlockBody(Container):
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
-        attestations: List[Attestation, MAX_ATTESTATIONS]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        proposer_slashings: ProposerSlashings
+        attester_slashings: AttesterSlashings
+        attestations: Attestations
+        deposits: Deposits
+        voluntary_exits: VoluntaryExits
         sync_aggregate: SyncAggregate
         # [New in Bellatrix]
         execution_payload: ExecutionPayload
@@ -188,20 +399,20 @@
     - file: packages/types/src/capella/sszTypes.ts
       search: export const BeaconBlockBody =
   spec: |
-    <spec container="BeaconBlockBody" fork="capella" hash="3136f99b">
+    <spec container="BeaconBlockBody" fork="capella" hash="626d8670">
     class BeaconBlockBody(Container):
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
-        attestations: List[Attestation, MAX_ATTESTATIONS]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        proposer_slashings: ProposerSlashings
+        attester_slashings: AttesterSlashings
+        attestations: Attestations
+        deposits: Deposits
+        voluntary_exits: VoluntaryExits
         sync_aggregate: SyncAggregate
         execution_payload: ExecutionPayload
         # [New in Capella]
-        bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
+        bls_to_execution_changes: BLSToExecutionChanges
     </spec>
 
 - name: BeaconBlockBody#deneb
@@ -209,22 +420,22 @@
     - file: packages/types/src/deneb/sszTypes.ts
       search: export const BeaconBlockBody =
   spec: |
-    <spec container="BeaconBlockBody" fork="deneb" hash="cf0c1053">
+    <spec container="BeaconBlockBody" fork="deneb" hash="28ee7033">
     class BeaconBlockBody(Container):
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
-        attestations: List[Attestation, MAX_ATTESTATIONS]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        proposer_slashings: ProposerSlashings
+        attester_slashings: AttesterSlashings
+        attestations: Attestations
+        deposits: Deposits
+        voluntary_exits: VoluntaryExits
         sync_aggregate: SyncAggregate
         # [Modified in Deneb:EIP4844]
         execution_payload: ExecutionPayload
-        bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
+        bls_to_execution_changes: BLSToExecutionChanges
         # [New in Deneb:EIP4844]
-        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        blob_kzg_commitments: BlobKZGCommitments
     </spec>
 
 - name: BeaconBlockBody#electra
@@ -232,22 +443,22 @@
     - file: packages/types/src/electra/sszTypes.ts
       search: export const BeaconBlockBody =
   spec: |
-    <spec container="BeaconBlockBody" fork="electra" hash="cd172b8c">
+    <spec container="BeaconBlockBody" fork="electra" hash="5f4ab5d1">
     class BeaconBlockBody(Container):
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
-        proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
+        proposer_slashings: ProposerSlashings
         # [Modified in Electra:EIP7549]
-        attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS_ELECTRA]
+        attester_slashings: AttesterSlashings
         # [Modified in Electra:EIP7549]
-        attestations: List[Attestation, MAX_ATTESTATIONS_ELECTRA]
-        deposits: List[Deposit, MAX_DEPOSITS]
-        voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+        attestations: Attestations
+        deposits: Deposits
+        voluntary_exits: VoluntaryExits
         sync_aggregate: SyncAggregate
         execution_payload: ExecutionPayload
-        bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
-        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        bls_to_execution_changes: BLSToExecutionChanges
+        blob_kzg_commitments: BlobKZGCommitments
         # [New in Electra]
         execution_requests: ExecutionRequests
     </spec>
@@ -257,26 +468,26 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const BeaconBlockBody =
   spec: |
-    <spec container="BeaconBlockBody" fork="gloas" hash="3e50ab06">
+    <spec container="BeaconBlockBody" fork="gloas" hash="58b93a4e">
     class BeaconBlockBody(ProgressiveContainer(active_fields=[1] * 13)):  # type: ignore
         randao_reveal: BLSSignature
         eth1_data: Eth1Data
         graffiti: Bytes32
         # [Modified in Gloas:EIP7688]
-        proposer_slashings: ProgressiveList[ProposerSlashing]
+        proposer_slashings: ProposerSlashings
         # [Modified in Gloas:EIP7688]
-        attester_slashings: ProgressiveList[AttesterSlashing]
+        attester_slashings: AttesterSlashings
         # [Modified in Gloas:EIP7688]
-        attestations: ProgressiveList[Attestation]
+        attestations: Attestations
         # [Modified in Gloas:EIP7688]
-        deposits: ProgressiveList[Deposit]
+        deposits: Deposits
         # [Modified in Gloas:EIP7688]
-        voluntary_exits: ProgressiveList[SignedVoluntaryExit]
+        voluntary_exits: VoluntaryExits
         sync_aggregate: SyncAggregate
         # [Modified in Gloas:EIP7732]
         # Removed `execution_payload`
         # [Modified in Gloas:EIP7688]
-        bls_to_execution_changes: ProgressiveList[SignedBLSToExecutionChange]
+        bls_to_execution_changes: BLSToExecutionChanges
         # [Modified in Gloas:EIP7732]
         # Removed `blob_kzg_commitments`
         # [Modified in Gloas:EIP7732]
@@ -284,7 +495,7 @@
         # [New in Gloas:EIP7732]
         signed_execution_payload_bid: SignedExecutionPayloadBid
         # [New in Gloas:EIP7732]
-        payload_attestations: ProgressiveList[PayloadAttestation]
+        payload_attestations: PayloadAttestations
         # [New in Gloas:EIP7732]
         parent_execution_requests: ExecutionRequests
     </spec>
@@ -303,31 +514,55 @@
         body_root: Root
     </spec>
 
+- name: BeaconBlockRoots#phase0
+  sources:
+    - file: packages/beacon-node/src/util/types.ts
+      search: "export const BeaconBlocksByRootRequestType ="
+  spec: |
+    <spec container="BeaconBlockRoots" fork="phase0" hash="962c9d1c">
+    class BeaconBlockRoots(List[Root, MAX_REQUEST_BLOCKS]):  # type: ignore
+        """
+        Beacon block roots requested in a ``BeaconBlocksByRoot`` request.
+        """
+    </spec>
+
+- name: BeaconBlockRoots#deneb
+  sources:
+    - file: packages/beacon-node/src/util/types.ts
+      search: "export const BeaconBlocksByRootRequestType ="
+  spec: |
+    <spec container="BeaconBlockRoots" fork="deneb" hash="adc6d62a">
+    class BeaconBlockRoots(List[Root, MAX_REQUEST_BLOCKS_DENEB]):  # type: ignore
+        """
+        Beacon block roots requested in a ``BeaconBlocksByRoot`` request.
+        """
+    </spec>
+
 - name: BeaconState#phase0
   sources:
     - file: packages/types/src/phase0/sszTypes.ts
       search: export const BeaconState =
   spec: |
-    <spec container="BeaconState" fork="phase0" hash="28d6a433">
+    <spec container="BeaconState" fork="phase0" hash="12a06e56">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_attestations: List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]
-        current_epoch_attestations: List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_attestations: PendingAttestations
+        current_epoch_attestations: PendingAttestations
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
@@ -338,33 +573,33 @@
     - file: packages/types/src/altair/sszTypes.ts
       search: export const BeaconState =
   spec: |
-    <spec container="BeaconState" fork="altair" hash="8f9563b2">
+    <spec container="BeaconState" fork="altair" hash="e8fdd772">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
         # [Modified in Altair]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
+        previous_epoch_participation: EpochParticipation
         # [Modified in Altair]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
         # [New in Altair]
-        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: InactivityScores
         # [New in Altair]
         current_sync_committee: SyncCommittee
         # [New in Altair]
@@ -376,30 +611,30 @@
     - file: packages/types/src/bellatrix/sszTypes.ts
       search: export const BeaconState =
   spec: |
-    <spec container="BeaconState" fork="bellatrix" hash="605f8b59">
+    <spec container="BeaconState" fork="bellatrix" hash="11a63238">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_participation: EpochParticipation
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [New in Bellatrix]
@@ -411,30 +646,30 @@
     - file: packages/types/src/capella/sszTypes.ts
       search: export const BeaconState =
   spec: |
-    <spec container="BeaconState" fork="capella" hash="cd669bb4">
+    <spec container="BeaconState" fork="capella" hash="c2303ee8">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_participation: EpochParticipation
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [Modified in Capella]
@@ -444,7 +679,7 @@
         # [New in Capella]
         next_withdrawal_validator_index: ValidatorIndex
         # [New in Capella]
-        historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
+        historical_summaries: HistoricalSummaries
     </spec>
 
 - name: BeaconState#deneb
@@ -452,37 +687,37 @@
     - file: packages/types/src/deneb/sszTypes.ts
       search: export const BeaconState =
   spec: |
-    <spec container="BeaconState" fork="deneb" hash="09a74ef7">
+    <spec container="BeaconState" fork="deneb" hash="dbdea71f">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_participation: EpochParticipation
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [Modified in Deneb:EIP4844]
         latest_execution_payload_header: ExecutionPayloadHeader
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
-        historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
+        historical_summaries: HistoricalSummaries
     </spec>
 
 - name: BeaconState#electra
@@ -490,36 +725,36 @@
     - file: packages/types/src/electra/sszTypes.ts
       search: export const BeaconState =
   spec: |
-    <spec container="BeaconState" fork="electra" hash="d2b13d5a">
+    <spec container="BeaconState" fork="electra" hash="aa3aa109">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_participation: EpochParticipation
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         latest_execution_payload_header: ExecutionPayloadHeader
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
-        historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
+        historical_summaries: HistoricalSummaries
         # [New in Electra:EIP6110]
         deposit_requests_start_index: Uint64
         # [New in Electra:EIP7251]
@@ -533,11 +768,11 @@
         # [New in Electra:EIP7251]
         earliest_consolidation_epoch: Epoch
         # [New in Electra:EIP7251]
-        pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]
+        pending_deposits: PendingDeposits
         # [New in Electra:EIP7251]
-        pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
+        pending_partial_withdrawals: PendingPartialWithdrawals
         # [New in Electra:EIP7251]
-        pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
+        pending_consolidations: PendingConsolidations
     </spec>
 
 - name: BeaconState#fulu
@@ -545,47 +780,47 @@
     - file: packages/types/src/fulu/sszTypes.ts
       search: export const BeaconState =
   spec: |
-    <spec container="BeaconState" fork="fulu" hash="5735dc82">
+    <spec container="BeaconState" fork="fulu" hash="4b837a4f">
     class BeaconState(Container):
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
-        balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_participation: EpochParticipation
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: List[Uint64, VALIDATOR_REGISTRY_LIMIT]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         latest_execution_payload_header: ExecutionPayloadHeader
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
-        historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
+        historical_summaries: HistoricalSummaries
         deposit_requests_start_index: Uint64
         deposit_balance_to_consume: Gwei
         exit_balance_to_consume: Gwei
         earliest_exit_epoch: Epoch
         consolidation_balance_to_consume: Gwei
         earliest_consolidation_epoch: Epoch
-        pending_deposits: List[PendingDeposit, PENDING_DEPOSITS_LIMIT]
-        pending_partial_withdrawals: List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]
-        pending_consolidations: List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]
+        pending_deposits: PendingDeposits
+        pending_partial_withdrawals: PendingPartialWithdrawals
+        pending_consolidations: PendingConsolidations
         # [New in Fulu:EIP7917]
-        proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
+        proposer_lookahead: ProposerLookahead
     </spec>
 
 - name: BeaconState#gloas
@@ -593,35 +828,35 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const BeaconState =
   spec: |
-    <spec container="BeaconState" fork="gloas" hash="8a133a4f">
+    <spec container="BeaconState" fork="gloas" hash="38539935">
     class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):  # type: ignore
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
         # [Modified in Gloas:EIP7688]
-        validators: ProgressiveList[Validator]
+        validators: Validators
         # [Modified in Gloas:EIP7688]
-        balances: ProgressiveList[Gwei]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
         # [Modified in Gloas:EIP7688]
-        previous_epoch_participation: ProgressiveList[ParticipationFlags]
+        previous_epoch_participation: EpochParticipation
         # [Modified in Gloas:EIP7688]
-        current_epoch_participation: ProgressiveList[ParticipationFlags]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
         # [Modified in Gloas:EIP7688]
-        inactivity_scores: ProgressiveList[Uint64]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         # [Modified in Gloas:EIP7732]
@@ -630,7 +865,7 @@
         latest_block_hash: Hash32
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
-        historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
+        historical_summaries: HistoricalSummaries
         deposit_requests_start_index: Uint64
         deposit_balance_to_consume: Gwei
         exit_balance_to_consume: Gwei
@@ -638,28 +873,28 @@
         consolidation_balance_to_consume: Gwei
         earliest_consolidation_epoch: Epoch
         # [Modified in Gloas:EIP7688]
-        pending_deposits: ProgressiveList[PendingDeposit]
+        pending_deposits: PendingDeposits
         # [Modified in Gloas:EIP7688]
-        pending_partial_withdrawals: ProgressiveList[PendingPartialWithdrawal]
+        pending_partial_withdrawals: PendingPartialWithdrawals
         # [Modified in Gloas:EIP7688]
-        pending_consolidations: ProgressiveList[PendingConsolidation]
-        proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
+        pending_consolidations: PendingConsolidations
+        proposer_lookahead: ProposerLookahead
         # [New in Gloas:EIP7732]
-        builders: ProgressiveList[Builder]
+        builders: Builders
         # [New in Gloas:EIP7732]
         next_withdrawal_builder_index: BuilderIndex
         # [New in Gloas:EIP7732]
-        execution_payload_availability: BitVector[SLOTS_PER_HISTORICAL_ROOT]
+        execution_payload_availability: ExecutionPayloadAvailability
         # [New in Gloas:EIP7732]
-        builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
+        builder_pending_payments: BuilderPendingPayments
         # [New in Gloas:EIP7732]
-        builder_pending_withdrawals: ProgressiveList[BuilderPendingWithdrawal]
+        builder_pending_withdrawals: BuilderPendingWithdrawals
         # [New in Gloas:EIP7732]
         latest_execution_payload_bid: ExecutionPayloadBid
         # [New in Gloas:EIP7732]
-        payload_expected_withdrawals: ProgressiveList[Withdrawal]
+        payload_expected_withdrawals: Withdrawals
         # [New in Gloas:EIP7732]
-        ptc_window: Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]
+        ptc_window: PTCWindow
     </spec>
 
 - name: BeaconState#heze
@@ -667,55 +902,67 @@
     - file: packages/types/src/heze/sszTypes.ts
       search: export const BeaconState =
   spec: |
-    <spec container="BeaconState" fork="heze" hash="ca002717">
+    <spec container="BeaconState" fork="heze" hash="61c0f802">
     class BeaconState(ProgressiveContainer(active_fields=[1] * 46)):  # type: ignore
         genesis_time: Uint64
         genesis_validators_root: Root
         slot: Slot
         fork: Fork
         latest_block_header: BeaconBlockHeader
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+        historical_roots: HistoricalRoots
         eth1_data: Eth1Data
-        eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+        eth1_data_votes: Eth1DataVotes
         eth1_deposit_index: Uint64
-        validators: ProgressiveList[Validator]
-        balances: ProgressiveList[Gwei]
-        randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
-        slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]
-        previous_epoch_participation: ProgressiveList[ParticipationFlags]
-        current_epoch_participation: ProgressiveList[ParticipationFlags]
-        justification_bits: BitVector[JUSTIFICATION_BITS_LENGTH]
+        validators: Validators
+        balances: Balances
+        randao_mixes: RandaoMixes
+        slashings: Slashings
+        previous_epoch_participation: EpochParticipation
+        current_epoch_participation: EpochParticipation
+        justification_bits: JustificationBits
         previous_justified_checkpoint: Checkpoint
         current_justified_checkpoint: Checkpoint
         finalized_checkpoint: Checkpoint
-        inactivity_scores: ProgressiveList[Uint64]
+        inactivity_scores: InactivityScores
         current_sync_committee: SyncCommittee
         next_sync_committee: SyncCommittee
         latest_block_hash: Hash32
         next_withdrawal_index: WithdrawalIndex
         next_withdrawal_validator_index: ValidatorIndex
-        historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
+        historical_summaries: HistoricalSummaries
         deposit_requests_start_index: Uint64
         deposit_balance_to_consume: Gwei
         exit_balance_to_consume: Gwei
         earliest_exit_epoch: Epoch
         consolidation_balance_to_consume: Gwei
         earliest_consolidation_epoch: Epoch
-        pending_deposits: ProgressiveList[PendingDeposit]
-        pending_partial_withdrawals: ProgressiveList[PendingPartialWithdrawal]
-        pending_consolidations: ProgressiveList[PendingConsolidation]
-        proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
-        builders: ProgressiveList[Builder]
+        pending_deposits: PendingDeposits
+        pending_partial_withdrawals: PendingPartialWithdrawals
+        pending_consolidations: PendingConsolidations
+        proposer_lookahead: ProposerLookahead
+        builders: Builders
         next_withdrawal_builder_index: BuilderIndex
-        execution_payload_availability: BitVector[SLOTS_PER_HISTORICAL_ROOT]
-        builder_pending_payments: Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]
-        builder_pending_withdrawals: ProgressiveList[BuilderPendingWithdrawal]
+        execution_payload_availability: ExecutionPayloadAvailability
+        builder_pending_payments: BuilderPendingPayments
+        builder_pending_withdrawals: BuilderPendingWithdrawals
         # [Modified in Heze:EIP7805]
         latest_execution_payload_bid: ExecutionPayloadBid
-        payload_expected_withdrawals: ProgressiveList[Withdrawal]
-        ptc_window: Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]
+        payload_expected_withdrawals: Withdrawals
+        ptc_window: PTCWindow
+    </spec>
+
+- name: Blob#deneb
+  sources:
+    - file: packages/types/src/deneb/sszTypes.ts
+      search: export const Blob =
+  spec: |
+    <spec container="Blob" fork="deneb" hash="b10cdd2e">
+    class Blob(ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]):  # type: ignore
+        """
+        A blob of data, encoded as a sequence of BLS scalar field elements.
+        """
     </spec>
 
 - name: BlobIdentifier#deneb
@@ -729,19 +976,80 @@
         index: BlobIndex
     </spec>
 
+- name: BlobKZGCommitments#deneb
+  sources:
+    - file: packages/types/src/deneb/sszTypes.ts
+      search: "export const BlobKzgCommitments ="
+  spec: |
+    <spec container="BlobKZGCommitments" fork="deneb" hash="4e091520">
+    class BlobKZGCommitments(List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+        """
+        The KZG commitments to the blobs of a beacon block.
+        """
+    </spec>
+
+- name: BlobKZGCommitments#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: "export const BlobKzgCommitments ="
+  spec: |
+    <spec container="BlobKZGCommitments" fork="gloas" hash="b314c15b">
+    class BlobKZGCommitments(ProgressiveList[KZGCommitment]):
+        """
+        The KZG commitments to the blobs of a beacon block.
+        """
+    </spec>
+
 - name: BlobSidecar#deneb
   sources:
     - file: packages/types/src/deneb/sszTypes.ts
       search: export const BlobSidecar =
   spec: |
-    <spec container="BlobSidecar" fork="deneb" hash="b4f28e34">
+    <spec container="BlobSidecar" fork="deneb" hash="e63cb211">
     class BlobSidecar(Container):
         index: BlobIndex
         blob: Blob
         kzg_commitment: KZGCommitment
         kzg_proof: KZGProof
         signed_block_header: SignedBeaconBlockHeader
-        kzg_commitment_inclusion_proof: Vector[Bytes32, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH]
+        kzg_commitment_inclusion_proof: KZGCommitmentInclusionProof
+    </spec>
+
+- name: Blobs#deneb
+  sources:
+    - file: packages/types/src/deneb/sszTypes.ts
+      search: export const Blobs =
+  spec: |
+    <spec container="Blobs" fork="deneb" hash="4c863507">
+    class Blobs(List[Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+        """
+        The blobs of a single beacon block.
+        """
+    </spec>
+
+- name: BlockAccessList#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const BlockAccessList =
+  spec: |
+    <spec container="BlockAccessList" fork="gloas" hash="d934028a">
+    class BlockAccessList(ProgressiveByteList):
+        """
+        The serialized block access list of an execution payload.
+        """
+    </spec>
+
+- name: BlockRoots#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "export const HistoricalBlockRoots ="
+  spec: |
+    <spec container="BlockRoots" fork="phase0" hash="196c676c">
+    class BlockRoots(Vector[Root, SLOTS_PER_HISTORICAL_ROOT]):
+        """
+        A rolling window of recent block roots, indexed by slot modulo
+        ``SLOTS_PER_HISTORICAL_ROOT``.
+        """
     </spec>
 
 - name: Builder#gloas
@@ -772,6 +1080,18 @@
         signature: BLSSignature
     </spec>
 
+- name: BuilderDepositRequests#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const BuilderDepositRequests =
+  spec: |
+    <spec container="BuilderDepositRequests" fork="gloas" hash="7e9ad1a2">
+    class BuilderDepositRequests(ProgressiveList[BuilderDepositRequest]):
+        """
+        The builder deposit requests pertaining to a single execution payload.
+        """
+    </spec>
+
 - name: BuilderExitRequest#gloas
   sources:
     - file: packages/types/src/gloas/sszTypes.ts
@@ -781,6 +1101,18 @@
     class BuilderExitRequest(Container):
         source_address: ExecutionAddress
         pubkey: BLSPubkey
+    </spec>
+
+- name: BuilderExitRequests#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const BuilderExitRequests =
+  spec: |
+    <spec container="BuilderExitRequests" fork="gloas" hash="97dd32ce">
+    class BuilderExitRequests(ProgressiveList[BuilderExitRequest]):
+        """
+        The builder exit requests pertaining to a single execution payload.
+        """
     </spec>
 
 - name: BuilderPendingPayment#gloas
@@ -795,6 +1127,18 @@
         proposer_index: ValidatorIndex
     </spec>
 
+- name: BuilderPendingPayments#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: "builderPendingPayments: new VectorCompositeType(BuilderPendingPayment, 2 * SLOTS_PER_EPOCH),"
+  spec: |
+    <spec container="BuilderPendingPayments" fork="gloas" hash="4287d317">
+    class BuilderPendingPayments(Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]):  # type: ignore
+        """
+        The pending builder payments of the previous and current epoch.
+        """
+    </spec>
+
 - name: BuilderPendingWithdrawal#gloas
   sources:
     - file: packages/types/src/gloas/sszTypes.ts
@@ -807,6 +1151,86 @@
         builder_index: BuilderIndex
     </spec>
 
+- name: BuilderPendingWithdrawals#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const BuilderPendingWithdrawals =
+  spec: |
+    <spec container="BuilderPendingWithdrawals" fork="gloas" hash="dbae2178">
+    class BuilderPendingWithdrawals(ProgressiveList[BuilderPendingWithdrawal]):
+        """
+        The queue of builder withdrawals awaiting processing.
+        """
+    </spec>
+
+- name: Builders#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const Builders =
+  spec: |
+    <spec container="Builders" fork="gloas" hash="20c737d4">
+    class Builders(ProgressiveList[Builder]):
+        """
+        The builder registry.
+        """
+    </spec>
+
+- name: Cell#fulu
+  sources:
+    - file: packages/types/src/fulu/sszTypes.ts
+      search: export const Cell =
+  spec: |
+    <spec container="Cell" fork="fulu" hash="fdb37a6c">
+    class Cell(ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_CELL]):  # type: ignore
+        """
+        The unit of extended blob data that has its own ``KZGProof``.
+        """
+    </spec>
+
+- name: CellKZGProofs#fulu
+  sources:
+    - file: packages/types/src/fulu/sszTypes.ts
+      search: "export const KZGProofs ="
+  spec: |
+    <spec container="CellKZGProofs" fork="fulu" hash="b1c99154">
+    class CellKZGProofs(List[KZGProof, FIELD_ELEMENTS_PER_EXT_BLOB * MAX_BLOB_COMMITMENTS_PER_BLOCK]):  # type: ignore
+        """
+        The KZG cell proofs for every blob in a block, one proof per cell.
+        """
+    </spec>
+
+- name: Cells#fulu
+  sources:
+    - file: packages/beacon-node/src/util/blobs.ts
+      search: "function cellsToBlob(cells: fulu.Cell[]): deneb.Blob {"
+  spec: |
+    <spec container="Cells" fork="fulu" hash="39e61657">
+    class Cells(Vector[Cell, CELLS_PER_EXT_BLOB]):
+        """
+        The cells of a single extended blob.
+        """
+    </spec>
+
+- name: CellsBitList#fulu
+  sources: []
+  spec: |
+    <spec container="CellsBitList" fork="fulu" hash="a8c28de7">
+    class CellsBitList(BitList[MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+        """
+        A bitfield over the cells of a column, one bit per blob.
+        """
+    </spec>
+
+- name: CellsBitList#gloas
+  sources: []
+  spec: |
+    <spec container="CellsBitList" fork="gloas" hash="3b9205a0">
+    class CellsBitList(ProgressiveBitList):
+        """
+        A bitfield over the cells of a column, one bit per blob.
+        """
+    </spec>
+
 - name: Checkpoint#phase0
   sources:
     - file: packages/types/src/phase0/sszTypes.ts
@@ -816,6 +1240,18 @@
     class Checkpoint(Container):
         epoch: Epoch
         root: Root
+    </spec>
+
+- name: CommitteeBits#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: "export const CommitteeBits ="
+  spec: |
+    <spec container="CommitteeBits" fork="electra" hash="6130444a">
+    class CommitteeBits(BitVector[MAX_COMMITTEES_PER_SLOT]):
+        """
+        Bits marking which committees of a slot participate in an attestation.
+        """
     </spec>
 
 - name: ConsolidationRequest#electra
@@ -830,6 +1266,30 @@
         target_pubkey: BLSPubkey
     </spec>
 
+- name: ConsolidationRequests#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: export const ConsolidationRequests =
+  spec: |
+    <spec container="ConsolidationRequests" fork="electra" hash="4f33783d">
+    class ConsolidationRequests(List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]):
+        """
+        The consolidation requests pertaining to a single execution payload.
+        """
+    </spec>
+
+- name: ConsolidationRequests#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const ConsolidationRequests =
+  spec: |
+    <spec container="ConsolidationRequests" fork="gloas" hash="0feeb09e">
+    class ConsolidationRequests(ProgressiveList[ConsolidationRequest]):
+        """
+        The consolidation requests pertaining to a single execution payload.
+        """
+    </spec>
+
 - name: ContributionAndProof#altair
   sources:
     - file: packages/types/src/altair/sszTypes.ts
@@ -842,19 +1302,103 @@
         selection_proof: BLSSignature
     </spec>
 
+- name: CurrentSyncCommitteeBranch#altair
+  sources:
+    - file: packages/types/src/altair/sszTypes.ts
+      search: export const CurrentSyncCommitteeBranch =
+  spec: |
+    <spec container="CurrentSyncCommitteeBranch" fork="altair" hash="2cc7c29c">
+    class CurrentSyncCommitteeBranch(Vector[Bytes32, floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX)]):  # type: ignore
+        """
+        A Merkle branch proving ``current_sync_committee`` within ``BeaconState``.
+        """
+    </spec>
+
+- name: CurrentSyncCommitteeBranch#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: export const CurrentSyncCommitteeBranch =
+  spec: |
+    <spec container="CurrentSyncCommitteeBranch" fork="electra" hash="e6355296">
+    class CurrentSyncCommitteeBranch(Vector[Bytes32, floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA)]):  # type: ignore
+        """
+        A Merkle branch proving ``current_sync_committee`` within ``BeaconState``.
+        """
+    </spec>
+
+- name: CurrentSyncCommitteeBranch#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const CurrentSyncCommitteeBranch =
+  spec: |
+    <spec container="CurrentSyncCommitteeBranch" fork="gloas" hash="cbd3b46f">
+    class CurrentSyncCommitteeBranch(Vector[Bytes32, floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX_GLOAS)]):  # type: ignore
+        """
+        A Merkle branch proving ``current_sync_committee`` within ``BeaconState``.
+        """
+    </spec>
+
+- name: CustodyColumnBits#gloas
+  sources:
+    - file: packages/beacon-node/src/util/dataColumns.ts
+      search: "private getCustodyColumnsIndex(custodyColumns: ColumnIndex[]): Uint8Array {"
+  spec: |
+    <spec container="CustodyColumnBits" fork="gloas" hash="78c70e93">
+    class CustodyColumnBits(BitVector[NUMBER_OF_COLUMNS]):
+        """
+        Bits marking the data columns custodied by a node, one bit per column.
+        """
+    </spec>
+
+- name: DataColumn#fulu
+  sources:
+    - file: packages/types/src/fulu/sszTypes.ts
+      search: export const DataColumn =
+  spec: |
+    <spec container="DataColumn" fork="fulu" hash="38c96fb5">
+    class DataColumn(List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+        """
+        A column of the extended blob data matrix, with at most one cell per blob.
+        """
+    </spec>
+
+- name: DataColumn#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const DataColumn =
+  spec: |
+    <spec container="DataColumn" fork="gloas" hash="2b5f55e6">
+    class DataColumn(ProgressiveList[Cell]):
+        """
+        A column of the extended blob data matrix, with at most one cell per blob.
+        """
+    </spec>
+
+- name: DataColumnIndices#fulu
+  sources:
+    - file: packages/types/src/fulu/sszTypes.ts
+      search: "export const DataColumnsByRootIdentifier ="
+  spec: |
+    <spec container="DataColumnIndices" fork="fulu" hash="ea49b569">
+    class DataColumnIndices(List[ColumnIndex, NUMBER_OF_COLUMNS]):
+        """
+        The indices of the data columns being requested.
+        """
+    </spec>
+
 - name: DataColumnSidecar#fulu
   sources:
     - file: packages/types/src/fulu/sszTypes.ts
       search: export const DataColumnSidecar =
   spec: |
-    <spec container="DataColumnSidecar" fork="fulu" hash="03586114">
+    <spec container="DataColumnSidecar" fork="fulu" hash="f33d3096">
     class DataColumnSidecar(Container):
         index: ColumnIndex
-        column: List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        column: DataColumn
+        kzg_commitments: BlobKZGCommitments
+        kzg_proofs: KZGProofs
         signed_block_header: SignedBeaconBlockHeader
-        kzg_commitments_inclusion_proof: Vector[Bytes32, KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH]
+        kzg_commitments_inclusion_proof: KZGCommitmentsInclusionProof
     </spec>
 
 - name: DataColumnSidecar#gloas
@@ -862,15 +1406,15 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const DataColumnSidecar =
   spec: |
-    <spec container="DataColumnSidecar" fork="gloas" hash="18cd6bcf">
+    <spec container="DataColumnSidecar" fork="gloas" hash="ee540fea">
     class DataColumnSidecar(Container):
         index: ColumnIndex
         # [Modified in Gloas:EIP7688]
-        column: ProgressiveList[Cell]
+        column: DataColumn
         # [Modified in Gloas:EIP7732]
         # Removed `kzg_commitments`
         # [Modified in Gloas:EIP7688]
-        kzg_proofs: ProgressiveList[KZGProof]
+        kzg_proofs: KZGProofs
         # [Modified in Gloas:EIP7732]
         # Removed `signed_block_header`
         # [Modified in Gloas:EIP7732]
@@ -884,12 +1428,25 @@
 - name: DataColumnsByRootIdentifier#fulu
   sources:
     - file: packages/types/src/fulu/sszTypes.ts
-      search: export const DataColumnsByRootIdentifier =
+      search: "export const DataColumnsByRootIdentifier ="
   spec: |
-    <spec container="DataColumnsByRootIdentifier" fork="fulu" hash="f0478456">
+    <spec container="DataColumnsByRootIdentifier" fork="fulu" hash="8865719d">
     class DataColumnsByRootIdentifier(Container):
         block_root: Root
-        columns: List[ColumnIndex, NUMBER_OF_COLUMNS]
+        columns: DataColumnIndices
+    </spec>
+
+- name: DataColumnsByRootIdentifiers#fulu
+  sources:
+    - file: packages/beacon-node/src/util/types.ts
+      search: "export const DataColumnSidecarsByRootRequestType ="
+  spec: |
+    <spec container="DataColumnsByRootIdentifiers" fork="fulu" hash="f41940f2">
+    class DataColumnsByRootIdentifiers(List[DataColumnsByRootIdentifier, MAX_REQUEST_BLOCKS_DENEB]):  # type: ignore
+        """
+        The identifiers of the data column sidecars requested in a
+        ``DataColumnSidecarsByRoot`` request.
+        """
     </spec>
 
 - name: Deposit#phase0
@@ -897,9 +1454,9 @@
     - file: packages/types/src/phase0/sszTypes.ts
       search: export const Deposit =
   spec: |
-    <spec container="Deposit" fork="phase0" hash="cc281399">
+    <spec container="Deposit" fork="phase0" hash="e820a881">
     class Deposit(Container):
-        proof: Vector[Bytes32, DEPOSIT_CONTRACT_TREE_DEPTH + 1]
+        proof: DepositProof
         data: DepositData
     </spec>
 
@@ -916,6 +1473,18 @@
         signature: BLSSignature
     </spec>
 
+- name: DepositDataList#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "export const DepositDataRootList ="
+  spec: |
+    <spec container="DepositDataList" fork="phase0" hash="8be91f3d">
+    class DepositDataList(List[DepositData, 2**DEPOSIT_CONTRACT_TREE_DEPTH]):  # type: ignore
+        """
+        The ``DepositData`` of deposits made to the deposit contract.
+        """
+    </spec>
+
 - name: DepositMessage#phase0
   sources:
     - file: packages/types/src/phase0/sszTypes.ts
@@ -926,6 +1495,19 @@
         pubkey: BLSPubkey
         withdrawal_credentials: Bytes32
         amount: Gwei
+    </spec>
+
+- name: DepositProof#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "proof: new VectorCompositeType(Bytes32, DEPOSIT_CONTRACT_TREE_DEPTH + 1),"
+  spec: |
+    <spec container="DepositProof" fork="phase0" hash="668dd08f">
+    class DepositProof(Vector[Bytes32, DEPOSIT_CONTRACT_TREE_DEPTH + 1]):  # type: ignore
+        """
+        A Merkle proof of a deposit in the deposit contract's tree. The node
+        beyond the tree depth accounts for the deposit count mix-in.
+        """
     </spec>
 
 - name: DepositRequest#electra
@@ -940,6 +1522,90 @@
         amount: Gwei
         signature: BLSSignature
         index: Uint64
+    </spec>
+
+- name: DepositRequests#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: export const DepositRequests =
+  spec: |
+    <spec container="DepositRequests" fork="electra" hash="7adac1d8">
+    class DepositRequests(List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]):
+        """
+        The deposit requests pertaining to a single execution payload.
+        """
+    </spec>
+
+- name: DepositRequests#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const DepositRequests =
+  spec: |
+    <spec container="DepositRequests" fork="gloas" hash="f4f6095a">
+    class DepositRequests(ProgressiveList[DepositRequest]):
+        """
+        The deposit requests pertaining to a single execution payload.
+        """
+    </spec>
+
+- name: Deposits#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "deposits: new ListCompositeType(Deposit, MAX_DEPOSITS),"
+  spec: |
+    <spec container="Deposits" fork="phase0" hash="471e25ca">
+    class Deposits(List[Deposit, MAX_DEPOSITS]):
+        """
+        The deposits included in a beacon block.
+        """
+    </spec>
+
+- name: Deposits#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const Deposits =
+  spec: |
+    <spec container="Deposits" fork="gloas" hash="630997d7">
+    class Deposits(ProgressiveList[Deposit]):
+        """
+        The deposits included in a beacon block.
+        """
+    </spec>
+
+- name: EpochParticipation#altair
+  sources:
+    - file: packages/types/src/altair/sszTypes.ts
+      search: export const EpochParticipation =
+  spec: |
+    <spec container="EpochParticipation" fork="altair" hash="c280fe2f">
+    class EpochParticipation(List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]):
+        """
+        The participation flags of each validator for an epoch.
+        """
+    </spec>
+
+- name: EpochParticipation#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const EpochParticipation =
+  spec: |
+    <spec container="EpochParticipation" fork="gloas" hash="90bed26d">
+    class EpochParticipation(ProgressiveList[ParticipationFlags]):
+        """
+        The participation flags of each validator for an epoch.
+        """
+    </spec>
+
+- name: ErrorMessage#phase0
+  sources:
+    - file: packages/reqresp/src/encoders/responseDecode.ts
+      search: "export async function readErrorMessage("
+  spec: |
+    <spec container="ErrorMessage" fork="phase0" hash="f7d2e797">
+    class ErrorMessage(List[Byte, 256]):
+        """
+        The error message of an unsuccessful response chunk.
+        """
     </spec>
 
 - name: Eth1Block#phase0
@@ -966,27 +1632,64 @@
         block_hash: Hash32
     </spec>
 
+- name: Eth1DataVotes#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: export const Eth1DataVotes =
+  spec: |
+    <spec container="Eth1DataVotes" fork="phase0" hash="6a8f99f0">
+    class Eth1DataVotes(List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]):  # type: ignore
+        """
+        The ``Eth1Data`` votes of the current voting period.
+        """
+    </spec>
+
+- name: ExecutionBranch#capella
+  sources:
+    - file: packages/types/src/capella/sszTypes.ts
+      search: export const ExecutionBranch =
+  spec: |
+    <spec container="ExecutionBranch" fork="capella" hash="80d7e50b">
+    class ExecutionBranch(Vector[Bytes32, floorlog2(EXECUTION_PAYLOAD_GINDEX)]):  # type: ignore
+        """
+        A Merkle branch proving ``execution_payload`` within ``BeaconBlockBody``.
+        """
+    </spec>
+
+- name: ExecutionBranch#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const ExecutionBranch =
+  spec: |
+    <spec container="ExecutionBranch" fork="gloas" hash="b18317f2">
+    class ExecutionBranch(Vector[Bytes32, floorlog2(EXECUTION_BLOCK_HASH_GINDEX_GLOAS)]):  # type: ignore
+        """
+        A Merkle branch proving the execution block hash within
+        ``BeaconBlockBody``.
+        """
+    </spec>
+
 - name: ExecutionPayload#bellatrix
   sources:
     - file: packages/types/src/bellatrix/sszTypes.ts
       search: export const ExecutionPayload =
   spec: |
-    <spec container="ExecutionPayload" fork="bellatrix" hash="4c14e8c9">
+    <spec container="ExecutionPayload" fork="bellatrix" hash="a6b01aa3">
     class ExecutionPayload(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
-        transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
+        transactions: Transactions
     </spec>
 
 - name: ExecutionPayload#capella
@@ -994,24 +1697,24 @@
     - file: packages/types/src/capella/sszTypes.ts
       search: export const ExecutionPayload =
   spec: |
-    <spec container="ExecutionPayload" fork="capella" hash="78dd6037">
+    <spec container="ExecutionPayload" fork="capella" hash="2a31ca39">
     class ExecutionPayload(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
-        transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
+        transactions: Transactions
         # [New in Capella]
-        withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+        withdrawals: Withdrawals
     </spec>
 
 - name: ExecutionPayload#deneb
@@ -1019,23 +1722,23 @@
     - file: packages/types/src/deneb/sszTypes.ts
       search: export const ExecutionPayload =
   spec: |
-    <spec container="ExecutionPayload" fork="deneb" hash="548fc639">
+    <spec container="ExecutionPayload" fork="deneb" hash="704edf55">
     class ExecutionPayload(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
-        transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
-        withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+        transactions: Transactions
+        withdrawals: Withdrawals
         # [New in Deneb:EIP4844]
         blob_gas_used: Uint64
         # [New in Deneb:EIP4844]
@@ -1047,25 +1750,25 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const ExecutionPayload =
   spec: |
-    <spec container="ExecutionPayload" fork="gloas" hash="e985ae4c">
+    <spec container="ExecutionPayload" fork="gloas" hash="ddd47b62">
     class ExecutionPayload(ProgressiveContainer(active_fields=[1] * 19)):  # type: ignore
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
         # [Modified in Gloas:EIP7688]
-        transactions: ProgressiveList[Transaction]
+        transactions: Transactions
         # [Modified in Gloas:EIP7688]
-        withdrawals: ProgressiveList[Withdrawal]
+        withdrawals: Withdrawals
         blob_gas_used: Uint64
         excess_blob_gas: Uint64
         # [New in Gloas:EIP7928]
@@ -1074,12 +1777,25 @@
         slot_number: Uint64
     </spec>
 
+- name: ExecutionPayloadAvailability#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: "executionPayloadAvailability: new BitVectorType(SLOTS_PER_HISTORICAL_ROOT),"
+  spec: |
+    <spec container="ExecutionPayloadAvailability" fork="gloas" hash="74d830bf">
+    class ExecutionPayloadAvailability(BitVector[SLOTS_PER_HISTORICAL_ROOT]):
+        """
+        Bits tracking payload availability for recent slots, indexed by slot
+        modulo ``SLOTS_PER_HISTORICAL_ROOT``.
+        """
+    </spec>
+
 - name: ExecutionPayloadBid#gloas
   sources:
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const ExecutionPayloadBid =
   spec: |
-    <spec container="ExecutionPayloadBid" fork="gloas" hash="3bc16ac1">
+    <spec container="ExecutionPayloadBid" fork="gloas" hash="9ebe1457">
     class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 12)):  # type: ignore
         parent_block_hash: Hash32
         parent_block_root: Root
@@ -1091,7 +1807,7 @@
         slot: Slot
         value: Gwei
         execution_payment: Gwei
-        blob_kzg_commitments: ProgressiveList[KZGCommitment]
+        blob_kzg_commitments: BlobKZGCommitments
         execution_requests_root: Root
     </spec>
 
@@ -1100,7 +1816,7 @@
     - file: packages/types/src/heze/sszTypes.ts
       search: export const ExecutionPayloadBid =
   spec: |
-    <spec container="ExecutionPayloadBid" fork="heze" hash="41633b32">
+    <spec container="ExecutionPayloadBid" fork="heze" hash="51303fe1">
     class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 13)):  # type: ignore
         parent_block_hash: Hash32
         parent_block_root: Root
@@ -1112,10 +1828,10 @@
         slot: Slot
         value: Gwei
         execution_payment: Gwei
-        blob_kzg_commitments: ProgressiveList[KZGCommitment]
+        blob_kzg_commitments: BlobKZGCommitments
         execution_requests_root: Root
         # [New in Heze:EIP7805]
-        inclusion_list_bits: BitVector[INCLUSION_LIST_COMMITTEE_SIZE]
+        inclusion_list_bits: InclusionListBits
     </spec>
 
 - name: ExecutionPayloadEnvelope#gloas
@@ -1132,24 +1848,37 @@
         parent_beacon_block_root: Root
     </spec>
 
+- name: ExecutionPayloadEnvelopeRoots#gloas
+  sources:
+    - file: packages/beacon-node/src/util/types.ts
+      search: "export const ExecutionPayloadEnvelopesByRootRequestType ="
+  spec: |
+    <spec container="ExecutionPayloadEnvelopeRoots" fork="gloas" hash="299d6842">
+    class ExecutionPayloadEnvelopeRoots(List[Root, MAX_REQUEST_PAYLOADS]):  # type: ignore
+        """
+        The beacon block roots of the payload envelopes requested in an
+        ``ExecutionPayloadEnvelopesByRoot`` request.
+        """
+    </spec>
+
 - name: ExecutionPayloadHeader#bellatrix
   sources:
     - file: packages/types/src/bellatrix/sszTypes.ts
       search: export const ExecutionPayloadHeader =
   spec: |
-    <spec container="ExecutionPayloadHeader" fork="bellatrix" hash="a3ed912a">
+    <spec container="ExecutionPayloadHeader" fork="bellatrix" hash="63fe743f">
     class ExecutionPayloadHeader(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
         transactions_root: Root
@@ -1160,19 +1889,19 @@
     - file: packages/types/src/capella/sszTypes.ts
       search: export const ExecutionPayloadHeader =
   spec: |
-    <spec container="ExecutionPayloadHeader" fork="capella" hash="521fff4a">
+    <spec container="ExecutionPayloadHeader" fork="capella" hash="dd46d040">
     class ExecutionPayloadHeader(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
         transactions_root: Root
@@ -1185,19 +1914,19 @@
     - file: packages/types/src/deneb/sszTypes.ts
       search: export const ExecutionPayloadHeader =
   spec: |
-    <spec container="ExecutionPayloadHeader" fork="deneb" hash="48bef01c">
+    <spec container="ExecutionPayloadHeader" fork="deneb" hash="a1fbee3d">
     class ExecutionPayloadHeader(Container):
         parent_hash: Hash32
         fee_recipient: ExecutionAddress
         state_root: Bytes32
         receipts_root: Bytes32
-        logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+        logs_bloom: LogsBloom
         prev_randao: Bytes32
         block_number: Uint64
         gas_limit: Uint64
         gas_used: Uint64
         timestamp: Uint64
-        extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+        extra_data: ExtraData
         base_fee_per_gas: Uint256
         block_hash: Hash32
         transactions_root: Root
@@ -1239,6 +1968,57 @@
         builder_exits: BuilderExitRequests
     </spec>
 
+- name: ExtraData#bellatrix
+  sources:
+    - file: packages/types/src/bellatrix/sszTypes.ts
+      search: "extraData: new ByteListType(MAX_EXTRA_DATA_BYTES),"
+  spec: |
+    <spec container="ExtraData" fork="bellatrix" hash="9f5bb1de">
+    class ExtraData(ByteList[MAX_EXTRA_DATA_BYTES]):
+        """
+        Arbitrary extra data included in an execution payload.
+        """
+    </spec>
+
+- name: FinalityBranch#altair
+  sources:
+    - file: packages/types/src/altair/sszTypes.ts
+      search: export const FinalityBranch =
+  spec: |
+    <spec container="FinalityBranch" fork="altair" hash="21164d98">
+    class FinalityBranch(Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX)]):  # type: ignore
+        """
+        A Merkle branch proving ``finalized_checkpoint.root`` within
+        ``BeaconState``.
+        """
+    </spec>
+
+- name: FinalityBranch#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: export const FinalityBranch =
+  spec: |
+    <spec container="FinalityBranch" fork="electra" hash="f22a787c">
+    class FinalityBranch(Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX_ELECTRA)]):  # type: ignore
+        """
+        A Merkle branch proving ``finalized_checkpoint.root`` within
+        ``BeaconState``.
+        """
+    </spec>
+
+- name: FinalityBranch#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const FinalityBranch =
+  spec: |
+    <spec container="FinalityBranch" fork="gloas" hash="7a001e91">
+    class FinalityBranch(Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX_GLOAS)]):  # type: ignore
+        """
+        A Merkle branch proving ``finalized_checkpoint.root`` within
+        ``BeaconState``.
+        """
+    </spec>
+
 - name: Fork#phase0
   sources:
     - file: packages/types/src/phase0/sszTypes.ts
@@ -1267,10 +2047,34 @@
     - file: packages/types/src/phase0/sszTypes.ts
       search: export const HistoricalBatch =
   spec: |
-    <spec container="HistoricalBatch" fork="phase0" hash="3b677eb3">
+    <spec container="HistoricalBatch" fork="phase0" hash="a39a75cd">
     class HistoricalBatch(Container):
-        block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
-        state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
+        block_roots: BlockRoots
+        state_roots: StateRoots
+    </spec>
+
+- name: HistoricalRoots#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "historicalRoots: new ListCompositeType(Root, HISTORICAL_ROOTS_LIMIT),"
+  spec: |
+    <spec container="HistoricalRoots" fork="phase0" hash="c255dc18">
+    class HistoricalRoots(List[Root, HISTORICAL_ROOTS_LIMIT]):
+        """
+        The roots of ``HistoricalBatch`` objects.
+        """
+    </spec>
+
+- name: HistoricalSummaries#capella
+  sources:
+    - file: packages/types/src/capella/sszTypes.ts
+      search: export const HistoricalSummaries =
+  spec: |
+    <spec container="HistoricalSummaries" fork="capella" hash="10e90a67">
+    class HistoricalSummaries(List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]):
+        """
+        Summaries of the chain's block and state root history.
+        """
     </spec>
 
 - name: HistoricalSummary#capella
@@ -1284,17 +2088,66 @@
         state_summary_root: Root
     </spec>
 
+- name: InactivityScores#altair
+  sources:
+    - file: packages/types/src/altair/sszTypes.ts
+      search: export const InactivityScores =
+  spec: |
+    <spec container="InactivityScores" fork="altair" hash="5fe95147">
+    class InactivityScores(List[Uint64, VALIDATOR_REGISTRY_LIMIT]):
+        """
+        Each validator's inactivity score, tracking missed timely target votes.
+        """
+    </spec>
+
+- name: InactivityScores#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const InactivityScores =
+  spec: |
+    <spec container="InactivityScores" fork="gloas" hash="a58ac260">
+    class InactivityScores(ProgressiveList[Uint64]):
+        """
+        Each validator's inactivity score, tracking missed timely target votes.
+        """
+    </spec>
+
 - name: InclusionList#heze
   sources:
     - file: packages/types/src/heze/sszTypes.ts
       search: export const InclusionList =
   spec: |
-    <spec container="InclusionList" fork="heze" hash="b6409409">
+    <spec container="InclusionList" fork="heze" hash="e97e4658">
     class InclusionList(Container):
         slot: Slot
         validator_index: ValidatorIndex
-        inclusion_list_committee_root: Root
-        transactions: ProgressiveList[Transaction]
+        dependent_root: Root
+        transactions: Transactions
+    </spec>
+
+- name: InclusionListBits#heze
+  sources:
+    - file: packages/types/src/heze/sszTypes.ts
+      search: export const InclusionListBits =
+  spec: |
+    <spec container="InclusionListBits" fork="heze" hash="201961a9">
+    class InclusionListBits(BitVector[INCLUSION_LIST_COMMITTEE_SIZE]):
+        """
+        A bitfield over the inclusion list committee, one bit per member in
+        committee order.
+        """
+    </spec>
+
+- name: InclusionListCommittee#heze
+  sources:
+    - file: packages/types/src/heze/sszTypes.ts
+      search: export const InclusionListCommittee =
+  spec: |
+    <spec container="InclusionListCommittee" fork="heze" hash="cee5c8bc">
+    class InclusionListCommittee(Vector[ValidatorIndex, INCLUSION_LIST_COMMITTEE_SIZE]):
+        """
+        The inclusion list committee of a slot.
+        """
     </spec>
 
 - name: IndexedAttestation#phase0
@@ -1302,9 +2155,9 @@
     - file: packages/types/src/phase0/sszTypes.ts
       search: export const IndexedAttestation =
   spec: |
-    <spec container="IndexedAttestation" fork="phase0" hash="b321d4c3">
+    <spec container="IndexedAttestation" fork="phase0" hash="c675364e">
     class IndexedAttestation(Container):
-        attesting_indices: List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE]
+        attesting_indices: AttestingIndices
         data: AttestationData
         signature: BLSSignature
     </spec>
@@ -1339,11 +2192,73 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const IndexedPayloadAttestation =
   spec: |
-    <spec container="IndexedPayloadAttestation" fork="gloas" hash="c165cb61">
+    <spec container="IndexedPayloadAttestation" fork="gloas" hash="940bfcab">
     class IndexedPayloadAttestation(ProgressiveContainer(active_fields=[1] * 3)):  # type: ignore
-        attesting_indices: List[ValidatorIndex, PTC_SIZE]
+        attesting_indices: PTCAttestingIndices
         data: PayloadAttestationData
         signature: BLSSignature
+    </spec>
+
+- name: JustificationBits#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: export const JustificationBits =
+  spec: |
+    <spec container="JustificationBits" fork="phase0" hash="3ed292d2">
+    class JustificationBits(BitVector[JUSTIFICATION_BITS_LENGTH]):
+        """
+        The justification status of the last ``JUSTIFICATION_BITS_LENGTH`` epochs.
+        """
+    </spec>
+
+- name: KZGCommitmentInclusionProof#deneb
+  sources:
+    - file: packages/types/src/deneb/sszTypes.ts
+      search: "export const KzgCommitmentInclusionProof ="
+  spec: |
+    <spec container="KZGCommitmentInclusionProof" fork="deneb" hash="4c82f6b2">
+    class KZGCommitmentInclusionProof(Vector[Bytes32, KZG_COMMITMENT_INCLUSION_PROOF_DEPTH]):
+        """
+        A Merkle branch proving a blob's KZG commitment within
+        ``BeaconBlockBody``.
+        """
+    </spec>
+
+- name: KZGCommitmentsInclusionProof#fulu
+  sources:
+    - file: packages/types/src/fulu/sszTypes.ts
+      search: "export const KzgCommitmentsInclusionProof ="
+  spec: |
+    <spec container="KZGCommitmentsInclusionProof" fork="fulu" hash="2eabcb42">
+    class KZGCommitmentsInclusionProof(Vector[Bytes32, KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH]):
+        """
+        A Merkle branch proving a block's blob KZG commitments within
+        ``BeaconBlockBody``.
+        """
+    </spec>
+
+- name: KZGProofs#deneb
+  sources:
+    - file: packages/types/src/deneb/sszTypes.ts
+      search: "export const KZGProofs ="
+  spec: |
+    <spec container="KZGProofs" fork="deneb" hash="7ced0c3c">
+    class KZGProofs(List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]):
+        """
+        A list of KZG proofs, one for each blob or cell being proven.
+        """
+    </spec>
+
+- name: KZGProofs#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: "export const KZGProofs ="
+  spec: |
+    <spec container="KZGProofs" fork="gloas" hash="5e0ae5cd">
+    class KZGProofs(ProgressiveList[KZGProof]):
+        """
+        The KZG cell proofs of the cells held by a data column.
+        """
     </spec>
 
 - name: LightClientBootstrap#altair
@@ -1512,6 +2427,30 @@
         signature_slot: Slot
     </spec>
 
+- name: LightClientUpdates#altair
+  sources:
+    - file: packages/beacon-node/src/network/network.ts
+      search: "async sendLightClientUpdatesByRange("
+  spec: |
+    <spec container="LightClientUpdates" fork="altair" hash="e7ff6e37">
+    class LightClientUpdates(List[LightClientUpdate, MAX_REQUEST_LIGHT_CLIENT_UPDATES]):
+        """
+        Light client updates returned in a ``LightClientUpdatesByRange`` response.
+        """
+    </spec>
+
+- name: LogsBloom#bellatrix
+  sources:
+    - file: packages/types/src/bellatrix/sszTypes.ts
+      search: "logsBloom: new ByteVectorType(BYTES_PER_LOGS_BLOOM),"
+  spec: |
+    <spec container="LogsBloom" fork="bellatrix" hash="99b65092">
+    class LogsBloom(ByteVector[BYTES_PER_LOGS_BLOOM]):
+        """
+        A Bloom filter aggregating the logs emitted by an execution payload.
+        """
+    </spec>
+
 - name: MatrixEntry#fulu
   sources:
     - file: packages/types/src/fulu/sszTypes.ts
@@ -1523,6 +2462,103 @@
         kzg_proof: KZGProof
         column_index: ColumnIndex
         row_index: RowIndex
+    </spec>
+
+- name: NextSyncCommitteeBranch#altair
+  sources:
+    - file: packages/types/src/altair/sszTypes.ts
+      search: export const NextSyncCommitteeBranch =
+  spec: |
+    <spec container="NextSyncCommitteeBranch" fork="altair" hash="419dde2d">
+    class NextSyncCommitteeBranch(Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX)]):  # type: ignore
+        """
+        A Merkle branch proving ``next_sync_committee`` within ``BeaconState``.
+        """
+    </spec>
+
+- name: NextSyncCommitteeBranch#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: export const NextSyncCommitteeBranch =
+  spec: |
+    <spec container="NextSyncCommitteeBranch" fork="electra" hash="3b6c578a">
+    class NextSyncCommitteeBranch(Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA)]):  # type: ignore
+        """
+        A Merkle branch proving ``next_sync_committee`` within ``BeaconState``.
+        """
+    </spec>
+
+- name: NextSyncCommitteeBranch#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const NextSyncCommitteeBranch =
+  spec: |
+    <spec container="NextSyncCommitteeBranch" fork="gloas" hash="e5bc4725">
+    class NextSyncCommitteeBranch(Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX_GLOAS)]):  # type: ignore
+        """
+        A Merkle branch proving ``next_sync_committee`` within ``BeaconState``.
+        """
+    </spec>
+
+- name: OptionalPartialDataColumnHeader#fulu
+  sources: []
+  spec: |
+    <spec container="OptionalPartialDataColumnHeader" fork="fulu" hash="67b3756a">
+    class OptionalPartialDataColumnHeader(List[PartialDataColumnHeader, 1]):
+        """
+        A header that may or may not be present, encoded as a list of length zero
+        or one.
+        """
+    </spec>
+
+- name: PTC#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: "export const PayloadTimelinessCommittee ="
+  spec: |
+    <spec container="PTC" fork="gloas" hash="6dbe4f6f">
+    class PTC(Vector[ValidatorIndex, PTC_SIZE]):
+        """
+        The payload timeliness committee of a slot.
+        """
+    </spec>
+
+- name: PTCAttestingIndices#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: "attestingIndices: new ListBasicType(ValidatorIndex, PTC_SIZE),"
+  spec: |
+    <spec container="PTCAttestingIndices" fork="gloas" hash="0a6cc1e3">
+    class PTCAttestingIndices(List[ValidatorIndex, PTC_SIZE]):
+        """
+        The indices of the PTC members participating in a payload attestation.
+        """
+    </spec>
+
+- name: PTCBits#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: "aggregationBits: new BitVectorType(PTC_SIZE),"
+  spec: |
+    <spec container="PTCBits" fork="gloas" hash="cdede459">
+    class PTCBits(BitVector[PTC_SIZE]):
+        """
+        The participation bits of the payload timeliness committee, one bit per
+        member in committee order.
+        """
+    </spec>
+
+- name: PTCWindow#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: "export const PtcWindow ="
+  spec: |
+    <spec container="PTCWindow" fork="gloas" hash="b4036da3">
+    class PTCWindow(Vector[PTC, (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]):  # type: ignore
+        """
+        A rolling window of payload timeliness committees for the previous,
+        current, and lookahead epochs.
+        """
     </spec>
 
 - name: PartialDataColumnGroupID#fulu
@@ -1543,14 +2579,25 @@
         slot: Slot
     </spec>
 
+- name: PartialDataColumnPartsMetadata#gloas
+  sources: []
+  spec: |
+    <spec container="PartialDataColumnPartsMetadata" fork="gloas" hash="5d754ee2">
+    class PartialDataColumnPartsMetadata(Container):
+        # [Modified in Gloas:EIP7688]
+        available: CellsBitList
+        # [Modified in Gloas:EIP7688]
+        requests: CellsBitList
+    </spec>
+
 - name: PartialDataColumnSidecar#gloas
   sources: []
   spec: |
-    <spec container="PartialDataColumnSidecar" fork="gloas" hash="50942bc3">
+    <spec container="PartialDataColumnSidecar" fork="gloas" hash="b7052f45">
     class PartialDataColumnSidecar(Container):
-        cells_present_bitmap: ProgressiveBitList
-        partial_column: ProgressiveList[Cell]
-        kzg_proofs: ProgressiveList[KZGProof]
+        cells_present_bitmap: CellsBitList
+        partial_column: DataColumn
+        kzg_proofs: KZGProofs
     </spec>
 
 - name: PayloadAttestation#gloas
@@ -1558,9 +2605,9 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const PayloadAttestation =
   spec: |
-    <spec container="PayloadAttestation" fork="gloas" hash="f239524c">
+    <spec container="PayloadAttestation" fork="gloas" hash="44b1d5c4">
     class PayloadAttestation(ProgressiveContainer(active_fields=[1] * 3)):  # type: ignore
-        aggregation_bits: BitVector[PTC_SIZE]
+        aggregation_bits: PTCBits
         data: PayloadAttestationData
         signature: BLSSignature
     </spec>
@@ -1590,17 +2637,41 @@
         signature: BLSSignature
     </spec>
 
+- name: PayloadAttestations#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const PayloadAttestations =
+  spec: |
+    <spec container="PayloadAttestations" fork="gloas" hash="e247813b">
+    class PayloadAttestations(ProgressiveList[PayloadAttestation]):
+        """
+        The payload attestations included in a beacon block.
+        """
+    </spec>
+
 - name: PendingAttestation#phase0
   sources:
     - file: packages/types/src/phase0/sszTypes.ts
       search: export const PendingAttestation =
   spec: |
-    <spec container="PendingAttestation" fork="phase0" hash="fb34e482">
+    <spec container="PendingAttestation" fork="phase0" hash="e82bd1c2">
     class PendingAttestation(Container):
-        aggregation_bits: BitList[MAX_VALIDATORS_PER_COMMITTEE]
+        aggregation_bits: AggregationBits
         data: AttestationData
         inclusion_delay: Slot
         proposer_index: ValidatorIndex
+    </spec>
+
+- name: PendingAttestations#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "export const EpochAttestations ="
+  spec: |
+    <spec container="PendingAttestations" fork="phase0" hash="77110d55">
+    class PendingAttestations(List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]):  # type: ignore
+        """
+        The attestations included in blocks during an epoch.
+        """
     </spec>
 
 - name: PendingConsolidation#electra
@@ -1612,6 +2683,30 @@
     class PendingConsolidation(Container):
         source_index: ValidatorIndex
         target_index: ValidatorIndex
+    </spec>
+
+- name: PendingConsolidations#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: export const PendingConsolidations =
+  spec: |
+    <spec container="PendingConsolidations" fork="electra" hash="68ab1d82">
+    class PendingConsolidations(List[PendingConsolidation, PENDING_CONSOLIDATIONS_LIMIT]):
+        """
+        The queue of consolidations awaiting processing.
+        """
+    </spec>
+
+- name: PendingConsolidations#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const PendingConsolidations =
+  spec: |
+    <spec container="PendingConsolidations" fork="gloas" hash="8a088d95">
+    class PendingConsolidations(ProgressiveList[PendingConsolidation]):
+        """
+        The queue of consolidations awaiting processing.
+        """
     </spec>
 
 - name: PendingDeposit#electra
@@ -1628,6 +2723,30 @@
         slot: Slot
     </spec>
 
+- name: PendingDeposits#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: export const PendingDeposits =
+  spec: |
+    <spec container="PendingDeposits" fork="electra" hash="3256ff43">
+    class PendingDeposits(List[PendingDeposit, PENDING_DEPOSITS_LIMIT]):
+        """
+        The queue of deposits awaiting processing.
+        """
+    </spec>
+
+- name: PendingDeposits#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const PendingDeposits =
+  spec: |
+    <spec container="PendingDeposits" fork="gloas" hash="5d204e7e">
+    class PendingDeposits(ProgressiveList[PendingDeposit]):
+        """
+        The queue of deposits awaiting processing.
+        """
+    </spec>
+
 - name: PendingPartialWithdrawal#electra
   sources:
     - file: packages/types/src/electra/sszTypes.ts
@@ -1640,6 +2759,30 @@
         withdrawable_epoch: Epoch
     </spec>
 
+- name: PendingPartialWithdrawals#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: export const PendingPartialWithdrawals =
+  spec: |
+    <spec container="PendingPartialWithdrawals" fork="electra" hash="8466ddd3">
+    class PendingPartialWithdrawals(List[PendingPartialWithdrawal, PENDING_PARTIAL_WITHDRAWALS_LIMIT]):
+        """
+        The queue of partial withdrawals awaiting processing.
+        """
+    </spec>
+
+- name: PendingPartialWithdrawals#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const PendingPartialWithdrawals =
+  spec: |
+    <spec container="PendingPartialWithdrawals" fork="gloas" hash="fdade6fe">
+    class PendingPartialWithdrawals(ProgressiveList[PendingPartialWithdrawal]):
+        """
+        The queue of partial withdrawals awaiting processing.
+        """
+    </spec>
+
 - name: PowBlock#bellatrix
   sources:
     - file: packages/types/src/bellatrix/sszTypes.ts
@@ -1650,6 +2793,43 @@
         block_hash: Hash32
         parent_hash: Hash32
         total_difficulty: Uint256
+    </spec>
+
+- name: Proofs#fulu
+  sources:
+    - file: packages/beacon-node/src/execution/engine/types.ts
+      search: "if (data.proofs.length !== CELLS_PER_EXT_BLOB) {"
+  spec: |
+    <spec container="Proofs" fork="fulu" hash="1a6f1e52">
+    class Proofs(Vector[KZGProof, CELLS_PER_EXT_BLOB]):
+        """
+        The KZG proofs for the cells of a single extended blob.
+        """
+    </spec>
+
+- name: ProposerIndices#fulu
+  sources:
+    - file: packages/state-transition/src/util/seed.ts
+      search: export function computeProposerIndices(
+  spec: |
+    <spec container="ProposerIndices" fork="fulu" hash="8093708b">
+    class ProposerIndices(Vector[ValidatorIndex, SLOTS_PER_EPOCH]):
+        """
+        The proposer indices for every slot of a single epoch.
+        """
+    </spec>
+
+- name: ProposerLookahead#fulu
+  sources:
+    - file: packages/types/src/fulu/sszTypes.ts
+      search: export const ProposerLookahead =
+  spec: |
+    <spec container="ProposerLookahead" fork="fulu" hash="0143c9d5">
+    class ProposerLookahead(Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]):  # type: ignore
+        """
+        The precomputed proposer indices for the current and next
+        ``MIN_SEED_LOOKAHEAD`` epochs.
+        """
     </spec>
 
 - name: ProposerPreferences#gloas
@@ -1675,6 +2855,43 @@
     class ProposerSlashing(Container):
         signed_header_1: SignedBeaconBlockHeader
         signed_header_2: SignedBeaconBlockHeader
+    </spec>
+
+- name: ProposerSlashings#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "proposerSlashings: new ListCompositeType(ProposerSlashing, MAX_PROPOSER_SLASHINGS),"
+  spec: |
+    <spec container="ProposerSlashings" fork="phase0" hash="e6e26c08">
+    class ProposerSlashings(List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]):
+        """
+        The proposer slashings included in a beacon block.
+        """
+    </spec>
+
+- name: ProposerSlashings#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const ProposerSlashings =
+  spec: |
+    <spec container="ProposerSlashings" fork="gloas" hash="3c87674a">
+    class ProposerSlashings(ProgressiveList[ProposerSlashing]):
+        """
+        The proposer slashings included in a beacon block.
+        """
+    </spec>
+
+- name: RandaoMixes#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: export const RandaoMixes =
+  spec: |
+    <spec container="RandaoMixes" fork="phase0" hash="f7381c81">
+    class RandaoMixes(Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]):
+        """
+        A rolling window of accumulated RANDAO mixes, indexed by epoch modulo
+        ``EPOCHS_PER_HISTORICAL_VECTOR``.
+        """
     </spec>
 
 - name: SignedAggregateAndProof#phase0
@@ -1733,6 +2950,32 @@
         signature: BLSSignature
     </spec>
 
+- name: SignedBeaconBlocks#phase0
+  sources:
+    - file: packages/beacon-node/src/network/network.ts
+      search: "async sendBeaconBlocksByRange("
+  spec: |
+    <spec container="SignedBeaconBlocks" fork="phase0" hash="1eee87ae">
+    class SignedBeaconBlocks(List[SignedBeaconBlock, MAX_REQUEST_BLOCKS]):  # type: ignore
+        """
+        Signed beacon blocks returned in a ``BeaconBlocksByRange`` or
+        ``BeaconBlocksByRoot`` response.
+        """
+    </spec>
+
+- name: SignedBeaconBlocks#deneb
+  sources:
+    - file: packages/beacon-node/src/network/network.ts
+      search: "async sendBeaconBlocksByRange("
+  spec: |
+    <spec container="SignedBeaconBlocks" fork="deneb" hash="30aa0fd7">
+    class SignedBeaconBlocks(List[SignedBeaconBlock, MAX_REQUEST_BLOCKS_DENEB]):  # type: ignore
+        """
+        Signed beacon blocks returned in a ``BeaconBlocksByRange`` or
+        ``BeaconBlocksByRoot`` response.
+        """
+    </spec>
+
 - name: SignedContributionAndProof#altair
   sources:
     - file: packages/types/src/altair/sszTypes.ts
@@ -1778,6 +3021,20 @@
         signature: BLSSignature
     </spec>
 
+- name: SignedExecutionPayloadEnvelopes#gloas
+  sources:
+    - file: packages/beacon-node/src/network/network.ts
+      search: "async sendExecutionPayloadEnvelopesByRange("
+  spec: |
+    <spec container="SignedExecutionPayloadEnvelopes" fork="gloas" hash="be7e5f39">
+    class SignedExecutionPayloadEnvelopes(List[SignedExecutionPayloadEnvelope, MAX_REQUEST_PAYLOADS]):  # type: ignore
+        """
+        Signed execution payload envelopes returned in an
+        ``ExecutionPayloadEnvelopesByRange`` or
+        ``ExecutionPayloadEnvelopesByRoot`` response.
+        """
+    </spec>
+
 - name: SignedInclusionList#heze
   sources:
     - file: packages/types/src/heze/sszTypes.ts
@@ -1787,6 +3044,17 @@
     class SignedInclusionList(Container):
         message: InclusionList
         signature: BLSSignature
+    </spec>
+
+- name: SignedInclusionLists#heze
+  sources: []
+  spec: |
+    <spec container="SignedInclusionLists" fork="heze" hash="1a3b31ea">
+    class SignedInclusionLists(List[SignedInclusionList, MAX_REQUEST_INCLUSION_LIST]):  # type: ignore
+        """
+        Signed inclusion lists returned in an ``InclusionListsByIndices``
+        response.
+        """
     </spec>
 
 - name: SignedProposerPreferences#gloas
@@ -1835,14 +3103,40 @@
         signature: BLSSignature
     </spec>
 
+- name: Slashings#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: export const Slashings =
+  spec: |
+    <spec container="Slashings" fork="phase0" hash="f6caea6a">
+    class Slashings(Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]):
+        """
+        Per-epoch sums of slashed effective balances, indexed by epoch modulo
+        ``EPOCHS_PER_SLASHINGS_VECTOR``.
+        """
+    </spec>
+
+- name: StateRoots#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "export const HistoricalStateRoots ="
+  spec: |
+    <spec container="StateRoots" fork="phase0" hash="7cf532bc">
+    class StateRoots(Vector[Root, SLOTS_PER_HISTORICAL_ROOT]):
+        """
+        A rolling window of recent state roots, indexed by slot modulo
+        ``SLOTS_PER_HISTORICAL_ROOT``.
+        """
+    </spec>
+
 - name: SyncAggregate#altair
   sources:
     - file: packages/types/src/altair/sszTypes.ts
       search: export const SyncAggregate =
   spec: |
-    <spec container="SyncAggregate" fork="altair" hash="4cdfb6ae">
+    <spec container="SyncAggregate" fork="altair" hash="615b4468">
     class SyncAggregate(Container):
-        sync_committee_bits: BitVector[SYNC_COMMITTEE_SIZE]
+        sync_committee_bits: SyncCommitteeBits
         sync_committee_signature: BLSSignature
     </spec>
 
@@ -1862,10 +3156,23 @@
     - file: packages/types/src/altair/sszTypes.ts
       search: export const SyncCommittee =
   spec: |
-    <spec container="SyncCommittee" fork="altair" hash="b1d52376">
+    <spec container="SyncCommittee" fork="altair" hash="ad00d2f4">
     class SyncCommittee(Container):
-        pubkeys: Vector[BLSPubkey, SYNC_COMMITTEE_SIZE]
+        pubkeys: SyncCommitteePubkeys
         aggregate_pubkey: BLSPubkey
+    </spec>
+
+- name: SyncCommitteeBits#altair
+  sources:
+    - file: packages/types/src/altair/sszTypes.ts
+      search: export const SyncCommitteeBits =
+  spec: |
+    <spec container="SyncCommitteeBits" fork="altair" hash="63754192">
+    class SyncCommitteeBits(BitVector[SYNC_COMMITTEE_SIZE]):
+        """
+        The participation bits of the sync committee, one bit per member in
+        committee order.
+        """
     </spec>
 
 - name: SyncCommitteeContribution#altair
@@ -1873,12 +3180,12 @@
     - file: packages/types/src/altair/sszTypes.ts
       search: export const SyncCommitteeContribution =
   spec: |
-    <spec container="SyncCommitteeContribution" fork="altair" hash="ee2e8fe5">
+    <spec container="SyncCommitteeContribution" fork="altair" hash="498358fb">
     class SyncCommitteeContribution(Container):
         slot: Slot
         beacon_block_root: Root
         subcommittee_index: Uint64
-        aggregation_bits: BitVector[SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT]
+        aggregation_bits: SyncSubcommitteeBits
         signature: BLSSignature
     </spec>
 
@@ -1893,6 +3200,93 @@
         beacon_block_root: Root
         validator_index: ValidatorIndex
         signature: BLSSignature
+    </spec>
+
+- name: SyncCommitteePubkeys#altair
+  sources:
+    - file: packages/types/src/altair/sszTypes.ts
+      search: "pubkeys: new VectorCompositeType(BLSPubkey, SYNC_COMMITTEE_SIZE),"
+  spec: |
+    <spec container="SyncCommitteePubkeys" fork="altair" hash="07f38259">
+    class SyncCommitteePubkeys(Vector[BLSPubkey, SYNC_COMMITTEE_SIZE]):
+        """
+        The public keys of the sync committee members, in committee order.
+        """
+    </spec>
+
+- name: SyncSubcommitteeBits#altair
+  sources:
+    - file: packages/types/src/altair/sszTypes.ts
+      search: "aggregationBits: new BitVectorType(SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT),"
+  spec: |
+    <spec container="SyncSubcommitteeBits" fork="altair" hash="50bd8f42">
+    class SyncSubcommitteeBits(BitVector[SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT]):  # type: ignore
+        """
+        The participation bits of a single sync subcommittee, one bit per member
+        in subcommittee order.
+        """
+    </spec>
+
+- name: Syncnets#altair
+  sources:
+    - file: packages/types/src/altair/sszTypes.ts
+      search: "export const SyncSubnets ="
+  spec: |
+    <spec container="Syncnets" fork="altair" hash="84ce1082">
+    class Syncnets(BitVector[SYNC_COMMITTEE_SUBNET_COUNT]):
+        """
+        The sync committee subnets a node is subscribed to, one bit per subnet.
+        """
+    </spec>
+
+- name: Transaction#bellatrix
+  sources:
+    - file: packages/types/src/bellatrix/sszTypes.ts
+      search: export const Transaction =
+  spec: |
+    <spec container="Transaction" fork="bellatrix" hash="9eccf41a">
+    class Transaction(ByteList[MAX_BYTES_PER_TRANSACTION]):
+        """
+        An opaque execution-layer transaction, either a typed transaction
+        envelope or a legacy RLP-encoded transaction.
+        """
+    </spec>
+
+- name: Transaction#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const Transaction =
+  spec: |
+    <spec container="Transaction" fork="gloas" hash="4478c825">
+    class Transaction(ProgressiveByteList):
+        """
+        An opaque execution-layer transaction, either a typed transaction
+        envelope or a legacy RLP-encoded transaction.
+        """
+    </spec>
+
+- name: Transactions#bellatrix
+  sources:
+    - file: packages/types/src/bellatrix/sszTypes.ts
+      search: export const Transactions =
+  spec: |
+    <spec container="Transactions" fork="bellatrix" hash="5b4e9a29">
+    class Transactions(List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]):
+        """
+        A list of execution-layer transactions.
+        """
+    </spec>
+
+- name: Transactions#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const Transactions =
+  spec: |
+    <spec container="Transactions" fork="gloas" hash="81b4dd22">
+    class Transactions(ProgressiveList[Transaction]):
+        """
+        A list of execution-layer transactions.
+        """
     </spec>
 
 - name: Validator#phase0
@@ -1912,6 +3306,30 @@
         withdrawable_epoch: Epoch
     </spec>
 
+- name: Validators#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: export const Validators =
+  spec: |
+    <spec container="Validators" fork="phase0" hash="c3d0467c">
+    class Validators(List[Validator, VALIDATOR_REGISTRY_LIMIT]):
+        """
+        The validator registry.
+        """
+    </spec>
+
+- name: Validators#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const Validators =
+  spec: |
+    <spec container="Validators" fork="gloas" hash="bc16b340">
+    class Validators(ProgressiveList[Validator]):
+        """
+        The validator registry.
+        """
+    </spec>
+
 - name: VoluntaryExit#phase0
   sources:
     - file: packages/types/src/phase0/sszTypes.ts
@@ -1921,6 +3339,30 @@
     class VoluntaryExit(Container):
         epoch: Epoch
         validator_index: ValidatorIndex
+    </spec>
+
+- name: VoluntaryExits#phase0
+  sources:
+    - file: packages/types/src/phase0/sszTypes.ts
+      search: "voluntaryExits: new ListCompositeType(SignedVoluntaryExit, MAX_VOLUNTARY_EXITS),"
+  spec: |
+    <spec container="VoluntaryExits" fork="phase0" hash="aaefdbc8">
+    class VoluntaryExits(List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]):
+        """
+        The signed voluntary exits included in a beacon block.
+        """
+    </spec>
+
+- name: VoluntaryExits#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const VoluntaryExits =
+  spec: |
+    <spec container="VoluntaryExits" fork="gloas" hash="471b4604">
+    class VoluntaryExits(ProgressiveList[SignedVoluntaryExit]):
+        """
+        The signed voluntary exits included in a beacon block.
+        """
     </spec>
 
 - name: Withdrawal#capella
@@ -1946,4 +3388,52 @@
         source_address: ExecutionAddress
         validator_pubkey: BLSPubkey
         amount: Gwei
+    </spec>
+
+- name: WithdrawalRequests#electra
+  sources:
+    - file: packages/types/src/electra/sszTypes.ts
+      search: export const WithdrawalRequests =
+  spec: |
+    <spec container="WithdrawalRequests" fork="electra" hash="67f70848">
+    class WithdrawalRequests(List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]):
+        """
+        The withdrawal requests pertaining to a single execution payload.
+        """
+    </spec>
+
+- name: WithdrawalRequests#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const WithdrawalRequests =
+  spec: |
+    <spec container="WithdrawalRequests" fork="gloas" hash="606da280">
+    class WithdrawalRequests(ProgressiveList[WithdrawalRequest]):
+        """
+        The withdrawal requests pertaining to a single execution payload.
+        """
+    </spec>
+
+- name: Withdrawals#capella
+  sources:
+    - file: packages/types/src/capella/sszTypes.ts
+      search: export const Withdrawals =
+  spec: |
+    <spec container="Withdrawals" fork="capella" hash="72abb06d">
+    class Withdrawals(List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]):
+        """
+        A list of withdrawals.
+        """
+    </spec>
+
+- name: Withdrawals#gloas
+  sources:
+    - file: packages/types/src/gloas/sszTypes.ts
+      search: export const Withdrawals =
+  spec: |
+    <spec container="Withdrawals" fork="gloas" hash="4c0df84b">
+    class Withdrawals(ProgressiveList[Withdrawal]):
+        """
+        A list of withdrawals.
+        """
     </spec>

--- a/specrefs/dataclasses.yml
+++ b/specrefs/dataclasses.yml
@@ -14,11 +14,11 @@
     - file: packages/types/src/deneb/sszTypes.ts
       search: export const BlobsBundle =
   spec: |
-    <spec dataclass="BlobsBundle" fork="deneb" hash="8baecab6">
+    <spec dataclass="BlobsBundle" fork="deneb" hash="a2e08deb">
     class BlobsBundle:
-        commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        blobs: List[Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        commitments: BlobKZGCommitments
+        proofs: KZGProofs
+        blobs: Blobs
     </spec>
 
 - name: BlobsBundle#fulu
@@ -26,12 +26,12 @@
     - file: packages/types/src/fulu/sszTypes.ts
       search: export const BlobsBundle =
   spec: |
-    <spec dataclass="BlobsBundle" fork="fulu" hash="322088f0">
+    <spec dataclass="BlobsBundle" fork="fulu" hash="badea909">
     class BlobsBundle:
-        commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        commitments: BlobKZGCommitments
         # [Modified in Fulu:EIP7594]
-        proofs: List[KZGProof, FIELD_ELEMENTS_PER_EXT_BLOB * MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        blobs: List[Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        proofs: CellKZGProofs
+        blobs: Blobs
     </spec>
 
 - name: ExpectedWithdrawals#capella
@@ -182,18 +182,23 @@
         execution_requests: Sequence[bytes]
     </spec>
 
+- name: InclusionListEntry#heze
+  sources: []
+  spec: |
+    <spec dataclass="InclusionListEntry" fork="heze" hash="c2557214">
+    @dataclass(eq=True, frozen=True)
+    class InclusionListEntry:
+        signed_inclusion_list: SignedInclusionList
+        timely: Boolean
+    </spec>
+
 - name: InclusionListStore#heze
   sources: []
   spec: |
-    <spec dataclass="InclusionListStore" fork="heze" hash="342cd889">
+    <spec dataclass="InclusionListStore" fork="heze" hash="325155c8">
     class InclusionListStore:
-        inclusion_lists: DefaultDict[Root, Dict[Root, SignedInclusionList]] = field(
-            default_factory=lambda: defaultdict(dict)
-        )
-        inclusion_list_timeliness: Dict[Root, Boolean] = field(default_factory=dict)
-        equivocators: DefaultDict[Root, Set[ValidatorIndex]] = field(
-            default_factory=lambda: defaultdict(set)
-        )
+        inclusion_lists: DefaultDict[Tuple[Slot, Root], Dict[ValidatorIndex, InclusionListEntry]]
+        equivocators: DefaultDict[Tuple[Slot, Root], Set[ValidatorIndex]]
     </spec>
 
 - name: LatestMessage#phase0
@@ -296,12 +301,12 @@
 - name: OptimisticStore#bellatrix
   sources: []
   spec: |
-    <spec dataclass="OptimisticStore" fork="bellatrix" hash="a2b2182c">
-    class OptimisticStore(object):
+    <spec dataclass="OptimisticStore" fork="bellatrix" hash="f2e97822">
+    class OptimisticStore:
         optimistic_roots: Set[Root]
         head_block_root: Root
-        blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
-        block_states: Dict[Root, BeaconState] = field(default_factory=dict)
+        blocks: Dict[Root, BeaconBlock]
+        block_states: Dict[Root, BeaconState]
     </spec>
 
 - name: PayloadAttributes#bellatrix
@@ -382,17 +387,17 @@
 - name: Seen#altair
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="altair" hash="e87cf7f7">
+    <spec dataclass="Seen" fork="altair" hash="c53317b3">
     class Seen:
-        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
-        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
+        aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         aggregate_data_roots: Dict[Root, Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
-        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         # [New in Altair]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         # [New in Altair]
         sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
         # [New in Altair]
@@ -402,16 +407,16 @@
 - name: Seen#capella
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="capella" hash="20ad1ead">
+    <spec dataclass="Seen" fork="capella" hash="1a759ee4">
     class Seen:
-        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
-        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
+        aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         aggregate_data_roots: Dict[Root, Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
-        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
+        sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         # [New in Capella]
@@ -421,16 +426,16 @@
 - name: Seen#deneb
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="deneb" hash="23e6b8c9">
+    <spec dataclass="Seen" fork="deneb" hash="d064fb97">
     class Seen:
-        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
-        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
+        aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         aggregate_data_roots: Dict[Root, Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
-        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
+        sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
@@ -441,17 +446,17 @@
 - name: Seen#electra
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="electra" hash="d07ba019">
+    <spec dataclass="Seen" fork="electra" hash="0a2a6112">
     class Seen:
-        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
-        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
+        aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         # [Modified in Electra:EIP7549]
         aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
-        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
+        sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
@@ -461,16 +466,16 @@
 - name: Seen#fulu
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="fulu" hash="0c9400e0">
+    <spec dataclass="Seen" fork="fulu" hash="e258b6b8">
     class Seen:
-        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
-        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
+        aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
-        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
+        sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
@@ -485,20 +490,35 @@
 - name: Seen#gloas
   sources: []
   spec: |
-    <spec dataclass="Seen" fork="gloas" hash="e2e5bf67">
+    <spec dataclass="Seen" fork="gloas" hash="7f193af0">
     class Seen:
-        proposer_slots: Set[Tuple[ValidatorIndex, Slot]]
-        aggregator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
+        proposer_slots: Set[Tuple[Slot, ValidatorIndex]]
+        aggregator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
         aggregate_data_roots: Dict[Tuple[Root, CommitteeIndex], Set[Tuple[Boolean, ...]]]
         voluntary_exit_indices: Set[ValidatorIndex]
         proposer_slashing_indices: Set[ValidatorIndex]
         attester_slashing_indices: Set[ValidatorIndex]
-        attestation_validator_epochs: Set[Tuple[ValidatorIndex, Epoch]]
-        sync_contribution_aggregator_slots: Set[Tuple[ValidatorIndex, Slot, Uint64]]
+        attestation_validator_epochs: Set[Tuple[Epoch, ValidatorIndex]]
+        sync_contribution_aggregator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         sync_contribution_data: Dict[Tuple[Slot, Root, Uint64], Set[Tuple[Boolean, ...]]]
         sync_message_validator_slots: Set[Tuple[Slot, ValidatorIndex, Uint64]]
         bls_to_execution_change_indices: Set[ValidatorIndex]
-        data_column_sidecar_tuples: Set[Tuple[Slot, ValidatorIndex, ColumnIndex]]
+        # [Modified in Gloas:EIP7732]
+        data_column_sidecar_tuples: Set[Tuple[Root, ColumnIndex]]
+        # [Modified in Gloas:EIP7732]
+        # Removed `partial_data_column_headers`
+        # [New in Gloas:EIP7732]
+        execution_payloads: Dict[Hash32, ExecutionPayload]
+        # [New in Gloas:EIP7732]
+        execution_payload_envelopes: Set[Tuple[Root, BuilderIndex]]
+        # [New in Gloas:EIP7732]
+        payload_attestation_validators: Set[Tuple[Slot, ValidatorIndex]]
+        # [New in Gloas:EIP7732]
+        execution_payload_bids: Set[Tuple[Slot, Hash32, Root, BuilderIndex]]
+        # [New in Gloas:EIP7732]
+        best_execution_payload_bid: Dict[Tuple[Slot, Hash32, Root], Gwei]
+        # [New in Gloas:EIP7732]
+        proposer_preferences: Dict[Tuple[Root, Slot], ProposerPreferences]
     </spec>
 
 - name: Store#phase0
@@ -506,7 +526,7 @@
     - file: packages/fork-choice/src/forkChoice/store.ts
       search: export interface IForkChoiceStore
   spec: |
-    <spec dataclass="Store" fork="phase0" hash="7fed6bfc">
+    <spec dataclass="Store" fork="phase0" hash="cb9919a9">
     class Store:
         time: Uint64
         genesis_time: Uint64
@@ -516,18 +536,18 @@
         unrealized_finalized_checkpoint: Checkpoint
         proposer_boost_root: Root
         equivocating_indices: Set[ValidatorIndex]
-        blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
-        block_states: Dict[Root, BeaconState] = field(default_factory=dict)
-        block_timeliness: Dict[Root, Boolean] = field(default_factory=dict)
-        checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
-        latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
-        unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
+        blocks: Dict[Root, BeaconBlock]
+        block_states: Dict[Root, BeaconState]
+        block_timeliness: Dict[Root, Boolean]
+        checkpoint_states: Dict[Checkpoint, BeaconState]
+        latest_messages: Dict[ValidatorIndex, LatestMessage]
+        unrealized_justifications: Dict[Root, Checkpoint]
     </spec>
 
 - name: Store#gloas
   sources: []
   spec: |
-    <spec dataclass="Store" fork="gloas" hash="7e0cbbb8">
+    <spec dataclass="Store" fork="gloas" hash="402837a7">
     class Store:
         time: Uint64
         genesis_time: Uint64
@@ -537,27 +557,25 @@
         unrealized_finalized_checkpoint: Checkpoint
         proposer_boost_root: Root
         equivocating_indices: Set[ValidatorIndex]
-        blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
-        block_states: Dict[Root, BeaconState] = field(default_factory=dict)
+        blocks: Dict[Root, BeaconBlock]
+        block_states: Dict[Root, BeaconState]
         # [Modified in Gloas:EIP7732]
-        block_timeliness: Dict[Root, list[Boolean]] = field(default_factory=dict)
-        checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
-        latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
-        unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
+        block_timeliness: Dict[Root, list[Boolean]]
+        checkpoint_states: Dict[Checkpoint, BeaconState]
+        latest_messages: Dict[ValidatorIndex, LatestMessage]
+        unrealized_justifications: Dict[Root, Checkpoint]
         # [New in Gloas:EIP7732]
-        payloads: Dict[Root, ExecutionPayloadEnvelope] = field(default_factory=dict)
+        payloads: Dict[Root, ExecutionPayloadEnvelope]
         # [New in Gloas:EIP7732]
-        payload_timeliness_vote: Dict[Root, list[Optional[Boolean]]] = field(default_factory=dict)
+        payload_timeliness_vote: Dict[Root, list[Optional[Boolean]]]
         # [New in Gloas:EIP7732]
-        payload_data_availability_vote: Dict[Root, list[Optional[Boolean]]] = field(
-            default_factory=dict
-        )
+        payload_data_availability_vote: Dict[Root, list[Optional[Boolean]]]
     </spec>
 
 - name: Store#heze
   sources: []
   spec: |
-    <spec dataclass="Store" fork="heze" hash="e95945a4">
+    <spec dataclass="Store" fork="heze" hash="e590dc15">
     class Store:
         time: Uint64
         genesis_time: Uint64
@@ -567,17 +585,15 @@
         unrealized_finalized_checkpoint: Checkpoint
         proposer_boost_root: Root
         equivocating_indices: Set[ValidatorIndex]
-        blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
-        block_states: Dict[Root, BeaconState] = field(default_factory=dict)
-        block_timeliness: Dict[Root, list[Boolean]] = field(default_factory=dict)
-        checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
-        latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
-        unrealized_justifications: Dict[Root, Checkpoint] = field(default_factory=dict)
-        payloads: Dict[Root, ExecutionPayloadEnvelope] = field(default_factory=dict)
-        payload_timeliness_vote: Dict[Root, list[Optional[Boolean]]] = field(default_factory=dict)
-        payload_data_availability_vote: Dict[Root, list[Optional[Boolean]]] = field(
-            default_factory=dict
-        )
+        blocks: Dict[Root, BeaconBlock]
+        block_states: Dict[Root, BeaconState]
+        block_timeliness: Dict[Root, list[Boolean]]
+        checkpoint_states: Dict[Checkpoint, BeaconState]
+        latest_messages: Dict[ValidatorIndex, LatestMessage]
+        unrealized_justifications: Dict[Root, Checkpoint]
+        payloads: Dict[Root, ExecutionPayloadEnvelope]
+        payload_timeliness_vote: Dict[Root, list[Optional[Boolean]]]
+        payload_data_availability_vote: Dict[Root, list[Optional[Boolean]]]
         # [New in Heze:EIP7805]
-        payload_inclusion_list_satisfaction: Dict[Root, Boolean] = field(default_factory=dict)
+        payload_inclusion_list_satisfaction: Dict[Root, Boolean]
     </spec>

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -579,7 +579,7 @@
 - name: compute_balance_weighted_selection#gloas
   sources: []
   spec: |
-    <spec fn="compute_balance_weighted_selection" fork="gloas" hash="1338c915">
+    <spec fn="compute_balance_weighted_selection" fork="gloas" hash="8c9a8335">
     def compute_balance_weighted_selection(
         state: BeaconState,
         indices: Sequence[ValidatorIndex],
@@ -597,7 +597,7 @@
         total = Uint64(len(indices))
         assert total > 0
         effective_balances = [state.validators[index].effective_balance for index in indices]
-        selected: List[ValidatorIndex] = []
+        selected: list[ValidatorIndex] = []
         i = Uint64(0)
         while len(selected) < size:
             offset = i % 16 * 2
@@ -1215,7 +1215,7 @@
 - name: compute_on_chain_aggregate#electra
   sources: []
   spec: |
-    <spec fn="compute_on_chain_aggregate" fork="electra" hash="a1d5aa73">
+    <spec fn="compute_on_chain_aggregate" fork="electra" hash="fbe05115">
     def compute_on_chain_aggregate(network_aggregates: Sequence[Attestation]) -> Attestation:
         aggregates = sorted(
             network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0]
@@ -1231,7 +1231,7 @@
 
         committee_indices = [get_committee_indices(a.committee_bits)[0] for a in aggregates]
         committee_flags = [(index in committee_indices) for index in range(MAX_COMMITTEES_PER_SLOT)]
-        committee_bits = BitVector[MAX_COMMITTEES_PER_SLOT](committee_flags)
+        committee_bits = CommitteeBits(committee_flags)
 
         return Attestation(
             aggregation_bits=aggregation_bits,
@@ -1301,35 +1301,35 @@
     - file: packages/state-transition/src/util/seed.ts
       search: export function computeProposerIndices(
   spec: |
-    <spec fn="compute_proposer_indices" fork="fulu" hash="9e13dbfe">
+    <spec fn="compute_proposer_indices" fork="fulu" hash="bbeb8423">
     def compute_proposer_indices(
         state: BeaconState, epoch: Epoch, seed: Bytes32, indices: Sequence[ValidatorIndex]
-    ) -> Vector[ValidatorIndex, SLOTS_PER_EPOCH]:
+    ) -> ProposerIndices:
         """
         Return the proposer indices for the given ``epoch``.
         """
         start_slot = compute_start_slot_at_epoch(epoch)
         seeds = [hash(seed + uint_to_bytes(Slot(start_slot + i))) for i in range(SLOTS_PER_EPOCH)]
-        return [compute_proposer_index(state, indices, seed) for seed in seeds]
+        return ProposerIndices(compute_proposer_index(state, indices, seed) for seed in seeds)
     </spec>
 
 - name: compute_proposer_indices#gloas
   sources: []
   spec: |
-    <spec fn="compute_proposer_indices" fork="gloas" hash="8aed10df">
+    <spec fn="compute_proposer_indices" fork="gloas" hash="2140e974">
     def compute_proposer_indices(
         state: BeaconState, epoch: Epoch, seed: Bytes32, indices: Sequence[ValidatorIndex]
-    ) -> Vector[ValidatorIndex, SLOTS_PER_EPOCH]:
+    ) -> ProposerIndices:
         """
         Return the proposer indices for the given ``epoch``.
         """
         start_slot = compute_start_slot_at_epoch(epoch)
         seeds = [hash(seed + uint_to_bytes(Slot(start_slot + i))) for i in range(SLOTS_PER_EPOCH)]
         # [Modified in Gloas:EIP7732]
-        return [
+        return ProposerIndices(
             compute_balance_weighted_selection(state, indices, seed, size=1, shuffle_indices=True)[0]
             for seed in seeds
-        ]
+        )
     </spec>
 
 - name: compute_proposer_score#phase0
@@ -1346,21 +1346,23 @@
     - file: packages/state-transition/src/util/seed.ts
       search: export function computePayloadTimelinessCommitteeForSlot(
   spec: |
-    <spec fn="compute_ptc" fork="gloas" hash="1dcaa117">
-    def compute_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
+    <spec fn="compute_ptc" fork="gloas" hash="01df9435">
+    def compute_ptc(state: BeaconState, slot: Slot) -> PTC:
         """
         Get the payload timeliness committee, with possible duplicates, for the given ``slot``.
         """
         epoch = compute_epoch_at_slot(slot)
         seed = hash(get_seed(state, epoch, DOMAIN_PTC_ATTESTER) + uint_to_bytes(slot))
-        indices: List[ValidatorIndex] = []
+        indices: list[ValidatorIndex] = []
         # Concatenate all committees for this slot in order
         committees_per_slot = get_committee_count_per_slot(state, epoch)
         for i in range(committees_per_slot):
             committee = get_beacon_committee(state, slot, CommitteeIndex(i))
             indices.extend(committee)
-        return compute_balance_weighted_selection(
-            state, indices, seed, size=PTC_SIZE, shuffle_indices=False
+        return PTC(
+            compute_balance_weighted_selection(
+                state, indices, seed, size=PTC_SIZE, shuffle_indices=False
+            )
         )
     </spec>
 
@@ -1457,6 +1459,18 @@
                 bit = (byte_val >> int(position % 8)) % 2
                 indices[i] = flip if bit else indices[i]
         return indices
+    </spec>
+
+- name: compute_shuffling_dependent_slot#phase0
+  sources:
+    - file: packages/fork-choice/src/forkChoice/forkChoice.ts
+      search: "const dependentSlot = computeStartSlotAtEpoch(epoch - MIN_SEED_LOOKAHEAD) - 1;"
+  spec: |
+    <spec fn="compute_shuffling_dependent_slot" fork="phase0" hash="dcce84a1">
+    def compute_shuffling_dependent_slot(epoch: Epoch) -> Slot:
+        if epoch <= MIN_SEED_LOOKAHEAD:
+            return GENESIS_SLOT
+        return compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - Slot(1)
     </spec>
 
 - name: compute_signed_block_header#deneb
@@ -1806,7 +1820,7 @@
 - name: create_light_client_update#altair
   sources: []
   spec: |
-    <spec fn="create_light_client_update" fork="altair" hash="cde7d86c">
+    <spec fn="create_light_client_update" fork="altair" hash="df199f52">
     def create_light_client_update(
         state: BeaconState,
         block: SignedBeaconBlock,
@@ -1816,7 +1830,7 @@
     ) -> LightClientUpdate:
         assert compute_epoch_at_slot(attested_state.slot) >= ALTAIR_FORK_EPOCH
         assert (
-            sum(block.message.body.sync_aggregate.sync_committee_bits)
+            get_set_bit_count(block.message.body.sync_aggregate.sync_committee_bits)
             >= MIN_SYNC_COMMITTEE_PARTICIPANTS
         )
 
@@ -2831,10 +2845,8 @@
 - name: get_beacon_proposer_indices#fulu
   sources: []
   spec: |
-    <spec fn="get_beacon_proposer_indices" fork="fulu" hash="f5866a8f">
-    def get_beacon_proposer_indices(
-        state: BeaconState, epoch: Epoch
-    ) -> Vector[ValidatorIndex, SLOTS_PER_EPOCH]:
+    <spec fn="get_beacon_proposer_indices" fork="fulu" hash="708a8b53">
+    def get_beacon_proposer_indices(state: BeaconState, epoch: Epoch) -> ProposerIndices:
         """
         Return the proposer indices for the given ``epoch``.
         """
@@ -2846,10 +2858,8 @@
 - name: get_beacon_proposer_indices#gloas
   sources: []
   spec: |
-    <spec fn="get_beacon_proposer_indices" fork="gloas" hash="a160057e">
-    def get_beacon_proposer_indices(
-        state: BeaconState, epoch: Epoch
-    ) -> Vector[ValidatorIndex, SLOTS_PER_EPOCH]:
+    <spec fn="get_beacon_proposer_indices" fork="gloas" hash="dc8a4ff6">
+    def get_beacon_proposer_indices(state: BeaconState, epoch: Epoch) -> ProposerIndices:
         """
         Return the proposer indices for the given ``epoch``.
         """
@@ -3030,7 +3040,7 @@
 - name: get_builder_withdrawals#gloas
   sources: []
   spec: |
-    <spec fn="get_builder_withdrawals" fork="gloas" hash="e816787f">
+    <spec fn="get_builder_withdrawals" fork="gloas" hash="99b163dc">
     def get_builder_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -3040,9 +3050,9 @@
         assert len(prior_withdrawals) <= withdrawals_limit
 
         processed_count: Uint64 = 0
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
         for withdrawal in state.builder_pending_withdrawals:
-            all_withdrawals = prior_withdrawals + withdrawals
+            all_withdrawals = list(prior_withdrawals) + withdrawals
             has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
@@ -3065,7 +3075,7 @@
 - name: get_builders_sweep_withdrawals#gloas
   sources: []
   spec: |
-    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="67af411a">
+    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="faa91d20">
     def get_builders_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -3077,10 +3087,10 @@
         assert len(prior_withdrawals) <= withdrawals_limit
 
         processed_count: Uint64 = 0
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
         builder_index = state.next_withdrawal_builder_index
         for _ in range(builders_limit):
-            all_withdrawals = prior_withdrawals + withdrawals
+            all_withdrawals = list(prior_withdrawals) + withdrawals
             has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
@@ -3375,12 +3385,31 @@
         )
     </spec>
 
+- name: get_custody_column_bits#gloas
+  sources:
+    - file: packages/beacon-node/src/util/dataColumns.ts
+      search: "export function getDataColumns("
+    - file: packages/beacon-node/src/util/dataColumns.ts
+      search: "private getCustodyColumnsIndex(custodyColumns: ColumnIndex[]): Uint8Array {"
+  spec: |
+    <spec fn="get_custody_column_bits" fork="gloas" hash="5729d06c">
+    def get_custody_column_bits(node_id: NodeID, custody_group_count: Uint64) -> CustodyColumnBits:
+        """
+        Compute the bitvector of column indices custodied by ``node_id``.
+        """
+        bits = CustodyColumnBits()
+        for custody_group in get_custody_groups(node_id, custody_group_count):
+            for column in compute_columns_for_custody_group(custody_group):
+                bits[column] = True
+        return bits
+    </spec>
+
 - name: get_custody_groups#fulu
   sources:
     - file: packages/beacon-node/src/util/dataColumns.ts
       search: export function getCustodyGroups(
   spec: |
-    <spec fn="get_custody_groups" fork="fulu" hash="aad37e2f">
+    <spec fn="get_custody_groups" fork="fulu" hash="4867eacc">
     def get_custody_groups(node_id: NodeID, custody_group_count: Uint64) -> Sequence[CustodyIndex]:
         assert custody_group_count <= NUMBER_OF_CUSTODY_GROUPS
 
@@ -3389,7 +3418,7 @@
             return [CustodyIndex(i) for i in range(NUMBER_OF_CUSTODY_GROUPS)]
 
         current_id = Uint256(node_id)
-        custody_groups: List[CustodyIndex] = []
+        custody_groups: list[CustodyIndex] = []
         while len(custody_groups) < custody_group_count:
             custody_group = CustodyIndex(
                 bytes_to_uint64(hash(uint_to_bytes(current_id))[0:8]) % NUMBER_OF_CUSTODY_GROUPS
@@ -3411,14 +3440,12 @@
     - file: packages/beacon-node/src/util/dataColumns.ts
       search: export function getFuluDataColumnSidecars(
   spec: |
-    <spec fn="get_data_column_sidecars" fork="fulu" hash="317fc596">
+    <spec fn="get_data_column_sidecars" fork="fulu" hash="83c64b4f">
     def get_data_column_sidecars(
         signed_block_header: SignedBeaconBlockHeader,
-        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
-        kzg_commitments_inclusion_proof: Vector[Bytes32, KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH],
-        cells_and_kzg_proofs: Sequence[
-            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-        ],
+        kzg_commitments: BlobKZGCommitments,
+        kzg_commitments_inclusion_proof: KZGCommitmentsInclusionProof,
+        cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
     ) -> Sequence[DataColumnSidecar]:
         """
         Given a signed block header and the commitments, inclusion proof, cells/proofs associated with
@@ -3428,7 +3455,8 @@
 
         sidecars = []
         for column_index in range(NUMBER_OF_COLUMNS):
-            column_cells, column_proofs = [], []
+            column_cells = DataColumn()
+            column_proofs = KZGProofs()
             for cells, proofs in cells_and_kzg_proofs:
                 column_cells.append(cells[column_index])
                 column_proofs.append(proofs[column_index])
@@ -3450,7 +3478,7 @@
     - file: packages/beacon-node/src/util/dataColumns.ts
       search: export function getGloasDataColumnSidecars(
   spec: |
-    <spec fn="get_data_column_sidecars" fork="gloas" hash="abaf4385">
+    <spec fn="get_data_column_sidecars" fork="gloas" hash="7e760965">
     def get_data_column_sidecars(
         # [Modified in Gloas:EIP7732]
         # Removed `signed_block_header`
@@ -3462,9 +3490,7 @@
         # Removed `kzg_commitments`
         # [Modified in Gloas:EIP7732]
         # Removed `kzg_commitments_inclusion_proof`
-        cells_and_kzg_proofs: Sequence[
-            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-        ],
+        cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
     ) -> Sequence[DataColumnSidecar]:
         """
         Given a beacon block root and the cells/proofs associated with each blob
@@ -3473,7 +3499,8 @@
         """
         sidecars = []
         for column_index in range(NUMBER_OF_COLUMNS):
-            column_cells, column_proofs = [], []
+            column_cells = DataColumn()
+            column_proofs = KZGProofs()
             for cells, proofs in cells_and_kzg_proofs:
                 column_cells.append(cells[column_index])
                 column_proofs.append(proofs[column_index])
@@ -3495,12 +3522,10 @@
     - file: packages/beacon-node/src/util/dataColumns.ts
       search: export function getDataColumnSidecarsFromBlock(
   spec: |
-    <spec fn="get_data_column_sidecars_from_block" fork="fulu" hash="02ffae23">
+    <spec fn="get_data_column_sidecars_from_block" fork="fulu" hash="24fa1fff">
     def get_data_column_sidecars_from_block(
         signed_block: SignedBeaconBlock,
-        cells_and_kzg_proofs: Sequence[
-            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-        ],
+        cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
     ) -> Sequence[DataColumnSidecar]:
         """
         Given a signed block and the cells/proofs associated with each blob in the
@@ -3508,9 +3533,11 @@
         """
         blob_kzg_commitments = signed_block.message.body.blob_kzg_commitments
         signed_block_header = compute_signed_block_header(signed_block)
-        kzg_commitments_inclusion_proof = compute_merkle_proof(
-            signed_block.message.body,
-            get_generalized_index(BeaconBlockBody, "blob_kzg_commitments"),
+        kzg_commitments_inclusion_proof = KZGCommitmentsInclusionProof(
+            compute_merkle_proof(
+                signed_block.message.body,
+                get_generalized_index(BeaconBlockBody, "blob_kzg_commitments"),
+            )
         )
         return get_data_column_sidecars(
             signed_block_header,
@@ -3525,12 +3552,10 @@
     - file: packages/beacon-node/src/util/dataColumns.ts
       search: export function getDataColumnSidecarsFromBlock(
   spec: |
-    <spec fn="get_data_column_sidecars_from_block" fork="gloas" hash="302616d2">
+    <spec fn="get_data_column_sidecars_from_block" fork="gloas" hash="5ad6b3a7">
     def get_data_column_sidecars_from_block(
         signed_block: SignedBeaconBlock,
-        cells_and_kzg_proofs: Sequence[
-            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-        ],
+        cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
     ) -> Sequence[DataColumnSidecar]:
         """
         Given a signed block and the cells/proofs associated with each blob in the
@@ -3549,12 +3574,10 @@
     - file: packages/beacon-node/src/util/dataColumns.ts
       search: export function getDataColumnSidecarsFromColumnSidecar(
   spec: |
-    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="fulu" hash="4877148a">
+    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="fulu" hash="92223ca3">
     def get_data_column_sidecars_from_column_sidecar(
         sidecar: DataColumnSidecar,
-        cells_and_kzg_proofs: Sequence[
-            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-        ],
+        cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
     ) -> Sequence[DataColumnSidecar]:
         """
         Given a data column sidecar and the cells/proofs associated with each blob corresponding
@@ -3575,12 +3598,10 @@
     - file: packages/beacon-node/src/util/dataColumns.ts
       search: export function getDataColumnSidecarsFromColumnSidecar(
   spec: |
-    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="gloas" hash="beb1f94f">
+    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="gloas" hash="a2a33bc7">
     def get_data_column_sidecars_from_column_sidecar(
         sidecar: DataColumnSidecar,
-        cells_and_kzg_proofs: Sequence[
-            Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
-        ],
+        cells_and_kzg_proofs: Sequence[Tuple[Cells, Proofs]],
     ) -> Sequence[DataColumnSidecar]:
         """
         Given a data column sidecar and the cells/proofs associated with each blob
@@ -3808,11 +3829,11 @@
     - file: packages/beacon-node/src/execution/engine/types.ts
       search: export function deserializeExecutionRequests(
   spec: |
-    <spec fn="get_execution_requests" fork="electra" hash="29513408">
+    <spec fn="get_execution_requests" fork="electra" hash="abf087cc">
     def get_execution_requests(execution_requests_list: Sequence[bytes]) -> ExecutionRequests:
-        deposits = []
-        withdrawals = []
-        consolidations = []
+        deposits = DepositRequests()
+        withdrawals = WithdrawalRequests()
+        consolidations = ConsolidationRequests()
 
         request_types = [
             DEPOSIT_REQUEST_TYPE,
@@ -3852,15 +3873,15 @@
     - file: packages/beacon-node/src/execution/engine/types.ts
       search: export function deserializeExecutionRequests(
   spec: |
-    <spec fn="get_execution_requests" fork="gloas" hash="31ff6b3d">
+    <spec fn="get_execution_requests" fork="gloas" hash="adb63e5d">
     def get_execution_requests(execution_requests_list: Sequence[bytes]) -> ExecutionRequests:
-        deposits = []
-        withdrawals = []
-        consolidations = []
+        deposits = DepositRequests()
+        withdrawals = WithdrawalRequests()
+        consolidations = ConsolidationRequests()
         # [New in Gloas:EIP8282]
-        builder_deposits = []
+        builder_deposits = BuilderDepositRequests()
         # [New in Gloas:EIP8282]
-        builder_exits = []
+        builder_exits = BuilderExitRequests()
 
         request_types = [
             DEPOSIT_REQUEST_TYPE,
@@ -3976,10 +3997,10 @@
     - file: packages/state-transition/src/block/processWithdrawals.ts
       search: export function getExpectedWithdrawals(
   spec: |
-    <spec fn="get_expected_withdrawals" fork="capella" hash="12088347">
+    <spec fn="get_expected_withdrawals" fork="capella" hash="85dcb7f1">
     def get_expected_withdrawals(state: BeaconState) -> ExpectedWithdrawals:
         withdrawal_index = state.next_withdrawal_index
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
 
         # Get validators sweep withdrawals
         validators_sweep_withdrawals, withdrawal_index, processed_validators_sweep_count = (
@@ -3998,10 +4019,10 @@
     - file: packages/state-transition/src/block/processWithdrawals.ts
       search: export function getExpectedWithdrawals(
   spec: |
-    <spec fn="get_expected_withdrawals" fork="electra" hash="254541e3">
+    <spec fn="get_expected_withdrawals" fork="electra" hash="3df378c7">
     def get_expected_withdrawals(state: BeaconState) -> ExpectedWithdrawals:
         withdrawal_index = state.next_withdrawal_index
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
 
         # [New in Electra:EIP7251]
         # Get partial withdrawals
@@ -4029,10 +4050,10 @@
     - file: packages/state-transition/src/block/processWithdrawals.ts
       search: export function getExpectedWithdrawals(
   spec: |
-    <spec fn="get_expected_withdrawals" fork="gloas" hash="8d0675cb">
+    <spec fn="get_expected_withdrawals" fork="gloas" hash="c817ad13">
     def get_expected_withdrawals(state: BeaconState) -> ExpectedWithdrawals:
         withdrawal_index = state.next_withdrawal_index
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
 
         # [New in Gloas:EIP7732]
         # Get builder withdrawals
@@ -4150,7 +4171,7 @@
 - name: get_forkchoice_store#phase0
   sources: []
   spec: |
-    <spec fn="get_forkchoice_store" fork="phase0" hash="8e0e5f17">
+    <spec fn="get_forkchoice_store" fork="phase0" hash="e51d771b">
     def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
         assert anchor_block.state_root == hash_tree_root(anchor_state)
         anchor_root = hash_tree_root(anchor_block)
@@ -4169,7 +4190,9 @@
             equivocating_indices=set(),
             blocks={anchor_root: copy(anchor_block)},
             block_states={anchor_root: copy(anchor_state)},
+            block_timeliness={},
             checkpoint_states={justified_checkpoint: copy(anchor_state)},
+            latest_messages={},
             unrealized_justifications={anchor_root: justified_checkpoint},
         )
     </spec>
@@ -4177,7 +4200,7 @@
 - name: get_forkchoice_store#gloas
   sources: []
   spec: |
-    <spec fn="get_forkchoice_store" fork="gloas" hash="94300183">
+    <spec fn="get_forkchoice_store" fork="gloas" hash="67f64d09">
     def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
         assert anchor_block.state_root == hash_tree_root(anchor_state)
         anchor_root = hash_tree_root(anchor_block)
@@ -4199,6 +4222,7 @@
             # [New in Gloas:EIP7732]
             block_timeliness={anchor_root: [True, True]},
             checkpoint_states={justified_checkpoint: copy(anchor_state)},
+            latest_messages={},
             unrealized_justifications={anchor_root: justified_checkpoint},
             # [New in Gloas:EIP7732]
             payloads={},
@@ -4212,7 +4236,7 @@
 - name: get_forkchoice_store#heze
   sources: []
   spec: |
-    <spec fn="get_forkchoice_store" fork="heze" hash="72e4155e">
+    <spec fn="get_forkchoice_store" fork="heze" hash="56444cf6">
     def get_forkchoice_store(anchor_state: BeaconState, anchor_block: BeaconBlock) -> Store:
         assert anchor_block.state_root == hash_tree_root(anchor_state)
         anchor_root = hash_tree_root(anchor_block)
@@ -4233,6 +4257,7 @@
             block_states={anchor_root: copy(anchor_state)},
             block_timeliness={anchor_root: [True, True]},
             checkpoint_states={justified_checkpoint: copy(anchor_state)},
+            latest_messages={},
             unrealized_justifications={anchor_root: justified_checkpoint},
             payloads={},
             payload_timeliness_vote={},
@@ -4422,53 +4447,51 @@
 - name: get_inclusion_list_bits#heze
   sources: []
   spec: |
-    <spec fn="get_inclusion_list_bits" fork="heze" hash="b0ea4eab">
+    <spec fn="get_inclusion_list_bits" fork="heze" hash="837232c2">
     def get_inclusion_list_bits(
-        store: InclusionListStore, state: BeaconState, slot: Slot, only_timely: bool = True
-    ) -> BitVector[INCLUSION_LIST_COMMITTEE_SIZE]:
-        """
-        Return a ``BitVector`` over inclusion list committee indices with bits set
-        for those who provided valid, non-equivocating inclusion lists for the given ``slot``.
-        """
-        committee = get_inclusion_list_committee(state, slot)
-        key = hash_tree_root(committee)
-
+        store: InclusionListStore,
+        committee: InclusionListCommittee,
+        slot: Slot,
+        dependent_root: Root,
+        only_timely: bool = True,
+    ) -> InclusionListBits:
+        key = (slot, dependent_root)
         inclusion_lists = store.inclusion_lists[key]
         equivocators = store.equivocators[key]
-        timeliness = store.inclusion_list_timeliness
 
-        validator_indices = [
-            inclusion_lists[inclusion_list_root].message.validator_index
-            for inclusion_list_root in inclusion_lists
-            if inclusion_lists[inclusion_list_root].message.validator_index not in equivocators
-            if not only_timely or timeliness[inclusion_list_root]
-        ]
+        validator_indices = []
+        for validator_index, inclusion_list in inclusion_lists.items():
+            # Ignore inclusion lists from equivocators
+            if validator_index in equivocators:
+                continue
 
-        return BitVector[INCLUSION_LIST_COMMITTEE_SIZE](
-            validator_index in validator_indices for validator_index in committee
-        )
+            # Ignore untimely inclusion lists if only timely ones are requested
+            if only_timely and not inclusion_list.timely:
+                continue
+
+            validator_indices.append(validator_index)
+
+        return InclusionListBits(validator_index in validator_indices for validator_index in committee)
     </spec>
 
 - name: get_inclusion_list_committee#heze
   sources: []
   spec: |
-    <spec fn="get_inclusion_list_committee" fork="heze" hash="26546ce3">
-    def get_inclusion_list_committee(
-        state: BeaconState, slot: Slot
-    ) -> Vector[ValidatorIndex, INCLUSION_LIST_COMMITTEE_SIZE]:
+    <spec fn="get_inclusion_list_committee" fork="heze" hash="ca898bdd">
+    def get_inclusion_list_committee(state: BeaconState, slot: Slot) -> InclusionListCommittee:
         """
         Get the inclusion list committee for the given ``slot``.
         """
         epoch = compute_epoch_at_slot(slot)
-        indices: List[ValidatorIndex] = []
+        indices: list[ValidatorIndex] = []
         # Concatenate all committees for this slot in order
         committees_per_slot = get_committee_count_per_slot(state, epoch)
         for i in range(committees_per_slot):
             committee = get_beacon_committee(state, slot, CommitteeIndex(i))
             indices.extend(committee)
-        return Vector[ValidatorIndex, INCLUSION_LIST_COMMITTEE_SIZE]([
+        return InclusionListCommittee(
             indices[i % len(indices)] for i in range(INCLUSION_LIST_COMMITTEE_SIZE)
-        ])
+        )
     </spec>
 
 - name: get_inclusion_list_committee_assignment#heze
@@ -4531,24 +4554,25 @@
 - name: get_inclusion_list_transactions#heze
   sources: []
   spec: |
-    <spec fn="get_inclusion_list_transactions" fork="heze" hash="6d7217f3">
+    <spec fn="get_inclusion_list_transactions" fork="heze" hash="18378c2a">
     def get_inclusion_list_transactions(
-        store: InclusionListStore, state: BeaconState, slot: Slot, only_timely: bool = True
+        store: InclusionListStore, slot: Slot, dependent_root: Root, only_timely: bool = True
     ) -> Sequence[Transaction]:
-        committee = get_inclusion_list_committee(state, slot)
-        key = hash_tree_root(committee)
-
+        key = (slot, dependent_root)
         inclusion_lists = store.inclusion_lists[key]
         equivocators = store.equivocators[key]
-        timeliness = store.inclusion_list_timeliness
 
-        transactions = [
-            transaction
-            for inclusion_list_root in inclusion_lists
-            if inclusion_lists[inclusion_list_root].message.validator_index not in equivocators
-            if not only_timely or timeliness[inclusion_list_root]
-            for transaction in inclusion_lists[inclusion_list_root].message.transactions
-        ]
+        transactions: list[Transaction] = []
+        for validator_index, inclusion_list in inclusion_lists.items():
+            # Ignore inclusion lists from equivocators
+            if validator_index in equivocators:
+                continue
+
+            # Ignore untimely inclusion lists if only timely ones are requested
+            if only_timely and not inclusion_list.timely:
+                continue
+
+            transactions.extend(inclusion_list.signed_inclusion_list.message.transactions)
 
         # Deduplicate inclusion list transactions. Order does not need to be preserved.
         return list(set(transactions))
@@ -4580,7 +4604,7 @@
     - file: packages/state-transition/src/cache/epochCache.ts
       search: "getIndexedAttestation(fork: ForkSeq, attestation: Attestation)"
   spec: |
-    <spec fn="get_indexed_attestation" fork="phase0" hash="424c7a96">
+    <spec fn="get_indexed_attestation" fork="phase0" hash="e101dfd9">
     def get_indexed_attestation(state: BeaconState, attestation: Attestation) -> IndexedAttestation:
         """
         Return the indexed attestation corresponding to ``attestation``.
@@ -4588,7 +4612,7 @@
         attesting_indices = get_attesting_indices(state, attestation)
 
         return IndexedAttestation(
-            attesting_indices=sorted(attesting_indices),
+            attesting_indices=AttestingIndices(sorted(attesting_indices)),
             data=attestation.data,
             signature=attestation.signature,
         )
@@ -4600,7 +4624,7 @@
       search: '^\s+getIndexedPayloadAttestation\('
       regex: true
   spec: |
-    <spec fn="get_indexed_payload_attestation" fork="gloas" hash="0e516ffb">
+    <spec fn="get_indexed_payload_attestation" fork="gloas" hash="118e619f">
     def get_indexed_payload_attestation(
         state: BeaconState, payload_attestation: PayloadAttestation
     ) -> IndexedPayloadAttestation:
@@ -4613,7 +4637,7 @@
         attesting_indices = [index for i, index in enumerate(ptc) if bits[i]]
 
         return IndexedPayloadAttestation(
-            attesting_indices=sorted(attesting_indices),
+            attesting_indices=PTCAttestingIndices(sorted(attesting_indices)),
             data=payload_attestation.data,
             signature=payload_attestation.signature,
         )
@@ -4896,7 +4920,7 @@
     - file: packages/state-transition/src/util/seed.ts
       search: export function getNextSyncCommitteeIndices(
   spec: |
-    <spec fn="get_next_sync_committee_indices" fork="altair" hash="6ed6661f">
+    <spec fn="get_next_sync_committee_indices" fork="altair" hash="328c4f02">
     def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
         """
         Return the sync committee indices, with possible duplicates, for the next sync committee.
@@ -4908,7 +4932,7 @@
         active_validator_count = Uint64(len(active_validator_indices))
         seed = get_seed(state, epoch, DOMAIN_SYNC_COMMITTEE)
         i = 0
-        sync_committee_indices: List[ValidatorIndex] = []
+        sync_committee_indices: list[ValidatorIndex] = []
         while len(sync_committee_indices) < SYNC_COMMITTEE_SIZE:
             shuffled_index = compute_shuffled_index(
                 Uint64(i % active_validator_count), active_validator_count, seed
@@ -4927,7 +4951,7 @@
     - file: packages/state-transition/src/util/seed.ts
       search: export function getNextSyncCommitteeIndices(
   spec: |
-    <spec fn="get_next_sync_committee_indices" fork="electra" hash="41a80dac">
+    <spec fn="get_next_sync_committee_indices" fork="electra" hash="24770847">
     def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
         """
         Return the sync committee indices, with possible duplicates, for the next sync committee.
@@ -4940,7 +4964,7 @@
         active_validator_count = Uint64(len(active_validator_indices))
         seed = get_seed(state, epoch, DOMAIN_SYNC_COMMITTEE)
         i = Uint64(0)
-        sync_committee_indices: List[ValidatorIndex] = []
+        sync_committee_indices: list[ValidatorIndex] = []
         while len(sync_committee_indices) < SYNC_COMMITTEE_SIZE:
             shuffled_index = compute_shuffled_index(
                 Uint64(i % active_validator_count), active_validator_count, seed
@@ -5137,7 +5161,7 @@
 - name: get_pending_partial_withdrawals#electra
   sources: []
   spec: |
-    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="31f145b3">
+    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="428778a4">
     def get_pending_partial_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -5151,9 +5175,9 @@
         assert len(prior_withdrawals) <= withdrawals_limit
 
         processed_count: Uint64 = 0
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
         for withdrawal in state.pending_partial_withdrawals:
-            all_withdrawals = prior_withdrawals + withdrawals
+            all_withdrawals = list(prior_withdrawals) + withdrawals
             is_withdrawable = withdrawal.withdrawable_epoch <= epoch
             has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if not is_withdrawable or has_reached_limit:
@@ -5229,7 +5253,7 @@
     - file: packages/fork-choice/src/forkChoice/forkChoice.ts
       search: "* Same as https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/phase0/fork-choice.md#get_proposer_head"
   spec: |
-    <spec fn="get_proposer_head" fork="phase0" hash="6868d4f2">
+    <spec fn="get_proposer_head" fork="phase0" hash="d6a7508e">
     def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> ForkChoiceNode:
         head_block = store.blocks[head_node.root]
         parent_root = head_block.parent_root
@@ -5239,8 +5263,8 @@
         # Only re-org the head block if it arrived later than the attestation deadline.
         head_late = is_head_late(store, head_node.root)
 
-        # Do not re-org on an epoch boundary.
-        not_epoch_boundary = is_not_epoch_boundary(slot)
+        # Do not re-org on an epoch boundary where the proposer shuffling could change.
+        shuffling_stable = is_shuffling_stable(slot)
 
         # Ensure that the FFG information of the new head will be competitive with the current head.
         ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
@@ -5268,7 +5292,68 @@
 
         if all([
             head_late,
-            not_epoch_boundary,
+            shuffling_stable,
+            ffg_competitive,
+            finalization_ok,
+            proposing_on_time,
+            single_slot_reorg,
+            head_weak,
+            parent_strong,
+        ]):
+            # We can re-org the current head by building upon its parent node.
+            return parent_node
+        elif all([head_weak, current_time_ok, proposer_equivocation]):
+            return parent_node
+        else:
+            return head_node
+    </spec>
+
+- name: get_proposer_head#fulu
+  sources:
+    - file: packages/fork-choice/src/forkChoice/forkChoice.ts
+      search: "private getPreliminaryProposerHead("
+  spec: |
+    <spec fn="get_proposer_head" fork="fulu" hash="b8612966">
+    def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> ForkChoiceNode:
+        head_block = store.blocks[head_node.root]
+        parent_root = head_block.parent_root
+        parent_block = store.blocks[parent_root]
+        parent_node = ForkChoiceNode(root=parent_root)
+
+        # Only re-org the head block if it arrived later than the attestation deadline.
+        head_late = is_head_late(store, head_node.root)
+
+        # [Modified in Fulu:EIP7917]
+        # Removed `shuffling_stable = is_shuffling_stable(slot)`
+
+        # Ensure that the FFG information of the new head will be competitive with the current head.
+        ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
+
+        # Do not re-org if the chain is not finalizing with acceptable frequency.
+        finalization_ok = is_finalization_ok(store, slot)
+
+        # Only re-org if we are proposing on-time.
+        proposing_on_time = is_proposing_on_time(store)
+
+        # Only re-org a single slot at most.
+        parent_slot_ok = parent_block.slot + 1 == head_block.slot
+        current_time_ok = head_block.slot + 1 == slot
+        single_slot_reorg = parent_slot_ok and current_time_ok
+
+        # Check that the head has few enough votes to be overpowered by our proposer boost.
+        assert store.proposer_boost_root != head_node.root  # ensure boost has worn off
+        head_weak = is_head_weak(store, head_node.root)
+
+        # Check that the missing votes are assigned to the parent and not being hoarded.
+        parent_strong = is_parent_strong(store, head_node.root)
+
+        # Re-org more aggressively if there is a proposer equivocation in the previous slot.
+        proposer_equivocation = is_proposer_equivocation(store, head_node.root)
+
+        if all([
+            head_late,
+            # [Modified in Fulu:EIP7917]
+            # Removed `shuffling_stable`
             ffg_competitive,
             finalization_ok,
             proposing_on_time,
@@ -5289,7 +5374,7 @@
     - file: packages/fork-choice/src/forkChoice/forkChoice.ts
       search: "* Same as https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/phase0/fork-choice.md#get_proposer_head"
   spec: |
-    <spec fn="get_proposer_head" fork="gloas" hash="121a187d">
+    <spec fn="get_proposer_head" fork="gloas" hash="b67ab6f8">
     def get_proposer_head(store: Store, head_node: ForkChoiceNode, slot: Slot) -> ForkChoiceNode:
         head_block = store.blocks[head_node.root]
         parent_root = head_block.parent_root
@@ -5300,9 +5385,6 @@
 
         # Only re-org the head block if it arrived later than the attestation deadline.
         head_late = is_head_late(store, head_node.root)
-
-        # Do not re-org on an epoch boundary.
-        not_epoch_boundary = is_not_epoch_boundary(slot)
 
         # Ensure that the FFG information of the new head will be competitive with the current head.
         ffg_competitive = is_ffg_competitive(store, head_node.root, parent_root)
@@ -5330,7 +5412,6 @@
 
         if all([
             head_late,
-            not_epoch_boundary,
             ffg_competitive,
             finalization_ok,
             proposing_on_time,
@@ -5379,8 +5460,8 @@
       search: '^\s+getPayloadTimelinessCommittee\('
       regex: true
   spec: |
-    <spec fn="get_ptc" fork="gloas" hash="b55ba184">
-    def get_ptc(state: BeaconState, slot: Slot) -> Vector[ValidatorIndex, PTC_SIZE]:
+    <spec fn="get_ptc" fork="gloas" hash="b38e3477">
+    def get_ptc(state: BeaconState, slot: Slot) -> PTC:
         """
         Get the payload timeliness committee for the given ``slot``.
         """
@@ -5482,6 +5563,22 @@
         )
     </spec>
 
+- name: get_scheduled_gas_limit#gloas
+  sources:
+    - file: packages/config/src/forkConfig/index.ts
+      search: "getScheduledGasLimit(epoch: Epoch): number | undefined {"
+  spec: |
+    <spec fn="get_scheduled_gas_limit" fork="gloas" hash="9f246e85">
+    def get_scheduled_gas_limit(epoch: Epoch) -> Optional[Uint64]:
+        """
+        Return the scheduled gas limit at a given epoch, if any.
+        """
+        for entry in sorted(GAS_LIMIT_SCHEDULE, key=lambda e: e["EPOCH"], reverse=True):
+            if epoch >= entry["EPOCH"]:
+                return entry["GAS_LIMIT"]
+        return None
+    </spec>
+
 - name: get_seed#phase0
   sources:
     - file: packages/state-transition/src/util/seed.ts
@@ -5498,19 +5595,28 @@
         return hash(domain_type + uint_to_bytes(epoch) + mix)
     </spec>
 
+- name: get_set_bit_count#phase0
+  sources:
+    - file: packages/state-transition/src/lightClient/spec/utils.ts
+      search: "export function sumBits(bits: BitArray): number {"
+  spec: |
+    <spec fn="get_set_bit_count" fork="phase0" hash="789bad21">
+    def get_set_bit_count(bits: Sequence[Boolean]) -> Uint64:
+        """
+        Return the number of bits that are set in ``bits``.
+        """
+        return Uint64(sum(1 for bit in bits if bit))
+    </spec>
+
 - name: get_shuffling_dependent_root#phase0
   sources:
     - file: packages/beacon-node/src/util/dependentRoot.ts
       search: export function getShufflingDependentRoot(
   spec: |
-    <spec fn="get_shuffling_dependent_root" fork="phase0" hash="bb6205ed">
+    <spec fn="get_shuffling_dependent_root" fork="phase0" hash="aa8f82b6">
     def get_shuffling_dependent_root(store: Store, root: Root, epoch: Epoch) -> Root:
-        if epoch <= MIN_SEED_LOOKAHEAD:
-            # Genesis block parent
-            return Root()
-
         node = ForkChoiceNode(root=root)
-        dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+        dependent_slot = compute_shuffling_dependent_slot(epoch)
         return get_ancestor(store, node, dependent_slot).root
     </spec>
 
@@ -5519,19 +5625,38 @@
     - file: packages/beacon-node/src/util/dependentRoot.ts
       search: export function getShufflingDependentRoot(
   spec: |
-    <spec fn="get_shuffling_dependent_root" fork="gloas" hash="57c2e2d6">
+    <spec fn="get_shuffling_dependent_root" fork="gloas" hash="06c3f93d">
     def get_shuffling_dependent_root(store: Store, root: Root, epoch: Epoch) -> Root:
-        if epoch <= MIN_SEED_LOOKAHEAD:
-            # Genesis block parent
-            return Root()
-
         # [Modified in Gloas:EIP7732]
         node = ForkChoiceNode(
             root=root,
             payload_status=PAYLOAD_STATUS_PENDING,
         )
-        dependent_slot = Slot(compute_start_slot_at_epoch(epoch - MIN_SEED_LOOKAHEAD) - 1)
+        dependent_slot = compute_shuffling_dependent_slot(epoch)
         return get_ancestor(store, node, dependent_slot).root
+    </spec>
+
+- name: get_signed_inclusion_list#heze
+  sources: []
+  spec: |
+    <spec fn="get_signed_inclusion_list" fork="heze" hash="89ea0efc">
+    def get_signed_inclusion_list(
+        store: Store,
+        state: BeaconState,
+        head_root: Root,
+        slot: Slot,
+        validator_index: ValidatorIndex,
+        inclusion_list_transactions: Sequence[Transaction],
+        privkey: int,
+    ) -> SignedInclusionList:
+        inclusion_list = InclusionList(
+            slot=slot,
+            validator_index=validator_index,
+            dependent_root=get_shuffling_dependent_root(store, head_root, compute_epoch_at_slot(slot)),
+            transactions=inclusion_list_transactions,
+        )
+        signature = get_inclusion_list_signature(state, inclusion_list, privkey)
+        return SignedInclusionList(message=inclusion_list, signature=signature)
     </spec>
 
 - name: get_signed_proposer_preferences#gloas
@@ -5990,7 +6115,7 @@
 - name: get_validators_sweep_withdrawals#capella
   sources: []
   spec: |
-    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="63669fe1">
+    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="7b378870">
     def get_validators_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -6003,10 +6128,10 @@
         assert len(prior_withdrawals) < withdrawals_limit
 
         processed_count: Uint64 = 0
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
         validator_index = state.next_withdrawal_validator_index
         for _ in range(validators_limit):
-            all_withdrawals = prior_withdrawals + withdrawals
+            all_withdrawals = list(prior_withdrawals) + withdrawals
             has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
@@ -6043,7 +6168,7 @@
 - name: get_validators_sweep_withdrawals#electra
   sources: []
   spec: |
-    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="9d487c12">
+    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="3b2caab3">
     def get_validators_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -6056,10 +6181,10 @@
         assert len(prior_withdrawals) < withdrawals_limit
 
         processed_count: Uint64 = 0
-        withdrawals: List[Withdrawal] = []
+        withdrawals: list[Withdrawal] = []
         validator_index = state.next_withdrawal_validator_index
         for _ in range(validators_limit):
-            all_withdrawals = prior_withdrawals + withdrawals
+            all_withdrawals = list(prior_withdrawals) + withdrawals
             has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
@@ -6249,7 +6374,7 @@
     - file: packages/state-transition/src/util/genesis.ts
       search: export function initializeBeaconStateFromEth1(
   spec: |
-    <spec fn="initialize_beacon_state_from_eth1" fork="phase0" hash="af20d2eb">
+    <spec fn="initialize_beacon_state_from_eth1" fork="phase0" hash="9f022dd9">
     def initialize_beacon_state_from_eth1(
         eth1_block_hash: Hash32, eth1_timestamp: Uint64, deposits: Sequence[Deposit]
     ) -> BeaconState:
@@ -6270,7 +6395,7 @@
         # Process deposits
         leaves = [deposit.data for deposit in deposits]
         for index, deposit in enumerate(deposits):
-            deposit_data_list = List[DepositData, 2**DEPOSIT_CONTRACT_TREE_DEPTH](*leaves[: index + 1])
+            deposit_data_list = DepositDataList(*leaves[: index + 1])
             state.eth1_data.deposit_root = hash_tree_root(deposit_data_list)
             process_deposit(state, deposit)
 
@@ -6325,19 +6450,19 @@
     - file: packages/state-transition/src/util/fulu.ts
       search: export function initializeProposerLookahead(
   spec: |
-    <spec fn="initialize_proposer_lookahead" fork="fulu" hash="58f9a307">
+    <spec fn="initialize_proposer_lookahead" fork="fulu" hash="e5046dd7">
     def initialize_proposer_lookahead(
         state: electra.BeaconState,
-    ) -> Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]:
+    ) -> ProposerLookahead:
         """
         Return the proposer indices for the full available lookahead starting from current epoch.
         Used to initialize the ``proposer_lookahead`` field in the beacon state at genesis and after forks.
         """
         current_epoch = get_current_epoch(state)
-        lookahead = []
+        lookahead: list[ValidatorIndex] = []
         for i in range(MIN_SEED_LOOKAHEAD + 1):
             lookahead.extend(get_beacon_proposer_indices(state, Epoch(current_epoch + i)))
-        return lookahead
+        return ProposerLookahead(lookahead)
     </spec>
 
 - name: initialize_ptc_window#gloas
@@ -6345,17 +6470,16 @@
     - file: packages/state-transition/src/util/gloas.ts
       search: export function initializePtcWindow(
   spec: |
-    <spec fn="initialize_ptc_window" fork="gloas" hash="3764b7f5">
+    <spec fn="initialize_ptc_window" fork="gloas" hash="86379eba">
     def initialize_ptc_window(
         state: BeaconState,
-    ) -> Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]:
+    ) -> PTCWindow:
         """
         Return the cached PTC window starting from the current epoch.
         Used to initialize the ``ptc_window`` field in the beacon state at genesis and after forks.
         """
         empty_previous_epoch = [
-            Vector[ValidatorIndex, PTC_SIZE]([ValidatorIndex(0) for _ in range(PTC_SIZE)])
-            for _ in range(SLOTS_PER_EPOCH)
+            PTC([ValidatorIndex(0) for _ in range(PTC_SIZE)]) for _ in range(SLOTS_PER_EPOCH)
         ]
 
         ptcs = []
@@ -6365,7 +6489,7 @@
             start_slot = compute_start_slot_at_epoch(epoch)
             ptcs += [compute_ptc(state, Slot(start_slot + i)) for i in range(SLOTS_PER_EPOCH)]
 
-        return empty_previous_epoch + ptcs
+        return PTCWindow(empty_previous_epoch + ptcs)
     </spec>
 
 - name: initiate_builder_exit#gloas
@@ -6568,12 +6692,12 @@
     - file: packages/state-transition/src/lightClient/spec/isBetterUpdate.ts
       search: export function isBetterUpdate(
   spec: |
-    <spec fn="is_better_update" fork="altair" hash="b99582ff">
+    <spec fn="is_better_update" fork="altair" hash="534f9f39">
     def is_better_update(new_update: LightClientUpdate, old_update: LightClientUpdate) -> bool:
         # Compare supermajority (> 2/3) sync committee participation
         max_active_participants = len(new_update.sync_aggregate.sync_committee_bits)
-        new_num_active_participants = sum(new_update.sync_aggregate.sync_committee_bits)
-        old_num_active_participants = sum(old_update.sync_aggregate.sync_committee_bits)
+        new_num_active_participants = get_set_bit_count(new_update.sync_aggregate.sync_committee_bits)
+        old_num_active_participants = get_set_bit_count(old_update.sync_aggregate.sync_committee_bits)
         new_has_supermajority = new_num_active_participants * 3 >= max_active_participants * 2
         old_has_supermajority = old_num_active_participants * 3 >= max_active_participants * 2
         if new_has_supermajority != old_has_supermajority:
@@ -6738,12 +6862,32 @@
         )
     </spec>
 
+- name: is_current_or_next_slot#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+      search: "!chain.clock.isCurrentSlotGivenGossipDisparity(bid.slot) &&"
+  spec: |
+    <spec fn="is_current_or_next_slot" fork="gloas" hash="f9531452">
+    def is_current_or_next_slot(
+        store: Store,
+        slot: Slot,
+        current_time_ms: Uint64,
+    ) -> bool:
+        """
+        Check if the given slot is the current slot or the next slot
+        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+        """
+        is_current = is_current_slot(store, slot, current_time_ms)
+        is_next = is_current_slot(store, Slot(slot - 1), current_time_ms)
+        return is_current or is_next
+    </spec>
+
 - name: is_current_or_previous_epoch#deneb
   sources: []
   spec: |
-    <spec fn="is_current_or_previous_epoch" fork="deneb" hash="b9a9edf6">
+    <spec fn="is_current_or_previous_epoch" fork="deneb" hash="defec055">
     def is_current_or_previous_epoch(
-        state: BeaconState,
+        store: Store,
         epoch: Epoch,
         current_time_ms: Uint64,
     ) -> bool:
@@ -6751,17 +6895,17 @@
         Check if the given epoch is the current or previous epoch
         (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
         """
-        is_current = is_within_epoch(state, epoch, current_time_ms)
-        is_previous = is_within_epoch(state, Epoch(epoch + 1), current_time_ms)
+        is_current = is_within_epoch(store, epoch, current_time_ms)
+        is_previous = is_within_epoch(store, Epoch(epoch + 1), current_time_ms)
         return is_current or is_previous
     </spec>
 
 - name: is_current_slot#altair
   sources: []
   spec: |
-    <spec fn="is_current_slot" fork="altair" hash="8748e6f0">
+    <spec fn="is_current_slot" fork="altair" hash="14c73d54">
     def is_current_slot(
-        state: BeaconState,
+        store: Store,
         slot: Slot,
         current_time_ms: Uint64,
     ) -> bool:
@@ -6769,7 +6913,7 @@
         Check if the given slot is the current slot
         (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
         """
-        return is_within_slot_range(state, slot, 0, current_time_ms)
+        return is_within_slot_range(store, slot, 0, current_time_ms)
     </spec>
 
 - name: is_data_available#deneb
@@ -6996,12 +7140,31 @@
         )
     </spec>
 
+- name: is_future_slot#phase0
+  sources:
+    - file: packages/beacon-node/src/chain/validation/block.ts
+      search: "if (currentSlotWithGossipDisparity < blockSlot) {"
+  spec: |
+    <spec fn="is_future_slot" fork="phase0" hash="24f51b32">
+    def is_future_slot(
+        store: Store,
+        slot: Slot,
+        current_time_ms: Uint64,
+    ) -> bool:
+        """
+        Check if the given slot is in the future
+        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+        """
+        slot_time_ms = compute_time_at_slot_ms(store, slot)
+        return current_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY < slot_time_ms
+    </spec>
+
 - name: is_gas_limit_target_compatible#gloas
   sources:
     - file: packages/state-transition/src/util/gloas.ts
       search: export function isGasLimitTargetCompatible(
   spec: |
-    <spec fn="is_gas_limit_target_compatible" fork="gloas" hash="6dffbd1d">
+    <spec fn="is_gas_limit_target_compatible" fork="gloas" hash="c45c6892">
     def is_gas_limit_target_compatible(
         parent_gas_limit: Uint64, gas_limit: Uint64, target_gas_limit: Uint64
     ) -> bool:
@@ -7013,11 +7176,11 @@
         min_gas_limit = parent_gas_limit - max_gas_limit_difference
         max_gas_limit = parent_gas_limit + max_gas_limit_difference
 
-        if target_gas_limit >= min_gas_limit and target_gas_limit <= max_gas_limit:
-            return gas_limit == target_gas_limit
+        if target_gas_limit < min_gas_limit:
+            return gas_limit == min_gas_limit
         if target_gas_limit > max_gas_limit:
             return gas_limit == max_gas_limit
-        return gas_limit == min_gas_limit
+        return gas_limit == target_gas_limit
     </spec>
 
 - name: is_head_late#phase0
@@ -7112,26 +7275,23 @@
 - name: is_inclusion_list_bits_inclusive#heze
   sources: []
   spec: |
-    <spec fn="is_inclusion_list_bits_inclusive" fork="heze" hash="5d803543">
+    <spec fn="is_inclusion_list_bits_inclusive" fork="heze" hash="ea1a888b">
     def is_inclusion_list_bits_inclusive(
         store: InclusionListStore,
-        state: BeaconState,
+        committee: InclusionListCommittee,
         slot: Slot,
-        inclusion_list_bits: BitVector[INCLUSION_LIST_COMMITTEE_SIZE],
+        dependent_root: Root,
+        inclusion_list_bits: InclusionListBits,
         only_timely: bool = True,
     ) -> bool:
-        """
-        Return ``True`` if and only if ``inclusion_list_bits`` has a bit set for
-        every bit set in the local inclusion list bits for the given ``slot``.
-        """
-        local_inclusion_list_bits = get_inclusion_list_bits(store, state, slot, only_timely)
-
-        return not any(
-            local_inclusion_bit and not inclusion_bit
-            for inclusion_bit, local_inclusion_bit in zip(
-                inclusion_list_bits, local_inclusion_list_bits, strict=True
-            )
+        local_inclusion_list_bits = get_inclusion_list_bits(
+            store, committee, slot, dependent_root, only_timely
         )
+
+        for i in range(INCLUSION_LIST_COMMITTEE_SIZE):
+            if local_inclusion_list_bits[i] and not inclusion_list_bits[i]:
+                return False
+        return True
     </spec>
 
 - name: is_merge_transition_block#bellatrix
@@ -7181,16 +7341,6 @@
             if is_superset:
                 return True
         return False
-    </spec>
-
-- name: is_not_epoch_boundary#phase0
-  sources:
-    - file: packages/state-transition/src/util/epoch.ts
-      search: export function isStartSlotOfEpoch(
-  spec: |
-    <spec fn="is_not_epoch_boundary" fork="phase0" hash="cad390e0">
-    def is_not_epoch_boundary(slot: Slot) -> bool:
-        return slot % SLOTS_PER_EPOCH != 0
     </spec>
 
 - name: is_one_confirmed#phase0
@@ -7309,6 +7459,25 @@
         )
     </spec>
 
+- name: is_past_slot#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/proposerPreferences.ts
+      search: "if (chain.clock.msFromSlot(proposalSlot) > chain.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY) {"
+  spec: |
+    <spec fn="is_past_slot" fork="gloas" hash="4bd9aba5">
+    def is_past_slot(
+        store: Store,
+        slot: Slot,
+        current_time_ms: Uint64,
+    ) -> bool:
+        """
+        Check if the given slot is in the past
+        (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
+        """
+        slot_time_ms = compute_time_at_slot_ms(store, slot)
+        return current_time_ms > slot_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+    </spec>
+
 - name: is_payload_inclusion_list_satisfied#heze
   sources: []
   spec: |
@@ -7415,6 +7584,16 @@
         return time_into_slot_ms <= proposer_reorg_cutoff_ms
     </spec>
 
+- name: is_shuffling_stable#phase0
+  sources:
+    - file: packages/fork-choice/src/forkChoice/forkChoice.ts
+      search: "const isShufflingStable = isForkPostFulu(this.config.getForkName(slot)) || slot % SLOTS_PER_EPOCH !== 0;"
+  spec: |
+    <spec fn="is_shuffling_stable" fork="phase0" hash="680f0aa0">
+    def is_shuffling_stable(slot: Slot) -> bool:
+        return slot % SLOTS_PER_EPOCH != 0
+    </spec>
+
 - name: is_slashable_attestation_data#phase0
   sources:
     - file: packages/state-transition/src/util/attestation.ts
@@ -7508,7 +7687,7 @@
     - file: packages/beacon-node/src/chain/validation/proposerPreferences.ts
       search: export function isValidDependentRoot
   spec: |
-    <spec fn="is_valid_dependent_root" fork="gloas" hash="2b049531">
+    <spec fn="is_valid_dependent_root" fork="gloas" hash="b441eb3d">
     def is_valid_dependent_root(store: Store, root: Root, epoch: Epoch) -> bool:
         """
         Check if the block with the given ``root`` is a possible dependent block
@@ -7516,12 +7695,13 @@
         become, the latest block prior to the start of the epoch.
         """
         epoch_start_slot = compute_start_slot_at_epoch(epoch)
-        if store.blocks[root].slot >= epoch_start_slot:
-            return False
         for block in store.blocks.values():
-            if block.parent_root == root and block.slot >= epoch_start_slot:
-                return True
-        return root == get_head(store).root
+            if block.parent_root == root:
+                if block.slot >= epoch_start_slot:
+                    return True
+        if root == get_head(store).root:
+            return True
+        return False
     </spec>
 
 - name: is_valid_deposit_signature#electra
@@ -7788,27 +7968,6 @@
         return is_valid_merkle_branch(leaf, branch[num_extra:], depth, index, root)
     </spec>
 
-- name: is_valid_proposal_slot#gloas
-  sources: []
-  spec: |
-    <spec fn="is_valid_proposal_slot" fork="gloas" hash="991b8b00">
-    def is_valid_proposal_slot(state: BeaconState, preferences: ProposerPreferences) -> bool:
-        """
-        Check if the validator is the proposer for the given slot within the
-        proposer lookahead.
-        """
-        current_epoch = get_current_epoch(state)
-        proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)
-        if proposal_epoch < current_epoch:
-            return False
-        if proposal_epoch > current_epoch + Epoch(MIN_SEED_LOOKAHEAD):
-            return False
-
-        index = (proposal_epoch - current_epoch) * SLOTS_PER_EPOCH
-        index += preferences.proposal_slot % SLOTS_PER_EPOCH
-        return state.proposer_lookahead[index] == preferences.validator_index
-    </spec>
-
 - name: is_valid_switch_to_compounding_request#electra
   sources: []
   spec: |
@@ -7861,9 +8020,9 @@
 - name: is_within_epoch#deneb
   sources: []
   spec: |
-    <spec fn="is_within_epoch" fork="deneb" hash="276fb799">
+    <spec fn="is_within_epoch" fork="deneb" hash="2c9c93d1">
     def is_within_epoch(
-        state: BeaconState,
+        store: Store,
         epoch: Epoch,
         current_time_ms: Uint64,
     ) -> bool:
@@ -7872,7 +8031,7 @@
         (with MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance on both ends).
         """
         return is_within_slot_range(
-            state,
+            store,
             compute_start_slot_at_epoch(epoch),
             SLOTS_PER_EPOCH - 1,
             current_time_ms,
@@ -8042,10 +8201,10 @@
       search: '^\s+onAttestation\('
       regex: true
   spec: |
-    <spec fn="on_attestation" fork="phase0" hash="b7b4d7de">
+    <spec fn="on_attestation" fork="phase0" hash="759f1fc0">
     def on_attestation(store: Store, attestation: Attestation, is_from_block: bool = False) -> None:
         """
-        Run ``on_attestation`` upon receiving a new ``attestation`` from either within a block or directly on the wire.
+        Run ``on_attestation`` upon receiving a new attestation from either within a block or directly on the wire.
 
         An ``attestation`` that is asserted as invalid may be valid at a later time,
         consider scheduling it for later processing in such case.
@@ -8069,10 +8228,10 @@
       search: '^\s+onAttesterSlashing\('
       regex: true
   spec: |
-    <spec fn="on_attester_slashing" fork="phase0" hash="73957b9b">
+    <spec fn="on_attester_slashing" fork="phase0" hash="35781098">
     def on_attester_slashing(store: Store, attester_slashing: AttesterSlashing) -> None:
         """
-        Run ``on_attester_slashing`` immediately upon receiving a new ``AttesterSlashing``
+        Run ``on_attester_slashing`` immediately upon receiving a new attester slashing
         from either within a block or directly on the wire.
         """
         attestation_1 = attester_slashing.attestation_1
@@ -8093,8 +8252,11 @@
       search: '^\s+onBlock\('
       regex: true
   spec: |
-    <spec fn="on_block" fork="phase0" hash="fd507f39">
+    <spec fn="on_block" fork="phase0" hash="de5e6920">
     def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
+        """
+        Run ``on_block`` upon receiving a new block.
+        """
         block = signed_block.message
         block_root = hash_tree_root(block)
 
@@ -8480,7 +8642,7 @@
 - name: on_execution_payload_envelope#heze
   sources: []
   spec: |
-    <spec fn="on_execution_payload_envelope" fork="heze" hash="eca893ad">
+    <spec fn="on_execution_payload_envelope" fork="heze" hash="afd9bdaf">
     def on_execution_payload_envelope(
         store: Store, signed_envelope: SignedExecutionPayloadEnvelope
     ) -> None:
@@ -8504,7 +8666,7 @@
         # Check if this payload satisfies the inclusion list constraints
         # If not, add this payload to the store as inclusion list constraints unsatisfied
         record_payload_inclusion_list_satisfaction(
-            store, state, envelope.beacon_block_root, envelope.payload, EXECUTION_ENGINE
+            store, envelope.beacon_block_root, envelope.payload, EXECUTION_ENGINE
         )
 
         # Add execution payload envelope to the store
@@ -8523,29 +8685,55 @@
 - name: on_inclusion_list#heze
   sources: []
   spec: |
-    <spec fn="on_inclusion_list" fork="heze" hash="ff3548fe">
+    <spec fn="on_inclusion_list" fork="heze" hash="110af39f">
     def on_inclusion_list(store: Store, signed_inclusion_list: SignedInclusionList) -> None:
         """
         Run ``on_inclusion_list`` upon receiving a new inclusion list.
         """
+        inclusion_list = signed_inclusion_list.message
+        current_slot = get_current_slot(store)
+
+        # The transactions must not exceed the maximum size
+        transactions_size = sum(len(transaction) for transaction in inclusion_list.transactions)
+        assert transactions_size <= MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST
+
+        # The slot must be within the retention window
+        assert inclusion_list.slot <= current_slot
+        assert inclusion_list.slot + MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS >= current_slot
+
+        # The dependent block must be known
+        assert inclusion_list.dependent_root in store.block_states
+
+        # Verify the validator is in the inclusion list committee
+        dependent_state = copy(store.block_states[inclusion_list.dependent_root])
+        if dependent_state.slot < inclusion_list.slot:
+            process_slots(dependent_state, inclusion_list.slot)
+        committee = get_inclusion_list_committee(dependent_state, inclusion_list.slot)
+        assert inclusion_list.validator_index in committee
+
+        # Verify the signature
+        assert is_valid_inclusion_list_signature(dependent_state, signed_inclusion_list)
+
+        # The inclusion list is timely if it arrives in its slot before the deadline
         seconds_since_genesis = store.time - store.genesis_time
         time_into_slot_ms = seconds_to_milliseconds(seconds_since_genesis) % SLOT_DURATION_MS
-        inclusion_list_due_ms = get_inclusion_list_due_ms()
-        is_timely = time_into_slot_ms < inclusion_list_due_ms
+        is_current_slot = inclusion_list.slot == current_slot
+        is_timely = is_current_slot and time_into_slot_ms < get_inclusion_list_due_ms()
 
+        # Process the inclusion list
         process_inclusion_list(get_inclusion_list_store(), signed_inclusion_list, is_timely)
     </spec>
 
 - name: on_payload_attestation_message#gloas
   sources: []
   spec: |
-    <spec fn="on_payload_attestation_message" fork="gloas" hash="122499c4">
+    <spec fn="on_payload_attestation_message" fork="gloas" hash="b94fe068">
     def on_payload_attestation_message(
         store: Store, ptc_message: PayloadAttestationMessage, is_from_block: bool = False
     ) -> None:
         """
-        Run ``on_payload_attestation_message`` upon receiving a new ``ptc_message`` from
-        either within a block or directly on the wire.
+        Run ``on_payload_attestation_message`` upon receiving a new payload attestation message
+        from either within a block or directly on the wire.
         """
         data = ptc_message.data
 
@@ -8639,7 +8827,7 @@
     - file: packages/state-transition/src/slot/upgradeStateToGloas.ts
       search: function onboardBuildersFromPendingDeposits(
   spec: |
-    <spec fn="onboard_builders_from_pending_deposits" fork="gloas" hash="2f9926a6">
+    <spec fn="onboard_builders_from_pending_deposits" fork="gloas" hash="49853afd">
     def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
         """
         Applies any pending deposit for builders, effectively
@@ -8647,7 +8835,7 @@
         """
         validator_pubkeys = [v.pubkey for v in state.validators]
 
-        pending_deposits = []
+        pending_deposits = PendingDeposits()
         for deposit in state.pending_deposits:
             # Deposits for existing validators stay in the pending queue
             if deposit.pubkey in validator_pubkeys:
@@ -8896,7 +9084,7 @@
 - name: prepare_execution_payload#gloas
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="gloas" hash="e25f2d5e">
+    <spec fn="prepare_execution_payload" fork="gloas" hash="ce616ceb">
     def prepare_execution_payload(
         # [New in Gloas:EIP7732]
         store: Store,
@@ -8943,13 +9131,15 @@
             safe_block_hash=safe_block_hash,
             finalized_block_hash=finalized_block_hash,
             payload_attributes=payload_attributes,
+            # [New in Gloas:EIP8070]
+            custody_columns=None,
         )
     </spec>
 
 - name: prepare_execution_payload#heze
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="heze" hash="c245b0c9">
+    <spec fn="prepare_execution_payload" fork="heze" hash="4c7356d6">
     def prepare_execution_payload(
         store: Store,
         head: ForkChoiceNode,
@@ -8984,7 +9174,12 @@
             target_gas_limit=target_gas_limit,
             # [New in Heze:EIP7805]
             inclusion_list_transactions=get_inclusion_list_transactions(
-                get_inclusion_list_store(), state, Slot(state.slot - 1), only_timely=False
+                get_inclusion_list_store(),
+                state.slot - Slot(1),
+                get_shuffling_dependent_root(
+                    store, head.root, compute_epoch_at_slot(state.slot - Slot(1))
+                ),
+                only_timely=False,
             ),
         )
         return execution_engine.notify_forkchoice_updated(
@@ -8992,6 +9187,7 @@
             safe_block_hash=safe_block_hash,
             finalized_block_hash=finalized_block_hash,
             payload_attributes=payload_attributes,
+            custody_columns=None,
         )
     </spec>
 
@@ -9188,7 +9384,7 @@
 - name: process_attestation#gloas
   sources: []
   spec: |
-    <spec fn="process_attestation" fork="gloas" hash="788ac81e">
+    <spec fn="process_attestation" fork="gloas" hash="9ffa1b1c">
     def process_attestation(
         state: BeaconState,
         attestation: Attestation,
@@ -9240,8 +9436,7 @@
         proposer_reward_numerator = 0
         for index in get_attesting_indices(state, attestation):
             # [New in Gloas:EIP7732]
-            # For same-slot attestations, check if we are setting any new flags.
-            # If we are, this validator has not contributed to this slot's quorum yet.
+            had_no_participation = epoch_participation[index] == ParticipationFlags(0b0000_0000)
             will_set_new_flag = False
 
             for flag_index, weight in enumerate(PARTICIPATION_FLAG_WEIGHTS):
@@ -9254,10 +9449,9 @@
                     will_set_new_flag = True
 
             # [New in Gloas:EIP7732]
-            # Add weight for same-slot attestations when any new flag is set.
-            # This ensures each validator contributes exactly once per slot.
             if (
                 will_set_new_flag
+                and had_no_participation
                 and is_attestation_same_slot(state, data)
                 and payment.withdrawal.amount > 0
             ):
@@ -9547,7 +9741,7 @@
     - file: packages/state-transition/src/epoch/processBuilderPendingPayments.ts
       search: export function processBuilderPendingPayments(
   spec: |
-    <spec fn="process_builder_pending_payments" fork="gloas" hash="10da48dd">
+    <spec fn="process_builder_pending_payments" fork="gloas" hash="dc889dd0">
     def process_builder_pending_payments(state: BeaconState) -> None:
         """
         Processes the builder pending payments from the previous epoch.
@@ -9559,7 +9753,7 @@
 
         old_payments = state.builder_pending_payments[SLOTS_PER_EPOCH:]
         new_payments = [BuilderPendingPayment() for _ in range(SLOTS_PER_EPOCH)]
-        state.builder_pending_payments = old_payments + new_payments
+        state.builder_pending_payments = BuilderPendingPayments(old_payments + new_payments)
     </spec>
 
 - name: process_consolidation_request#electra
@@ -9979,12 +10173,12 @@
     - file: packages/state-transition/src/epoch/processEth1DataReset.ts
       search: export function processEth1DataReset(
   spec: |
-    <spec fn="process_eth1_data_reset" fork="phase0" hash="c777739e">
+    <spec fn="process_eth1_data_reset" fork="phase0" hash="bd342dd2">
     def process_eth1_data_reset(state: BeaconState) -> None:
         next_epoch = Epoch(get_current_epoch(state) + 1)
         # Reset eth1 data votes
         if next_epoch % EPOCHS_PER_ETH1_VOTING_PERIOD == 0:
-            state.eth1_data_votes = []
+            state.eth1_data_votes = Eth1DataVotes()
     </spec>
 
 - name: process_execution_payload#bellatrix
@@ -10439,34 +10633,29 @@
 - name: process_inclusion_list#heze
   sources: []
   spec: |
-    <spec fn="process_inclusion_list" fork="heze" hash="6478d176">
+    <spec fn="process_inclusion_list" fork="heze" hash="a441f361">
     def process_inclusion_list(
-        store: InclusionListStore,
-        signed_inclusion_list: SignedInclusionList,
-        is_timely: bool,
+        store: InclusionListStore, signed_inclusion_list: SignedInclusionList, timely: bool
     ) -> None:
         inclusion_list = signed_inclusion_list.message
-        key = inclusion_list.inclusion_list_committee_root
+        validator_index = inclusion_list.validator_index
+        key = (inclusion_list.slot, inclusion_list.dependent_root)
 
-        # Ignore `inclusion_list` from equivocators.
-        if inclusion_list.validator_index in store.equivocators[key]:
-            return
-
-        for stored_root in store.inclusion_lists[key]:
-            stored_inclusion_list = store.inclusion_lists[key][stored_root].message
-            if stored_inclusion_list.validator_index != inclusion_list.validator_index:
-                continue
-
+        if validator_index in store.inclusion_lists[key]:
+            # Mark the validator as an equivocator if it published a different inclusion list
+            stored_entry = store.inclusion_lists[key][validator_index]
+            stored_inclusion_list = stored_entry.signed_inclusion_list.message
             if stored_inclusion_list != inclusion_list:
-                store.equivocators[key].add(inclusion_list.validator_index)
+                store.equivocators[key].add(validator_index)
 
-            # Whether it was an equivocation or not, we have processed this `inclusion_list`.
+            # Ignore an inclusion list that has already been processed
             return
 
-        # Store `signed_inclusion_list` and its timeliness.
-        inclusion_list_root = hash_tree_root(inclusion_list)
-        store.inclusion_lists[key][inclusion_list_root] = signed_inclusion_list
-        store.inclusion_list_timeliness[inclusion_list_root] = is_timely
+        # Store the signed inclusion list and its timeliness
+        store.inclusion_lists[key][validator_index] = InclusionListEntry(
+            signed_inclusion_list=signed_inclusion_list,
+            timely=timely,
+        )
     </spec>
 
 - name: process_justification_and_finalization#phase0
@@ -10586,7 +10775,7 @@
     - file: packages/state-transition/src/lightClient/spec/processLightClientUpdate.ts
       search: export function processLightClientUpdate(
   spec: |
-    <spec fn="process_light_client_update" fork="altair" hash="b64a67ff">
+    <spec fn="process_light_client_update" fork="altair" hash="1a1d3ae2">
     def process_light_client_update(
         store: LightClientStore,
         update: LightClientUpdate,
@@ -10604,12 +10793,12 @@
         # Track the maximum number of active participants in the committee signatures
         store.current_max_active_participants = max(
             store.current_max_active_participants,
-            sum(sync_committee_bits),
+            get_set_bit_count(sync_committee_bits),
         )
 
         # Update the optimistic header
         if (
-            sum(sync_committee_bits) > get_safety_threshold(store)
+            get_set_bit_count(sync_committee_bits) > get_safety_threshold(store)
             and update.attested_header.beacon.slot > store.optimistic_header.beacon.slot
         ):
             store.optimistic_header = update.attested_header
@@ -10624,7 +10813,7 @@
                 == compute_sync_committee_period_at_slot(update.attested_header.beacon.slot)
             )
         )
-        if sum(sync_committee_bits) * 3 >= len(sync_committee_bits) * 2 and (
+        if get_set_bit_count(sync_committee_bits) * 3 >= len(sync_committee_bits) * 2 and (
             update.finalized_header.beacon.slot > store.finalized_header.beacon.slot
             or update_has_finalized_next_sync_committee
         ):
@@ -10814,12 +11003,12 @@
     - file: packages/state-transition/src/epoch/processParticipationFlagUpdates.ts
       search: export function processParticipationFlagUpdates(
   spec: |
-    <spec fn="process_participation_flag_updates" fork="altair" hash="92852f31">
+    <spec fn="process_participation_flag_updates" fork="altair" hash="db156e47">
     def process_participation_flag_updates(state: BeaconState) -> None:
         state.previous_epoch_participation = state.current_epoch_participation
-        state.current_epoch_participation = [
+        state.current_epoch_participation = EpochParticipation(
             ParticipationFlags(0b0000_0000) for _ in range(len(state.validators))
-        ]
+        )
     </spec>
 
 - name: process_participation_record_updates#phase0
@@ -10827,11 +11016,11 @@
     - file: packages/state-transition/src/epoch/processParticipationRecordUpdates.ts
       search: export function processParticipationRecordUpdates(
   spec: |
-    <spec fn="process_participation_record_updates" fork="phase0" hash="6a203574">
+    <spec fn="process_participation_record_updates" fork="phase0" hash="b6a8da60">
     def process_participation_record_updates(state: BeaconState) -> None:
         # Rotate current/previous epoch attestations
         state.previous_epoch_attestations = state.current_epoch_attestations
-        state.current_epoch_attestations = []
+        state.current_epoch_attestations = PendingAttestations()
     </spec>
 
 - name: process_payload_attestation#gloas
@@ -10859,7 +11048,7 @@
     - file: packages/state-transition/src/epoch/processPendingConsolidations.ts
       search: export function processPendingConsolidations(
   spec: |
-    <spec fn="process_pending_consolidations" fork="electra" hash="75e32e4b">
+    <spec fn="process_pending_consolidations" fork="electra" hash="f9915ba2">
     def process_pending_consolidations(state: BeaconState) -> None:
         next_epoch = Epoch(get_current_epoch(state) + 1)
         next_pending_consolidation = 0
@@ -10881,7 +11070,9 @@
             increase_balance(state, pending_consolidation.target_index, source_effective_balance)
             next_pending_consolidation += 1
 
-        state.pending_consolidations = state.pending_consolidations[next_pending_consolidation:]
+        state.pending_consolidations = PendingConsolidations(
+            state.pending_consolidations[next_pending_consolidation:]
+        )
     </spec>
 
 - name: process_pending_deposits#electra
@@ -10889,7 +11080,7 @@
     - file: packages/state-transition/src/epoch/processPendingDeposits.ts
       search: export function processPendingDeposits(
   spec: |
-    <spec fn="process_pending_deposits" fork="electra" hash="f0e7c738">
+    <spec fn="process_pending_deposits" fork="electra" hash="799d1035">
     def process_pending_deposits(state: BeaconState) -> None:
         next_epoch = Epoch(get_current_epoch(state) + 1)
         available_for_processing = state.deposit_balance_to_consume + get_activation_exit_churn_limit(
@@ -10948,7 +11139,9 @@
             # Regardless of how the deposit was handled, we move on in the queue.
             next_deposit_index += 1
 
-        state.pending_deposits = state.pending_deposits[next_deposit_index:] + deposits_to_postpone
+        state.pending_deposits = PendingDeposits(
+            state.pending_deposits[next_deposit_index:] + deposits_to_postpone
+        )
 
         # Accumulate churn only if the churn limit has been hit.
         if is_churn_limit_reached:
@@ -10962,7 +11155,7 @@
     - file: packages/state-transition/src/epoch/processPendingDeposits.ts
       search: export function processPendingDeposits(
   spec: |
-    <spec fn="process_pending_deposits" fork="fulu" hash="02e6116b">
+    <spec fn="process_pending_deposits" fork="fulu" hash="40bfbd9f">
     def process_pending_deposits(state: BeaconState) -> None:
         next_epoch = Epoch(get_current_epoch(state) + 1)
         available_for_processing = state.deposit_balance_to_consume + get_activation_exit_churn_limit(
@@ -11011,7 +11204,9 @@
             # Regardless of how the deposit was handled, we move on in the queue.
             next_deposit_index += 1
 
-        state.pending_deposits = state.pending_deposits[next_deposit_index:] + deposits_to_postpone
+        state.pending_deposits = PendingDeposits(
+            state.pending_deposits[next_deposit_index:] + deposits_to_postpone
+        )
 
         # Accumulate churn only if the churn limit has been hit.
         if is_churn_limit_reached:
@@ -11025,7 +11220,7 @@
     - file: packages/state-transition/src/epoch/processPendingDeposits.ts
       search: export function processPendingDeposits(
   spec: |
-    <spec fn="process_pending_deposits" fork="gloas" hash="1218fecc">
+    <spec fn="process_pending_deposits" fork="gloas" hash="3eb388c8">
     def process_pending_deposits(state: BeaconState) -> None:
         next_epoch = Epoch(get_current_epoch(state) + 1)
         # [Modified in Gloas:EIP8061]
@@ -11074,7 +11269,9 @@
             # Regardless of how the deposit was handled, we move on in the queue.
             next_deposit_index += 1
 
-        state.pending_deposits = state.pending_deposits[next_deposit_index:] + deposits_to_postpone
+        state.pending_deposits = PendingDeposits(
+            state.pending_deposits[next_deposit_index:] + deposits_to_postpone
+        )
 
         # Accumulate churn only if the churn limit has been hit.
         if is_churn_limit_reached:
@@ -11538,15 +11735,15 @@
     - file: packages/state-transition/src/block/processSyncCommittee.ts
       search: export function processSyncAggregate(
   spec: |
-    <spec fn="process_sync_aggregate" fork="altair" hash="eb56554b">
+    <spec fn="process_sync_aggregate" fork="altair" hash="d7805726">
     def process_sync_aggregate(state: BeaconState, sync_aggregate: SyncAggregate) -> None:
         # Verify sync committee aggregate signature signing over the previous slot block root
         committee_pubkeys = state.current_sync_committee.pubkeys
         committee_bits = sync_aggregate.sync_committee_bits
-        if sum(committee_bits) == SYNC_COMMITTEE_SIZE:
+        if get_set_bit_count(committee_bits) == SYNC_COMMITTEE_SIZE:
             # All members participated - use precomputed aggregate key
             participant_pubkeys = [state.current_sync_committee.aggregate_pubkey]
-        elif sum(committee_bits) > SYNC_COMMITTEE_SIZE // 2:
+        elif get_set_bit_count(committee_bits) > SYNC_COMMITTEE_SIZE // 2:
             # More than half participated - subtract non-participant keys.
             # First determine nonparticipating members
             non_participant_pubkeys = [
@@ -11964,16 +12161,17 @@
 - name: record_payload_inclusion_list_satisfaction#heze
   sources: []
   spec: |
-    <spec fn="record_payload_inclusion_list_satisfaction" fork="heze" hash="49a9cc89">
+    <spec fn="record_payload_inclusion_list_satisfaction" fork="heze" hash="b3f322e6">
     def record_payload_inclusion_list_satisfaction(
         store: Store,
-        state: BeaconState,
         root: Root,
         payload: ExecutionPayload,
         execution_engine: ExecutionEngine,
     ) -> None:
+        slot = store.blocks[root].slot - Slot(1)
+        dependent_root = get_shuffling_dependent_root(store, root, compute_epoch_at_slot(slot))
         inclusion_list_transactions = get_inclusion_list_transactions(
-            get_inclusion_list_store(), state, Slot(state.slot - 1), only_timely=True
+            get_inclusion_list_store(), slot, dependent_root, only_timely=True
         )
         is_inclusion_list_satisfied = execution_engine.is_inclusion_list_satisfied(
             payload, inclusion_list_transactions
@@ -12376,13 +12574,13 @@
 - name: update_builder_pending_withdrawals#gloas
   sources: []
   spec: |
-    <spec fn="update_builder_pending_withdrawals" fork="gloas" hash="d9882622">
+    <spec fn="update_builder_pending_withdrawals" fork="gloas" hash="4b13c273">
     def update_builder_pending_withdrawals(
         state: BeaconState, processed_builder_withdrawals_count: Uint64
     ) -> None:
-        state.builder_pending_withdrawals = state.builder_pending_withdrawals[
-            processed_builder_withdrawals_count:
-        ]
+        state.builder_pending_withdrawals = BuilderPendingWithdrawals(
+            state.builder_pending_withdrawals[processed_builder_withdrawals_count:]
+        )
     </spec>
 
 - name: update_checkpoints#phase0
@@ -12524,23 +12722,23 @@
 - name: update_payload_expected_withdrawals#gloas
   sources: []
   spec: |
-    <spec fn="update_payload_expected_withdrawals" fork="gloas" hash="55907aeb">
+    <spec fn="update_payload_expected_withdrawals" fork="gloas" hash="8fd37079">
     def update_payload_expected_withdrawals(
         state: BeaconState, withdrawals: Sequence[Withdrawal]
     ) -> None:
-        state.payload_expected_withdrawals = ProgressiveList[Withdrawal](withdrawals)
+        state.payload_expected_withdrawals = Withdrawals(withdrawals)
     </spec>
 
 - name: update_pending_partial_withdrawals#electra
   sources: []
   spec: |
-    <spec fn="update_pending_partial_withdrawals" fork="electra" hash="ab8f3216">
+    <spec fn="update_pending_partial_withdrawals" fork="electra" hash="ef9cb1f2">
     def update_pending_partial_withdrawals(
         state: BeaconState, processed_partial_withdrawals_count: Uint64
     ) -> None:
-        state.pending_partial_withdrawals = state.pending_partial_withdrawals[
-            processed_partial_withdrawals_count:
-        ]
+        state.pending_partial_withdrawals = PendingPartialWithdrawals(
+            state.pending_partial_withdrawals[processed_partial_withdrawals_count:]
+        )
     </spec>
 
 - name: update_proposer_boost_root#phase0
@@ -13115,7 +13313,7 @@
     - file: packages/state-transition/src/slot/upgradeStateToAltair.ts
       search: export function upgradeStateToAltair(
   spec: |
-    <spec fn="upgrade_to_altair" fork="altair" hash="10e7fa01">
+    <spec fn="upgrade_to_altair" fork="altair" hash="2185873e">
     def upgrade_to_altair(pre: phase0.BeaconState) -> BeaconState:
         epoch = phase0.get_current_epoch(pre)
         post = BeaconState(
@@ -13139,17 +13337,17 @@
             balances=pre.balances,
             randao_mixes=pre.randao_mixes,
             slashings=pre.slashings,
-            previous_epoch_participation=[
+            previous_epoch_participation=EpochParticipation([
                 ParticipationFlags(0b0000_0000) for _ in range(len(pre.validators))
-            ],
-            current_epoch_participation=[
+            ]),
+            current_epoch_participation=EpochParticipation([
                 ParticipationFlags(0b0000_0000) for _ in range(len(pre.validators))
-            ],
+            ]),
             justification_bits=pre.justification_bits,
             previous_justified_checkpoint=pre.previous_justified_checkpoint,
             current_justified_checkpoint=pre.current_justified_checkpoint,
             finalized_checkpoint=pre.finalized_checkpoint,
-            inactivity_scores=[Uint64(0) for _ in range(len(pre.validators))],
+            inactivity_scores=InactivityScores([Uint64(0) for _ in range(len(pre.validators))]),
         )
         # Fill in previous epoch participation from the pre state's pending attestations
         translate_participation(post, pre.previous_epoch_attestations)
@@ -13211,7 +13409,7 @@
     - file: packages/state-transition/src/slot/upgradeStateToCapella.ts
       search: export function upgradeStateToCapella(
   spec: |
-    <spec fn="upgrade_to_capella" fork="capella" hash="f1f20b37">
+    <spec fn="upgrade_to_capella" fork="capella" hash="6b3e269a">
     def upgrade_to_capella(pre: bellatrix.BeaconState) -> BeaconState:
         epoch = bellatrix.get_current_epoch(pre)
         latest_execution_payload_header = ExecutionPayloadHeader(
@@ -13268,7 +13466,7 @@
             # [New in Capella]
             next_withdrawal_validator_index=ValidatorIndex(0),
             # [New in Capella]
-            historical_summaries=List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]([]),
+            historical_summaries=HistoricalSummaries(),
         )
 
         return post
@@ -13348,7 +13546,7 @@
     - file: packages/state-transition/src/slot/upgradeStateToElectra.ts
       search: export function upgradeStateToElectra(
   spec: |
-    <spec fn="upgrade_to_electra" fork="electra" hash="cdae19f9">
+    <spec fn="upgrade_to_electra" fork="electra" hash="40c321ed">
     def upgrade_to_electra(pre: deneb.BeaconState) -> BeaconState:
         epoch = deneb.get_current_epoch(pre)
 
@@ -13405,11 +13603,11 @@
             # [New in Electra:EIP7251]
             earliest_consolidation_epoch=compute_activation_exit_epoch(get_current_epoch(pre)),
             # [New in Electra:EIP7251]
-            pending_deposits=[],
+            pending_deposits=PendingDeposits(),
             # [New in Electra:EIP7251]
-            pending_partial_withdrawals=[],
+            pending_partial_withdrawals=PendingPartialWithdrawals(),
             # [New in Electra:EIP7251]
-            pending_consolidations=[],
+            pending_consolidations=PendingConsolidations(),
         )
 
         post.exit_balance_to_consume = get_activation_exit_churn_limit(post)
@@ -13515,7 +13713,7 @@
     - file: packages/state-transition/src/slot/upgradeStateToGloas.ts
       search: export function upgradeStateToGloas(
   spec: |
-    <spec fn="upgrade_to_gloas" fork="gloas" hash="013b8366">
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="ea194305">
     def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         epoch = fulu.get_current_epoch(pre)
 
@@ -13537,25 +13735,21 @@
             eth1_data_votes=pre.eth1_data_votes,
             eth1_deposit_index=pre.eth1_deposit_index,
             # [Modified in Gloas:EIP7688]
-            validators=ProgressiveList[Validator](list(pre.validators)),
+            validators=Validators(list(pre.validators)),
             # [Modified in Gloas:EIP7688]
-            balances=ProgressiveList[Gwei](list(pre.balances)),
+            balances=Balances(list(pre.balances)),
             randao_mixes=pre.randao_mixes,
             slashings=pre.slashings,
             # [Modified in Gloas:EIP7688]
-            previous_epoch_participation=ProgressiveList[ParticipationFlags](
-                list(pre.previous_epoch_participation)
-            ),
+            previous_epoch_participation=EpochParticipation(list(pre.previous_epoch_participation)),
             # [Modified in Gloas:EIP7688]
-            current_epoch_participation=ProgressiveList[ParticipationFlags](
-                list(pre.current_epoch_participation)
-            ),
+            current_epoch_participation=EpochParticipation(list(pre.current_epoch_participation)),
             justification_bits=pre.justification_bits,
             previous_justified_checkpoint=pre.previous_justified_checkpoint,
             current_justified_checkpoint=pre.current_justified_checkpoint,
             finalized_checkpoint=pre.finalized_checkpoint,
             # [Modified in Gloas:EIP7688]
-            inactivity_scores=ProgressiveList[Uint64](list(pre.inactivity_scores)),
+            inactivity_scores=InactivityScores(list(pre.inactivity_scores)),
             current_sync_committee=pre.current_sync_committee,
             next_sync_committee=pre.next_sync_committee,
             # [Modified in Gloas:EIP7732]
@@ -13572,34 +13766,43 @@
             consolidation_balance_to_consume=pre.consolidation_balance_to_consume,
             earliest_consolidation_epoch=pre.earliest_consolidation_epoch,
             # [Modified in Gloas:EIP7688]
-            pending_deposits=ProgressiveList[PendingDeposit](list(pre.pending_deposits)),
+            pending_deposits=PendingDeposits(list(pre.pending_deposits)),
             # [Modified in Gloas:EIP7688]
-            pending_partial_withdrawals=ProgressiveList[PendingPartialWithdrawal](
+            pending_partial_withdrawals=PendingPartialWithdrawals(
                 list(pre.pending_partial_withdrawals)
             ),
             # [Modified in Gloas:EIP7688]
-            pending_consolidations=ProgressiveList[PendingConsolidation](
-                list(pre.pending_consolidations)
-            ),
+            pending_consolidations=PendingConsolidations(list(pre.pending_consolidations)),
             proposer_lookahead=pre.proposer_lookahead,
             # [New in Gloas:EIP7732]
-            builders=[],
+            builders=Builders(),
             # [New in Gloas:EIP7732]
             next_withdrawal_builder_index=BuilderIndex(0),
             # [New in Gloas:EIP7732]
-            execution_payload_availability=[0b1 for _ in range(SLOTS_PER_HISTORICAL_ROOT)],
+            execution_payload_availability=ExecutionPayloadAvailability([
+                0b1 for _ in range(SLOTS_PER_HISTORICAL_ROOT)
+            ]),
             # [New in Gloas:EIP7732]
-            builder_pending_payments=[BuilderPendingPayment() for _ in range(2 * SLOTS_PER_EPOCH)],
+            builder_pending_payments=BuilderPendingPayments(),
             # [New in Gloas:EIP7732]
-            builder_pending_withdrawals=[],
+            builder_pending_withdrawals=BuilderPendingWithdrawals(),
             # [New in Gloas:EIP7732]
             latest_execution_payload_bid=ExecutionPayloadBid(
+                parent_block_hash=pre.latest_execution_payload_header.parent_hash,
+                parent_block_root=pre.latest_block_header.parent_root,
                 block_hash=pre.latest_execution_payload_header.block_hash,
+                prev_randao=pre.latest_execution_payload_header.prev_randao,
+                fee_recipient=ExecutionAddress(),
                 gas_limit=pre.latest_execution_payload_header.gas_limit,
+                builder_index=BUILDER_INDEX_SELF_BUILD,
+                slot=pre.latest_block_header.slot,
+                value=Gwei(0),
+                execution_payment=Gwei(0),
+                blob_kzg_commitments=BlobKZGCommitments(),
                 execution_requests_root=hash_tree_root(ExecutionRequests()),
             ),
             # [New in Gloas:EIP7732]
-            payload_expected_withdrawals=[],
+            payload_expected_withdrawals=Withdrawals(),
             # [New in Gloas:EIP7732]
             ptc_window=initialize_ptc_window(pre),
         )
@@ -13615,7 +13818,7 @@
     - file: packages/state-transition/src/slot/upgradeStateToHeze.ts
       search: export function upgradeStateToHeze(
   spec: |
-    <spec fn="upgrade_to_heze" fork="heze" hash="db6fc133">
+    <spec fn="upgrade_to_heze" fork="heze" hash="0a9fa4ec">
     def upgrade_to_heze(pre: gloas.BeaconState) -> BeaconState:
         epoch = gloas.get_current_epoch(pre)
         latest_execution_payload_bid = ExecutionPayloadBid(
@@ -13632,7 +13835,7 @@
             blob_kzg_commitments=pre.latest_execution_payload_bid.blob_kzg_commitments,
             execution_requests_root=pre.latest_execution_payload_bid.execution_requests_root,
             # [New in Heze:EIP7805]
-            inclusion_list_bits=BitVector[INCLUSION_LIST_COMMITTEE_SIZE](),
+            inclusion_list_bits=InclusionListBits(),
         )
 
         post = BeaconState(
@@ -13696,7 +13899,7 @@
 - name: validate_beacon_aggregate_and_proof_gossip#deneb
   sources: []
   spec: |
-    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="deneb" hash="4a576fc4">
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="deneb" hash="ccbed6f7">
     def validate_beacon_aggregate_and_proof_gossip(
         seen: Seen,
         store: Store,
@@ -13721,13 +13924,13 @@
         # [New in Deneb:EIP7045]
         # [IGNORE] The aggregate attestation's slot is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, aggregate.data.slot, current_time_ms):
+        if is_future_slot(store, aggregate.data.slot, current_time_ms):
             raise GossipIgnore("aggregate slot is from a future slot")
 
         # [Modified in Deneb:EIP7045]
         # [IGNORE] The aggregate attestation's epoch is either the current or previous epoch
         attestation_epoch = compute_epoch_at_slot(aggregate.data.slot)
-        if not is_current_or_previous_epoch(state, attestation_epoch, current_time_ms):
+        if not is_current_or_previous_epoch(store, attestation_epoch, current_time_ms):
             raise GossipIgnore("aggregate epoch is not current or previous epoch")
 
         # [REJECT] The aggregate attestation's epoch matches its target
@@ -13751,11 +13954,12 @@
         if is_non_strict_superset(seen_bits, aggregate_bits):
             raise GossipIgnore("already seen aggregate for this data")
 
-        # [IGNORE] This is the first valid aggregate for this aggregator in this epoch
+        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
         aggregator_index = aggregate_and_proof.aggregator_index
         target_epoch = aggregate.data.target.epoch
-        if (aggregator_index, target_epoch) in seen.aggregator_epochs:
-            raise GossipIgnore("already seen aggregate from this aggregator for this epoch")
+        aggregator_epoch_key = (target_epoch, aggregator_index)
+        if aggregator_epoch_key in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
 
         # [REJECT] The selection proof selects the validator as an aggregator
         if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
@@ -13784,29 +13988,27 @@
 
         # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
         # (MAY be queued until block is retrieved)
-        if aggregate.data.beacon_block_root not in store.blocks:
+        block_root = aggregate.data.beacon_block_root
+        if block_root not in store.blocks:
             raise GossipIgnore("block being voted for has not been seen")
 
         # [REJECT] The block being voted for passes validation
-        if aggregate.data.beacon_block_root not in store.block_states:
+        if block_root not in store.block_states:
             raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The target block is an ancestor of the LMD vote block
-        checkpoint_block = get_checkpoint_block(
-            store, aggregate.data.beacon_block_root, aggregate.data.target.epoch
-        )
+        checkpoint_block = get_checkpoint_block(store, block_root, aggregate.data.target.epoch)
         if checkpoint_block != aggregate.data.target.root:
             raise GossipReject("target block is not an ancestor of LMD vote block")
 
         # [IGNORE] The finalized checkpoint is an ancestor of the block
-        finalized_checkpoint_block = get_checkpoint_block(
-            store, aggregate.data.beacon_block_root, store.finalized_checkpoint.epoch
-        )
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
         if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipIgnore("finalized checkpoint is not an ancestor of block")
 
         # Mark this aggregate as seen
-        seen.aggregator_epochs.add((aggregator_index, target_epoch))
+        seen.aggregator_epochs.add(aggregator_epoch_key)
         if aggregate_data_root not in seen.aggregate_data_roots:
             seen.aggregate_data_roots[aggregate_data_root] = set()
         seen.aggregate_data_roots[aggregate_data_root].add(aggregate_bits)
@@ -13815,7 +14017,7 @@
 - name: validate_beacon_aggregate_and_proof_gossip#electra
   sources: []
   spec: |
-    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="electra" hash="573a95ef">
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="electra" hash="c5e48059">
     def validate_beacon_aggregate_and_proof_gossip(
         seen: Seen,
         store: Store,
@@ -13850,12 +14052,12 @@
 
         # [IGNORE] The aggregate attestation's slot is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, aggregate.data.slot, current_time_ms):
+        if is_future_slot(store, aggregate.data.slot, current_time_ms):
             raise GossipIgnore("aggregate slot is from a future slot")
 
         # [IGNORE] The aggregate attestation's epoch is either the current or previous epoch
         attestation_epoch = compute_epoch_at_slot(aggregate.data.slot)
-        if not is_current_or_previous_epoch(state, attestation_epoch, current_time_ms):
+        if not is_current_or_previous_epoch(store, attestation_epoch, current_time_ms):
             raise GossipIgnore("aggregate epoch is not current or previous epoch")
 
         # [REJECT] The aggregate attestation's epoch matches its target
@@ -13881,11 +14083,12 @@
         if is_non_strict_superset(seen_bits, aggregate_bits):
             raise GossipIgnore("already seen aggregate for this data")
 
-        # [IGNORE] This is the first valid aggregate for this aggregator in this epoch
+        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
         aggregator_index = aggregate_and_proof.aggregator_index
         target_epoch = aggregate.data.target.epoch
-        if (aggregator_index, target_epoch) in seen.aggregator_epochs:
-            raise GossipIgnore("already seen aggregate from this aggregator for this epoch")
+        aggregator_epoch_key = (target_epoch, aggregator_index)
+        if aggregator_epoch_key in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
 
         # [REJECT] The selection proof selects the validator as an aggregator
         if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
@@ -13914,29 +14117,162 @@
 
         # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
         # (MAY be queued until block is retrieved)
-        if aggregate.data.beacon_block_root not in store.blocks:
+        block_root = aggregate.data.beacon_block_root
+        if block_root not in store.blocks:
             raise GossipIgnore("block being voted for has not been seen")
 
         # [REJECT] The block being voted for passes validation
-        if aggregate.data.beacon_block_root not in store.block_states:
+        if block_root not in store.block_states:
             raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The target block is an ancestor of the LMD vote block
-        checkpoint_block = get_checkpoint_block(
-            store, aggregate.data.beacon_block_root, aggregate.data.target.epoch
-        )
+        checkpoint_block = get_checkpoint_block(store, block_root, aggregate.data.target.epoch)
         if checkpoint_block != aggregate.data.target.root:
             raise GossipReject("target block is not an ancestor of LMD vote block")
 
         # [IGNORE] The finalized checkpoint is an ancestor of the block
-        finalized_checkpoint_block = get_checkpoint_block(
-            store, aggregate.data.beacon_block_root, store.finalized_checkpoint.epoch
-        )
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
         if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipIgnore("finalized checkpoint is not an ancestor of block")
 
         # Mark this aggregate as seen
-        seen.aggregator_epochs.add((aggregator_index, target_epoch))
+        seen.aggregator_epochs.add(aggregator_epoch_key)
+        if aggregate_cache_key not in seen.aggregate_data_roots:
+            seen.aggregate_data_roots[aggregate_cache_key] = set()
+        seen.aggregate_data_roots[aggregate_cache_key].add(aggregate_bits)
+    </spec>
+
+- name: validate_beacon_aggregate_and_proof_gossip#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+      search: "export async function validateGossipAggregateAndProof("
+  spec: |
+    <spec fn="validate_beacon_aggregate_and_proof_gossip" fork="gloas" hash="0b575b98">
+    def validate_beacon_aggregate_and_proof_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        signed_aggregate_and_proof: SignedAggregateAndProof,
+        current_time_ms: Uint64,
+        # [New in Gloas:EIP7732]
+        block_payload_statuses: Dict[Root, PayloadValidationStatus],
+    ) -> None:
+        """
+        Validate a SignedAggregateAndProof for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        aggregate_and_proof = signed_aggregate_and_proof.message
+        aggregate = aggregate_and_proof.aggregate
+        aggregation_bits = aggregate.aggregation_bits
+
+        # [New in Gloas:EIP7732]
+        # [REJECT] The aggregate attestation's data index is 0 or 1
+        if aggregate.data.index > 1:
+            raise GossipReject("aggregate data index must be 0 or 1")
+
+        # [REJECT] Exactly one committee is specified by the committee bits
+        committee_indices = get_committee_indices(aggregate.committee_bits)
+        if len(committee_indices) != 1:
+            raise GossipReject("aggregate committee bits must specify exactly one committee")
+        index = committee_indices[0]
+
+        # [REJECT] The committee index is within the expected range
+        committee_count = get_committee_count_per_slot(state, aggregate.data.target.epoch)
+        if index >= committee_count:
+            raise GossipReject("committee index out of range")
+
+        # [IGNORE] The aggregate attestation's slot is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if is_future_slot(store, aggregate.data.slot, current_time_ms):
+            raise GossipIgnore("aggregate slot is from a future slot")
+
+        # [IGNORE] The aggregate attestation's epoch is either the current or previous epoch
+        attestation_epoch = compute_epoch_at_slot(aggregate.data.slot)
+        if not is_current_or_previous_epoch(store, attestation_epoch, current_time_ms):
+            raise GossipIgnore("aggregate epoch is not current or previous epoch")
+
+        # [REJECT] The aggregate attestation's epoch matches its target
+        if aggregate.data.target.epoch != compute_epoch_at_slot(aggregate.data.slot):
+            raise GossipReject("attestation epoch does not match target epoch")
+
+        # [REJECT] The number of aggregation bits matches the committee size
+        committee = get_beacon_committee(state, aggregate.data.slot, index)
+        if len(aggregation_bits) != len(committee):
+            raise GossipReject("aggregation bits length does not match committee size")
+
+        # [REJECT] The aggregate attestation has participants
+        attesting_indices = get_attesting_indices(state, aggregate)
+        if len(attesting_indices) < 1:
+            raise GossipReject("aggregate has no participants")
+
+        # [IGNORE] A valid aggregate with a superset of aggregation bits has not already been seen
+        aggregate_data_root = hash_tree_root(aggregate.data)
+        aggregate_cache_key = (aggregate_data_root, index)
+        aggregate_bits = tuple(bool(bit) for bit in aggregation_bits)
+        seen_bits = seen.aggregate_data_roots.get(aggregate_cache_key, set())
+        if is_non_strict_superset(seen_bits, aggregate_bits):
+            raise GossipIgnore("already seen aggregate for this data")
+
+        # [IGNORE] This is the first valid aggregate for this epoch and aggregator
+        aggregator_index = aggregate_and_proof.aggregator_index
+        target_epoch = aggregate.data.target.epoch
+        aggregator_epoch_key = (target_epoch, aggregator_index)
+        if aggregator_epoch_key in seen.aggregator_epochs:
+            raise GossipIgnore("already seen aggregate for this epoch and aggregator")
+
+        # [REJECT] The selection proof selects the validator as an aggregator
+        if not is_aggregator(state, aggregate.data.slot, index, aggregate_and_proof.selection_proof):
+            raise GossipReject("validator is not selected as aggregator")
+
+        # [REJECT] The aggregator's validator index is within the committee
+        if aggregator_index not in committee:
+            raise GossipReject("aggregator index not in committee")
+
+        # [REJECT] The selection proof signature is valid
+        aggregator = state.validators[aggregator_index]
+        domain = get_domain(state, DOMAIN_SELECTION_PROOF, target_epoch)
+        signing_root = compute_signing_root(aggregate.data.slot, domain)
+        if not bls.Verify(aggregator.pubkey, signing_root, aggregate_and_proof.selection_proof):
+            raise GossipReject("invalid selection proof signature")
+
+        # [REJECT] The aggregator signature is valid
+        domain = get_domain(state, DOMAIN_AGGREGATE_AND_PROOF, target_epoch)
+        signing_root = compute_signing_root(aggregate_and_proof, domain)
+        if not bls.Verify(aggregator.pubkey, signing_root, signed_aggregate_and_proof.signature):
+            raise GossipReject("invalid aggregator signature")
+
+        # [REJECT] The aggregate signature is valid
+        if not is_valid_indexed_attestation(state, get_indexed_attestation(state, aggregate)):
+            raise GossipReject("invalid aggregate signature")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        block_root = aggregate.data.beacon_block_root
+        if block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        # [REJECT] The target block is an ancestor of the LMD vote block
+        checkpoint_block = get_checkpoint_block(store, block_root, aggregate.data.target.epoch)
+        if checkpoint_block != aggregate.data.target.root:
+            raise GossipReject("target block is not an ancestor of LMD vote block")
+
+        # [IGNORE] The finalized checkpoint is an ancestor of the block
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipIgnore("finalized checkpoint is not an ancestor of block")
+
+        # [New in Gloas:EIP7732]
+        # The attested payload status is consistent with the block's execution payload
+        verify_attestation_payload_status(store, aggregate.data, block_payload_statuses)
+
+        # Mark this aggregate as seen
+        seen.aggregator_epochs.add(aggregator_epoch_key)
         if aggregate_cache_key not in seen.aggregate_data_roots:
             seen.aggregate_data_roots[aggregate_cache_key] = set()
         seen.aggregate_data_roots[aggregate_cache_key].add(aggregate_bits)
@@ -13945,7 +14281,7 @@
 - name: validate_beacon_attestation_gossip#deneb
   sources: []
   spec: |
-    <spec fn="validate_beacon_attestation_gossip" fork="deneb" hash="e75305a8">
+    <spec fn="validate_beacon_attestation_gossip" fork="deneb" hash="66ded0a9">
     def validate_beacon_attestation_gossip(
         seen: Seen,
         store: Store,
@@ -13978,13 +14314,13 @@
         # [Modified in Deneb:EIP7045]
         # [IGNORE] The attestation's slot is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, data.slot, current_time_ms):
+        if is_future_slot(store, data.slot, current_time_ms):
             raise GossipIgnore("attestation slot is from a future slot")
 
         # [Modified in Deneb:EIP7045]
         # [IGNORE] The attestation's epoch is either the current or previous epoch
         attestation_epoch = compute_epoch_at_slot(data.slot)
-        if not is_current_or_previous_epoch(state, attestation_epoch, current_time_ms):
+        if not is_current_or_previous_epoch(store, attestation_epoch, current_time_ms):
             raise GossipIgnore("attestation epoch is not current or previous epoch")
 
         # [REJECT] The attestation's epoch matches its target
@@ -13992,7 +14328,7 @@
             raise GossipReject("attestation epoch does not match target epoch")
 
         # [REJECT] The attestation is unaggregated (exactly one bit set)
-        num_bits_set = sum(1 for bit in aggregation_bits if bit)
+        num_bits_set = get_set_bit_count(aggregation_bits)
         if num_bits_set != 1:
             raise GossipReject("attestation is not unaggregated")
 
@@ -14001,10 +14337,11 @@
         if len(aggregation_bits) != len(committee):
             raise GossipReject("aggregation bits length does not match committee size")
 
-        # [IGNORE] No other valid attestation seen for this validator and target epoch
+        # [IGNORE] No other valid attestation seen for this target epoch and validator
         participant_index = committee[aggregation_bits.index(True)]
-        if (participant_index, target_epoch) in seen.attestation_validator_epochs:
-            raise GossipIgnore("already seen attestation from this validator for this epoch")
+        attestation_epoch_key = (target_epoch, participant_index)
+        if attestation_epoch_key in seen.attestation_validator_epochs:
+            raise GossipIgnore("already seen attestation for this epoch and validator")
 
         # [REJECT] The attestation signature is valid
         indexed_attestation = get_indexed_attestation(state, attestation)
@@ -14013,34 +14350,33 @@
 
         # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
         # (MAY be queued until block is retrieved)
-        beacon_block_root = data.beacon_block_root
-        if beacon_block_root not in store.blocks:
+        block_root = data.beacon_block_root
+        if block_root not in store.blocks:
             raise GossipIgnore("block being voted for has not been seen")
 
         # [REJECT] The block being voted for passes validation
-        if beacon_block_root not in store.block_states:
+        if block_root not in store.block_states:
             raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The attestation's target block is an ancestor of the LMD vote block
-        target_checkpoint_block = get_checkpoint_block(store, beacon_block_root, target_epoch)
+        target_checkpoint_block = get_checkpoint_block(store, block_root, target_epoch)
         if target_checkpoint_block != data.target.root:
             raise GossipReject("target block is not an ancestor of LMD vote block")
 
         # [IGNORE] The current finalized_checkpoint is an ancestor of the block
-        finalized_checkpoint_block = get_checkpoint_block(
-            store, beacon_block_root, store.finalized_checkpoint.epoch
-        )
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
         if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipIgnore("finalized checkpoint is not an ancestor of block")
 
         # Mark this attestation as seen
-        seen.attestation_validator_epochs.add((participant_index, target_epoch))
+        seen.attestation_validator_epochs.add(attestation_epoch_key)
     </spec>
 
 - name: validate_beacon_attestation_gossip#electra
   sources: []
   spec: |
-    <spec fn="validate_beacon_attestation_gossip" fork="electra" hash="3b002df3">
+    <spec fn="validate_beacon_attestation_gossip" fork="electra" hash="0a76c78b">
     def validate_beacon_attestation_gossip(
         seen: Seen,
         store: Store,
@@ -14079,12 +14415,12 @@
 
         # [IGNORE] The attestation's slot is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, data.slot, current_time_ms):
+        if is_future_slot(store, data.slot, current_time_ms):
             raise GossipIgnore("attestation slot is from a future slot")
 
         # [IGNORE] The attestation's epoch is either the current or previous epoch
         attestation_epoch = compute_epoch_at_slot(data.slot)
-        if not is_current_or_previous_epoch(state, attestation_epoch, current_time_ms):
+        if not is_current_or_previous_epoch(store, attestation_epoch, current_time_ms):
             raise GossipIgnore("attestation epoch is not current or previous epoch")
 
         # [REJECT] The attestation's epoch matches its target
@@ -14098,9 +14434,10 @@
             raise GossipReject("attester is not a member of the committee")
 
         # [Modified in Electra:EIP7549]
-        # [IGNORE] No other valid attestation seen for this validator and target epoch
-        if (attester_index, target_epoch) in seen.attestation_validator_epochs:
-            raise GossipIgnore("already seen attestation from this validator for this epoch")
+        # [IGNORE] No other valid attestation seen for this target epoch and validator
+        attestation_epoch_key = (target_epoch, attester_index)
+        if attestation_epoch_key in seen.attestation_validator_epochs:
+            raise GossipIgnore("already seen attestation for this epoch and validator")
 
         # [Modified in Electra:EIP7549]
         # [REJECT] The attestation signature is valid
@@ -14112,34 +14449,135 @@
 
         # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
         # (MAY be queued until block is retrieved)
-        beacon_block_root = data.beacon_block_root
-        if beacon_block_root not in store.blocks:
+        block_root = data.beacon_block_root
+        if block_root not in store.blocks:
             raise GossipIgnore("block being voted for has not been seen")
 
         # [REJECT] The block being voted for passes validation
-        if beacon_block_root not in store.block_states:
+        if block_root not in store.block_states:
             raise GossipReject("block being voted for failed validation")
 
         # [REJECT] The attestation's target block is an ancestor of the LMD vote block
-        target_checkpoint_block = get_checkpoint_block(store, beacon_block_root, target_epoch)
+        target_checkpoint_block = get_checkpoint_block(store, block_root, target_epoch)
         if target_checkpoint_block != data.target.root:
             raise GossipReject("target block is not an ancestor of LMD vote block")
 
         # [IGNORE] The current finalized_checkpoint is an ancestor of the block
-        finalized_checkpoint_block = get_checkpoint_block(
-            store, beacon_block_root, store.finalized_checkpoint.epoch
-        )
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
         if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipIgnore("finalized checkpoint is not an ancestor of block")
 
         # Mark this attestation as seen
-        seen.attestation_validator_epochs.add((attester_index, target_epoch))
+        seen.attestation_validator_epochs.add(attestation_epoch_key)
+    </spec>
+
+- name: validate_beacon_attestation_gossip#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/attestation.ts
+      search: "export async function validateGossipAttestationsSameAttData("
+  spec: |
+    <spec fn="validate_beacon_attestation_gossip" fork="gloas" hash="c2dabf99">
+    def validate_beacon_attestation_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        attestation: SingleAttestation,
+        current_time_ms: Uint64,
+        subnet_id: SubnetID,
+        # [New in Gloas:EIP7732]
+        block_payload_statuses: Dict[Root, PayloadValidationStatus],
+    ) -> None:
+        """
+        Validate a SingleAttestation for gossip propagation on a subnet.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        data = attestation.data
+        committee_index = attestation.committee_index
+        attester_index = attestation.attester_index
+        target_epoch = data.target.epoch
+
+        # [New in Gloas:EIP7732]
+        # [REJECT] The attestation's data index is 0 or 1
+        if data.index > 1:
+            raise GossipReject("attestation data index must be 0 or 1")
+
+        # [REJECT] The committee index is within the expected range
+        committees_per_slot = get_committee_count_per_slot(state, target_epoch)
+        if committee_index >= committees_per_slot:
+            raise GossipReject("committee index out of range")
+
+        # [REJECT] The attestation is for the correct subnet
+        expected_subnet = compute_subnet_for_attestation(
+            committees_per_slot, data.slot, committee_index
+        )
+        if expected_subnet != subnet_id:
+            raise GossipReject("attestation is for wrong subnet")
+
+        # [IGNORE] The attestation's slot is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if is_future_slot(store, data.slot, current_time_ms):
+            raise GossipIgnore("attestation slot is from a future slot")
+
+        # [IGNORE] The attestation's epoch is either the current or previous epoch
+        attestation_epoch = compute_epoch_at_slot(data.slot)
+        if not is_current_or_previous_epoch(store, attestation_epoch, current_time_ms):
+            raise GossipIgnore("attestation epoch is not current or previous epoch")
+
+        # [REJECT] The attestation's epoch matches its target
+        if target_epoch != compute_epoch_at_slot(data.slot):
+            raise GossipReject("attestation epoch does not match target epoch")
+
+        # [REJECT] The attester is a member of the committee
+        committee = get_beacon_committee(state, data.slot, committee_index)
+        if attester_index not in committee:
+            raise GossipReject("attester is not a member of the committee")
+
+        # [IGNORE] No other valid attestation seen for this target epoch and validator
+        attestation_epoch_key = (target_epoch, attester_index)
+        if attestation_epoch_key in seen.attestation_validator_epochs:
+            raise GossipIgnore("already seen attestation for this epoch and validator")
+
+        # [REJECT] The attestation signature is valid
+        attester = state.validators[attester_index]
+        domain = get_domain(state, DOMAIN_BEACON_ATTESTER, target_epoch)
+        signing_root = compute_signing_root(data, domain)
+        if not bls.Verify(attester.pubkey, signing_root, attestation.signature):
+            raise GossipReject("invalid attestation signature")
+
+        # [IGNORE] The block being voted for has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        block_root = data.beacon_block_root
+        if block_root not in store.blocks:
+            raise GossipIgnore("block being voted for has not been seen")
+
+        # [REJECT] The block being voted for passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("block being voted for failed validation")
+
+        # [REJECT] The attestation's target block is an ancestor of the LMD vote block
+        target_checkpoint_block = get_checkpoint_block(store, block_root, target_epoch)
+        if target_checkpoint_block != data.target.root:
+            raise GossipReject("target block is not an ancestor of LMD vote block")
+
+        # [IGNORE] The current finalized checkpoint is an ancestor of the block
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipIgnore("finalized checkpoint is not an ancestor of block")
+
+        # [New in Gloas:EIP7732]
+        # The attested payload status is consistent with the block's execution payload
+        verify_attestation_payload_status(store, data, block_payload_statuses)
+
+        # Mark this attestation as seen
+        seen.attestation_validator_epochs.add(attestation_epoch_key)
     </spec>
 
 - name: validate_beacon_block_gossip#bellatrix
   sources: []
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="bellatrix" hash="31da1c6c">
+    <spec fn="validate_beacon_block_gossip" fork="bellatrix" hash="c8435637">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
@@ -14158,7 +14596,7 @@
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+        if is_future_slot(store, block.slot, current_time_ms):
             raise GossipIgnore("block is from a future slot")
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
@@ -14168,9 +14606,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
-        if (block.proposer_index, block.slot) in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -14220,10 +14659,9 @@
             raise GossipReject("block is not from a higher slot than its parent")
 
         # [REJECT] The current finalized checkpoint is an ancestor of the block
-        checkpoint_block = get_checkpoint_block(
-            store, block.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of block")
 
         # [REJECT] The block is proposed by the expected proposer for the slot
@@ -14235,13 +14673,13 @@
             raise GossipReject("block proposer_index does not match expected proposer")
 
         # Mark this block as seen
-        seen.proposer_slots.add((block.proposer_index, block.slot))
+        seen.proposer_slots.add(proposer_slot_key)
     </spec>
 
 - name: validate_beacon_block_gossip#capella
   sources: []
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="capella" hash="9d2a397e">
+    <spec fn="validate_beacon_block_gossip" fork="capella" hash="9cf72386">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
@@ -14259,7 +14697,7 @@
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+        if is_future_slot(store, block.slot, current_time_ms):
             raise GossipIgnore("block is from a future slot")
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
@@ -14269,9 +14707,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
-        if (block.proposer_index, block.slot) in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -14314,10 +14753,9 @@
             raise GossipReject("block is not from a higher slot than its parent")
 
         # [REJECT] The current finalized checkpoint is an ancestor of the block
-        checkpoint_block = get_checkpoint_block(
-            store, block.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of block")
 
         # [REJECT] The block is proposed by the expected proposer for the slot
@@ -14329,13 +14767,13 @@
             raise GossipReject("block proposer_index does not match expected proposer")
 
         # Mark this block as seen
-        seen.proposer_slots.add((block.proposer_index, block.slot))
+        seen.proposer_slots.add(proposer_slot_key)
     </spec>
 
 - name: validate_beacon_block_gossip#deneb
   sources: []
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="deneb" hash="85275293">
+    <spec fn="validate_beacon_block_gossip" fork="deneb" hash="f6c1c88d">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
@@ -14353,7 +14791,7 @@
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+        if is_future_slot(store, block.slot, current_time_ms):
             raise GossipIgnore("block is from a future slot")
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
@@ -14363,9 +14801,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
-        if (block.proposer_index, block.slot) in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -14408,10 +14847,9 @@
             raise GossipReject("block is not from a higher slot than its parent")
 
         # [REJECT] The current finalized checkpoint is an ancestor of the block
-        checkpoint_block = get_checkpoint_block(
-            store, block.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of block")
 
         # [New in Deneb:EIP4844]
@@ -14428,13 +14866,13 @@
             raise GossipReject("block proposer_index does not match expected proposer")
 
         # Mark this block as seen
-        seen.proposer_slots.add((block.proposer_index, block.slot))
+        seen.proposer_slots.add(proposer_slot_key)
     </spec>
 
 - name: validate_beacon_block_gossip#electra
   sources: []
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="electra" hash="b5e31e17">
+    <spec fn="validate_beacon_block_gossip" fork="electra" hash="357bca11">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
@@ -14452,7 +14890,7 @@
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+        if is_future_slot(store, block.slot, current_time_ms):
             raise GossipIgnore("block is from a future slot")
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
@@ -14462,9 +14900,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
-        if (block.proposer_index, block.slot) in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -14507,10 +14946,9 @@
             raise GossipReject("block is not from a higher slot than its parent")
 
         # [REJECT] The current finalized checkpoint is an ancestor of the block
-        checkpoint_block = get_checkpoint_block(
-            store, block.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of block")
 
         # [Modified in Electra:EIP7691]
@@ -14527,33 +14965,31 @@
             raise GossipReject("block proposer_index does not match expected proposer")
 
         # Mark this block as seen
-        seen.proposer_slots.add((block.proposer_index, block.slot))
+        seen.proposer_slots.add(proposer_slot_key)
     </spec>
 
 - name: validate_beacon_block_gossip#fulu
   sources: []
   spec: |
-    <spec fn="validate_beacon_block_gossip" fork="fulu" hash="aeb637f6">
+    <spec fn="validate_beacon_block_gossip" fork="fulu" hash="84ab834d">
     def validate_beacon_block_gossip(
         seen: Seen,
         store: Store,
         state: BeaconState,
         signed_beacon_block: SignedBeaconBlock,
         current_time_ms: Uint64,
-        block_payload_statuses: Optional[Dict[Root, PayloadValidationStatus]] = None,
+        block_payload_statuses: Dict[Root, PayloadValidationStatus],
     ) -> None:
         """
         Validate a SignedBeaconBlock for gossip propagation.
         Raises GossipIgnore or GossipReject on validation failure.
         """
-        if block_payload_statuses is None:
-            block_payload_statuses = {}
         block = signed_beacon_block.message
         execution_payload = block.body.execution_payload
 
         # [IGNORE] The block is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block.slot, current_time_ms):
+        if is_future_slot(store, block.slot, current_time_ms):
             raise GossipIgnore("block is from a future slot")
 
         # [IGNORE] The block is from a slot greater than the latest finalized slot
@@ -14563,9 +14999,10 @@
         if block.slot <= finalized_slot:
             raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
 
-        # [IGNORE] The block is the first block with valid signature received for the proposer for the slot
-        if (block.proposer_index, block.slot) in seen.proposer_slots:
-            raise GossipIgnore("block is not the first valid block for this proposer and slot")
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
 
         # [REJECT] The proposer index is a valid validator index
         if block.proposer_index >= len(state.validators):
@@ -14608,10 +15045,9 @@
             raise GossipReject("block is not from a higher slot than its parent")
 
         # [REJECT] The current finalized checkpoint is an ancestor of the block
-        checkpoint_block = get_checkpoint_block(
-            store, block.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of block")
 
         # [Modified in Fulu:EIP7892]
@@ -14629,13 +15065,125 @@
             raise GossipReject("block proposer_index does not match expected proposer")
 
         # Mark this block as seen
-        seen.proposer_slots.add((block.proposer_index, block.slot))
+        seen.proposer_slots.add(proposer_slot_key)
+    </spec>
+
+- name: validate_beacon_block_gossip#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/block.ts
+      search: "export async function validateGossipBlock("
+  spec: |
+    <spec fn="validate_beacon_block_gossip" fork="gloas" hash="2404fa82">
+    def validate_beacon_block_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        signed_beacon_block: SignedBeaconBlock,
+        current_time_ms: Uint64,
+        # [Modified in Gloas:EIP7732]
+        # Removed `block_payload_statuses`
+    ) -> None:
+        """
+        Validate a SignedBeaconBlock for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        block = signed_beacon_block.message
+        bid = block.body.signed_execution_payload_bid.message
+
+        # [IGNORE] The block is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if is_future_slot(store, block.slot, current_time_ms):
+            raise GossipIgnore("block is from a future slot")
+
+        # [IGNORE] The block is from a slot greater than the latest finalized slot
+        # (MAY choose to validate and store such blocks for additional purposes
+        # -- e.g. slashing detection, archive nodes, etc)
+        finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+        if block.slot <= finalized_slot:
+            raise GossipIgnore("block is not from a slot greater than the latest finalized slot")
+
+        # [IGNORE] The block is the first block with valid signature received for the slot and proposer
+        proposer_slot_key = (block.slot, block.proposer_index)
+        if proposer_slot_key in seen.proposer_slots:
+            raise GossipIgnore("block is not the first valid block for this slot and proposer")
+
+        # [New in Gloas:EIP7688]
+        # [REJECT] The block body operation counts are within their limits
+        verify_block_body_operation_limits(block.body)
+
+        # [New in Gloas:EIP7688]
+        # [REJECT] The parent execution request counts are within their limits
+        verify_execution_requests_limits(block.body.parent_execution_requests)
+
+        # [REJECT] The proposer index is a valid validator index
+        if block.proposer_index >= len(state.validators):
+            raise GossipReject("proposer index out of range")
+
+        # [REJECT] The proposer signature is valid
+        proposer = state.validators[block.proposer_index]
+        domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
+        signing_root = compute_signing_root(block, domain)
+        if not bls.Verify(proposer.pubkey, signing_root, signed_beacon_block.signature):
+            raise GossipReject("invalid proposer signature")
+
+        # [IGNORE] The block's parent has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until parent is retrieved)
+        if block.parent_root not in store.blocks:
+            raise GossipIgnore("block's parent has not been seen")
+
+        # [New in Gloas:EIP7732]
+        # [IGNORE] If the parent block is full, the parent payload is valid
+        # (MAY be queued until the parent payload is verified)
+        if is_parent_node_full(store, block):
+            if not is_payload_verified(store, block.parent_root):
+                raise GossipIgnore("parent payload is not verified")
+
+        # [REJECT] The block is from a higher slot than its parent
+        if block.slot <= store.blocks[block.parent_root].slot:
+            raise GossipReject("block is not from a higher slot than its parent")
+
+        # [REJECT] The current finalized checkpoint is an ancestor of the block
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, block.parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
+            raise GossipReject("finalized checkpoint is not an ancestor of block")
+
+        # [Modified in Gloas:EIP7732]
+        # [REJECT] The bid's blob KZG commitment count is within the per-epoch limit
+        max_blobs = get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
+        if len(bid.blob_kzg_commitments) > max_blobs:
+            raise GossipReject("too many blob kzg commitments")
+
+        # [Modified in Gloas:EIP7732]
+        # [REJECT] The bid's parent equals the block's parent
+        if bid.parent_block_root != block.parent_root:
+            raise GossipReject("bid's parent does not equal block's parent")
+
+        # [REJECT] The block's parent passes validation
+        if block.parent_root not in store.block_states:
+            raise GossipReject("block's parent is invalid")
+
+        # [REJECT] The block is proposed by the expected proposer for the slot
+        parent_state = store.block_states[block.parent_root].copy()
+        process_slots(parent_state, block.slot)
+        expected_proposer = get_beacon_proposer_index(parent_state)
+        if block.proposer_index != expected_proposer:
+            raise GossipReject("block proposer_index does not match expected proposer")
+
+        # [New in Gloas:EIP7732]
+        # [REJECT] If the parent is not full, the bid builds on the parent's execution head
+        if not is_parent_node_full(store, block):
+            if bid.parent_block_hash != parent_state.latest_block_hash:
+                raise GossipReject("bid does not build on the parent's execution head")
+
+        # Mark this block as seen
+        seen.proposer_slots.add(proposer_slot_key)
     </spec>
 
 - name: validate_blob_sidecar_gossip#deneb
   sources: []
   spec: |
-    <spec fn="validate_blob_sidecar_gossip" fork="deneb" hash="2ad40697">
+    <spec fn="validate_blob_sidecar_gossip" fork="deneb" hash="ac24e316">
     def validate_blob_sidecar_gossip(
         seen: Seen,
         store: Store,
@@ -14660,7 +15208,7 @@
 
         # [IGNORE] The sidecar is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+        if is_future_slot(store, block_header.slot, current_time_ms):
             raise GossipIgnore("blob sidecar is from a future slot")
 
         # [IGNORE] The sidecar is from a slot greater than the latest finalized slot
@@ -14681,22 +15229,22 @@
 
         # [IGNORE] The sidecar's block's parent has been seen
         # (MAY be queued for processing once the parent block is retrieved)
-        if block_header.parent_root not in store.blocks:
+        parent_root = block_header.parent_root
+        if parent_root not in store.blocks:
             raise GossipIgnore("blob sidecar's parent has not been seen")
 
         # [REJECT] The sidecar's block's parent passes validation
-        if block_header.parent_root not in store.block_states:
+        if parent_root not in store.block_states:
             raise GossipReject("blob sidecar's parent failed validation")
 
         # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
-        if block_header.slot <= store.blocks[block_header.parent_root].slot:
+        if block_header.slot <= store.blocks[parent_root].slot:
             raise GossipReject("blob sidecar is not from a higher slot than its parent")
 
         # [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
-        checkpoint_block = get_checkpoint_block(
-            store, block_header.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of blob sidecar's block")
 
         # [REJECT] The sidecar's inclusion proof is valid as verified by verify_blob_sidecar_inclusion_proof
@@ -14717,7 +15265,7 @@
 
         # [REJECT] The sidecar is proposed by the expected proposer_index
         # (if shuffling is not available, IGNORE instead and MAY be queued for later)
-        parent_state = store.block_states[block_header.parent_root].copy()
+        parent_state = store.block_states[parent_root].copy()
         process_slots(parent_state, block_header.slot)
         expected_proposer = get_beacon_proposer_index(parent_state)
         if block_header.proposer_index != expected_proposer:
@@ -14730,7 +15278,7 @@
 - name: validate_blob_sidecar_gossip#electra
   sources: []
   spec: |
-    <spec fn="validate_blob_sidecar_gossip" fork="electra" hash="23259565">
+    <spec fn="validate_blob_sidecar_gossip" fork="electra" hash="e4b39cab">
     def validate_blob_sidecar_gossip(
         seen: Seen,
         store: Store,
@@ -14756,7 +15304,7 @@
 
         # [IGNORE] The sidecar is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+        if is_future_slot(store, block_header.slot, current_time_ms):
             raise GossipIgnore("blob sidecar is from a future slot")
 
         # [IGNORE] The sidecar is from a slot greater than the latest finalized slot
@@ -14777,22 +15325,22 @@
 
         # [IGNORE] The sidecar's block's parent has been seen
         # (MAY be queued for processing once the parent block is retrieved)
-        if block_header.parent_root not in store.blocks:
+        parent_root = block_header.parent_root
+        if parent_root not in store.blocks:
             raise GossipIgnore("blob sidecar's parent has not been seen")
 
         # [REJECT] The sidecar's block's parent passes validation
-        if block_header.parent_root not in store.block_states:
+        if parent_root not in store.block_states:
             raise GossipReject("blob sidecar's parent failed validation")
 
         # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
-        if block_header.slot <= store.blocks[block_header.parent_root].slot:
+        if block_header.slot <= store.blocks[parent_root].slot:
             raise GossipReject("blob sidecar is not from a higher slot than its parent")
 
         # [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
-        checkpoint_block = get_checkpoint_block(
-            store, block_header.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of blob sidecar's block")
 
         # [REJECT] The sidecar's inclusion proof is valid as verified by verify_blob_sidecar_inclusion_proof
@@ -14813,7 +15361,7 @@
 
         # [REJECT] The sidecar is proposed by the expected proposer_index
         # (if shuffling is not available, IGNORE instead and MAY be queued for later)
-        parent_state = store.block_states[block_header.parent_root].copy()
+        parent_state = store.block_states[parent_root].copy()
         process_slots(parent_state, block_header.slot)
         expected_proposer = get_beacon_proposer_index(parent_state)
         if block_header.proposer_index != expected_proposer:
@@ -14885,7 +15433,7 @@
 - name: validate_data_column_sidecar_gossip#fulu
   sources: []
   spec: |
-    <spec fn="validate_data_column_sidecar_gossip" fork="fulu" hash="ec896133">
+    <spec fn="validate_data_column_sidecar_gossip" fork="fulu" hash="c6020913">
     def validate_data_column_sidecar_gossip(
         seen: Seen,
         store: Store,
@@ -14902,8 +15450,8 @@
 
         # [IGNORE] The sidecar is the first sidecar for the tuple
         # (block_header.slot, block_header.proposer_index, sidecar.index)
-        sidecar_tuple = (block_header.slot, block_header.proposer_index, sidecar.index)
-        if sidecar_tuple in seen.data_column_sidecar_tuples:
+        sidecar_key = (block_header.slot, block_header.proposer_index, sidecar.index)
+        if sidecar_key in seen.data_column_sidecar_tuples:
             raise GossipIgnore("already seen sidecar from this proposer for this slot and index")
 
         # [REJECT] The sidecar is valid as verified by verify_data_column_sidecar
@@ -14916,7 +15464,7 @@
 
         # [IGNORE] The sidecar is not from a future slot
         # (MAY be queued for processing at the appropriate slot)
-        if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+        if is_future_slot(store, block_header.slot, current_time_ms):
             raise GossipIgnore("sidecar is from a future slot")
 
         # [IGNORE] The sidecar is from a slot greater than the latest finalized slot
@@ -14937,22 +15485,22 @@
 
         # [IGNORE] The sidecar's block's parent has been seen
         # (MAY be queued for processing once the parent block is retrieved)
-        if block_header.parent_root not in store.blocks:
+        parent_root = block_header.parent_root
+        if parent_root not in store.blocks:
             raise GossipIgnore("sidecar's parent has not been seen")
 
         # [REJECT] The sidecar's block's parent passes validation
-        if block_header.parent_root not in store.block_states:
+        if parent_root not in store.block_states:
             raise GossipReject("sidecar's parent failed validation")
 
         # [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
-        if block_header.slot <= store.blocks[block_header.parent_root].slot:
+        if block_header.slot <= store.blocks[parent_root].slot:
             raise GossipReject("sidecar is not from a higher slot than its parent")
 
         # [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
-        checkpoint_block = get_checkpoint_block(
-            store, block_header.parent_root, store.finalized_checkpoint.epoch
-        )
-        if checkpoint_block != store.finalized_checkpoint.root:
+        finalized_epoch = store.finalized_checkpoint.epoch
+        finalized_checkpoint_block = get_checkpoint_block(store, parent_root, finalized_epoch)
+        if finalized_checkpoint_block != store.finalized_checkpoint.root:
             raise GossipReject("finalized checkpoint is not an ancestor of sidecar's block")
 
         # [REJECT] The sidecar is valid as verified by verify_data_column_sidecar_inclusion_proof
@@ -14965,14 +15513,275 @@
 
         # [REJECT] The sidecar is proposed by the expected proposer_index
         # (if shuffling is not available, IGNORE instead and MAY be queued for later)
-        parent_state = store.block_states[block_header.parent_root].copy()
+        parent_state = store.block_states[parent_root].copy()
         process_slots(parent_state, block_header.slot)
         expected_proposer = get_beacon_proposer_index(parent_state)
         if block_header.proposer_index != expected_proposer:
             raise GossipReject("sidecar proposer_index does not match expected proposer")
 
         # Mark this data column sidecar as seen
-        seen.data_column_sidecar_tuples.add(sidecar_tuple)
+        seen.data_column_sidecar_tuples.add(sidecar_key)
+    </spec>
+
+- name: validate_data_column_sidecar_gossip#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+      search: "export async function validateGossipGloasDataColumnSidecar("
+  spec: |
+    <spec fn="validate_data_column_sidecar_gossip" fork="gloas" hash="1ac8f763">
+    def validate_data_column_sidecar_gossip(
+        seen: Seen,
+        store: Store,
+        # [Modified in Gloas:EIP7732]
+        # Removed `state`
+        sidecar: DataColumnSidecar,
+        current_time_ms: Uint64,
+        subnet_id: SubnetID,
+    ) -> None:
+        """
+        Validate a DataColumnSidecar for gossip propagation on a subnet.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        # [IGNORE] This is the first sidecar seen for this block root and column index
+        sidecar_key = (sidecar.beacon_block_root, sidecar.index)
+        if sidecar_key in seen.data_column_sidecar_tuples:
+            raise GossipIgnore("already seen sidecar for this block root and index")
+
+        # [REJECT] The sidecar is for the correct subnet
+        if compute_subnet_for_data_column_sidecar(sidecar.index) != subnet_id:
+            raise GossipReject("sidecar is for wrong subnet")
+
+        # [IGNORE] The sidecar is not from a future slot
+        # (MAY be queued for processing at the appropriate slot)
+        if is_future_slot(store, sidecar.slot, current_time_ms):
+            raise GossipIgnore("sidecar is from a future slot")
+
+        # [IGNORE] A block for the sidecar has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        # (SHOULD queue at least one sidecar per peer per subnet)
+        if sidecar.beacon_block_root not in store.blocks:
+            raise GossipIgnore("block for sidecar's beacon block root has not been seen")
+
+        # [REJECT] The block for the sidecar passes validation
+        if sidecar.beacon_block_root not in store.block_states:
+            raise GossipReject("block for sidecar's beacon block root failed validation")
+
+        block = store.blocks[sidecar.beacon_block_root]
+
+        # [REJECT] The sidecar's slot matches the slot of the block
+        if sidecar.slot != block.slot:
+            raise GossipReject("sidecar's slot does not match block's slot")
+
+        bid = block.body.signed_execution_payload_bid.message
+
+        # [REJECT] The sidecar passes structural validation
+        if not verify_data_column_sidecar(sidecar, bid.blob_kzg_commitments):
+            raise GossipReject("invalid sidecar")
+
+        # [REJECT] The sidecar's column data passes KZG verification
+        if not verify_data_column_sidecar_kzg_proofs(sidecar, bid.blob_kzg_commitments):
+            raise GossipReject("invalid sidecar kzg proofs")
+
+        # Mark this data column sidecar as seen
+        seen.data_column_sidecar_tuples.add(sidecar_key)
+    </spec>
+
+- name: validate_execution_payload_bid_gossip#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+      search: "export async function validateGossipExecutionPayloadBid("
+  spec: |
+    <spec fn="validate_execution_payload_bid_gossip" fork="gloas" hash="5c494718">
+    def validate_execution_payload_bid_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        signed_execution_payload_bid: SignedExecutionPayloadBid,
+        current_time_ms: Uint64,
+    ) -> None:
+        """
+        Validate a SignedExecutionPayloadBid for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        bid = signed_execution_payload_bid.message
+
+        # [IGNORE] The bid's slot is the current slot or the next slot
+        if not is_current_or_next_slot(store, bid.slot, current_time_ms):
+            raise GossipIgnore("bid's slot is not the current or next slot")
+
+        # [IGNORE] This is the first bid for this slot, parent, and builder
+        bid_key = (bid.slot, bid.parent_block_hash, bid.parent_block_root, bid.builder_index)
+        if bid_key in seen.execution_payload_bids:
+            raise GossipIgnore("already seen valid bid for this slot, parent, and builder")
+
+        # [IGNORE] This is the highest value bid seen for the slot and parent
+        best_bid_key = (bid.slot, bid.parent_block_hash, bid.parent_block_root)
+        if best_bid_key in seen.best_execution_payload_bid:
+            if bid.value <= seen.best_execution_payload_bid[best_bid_key]:
+                raise GossipIgnore("bid is not the highest value bid seen for this slot and parent")
+
+        # [REJECT] The bid is for a higher slot than its parent block
+        if bid.slot <= state.slot:
+            raise GossipReject("bid's slot is not higher than its parent's slot")
+
+        # [REJECT] The bid's execution payment is zero
+        if bid.execution_payment != 0:
+            raise GossipReject("bid's execution payment must be zero")
+
+        # [REJECT] The bid's blob KZG commitment count is within the per-epoch limit
+        proposal_epoch = compute_epoch_at_slot(bid.slot)
+        max_blobs = get_blob_parameters(proposal_epoch).max_blobs_per_block
+        if len(bid.blob_kzg_commitments) > max_blobs:
+            raise GossipReject("too many blob kzg commitments")
+
+        # [IGNORE] The bid's parent block root is a known beacon block
+        # (MAY be queued until parent is retrieved)
+        if bid.parent_block_root not in store.blocks:
+            raise GossipIgnore("bid's parent block root is not a known beacon block")
+
+        # [IGNORE] The state is the bid's parent block post-state
+        parent_block = store.blocks[bid.parent_block_root]
+        header = state.latest_block_header.copy()
+        header.state_root = parent_block.state_root
+        if hash_tree_root(header) != bid.parent_block_root:
+            raise GossipIgnore("state is not the bid's parent block post-state")
+
+        # [IGNORE] The bid's slot is within the parent's proposer lookahead
+        if proposal_epoch > get_current_epoch(state) + Epoch(MIN_SEED_LOOKAHEAD):
+            raise GossipIgnore("bid's slot is past the parent's proposer lookahead")
+
+        # [IGNORE] The matching proposer preferences have been seen
+        dependent_root = get_shuffling_dependent_root(store, bid.parent_block_root, proposal_epoch)
+        prefs_key = (dependent_root, bid.slot)
+        if prefs_key not in seen.proposer_preferences:
+            raise GossipIgnore("matching proposer preferences have not been seen")
+
+        proposer_preferences = seen.proposer_preferences[prefs_key]
+
+        # [IGNORE] The bid's fee recipient matches the proposer's preference
+        if bid.fee_recipient != proposer_preferences.fee_recipient:
+            raise GossipIgnore("bid's fee recipient does not match the proposer's preference")
+
+        # [IGNORE] The bid's parent block hash is the hash of a known execution payload
+        if bid.parent_block_hash not in seen.execution_payloads:
+            raise GossipIgnore("bid's parent block hash is not a known execution payload")
+
+        # [IGNORE] The bid's gas limit is compatible with the proposer's target gas limit
+        parent_gas_limit = seen.execution_payloads[bid.parent_block_hash].gas_limit
+        if not is_gas_limit_target_compatible(
+            parent_gas_limit, bid.gas_limit, proposer_preferences.target_gas_limit
+        ):
+            raise GossipIgnore("bid's gas limit is not compatible with the proposer's target")
+
+        # [IGNORE] The bid is compatible with the current head branch
+        if not is_bid_compatible_with_head(store, bid):
+            raise GossipIgnore("bid is not compatible with the current head branch")
+
+        # [REJECT] The bid's previous randao is correct
+        if bid.prev_randao != get_randao_mix(state, get_current_epoch(state)):
+            raise GossipReject("bid's previous randao is incorrect")
+
+        # Advance state
+        state = state.copy()
+        process_slots(state, bid.slot)
+
+        # [REJECT] The builder index is valid
+        if bid.builder_index >= len(state.builders):
+            raise GossipReject("builder index out of range")
+
+        # [IGNORE] The builder can cover the bid
+        if not can_builder_cover_bid(state, bid.builder_index, bid.value):
+            raise GossipIgnore("builder cannot cover bid value")
+
+        # [REJECT] The builder is active
+        if not is_active_builder(state, bid.builder_index):
+            raise GossipReject("builder is not active")
+
+        # [REJECT] The builder is a payload builder
+        if state.builders[bid.builder_index].version != PAYLOAD_BUILDER_VERSION:
+            raise GossipReject("builder is not a payload builder")
+
+        # [REJECT] The bid signature is valid
+        if not verify_execution_payload_bid_signature(state, signed_execution_payload_bid):
+            raise GossipReject("invalid bid signature")
+
+        # Mark this bid as seen and update the highest-value bid for this slot/parent
+        seen.execution_payload_bids.add(bid_key)
+        seen.best_execution_payload_bid[best_bid_key] = bid.value
+    </spec>
+
+- name: validate_execution_payload_envelope_gossip#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
+      search: "export async function validateGossipExecutionPayloadEnvelope("
+  spec: |
+    <spec fn="validate_execution_payload_envelope_gossip" fork="gloas" hash="946fce68">
+    def validate_execution_payload_envelope_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        signed_execution_payload_envelope: SignedExecutionPayloadEnvelope,
+    ) -> None:
+        """
+        Validate a SignedExecutionPayloadEnvelope for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        envelope = signed_execution_payload_envelope.message
+        payload = envelope.payload
+        block_root = envelope.beacon_block_root
+
+        # [IGNORE] The envelope's block root has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        if block_root not in store.blocks:
+            raise GossipIgnore("envelope's block has not been seen")
+
+        # [REJECT] The envelope's block passes validation
+        if block_root not in store.block_states:
+            raise GossipReject("envelope's block failed validation")
+
+        # [IGNORE] The node has not seen another valid envelope for this block root from this builder
+        envelope_key = (block_root, envelope.builder_index)
+        if envelope_key in seen.execution_payload_envelopes:
+            raise GossipIgnore("already seen envelope for this block root from this builder")
+
+        # [IGNORE] The envelope is from a slot greater than or equal to the latest finalized slot
+        finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+        if payload.slot_number < finalized_slot:
+            raise GossipIgnore("envelope is from a slot before the latest finalized slot")
+
+        block = store.blocks[block_root]
+        bid = block.body.signed_execution_payload_bid.message
+
+        # [REJECT] The block's slot matches the payload's slot number
+        if block.slot != payload.slot_number:
+            raise GossipReject("block's slot does not match payload's slot number")
+
+        # [REJECT] The envelope is from the builder committed to by the bid
+        if envelope.builder_index != bid.builder_index:
+            raise GossipReject("envelope's builder index does not match the bid's builder index")
+
+        # [REJECT] The payload's block hash matches the bid's block hash
+        if payload.block_hash != bid.block_hash:
+            raise GossipReject("payload's block hash does not match the bid's block hash")
+
+        # [REJECT] The envelope's execution requests root matches the bid's execution requests root
+        if hash_tree_root(envelope.execution_requests) != bid.execution_requests_root:
+            raise GossipReject("envelope's execution requests root does not match the bid's")
+
+        # [REJECT] The execution request counts are within their limits
+        verify_execution_requests_limits(envelope.execution_requests)
+
+        # [REJECT] The number of withdrawals is within the limit
+        if len(payload.withdrawals) > MAX_WITHDRAWALS_PER_PAYLOAD:
+            raise GossipReject("too many withdrawals")
+
+        # [REJECT] The envelope signature is valid
+        if not verify_execution_payload_envelope_signature(state, signed_execution_payload_envelope):
+            raise GossipReject("invalid envelope signature")
+
+        # Mark this envelope as seen and store its payload
+        seen.execution_payload_envelopes.add(envelope_key)
+        seen.execution_payloads[payload.block_hash] = payload
     </spec>
 
 - name: validate_light_client_update#altair
@@ -14980,7 +15789,7 @@
     - file: packages/state-transition/src/lightClient/spec/validateLightClientUpdate.ts
       search: export function validateLightClientUpdate(
   spec: |
-    <spec fn="validate_light_client_update" fork="altair" hash="1b14fa8e">
+    <spec fn="validate_light_client_update" fork="altair" hash="4480c2e9">
     def validate_light_client_update(
         store: LightClientStore,
         update: LightClientUpdate,
@@ -14989,7 +15798,7 @@
     ) -> None:
         # Verify sync committee has sufficient participants
         sync_aggregate = update.sync_aggregate
-        assert sum(sync_aggregate.sync_committee_bits) >= MIN_SYNC_COMMITTEE_PARTICIPANTS
+        assert get_set_bit_count(sync_aggregate.sync_committee_bits) >= MIN_SYNC_COMMITTEE_PARTICIPANTS
 
         # Verify update does not skip a sync committee period
         assert is_valid_light_client_header(update.attested_header)
@@ -15206,7 +16015,7 @@
 - name: validate_partial_data_column_sidecar_gossip#fulu
   sources: []
   spec: |
-    <spec fn="validate_partial_data_column_sidecar_gossip" fork="fulu" hash="53eac7ee">
+    <spec fn="validate_partial_data_column_sidecar_gossip" fork="fulu" hash="ba060c6c">
     def validate_partial_data_column_sidecar_gossip(
         seen: Seen,
         store: Store,
@@ -15221,7 +16030,7 @@
         Raises GossipIgnore or GossipReject on validation failure.
         """
         has_header = len(sidecar.header) == 1
-        num_cells_present = sum(1 for b in sidecar.cells_present_bitmap if b)
+        num_cells_present = get_set_bit_count(sidecar.cells_present_bitmap)
         has_cells = num_cells_present > 0
 
         # [REJECT] A header and/or cells are present in the message
@@ -15255,7 +16064,7 @@
 
             # [IGNORE] The header is not from a future slot
             # (MAY be queued for processing at the appropriate slot)
-            if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+            if is_future_slot(store, block_header.slot, current_time_ms):
                 raise GossipIgnore("header is from a future slot")
 
             # [IGNORE] The header is from a slot greater than the latest finalized slot
@@ -15276,22 +16085,22 @@
 
             # [IGNORE] The header's block's parent has been seen
             # (MAY be queued for processing once the parent block is retrieved)
-            if block_header.parent_root not in store.blocks:
+            parent_root = block_header.parent_root
+            if parent_root not in store.blocks:
                 raise GossipIgnore("header's parent has not been seen")
 
             # [REJECT] The header's block's parent passes validation
-            if block_header.parent_root not in store.block_states:
+            if parent_root not in store.block_states:
                 raise GossipReject("header's parent failed validation")
 
             # [REJECT] The header is from a higher slot than the header's block's parent
-            if block_header.slot <= store.blocks[block_header.parent_root].slot:
+            if block_header.slot <= store.blocks[parent_root].slot:
                 raise GossipReject("header is not from a higher slot than its parent")
 
             # [REJECT] The current finalized_checkpoint is an ancestor of the header's block
-            checkpoint_block = get_checkpoint_block(
-                store, block_header.parent_root, store.finalized_checkpoint.epoch
-            )
-            if checkpoint_block != store.finalized_checkpoint.root:
+            finalized_epoch = store.finalized_checkpoint.epoch
+            finalized_checkpoint_block = get_checkpoint_block(store, parent_root, finalized_epoch)
+            if finalized_checkpoint_block != store.finalized_checkpoint.root:
                 raise GossipReject("finalized checkpoint is not an ancestor of header's block")
 
             # [REJECT] The header's kzg_commitments inclusion proof is valid
@@ -15300,7 +16109,7 @@
 
             # [REJECT] The header is proposed by the expected proposer_index
             # (if shuffling is not available, IGNORE instead and MAY be queued for later)
-            parent_state = store.block_states[block_header.parent_root].copy()
+            parent_state = store.block_states[parent_root].copy()
             process_slots(parent_state, block_header.slot)
             expected_proposer = get_beacon_proposer_index(parent_state)
             if block_header.proposer_index != expected_proposer:
@@ -15319,7 +16128,7 @@
 
             # [IGNORE] The corresponding header is not from a future slot
             # (MAY be queued for processing at the appropriate slot)
-            if not is_not_from_future_slot(state, block_header.slot, current_time_ms):
+            if is_future_slot(store, block_header.slot, current_time_ms):
                 raise GossipIgnore("corresponding header is from a future slot")
 
             # [IGNORE] The corresponding header is from a slot greater than the latest finalized slot
@@ -15340,12 +16149,212 @@
                 raise GossipReject("invalid sidecar kzg proofs")
     </spec>
 
+- name: validate_partial_data_column_sidecar_gossip#gloas
+  sources: []
+  spec: |
+    <spec fn="validate_partial_data_column_sidecar_gossip" fork="gloas" hash="812d5818">
+    def validate_partial_data_column_sidecar_gossip(
+        # [Modified in Gloas:EIP7732]
+        # Removed `seen`
+        store: Store,
+        # [Modified in Gloas:EIP7732]
+        # Removed `state`
+        sidecar: PartialDataColumnSidecar,
+        # [Modified in Gloas:EIP7732]
+        # Removed `current_time_ms`
+        group_id: PartialDataColumnGroupID,
+        column_index: ColumnIndex,
+    ) -> None:
+        """
+        Validate a PartialDataColumnSidecar for gossip propagation on a subnet.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        num_cells_present = get_set_bit_count(sidecar.cells_present_bitmap)
+
+        # [Modified in Gloas:EIP7732]
+        # [REJECT] The message contains at least one cell
+        if num_cells_present == 0:
+            raise GossipReject("partial message is semantically empty")
+
+        # [REJECT] The cell count equals the number of set bits in the bitmap
+        if len(sidecar.partial_column) != num_cells_present:
+            raise GossipReject("number of cells does not match number of set bits")
+
+        # [REJECT] The proof count equals the number of set bits in the bitmap
+        if len(sidecar.kzg_proofs) != num_cells_present:
+            raise GossipReject("number of proofs does not match number of set bits")
+
+        # [New in Gloas:EIP7732]
+        # [IGNORE] The group ID's block has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        # (SHOULD queue at least one sidecar per peer per subnet)
+        if group_id.beacon_block_root not in store.blocks:
+            raise GossipIgnore("group id's block has not been seen")
+
+        # [New in Gloas:EIP7732]
+        # [REJECT] The group ID's block passes validation
+        if group_id.beacon_block_root not in store.block_states:
+            raise GossipReject("group id's block failed validation")
+
+        block = store.blocks[group_id.beacon_block_root]
+
+        # [New in Gloas:EIP7732]
+        # [REJECT] The group ID's slot matches the slot of the block
+        if group_id.slot != block.slot:
+            raise GossipReject("group id's slot does not match the block's slot")
+
+        bid = block.body.signed_execution_payload_bid.message
+
+        # [Modified in Gloas:EIP7732]
+        # [REJECT] The cells present bitmap length equals the number of bid commitments
+        if len(sidecar.cells_present_bitmap) != len(bid.blob_kzg_commitments):
+            raise GossipReject("bitmap length does not match commitments length")
+
+        # [Modified in Gloas:EIP7732]
+        # [REJECT] The sidecar's cell and proof data passes KZG verification
+        if not verify_partial_data_column_sidecar_kzg_proofs(
+            sidecar, bid.blob_kzg_commitments, column_index
+        ):
+            raise GossipReject("invalid sidecar kzg proofs")
+    </spec>
+
+- name: validate_payload_attestation_message_gossip#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
+      search: "export async function validateGossipPayloadAttestationMessage("
+  spec: |
+    <spec fn="validate_payload_attestation_message_gossip" fork="gloas" hash="fdf2e632">
+    def validate_payload_attestation_message_gossip(
+        seen: Seen,
+        store: Store,
+        state: BeaconState,
+        payload_attestation_message: PayloadAttestationMessage,
+        current_time_ms: Uint64,
+    ) -> None:
+        """
+        Validate a PayloadAttestationMessage for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        data = payload_attestation_message.data
+        validator_index = payload_attestation_message.validator_index
+
+        # [IGNORE] The payload attestation's slot is the current slot
+        if not is_current_slot(store, data.slot, current_time_ms):
+            raise GossipIgnore("payload attestation's slot is not the current slot")
+
+        # [IGNORE] This is the first valid payload attestation from this validator index
+        payload_attestation_key = (data.slot, validator_index)
+        if payload_attestation_key in seen.payload_attestation_validators:
+            raise GossipIgnore("already seen payload attestation from this validator")
+
+        # [IGNORE] The payload attestation's block has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        if data.beacon_block_root not in store.blocks:
+            raise GossipIgnore("payload attestation's block has not been seen")
+
+        # [REJECT] The payload attestation's block passes validation
+        if data.beacon_block_root not in store.block_states:
+            raise GossipReject("payload attestation's block failed validation")
+
+        # [IGNORE] The payload attestation's block is at the assigned slot
+        if store.blocks[data.beacon_block_root].slot != data.slot:
+            raise GossipIgnore("payload attestation's block is not at the assigned slot")
+
+        # [REJECT] The validator index is valid
+        if validator_index >= len(state.validators):
+            raise GossipReject("validator index out of range")
+
+        # [REJECT] The validator is a member of the payload timeliness committee
+        if validator_index not in get_ptc(state, data.slot):
+            raise GossipReject("validator is not in the payload timeliness committee")
+
+        # [REJECT] The signature is valid with respect to the validator's public key
+        validator = state.validators[validator_index]
+        domain = get_domain(state, DOMAIN_PTC_ATTESTER, compute_epoch_at_slot(data.slot))
+        signing_root = compute_signing_root(data, domain)
+        if not bls.Verify(validator.pubkey, signing_root, payload_attestation_message.signature):
+            raise GossipReject("invalid payload attestation signature")
+
+        # Mark this payload_attestation as seen
+        seen.payload_attestation_validators.add(payload_attestation_key)
+    </spec>
+
+- name: validate_proposer_preferences_gossip#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/proposerPreferences.ts
+      search: "export async function validateGossipProposerPreferences("
+  spec: |
+    <spec fn="validate_proposer_preferences_gossip" fork="gloas" hash="c254347a">
+    def validate_proposer_preferences_gossip(
+        seen: Seen,
+        store: Store,
+        signed_proposer_preferences: SignedProposerPreferences,
+        current_time_ms: Uint64,
+    ) -> None:
+        """
+        Validate a SignedProposerPreferences for gossip propagation.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        preferences = signed_proposer_preferences.message
+        proposal_epoch = compute_epoch_at_slot(preferences.proposal_slot)
+
+        # [IGNORE] The proposal slot has not started yet
+        if is_past_slot(store, preferences.proposal_slot, current_time_ms):
+            raise GossipIgnore("proposal slot has already started")
+
+        # [IGNORE] The proposer for the proposal slot is known
+        lookahead_epoch = Epoch(proposal_epoch - MIN_SEED_LOOKAHEAD)
+        lookahead_epoch_start_slot = compute_start_slot_at_epoch(lookahead_epoch)
+        if is_future_slot(store, lookahead_epoch_start_slot, current_time_ms):
+            raise GossipIgnore("proposer for the proposal slot is not yet known")
+
+        # [IGNORE] The dependent block has been seen (via gossip or non-gossip sources)
+        # (MAY be queued until block is retrieved)
+        if preferences.dependent_root not in store.blocks:
+            raise GossipIgnore("dependent block has not been seen")
+
+        # [IGNORE] These are the first valid preferences seen for this dependent root and slot
+        prefs_key = (preferences.dependent_root, preferences.proposal_slot)
+        if prefs_key in seen.proposer_preferences:
+            raise GossipIgnore("already seen preferences for this dependent root and proposal slot")
+
+        # [IGNORE] The dependent block passes validation
+        if preferences.dependent_root not in store.block_states:
+            raise GossipIgnore("dependent block failed validation")
+
+        # [REJECT] The dependent root is a valid dependent block for the proposal slot
+        if store.blocks[preferences.dependent_root].slot >= lookahead_epoch_start_slot:
+            raise GossipReject("dependent root is not before the proposer lookahead epoch")
+
+        # [IGNORE] The dependent root is a possible dependent block for the lookahead epoch
+        if not is_valid_dependent_root(store, preferences.dependent_root, lookahead_epoch):
+            raise GossipIgnore("dependent root is not a possible dependent block")
+
+        # [REJECT] The validator is the proposer for the given slot in the proposer lookahead
+        lookahead_state = store.block_states[preferences.dependent_root].copy()
+        process_slots(lookahead_state, lookahead_epoch_start_slot)
+        lookahead_index = preferences.proposal_slot - lookahead_epoch_start_slot
+        if lookahead_state.proposer_lookahead[lookahead_index] != preferences.validator_index:
+            raise GossipReject("validator is not the proposer for the given slot")
+
+        # [REJECT] The signature is valid with respect to the validator's public key
+        validator = lookahead_state.validators[preferences.validator_index]
+        domain = get_domain(lookahead_state, DOMAIN_PROPOSER_PREFERENCES, proposal_epoch)
+        signing_root = compute_signing_root(preferences, domain)
+        if not bls.Verify(validator.pubkey, signing_root, signed_proposer_preferences.signature):
+            raise GossipReject("invalid proposer preferences signature")
+
+        # Mark these preferences as seen
+        seen.proposer_preferences[prefs_key] = preferences
+    </spec>
+
 - name: validate_sync_committee_contribution_and_proof_gossip#altair
   sources: []
   spec: |
-    <spec fn="validate_sync_committee_contribution_and_proof_gossip" fork="altair" hash="6dd060ef">
+    <spec fn="validate_sync_committee_contribution_and_proof_gossip" fork="altair" hash="732e2f42">
     def validate_sync_committee_contribution_and_proof_gossip(
         seen: Seen,
+        store: Store,
         state: BeaconState,
         signed_contribution_and_proof: SignedContributionAndProof,
         current_time_ms: Uint64,
@@ -15358,7 +16367,7 @@
         contribution = contribution_and_proof.contribution
 
         # [IGNORE] The contribution's slot is for the current slot
-        if not is_current_slot(state, contribution.slot, current_time_ms):
+        if not is_current_slot(store, contribution.slot, current_time_ms):
             raise GossipIgnore("contribution is not for the current slot")
 
         # [REJECT] The subcommittee index is in the allowed range
@@ -15398,11 +16407,11 @@
             raise GossipIgnore("already seen contribution for this data")
 
         # [IGNORE] The sync committee contribution is the first valid contribution received
-        # for the aggregator with index contribution_and_proof.aggregator_index
-        # for the slot contribution.slot and subcommittee index contribution.subcommittee_index
+        # for the slot contribution.slot, aggregator with index contribution_and_proof.aggregator_index,
+        # and subcommittee index contribution.subcommittee_index
         aggregator_key = (
-            contribution_and_proof.aggregator_index,
             contribution.slot,
+            contribution_and_proof.aggregator_index,
             contribution.subcommittee_index,
         )
         if aggregator_key in seen.sync_contribution_aggregator_slots:
@@ -15451,9 +16460,10 @@
 - name: validate_sync_committee_message_gossip#altair
   sources: []
   spec: |
-    <spec fn="validate_sync_committee_message_gossip" fork="altair" hash="01f56b45">
+    <spec fn="validate_sync_committee_message_gossip" fork="altair" hash="c5c64898">
     def validate_sync_committee_message_gossip(
         seen: Seen,
+        store: Store,
         state: BeaconState,
         sync_committee_message: SyncCommitteeMessage,
         current_time_ms: Uint64,
@@ -15464,7 +16474,7 @@
         Raises GossipIgnore or GossipReject on validation failure.
         """
         # [IGNORE] The message's slot is for the current slot
-        if not is_current_slot(state, sync_committee_message.slot, current_time_ms):
+        if not is_current_slot(store, sync_committee_message.slot, current_time_ms):
             raise GossipIgnore("message is not for the current slot")
 
         # [REJECT] The validator index is valid
@@ -15573,6 +16583,50 @@
         seen.voluntary_exit_indices.add(validator_index)
     </spec>
 
+- name: verify_attestation_payload_status#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/attestation.ts
+      search: "async function validateAttestationNoSignatureCheck("
+    - file: packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+      search: "async function validateAggregateAndProof("
+  spec: |
+    <spec fn="verify_attestation_payload_status" fork="gloas" hash="7006ea07">
+    def verify_attestation_payload_status(
+        store: Store,
+        data: AttestationData,
+        block_payload_statuses: Dict[Root, PayloadValidationStatus],
+    ) -> None:
+        """
+        Verify that the attested payload status is consistent with the block's payload.
+        Raises GossipIgnore or GossipReject on validation failure.
+        """
+        block_root = data.beacon_block_root
+        block = store.blocks[block_root]
+
+        # [REJECT] For same-slot attestations, the payload cannot yet be present
+        if block.slot == data.slot and data.index != 0:
+            raise GossipReject("same-slot attestation must attest with index 0")
+
+        if data.index != 1:
+            return
+
+        # [IGNORE] The corresponding execution payload envelope has been seen and verified
+        # (MAY queue attestations for processing once the payload is retrieved and
+        # SHOULD request the payload envelope via ExecutionPayloadEnvelopesByRoot
+        # using data.beacon_block_root)
+        if not is_payload_verified(store, block_root):
+            raise GossipIgnore("execution payload envelope has not been seen")
+
+        # [IGNORE] The attested execution payload is optimistic
+        payload_status = block_payload_statuses.get(block_root, PAYLOAD_STATUS_NOT_VALIDATED)
+        if payload_status == PAYLOAD_STATUS_NOT_VALIDATED:
+            raise GossipIgnore("attested payload is optimistic")
+
+        # [REJECT] The attested execution payload is processed and invalid
+        if payload_status == PAYLOAD_STATUS_INVALIDATED:
+            raise GossipReject("attested payload is invalid")
+    </spec>
+
 - name: verify_blob_sidecar_inclusion_proof#deneb
   sources:
     - file: packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -15590,6 +16644,46 @@
             index=gindex,
             root=blob_sidecar.signed_block_header.message.body_root,
         )
+    </spec>
+
+- name: verify_block_body_operation_limits#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/block.ts
+      search: "const countLimits: [string, number, number][] = ["
+  spec: |
+    <spec fn="verify_block_body_operation_limits" fork="gloas" hash="cc23d563">
+    def verify_block_body_operation_limits(body: BeaconBlockBody) -> None:
+        """
+        Verify that each block body operation count is within its limit.
+        Raises GossipReject on validation failure.
+        """
+        # [REJECT] The proposer slashing count is within the limit
+        if len(body.proposer_slashings) > MAX_PROPOSER_SLASHINGS:
+            raise GossipReject("too many proposer slashings")
+
+        # [REJECT] The attester slashing count is within the limit
+        if len(body.attester_slashings) > MAX_ATTESTER_SLASHINGS_ELECTRA:
+            raise GossipReject("too many attester slashings")
+
+        # [REJECT] The attestation count is within the limit
+        if len(body.attestations) > MAX_ATTESTATIONS_ELECTRA:
+            raise GossipReject("too many attestations")
+
+        # [REJECT] The block contains no deposits
+        if len(body.deposits) != 0:
+            raise GossipReject("block must not contain deposits")
+
+        # [REJECT] The voluntary exit count is within the limit
+        if len(body.voluntary_exits) > MAX_VOLUNTARY_EXITS:
+            raise GossipReject("too many voluntary exits")
+
+        # [REJECT] The BLS to execution change count is within the limit
+        if len(body.bls_to_execution_changes) > MAX_BLS_TO_EXECUTION_CHANGES:
+            raise GossipReject("too many bls to execution changes")
+
+        # [REJECT] The payload attestation count is within the limit
+        if len(body.payload_attestations) > MAX_PAYLOAD_ATTESTATIONS:
+            raise GossipReject("too many payload attestations")
     </spec>
 
 - name: verify_block_signature#phase0
@@ -15611,7 +16705,7 @@
     - file: packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
       search: function verifyFuluDataColumnSidecar(
   spec: |
-    <spec fn="verify_data_column_sidecar" fork="fulu" hash="1517491f">
+    <spec fn="verify_data_column_sidecar" fork="fulu" hash="ca67201c">
     def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
         """
         Verify if the data column sidecar is valid.
@@ -15629,10 +16723,12 @@
         if len(sidecar.kzg_commitments) > get_blob_parameters(epoch).max_blobs_per_block:
             return False
 
-        # The column length must be equal to the number of commitments/proofs
-        if len(sidecar.column) != len(sidecar.kzg_commitments) or len(sidecar.column) != len(
-            sidecar.kzg_proofs
-        ):
+        # The column length must be equal to the number of commitments
+        if len(sidecar.column) != len(sidecar.kzg_commitments):
+            return False
+
+        # The column length must be equal to the number of proofs
+        if len(sidecar.column) != len(sidecar.kzg_proofs):
             return False
 
         return True
@@ -15643,11 +16739,11 @@
     - file: packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
       search: function verifyGloasDataColumnSidecar(
   spec: |
-    <spec fn="verify_data_column_sidecar" fork="gloas" hash="52204844">
+    <spec fn="verify_data_column_sidecar" fork="gloas" hash="5620cd9c">
     def verify_data_column_sidecar(
         sidecar: DataColumnSidecar,
         # [New in Gloas:EIP7732]
-        kzg_commitments: ProgressiveList[KZGCommitment],
+        kzg_commitments: BlobKZGCommitments,
     ) -> bool:
         """
         Verify if the data column sidecar is valid.
@@ -15662,10 +16758,12 @@
             return False
 
         # [Modified in Gloas:EIP7732]
-        # The column length must be equal to the number of commitments/proofs
-        if len(sidecar.column) != len(kzg_commitments) or len(sidecar.column) != len(
-            sidecar.kzg_proofs
-        ):
+        # The column length must be equal to the number of commitments
+        if len(sidecar.column) != len(kzg_commitments):
+            return False
+
+        # The column length must be equal to the number of proofs
+        if len(sidecar.column) != len(sidecar.kzg_proofs):
             return False
 
         return True
@@ -15717,11 +16815,11 @@
     - file: packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
       search: export async function verifyDataColumnSidecarKzgProofs(
   spec: |
-    <spec fn="verify_data_column_sidecar_kzg_proofs" fork="gloas" hash="401fafe6">
+    <spec fn="verify_data_column_sidecar_kzg_proofs" fork="gloas" hash="d5a97c26">
     def verify_data_column_sidecar_kzg_proofs(
         sidecar: DataColumnSidecar,
         # [New in Gloas:EIP7732]
-        kzg_commitments: ProgressiveList[KZGCommitment],
+        kzg_commitments: BlobKZGCommitments,
     ) -> bool:
         """
         Verify if the KZG proofs are correct.
@@ -15824,6 +16922,36 @@
             signed_envelope.message, get_domain(state, DOMAIN_BEACON_BUILDER)
         )
         return bls.Verify(pubkey, signing_root, signed_envelope.signature)
+    </spec>
+
+- name: verify_execution_requests_limits#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/block.ts
+      search: "const countLimits: [string, number, number][] = ["
+    - file: packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
+      search: "const requestCountLimits: [string, number, number][] = ["
+  spec: |
+    <spec fn="verify_execution_requests_limits" fork="gloas" hash="a15850cf">
+    def verify_execution_requests_limits(execution_requests: ExecutionRequests) -> None:
+        """
+        Verify that each execution request count is within its limit.
+        Raises GossipReject on validation failure.
+        """
+        # [REJECT] The withdrawal request count is within the limit
+        if len(execution_requests.withdrawals) > MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD:
+            raise GossipReject("too many withdrawal requests")
+
+        # [REJECT] The consolidation request count is within the limit
+        if len(execution_requests.consolidations) > MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD:
+            raise GossipReject("too many consolidation requests")
+
+        # [REJECT] The builder deposit request count is within the limit
+        if len(execution_requests.builder_deposits) > MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD:
+            raise GossipReject("too many builder deposit requests")
+
+        # [REJECT] The builder exit request count is within the limit
+        if len(execution_requests.builder_exits) > MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD:
+            raise GossipReject("too many builder exit requests")
     </spec>
 
 - name: voting_period_start_time#phase0

--- a/specrefs/types.yml
+++ b/specrefs/types.yml
@@ -1,39 +1,3 @@
-- name: AggregationBits#electra
-  sources:
-    - file: packages/types/src/electra/sszTypes.ts
-      search: export const AggregationBits =
-  spec: |
-    <spec custom_type="AggregationBits" fork="electra" hash="229bd765">
-    AggregationBits = BitList[MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]
-    </spec>
-
-- name: AggregationBits#gloas
-  sources:
-    - file: packages/types/src/gloas/sszTypes.ts
-      search: export const AggregationBits =
-  spec: |
-    <spec custom_type="AggregationBits" fork="gloas" hash="ba289449">
-    AggregationBits = ProgressiveBitList
-    </spec>
-
-- name: AttestingIndices#electra
-  sources:
-    - file: packages/types/src/electra/sszTypes.ts
-      search: export const AttestingIndices =
-  spec: |
-    <spec custom_type="AttestingIndices" fork="electra" hash="5df7e7b5">
-    AttestingIndices = List[ValidatorIndex, MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]
-    </spec>
-
-- name: AttestingIndices#gloas
-  sources:
-    - file: packages/types/src/gloas/sszTypes.ts
-      search: export const AttestingIndices =
-  spec: |
-    <spec custom_type="AttestingIndices" fork="gloas" hash="1494a972">
-    AttestingIndices = ProgressiveList[ValidatorIndex]
-    </spec>
-
 - name: BLSPubkey#phase0
   sources:
     - file: packages/types/src/primitive/sszTypes.ts
@@ -52,15 +16,6 @@
     BLSSignature = Bytes96
     </spec>
 
-- name: Blob#deneb
-  sources:
-    - file: packages/types/src/deneb/sszTypes.ts
-      search: export const Blob =
-  spec: |
-    <spec custom_type="Blob" fork="deneb" hash="ad6dd66e">
-    Blob = ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]
-    </spec>
-
 - name: BlobIndex#deneb
   sources:
     - file: packages/types/src/primitive/sszTypes.ts
@@ -70,33 +25,6 @@
     BlobIndex = Uint64
     </spec>
 
-- name: BlockAccessList#gloas
-  sources:
-    - file: packages/types/src/gloas/sszTypes.ts
-      search: export const BlockAccessList =
-  spec: |
-    <spec custom_type="BlockAccessList" fork="gloas" hash="350929e4">
-    BlockAccessList = ProgressiveByteList
-    </spec>
-
-- name: BuilderDepositRequests#gloas
-  sources:
-    - file: packages/types/src/gloas/sszTypes.ts
-      search: export const BuilderDepositRequests =
-  spec: |
-    <spec custom_type="BuilderDepositRequests" fork="gloas" hash="2791bf22">
-    BuilderDepositRequests = ProgressiveList[BuilderDepositRequest]
-    </spec>
-
-- name: BuilderExitRequests#gloas
-  sources:
-    - file: packages/types/src/gloas/sszTypes.ts
-      search: export const BuilderExitRequests =
-  spec: |
-    <spec custom_type="BuilderExitRequests" fork="gloas" hash="51f8ba69">
-    BuilderExitRequests = ProgressiveList[BuilderExitRequest]
-    </spec>
-
 - name: BuilderIndex#gloas
   sources:
     - file: packages/types/src/primitive/sszTypes.ts
@@ -104,15 +32,6 @@
   spec: |
     <spec custom_type="BuilderIndex" fork="gloas" hash="e7ea6e8b">
     BuilderIndex = Uint64
-    </spec>
-
-- name: Cell#fulu
-  sources:
-    - file: packages/types/src/fulu/sszTypes.ts
-      search: export const Cell =
-  spec: |
-    <spec custom_type="Cell" fork="fulu" hash="d7af27c2">
-    Cell = ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_CELL]
     </spec>
 
 - name: CellIndex#fulu
@@ -140,51 +59,6 @@
     CommitteeIndex = Uint64
     </spec>
 
-- name: ConsolidationRequests#electra
-  sources:
-    - file: packages/types/src/electra/sszTypes.ts
-      search: export const ConsolidationRequests =
-  spec: |
-    <spec custom_type="ConsolidationRequests" fork="electra" hash="b793a4dc">
-    ConsolidationRequests = List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]
-    </spec>
-
-- name: ConsolidationRequests#gloas
-  sources:
-    - file: packages/types/src/gloas/sszTypes.ts
-      search: export const ConsolidationRequests =
-  spec: |
-    <spec custom_type="ConsolidationRequests" fork="gloas" hash="44563d58">
-    ConsolidationRequests = ProgressiveList[ConsolidationRequest]
-    </spec>
-
-- name: CurrentSyncCommitteeBranch#altair
-  sources:
-    - file: packages/types/src/altair/sszTypes.ts
-      search: export const CurrentSyncCommitteeBranch =
-  spec: |
-    <spec custom_type="CurrentSyncCommitteeBranch" fork="altair" hash="f19e3670">
-    CurrentSyncCommitteeBranch = Vector[Bytes32, floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX)]
-    </spec>
-
-- name: CurrentSyncCommitteeBranch#electra
-  sources:
-    - file: packages/types/src/electra/sszTypes.ts
-      search: export const CurrentSyncCommitteeBranch =
-  spec: |
-    <spec custom_type="CurrentSyncCommitteeBranch" fork="electra" hash="f530f78f">
-    CurrentSyncCommitteeBranch = Vector[Bytes32, floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA)]
-    </spec>
-
-- name: CurrentSyncCommitteeBranch#gloas
-  sources:
-    - file: packages/types/src/gloas/sszTypes.ts
-      search: export const CurrentSyncCommitteeBranch =
-  spec: |
-    <spec custom_type="CurrentSyncCommitteeBranch" fork="gloas" hash="84e2f843">
-    CurrentSyncCommitteeBranch = Vector[Bytes32, floorlog2(CURRENT_SYNC_COMMITTEE_GINDEX_GLOAS)]
-    </spec>
-
 - name: CustodyIndex#fulu
   sources:
     - file: packages/types/src/primitive/sszTypes.ts
@@ -192,24 +66,6 @@
   spec: |
     <spec custom_type="CustodyIndex" fork="fulu" hash="519f8cbf">
     CustodyIndex = Uint64
-    </spec>
-
-- name: DepositRequests#electra
-  sources:
-    - file: packages/types/src/electra/sszTypes.ts
-      search: export const DepositRequests =
-  spec: |
-    <spec custom_type="DepositRequests" fork="electra" hash="3f9b774d">
-    DepositRequests = List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]
-    </spec>
-
-- name: DepositRequests#gloas
-  sources:
-    - file: packages/types/src/gloas/sszTypes.ts
-      search: export const DepositRequests =
-  spec: |
-    <spec custom_type="DepositRequests" fork="gloas" hash="f4af5063">
-    DepositRequests = ProgressiveList[DepositRequest]
     </spec>
 
 - name: Domain#phase0
@@ -255,49 +111,6 @@
     ExecutionAddress = Bytes20
     </spec>
 
-- name: ExecutionBranch#capella
-  sources:
-    - file: packages/types/src/capella/sszTypes.ts
-      search: export const ExecutionBranch =
-  spec: |
-    <spec custom_type="ExecutionBranch" fork="capella" hash="c07ece0a">
-    ExecutionBranch = Vector[Bytes32, floorlog2(EXECUTION_PAYLOAD_GINDEX)]
-    </spec>
-
-- name: ExecutionBranch#gloas
-  sources: []
-  spec: |
-    <spec custom_type="ExecutionBranch" fork="gloas" hash="55dfec8c">
-    ExecutionBranch = Vector[Bytes32, floorlog2(EXECUTION_BLOCK_HASH_GINDEX_GLOAS)]
-    </spec>
-
-- name: FinalityBranch#altair
-  sources:
-    - file: packages/types/src/altair/sszTypes.ts
-      search: export const FinalityBranch =
-  spec: |
-    <spec custom_type="FinalityBranch" fork="altair" hash="b16f24b7">
-    FinalityBranch = Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX)]
-    </spec>
-
-- name: FinalityBranch#electra
-  sources:
-    - file: packages/types/src/electra/sszTypes.ts
-      search: export const FinalityBranch =
-  spec: |
-    <spec custom_type="FinalityBranch" fork="electra" hash="3ec55c30">
-    FinalityBranch = Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX_ELECTRA)]
-    </spec>
-
-- name: FinalityBranch#gloas
-  sources:
-    - file: packages/types/src/gloas/sszTypes.ts
-      search: export const FinalityBranch =
-  spec: |
-    <spec custom_type="FinalityBranch" fork="gloas" hash="9d9b31ea">
-    FinalityBranch = Vector[Bytes32, floorlog2(FINALIZED_ROOT_GINDEX_GLOAS)]
-    </spec>
-
 - name: ForkDigest#phase0
   sources:
     - file: packages/types/src/primitive/sszTypes.ts
@@ -339,33 +152,6 @@
   spec: |
     <spec custom_type="KZGProof" fork="deneb" hash="cd122a70">
     KZGProof = Bytes48
-    </spec>
-
-- name: NextSyncCommitteeBranch#altair
-  sources:
-    - file: packages/types/src/altair/sszTypes.ts
-      search: export const NextSyncCommitteeBranch =
-  spec: |
-    <spec custom_type="NextSyncCommitteeBranch" fork="altair" hash="efe158e9">
-    NextSyncCommitteeBranch = Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX)]
-    </spec>
-
-- name: NextSyncCommitteeBranch#electra
-  sources:
-    - file: packages/types/src/electra/sszTypes.ts
-      search: export const NextSyncCommitteeBranch =
-  spec: |
-    <spec custom_type="NextSyncCommitteeBranch" fork="electra" hash="7f5e5585">
-    NextSyncCommitteeBranch = Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA)]
-    </spec>
-
-- name: NextSyncCommitteeBranch#gloas
-  sources:
-    - file: packages/types/src/gloas/sszTypes.ts
-      search: export const NextSyncCommitteeBranch =
-  spec: |
-    <spec custom_type="NextSyncCommitteeBranch" fork="gloas" hash="314644a9">
-    NextSyncCommitteeBranch = Vector[Bytes32, floorlog2(NEXT_SYNC_COMMITTEE_GINDEX_GLOAS)]
     </spec>
 
 - name: NodeID#phase0
@@ -439,24 +225,6 @@
     SubnetID = Uint64
     </spec>
 
-- name: Transaction#bellatrix
-  sources:
-    - file: packages/types/src/bellatrix/sszTypes.ts
-      search: export const Transaction =
-  spec: |
-    <spec custom_type="Transaction" fork="bellatrix" hash="816d420e">
-    Transaction = ByteList[MAX_BYTES_PER_TRANSACTION]
-    </spec>
-
-- name: Transaction#gloas
-  sources:
-    - file: packages/types/src/gloas/sszTypes.ts
-      search: export const Transaction =
-  spec: |
-    <spec custom_type="Transaction" fork="gloas" hash="dd671210">
-    Transaction = ProgressiveByteList
-    </spec>
-
 - name: ValidatorIndex#phase0
   sources:
     - file: packages/types/src/primitive/sszTypes.ts
@@ -491,22 +259,4 @@
   spec: |
     <spec custom_type="WithdrawalIndex" fork="capella" hash="fe950522">
     WithdrawalIndex = Uint64
-    </spec>
-
-- name: WithdrawalRequests#electra
-  sources:
-    - file: packages/types/src/electra/sszTypes.ts
-      search: export const WithdrawalRequests =
-  spec: |
-    <spec custom_type="WithdrawalRequests" fork="electra" hash="02a78460">
-    WithdrawalRequests = List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]
-    </spec>
-
-- name: WithdrawalRequests#gloas
-  sources:
-    - file: packages/types/src/gloas/sszTypes.ts
-      search: export const WithdrawalRequests =
-  spec: |
-    <spec custom_type="WithdrawalRequests" fork="gloas" hash="a26ff177">
-    WithdrawalRequests = ProgressiveList[WithdrawalRequest]
     </spec>


### PR DESCRIPTION
- fully initialize the execution payload bid when upgrading to gloas
  - https://github.com/ethereum/consensus-specs/pull/5550
  - https://github.com/ethereum/consensus-specs/pull/5553
- update Gloas/Heze types, spec tests and ethspecify for `v1.7.0-alpha.14`

standalone `ethereum/ssz-specs` integration will follow separately