### PR TITLE
fix(bls): address scheduler metrics feedback

### DIFF
--- a/dashboards/lodestar_bls_thread_pool.json
+++ b/dashboards/lodestar_bls_thread_pool.json
@@ -644,9 +644,9 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.5, sum by (instance, le, type, priority, batchable) (rate(lodestar_bls_thread_pool_queue_job_wait_time_seconds_bucket[$rate_interval])))",
+          "expr": "histogram_quantile(0.5, sum by (instance, le, type) (rate(lodestar_bls_thread_pool_queue_job_wait_time_seconds_bucket[$rate_interval])))",
           "interval": "",
-          "legendFormat": "p50 {{type}} priority={{priority}} batchable={{batchable}}",
+          "legendFormat": "p50 {{type}}",
           "refId": "A"
         },
         {
@@ -654,9 +654,9 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "histogram_quantile(0.95, sum by (instance, le, type, priority, batchable) (rate(lodestar_bls_thread_pool_queue_job_wait_time_seconds_bucket[$rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (instance, le, type) (rate(lodestar_bls_thread_pool_queue_job_wait_time_seconds_bucket[$rate_interval])))",
           "interval": "",
-          "legendFormat": "p95 {{type}} priority={{priority}} batchable={{batchable}}",
+          "legendFormat": "p95 {{type}}",
           "refId": "B"
         }
       ],

--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -50,9 +50,9 @@ const blsPoolSize = Math.max(defaultPoolSize - 1, 1);
  * The biggest sets happen during sync, on mainnet batches of 64 blocks have around ~8000 signatures.
  * The latency cost of sending the job to and from the worker is approx a single sig verification.
  * If you split a big signature into 2, the extra time cost is `(2+2N)/(1+2N)`.
- * For 128, the extra time cost is about 0.3%. No specific reasoning for `128`, it's just good enough.
+ * For 256, the extra time cost is about 0.2% and matches the maximum supported by Lodestar-Z.
  */
-const MAX_SIGNATURE_SETS_PER_JOB = 128;
+const MAX_SIGNATURE_SETS_PER_JOB = 256;
 
 /**
  * If there are more than `MAX_BUFFERED_SIGS` buffered sigs, verify them immediately without waiting `MAX_BUFFER_WAIT_MS`.
@@ -102,7 +102,7 @@ type WorkerDescriptor = {
 };
 
 type BufferFlushReason = "size" | "timeout";
-type BlsJobOutcome = "valid" | "invalid" | "error";
+type BlsJobOutcome = "valid" | "invalid" | "prepError" | "verifyError" | "workerError";
 
 /**
  * Wraps "threads" library thread pool queue system with the goals:
@@ -398,7 +398,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
           workReq = jobItemWorkReq(job);
         } catch (e) {
           this.metrics?.blsThreadPool.errorJobsSignatureSetsCount.inc(jobItemSigSets(job));
-          this.observeJobCompletion(job, "error");
+          this.observeJobCompletion(job, "prepError");
           job.reject(e as Error);
           continue;
         }
@@ -456,7 +456,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
         const outcome = completeJob(job, jobResult, i, signatureSets);
         completedJobsCount = i + 1;
         this.observeJobCompletion(job, outcome);
-        if (outcome === "error") {
+        if (outcome === "prepError" || outcome === "verifyError" || outcome === "workerError") {
           errorCount += signatureSets;
         } else {
           successCount += signatureSets;
@@ -488,7 +488,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
       let errorSignatureSets = 0;
       for (let i = completedJobsCount; i < jobsStarted.length; i++) {
         const job = jobsStarted[i];
-        this.observeJobCompletion(job, "error");
+        this.observeJobCompletion(job, "workerError");
         errorSignatureSets += jobItemSigSets(job);
         job.reject(e as Error);
       }
@@ -571,7 +571,7 @@ function completeJob(
 ): BlsJobOutcome {
   if (!jobResult || jobResult.code !== WorkResultCode.success) {
     job.reject(getJobResultError(jobResult ?? null, index));
-    return "error";
+    return "verifyError";
   }
 
   switch (job.type) {
@@ -579,7 +579,7 @@ function completeJob(
       const [result] = jobResult.result;
       if (jobResult.result.length !== 1 || result === undefined) {
         job.reject(getInvalidResultLengthError(index, 1, jobResult.result.length));
-        return "error";
+        return "workerError";
       }
 
       job.resolve(result);
@@ -589,7 +589,7 @@ function completeJob(
     case JobQueueItemType.sameMessage:
       if (jobResult.result.length !== signatureSets) {
         job.reject(getInvalidResultLengthError(index, signatureSets, jobResult.result.length));
-        return "error";
+        return "workerError";
       }
 
       job.resolve(jobResult.result);
@@ -597,16 +597,8 @@ function completeJob(
   }
 }
 
-function jobMetricLabels(job: JobQueueItem): {
-  type: JobQueueItemType;
-  priority: "true" | "false";
-  batchable: "true" | "false";
-} {
-  return {
-    type: job.type,
-    priority: job.opts.priority ? "true" : "false",
-    batchable: job.opts.batchable ? "true" : "false",
-  };
+function jobMetricLabels(job: JobQueueItem): {type: JobQueueItemType} {
+  return {type: job.type};
 }
 
 function getJobResultError(jobResult: WorkResultError | null, i: number): Error {

--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -25,7 +25,7 @@ import {
   WorkResultError,
   WorkerData,
 } from "./types.js";
-import {chunkifyMaximizeChunkSize} from "./utils.js";
+import {chunkifyMaxChunkSize} from "./utils.js";
 
 // Worker constructor consider the path relative to the current working directory
 const workerDir = process.env.NODE_ENV === "test" ? "../../../../lib/chain/bls/multithread" : "./";
@@ -177,7 +177,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
     // Split large array of sets into smaller.
     // Very helpful when syncing finalized, sync may submit +1000 sets so chunkify allows to distribute to many workers
     const results = await Promise.all(
-      chunkifyMaximizeChunkSize(sets, MAX_SIGNATURE_SETS_PER_JOB).map(
+      chunkifyMaxChunkSize(sets, MAX_SIGNATURE_SETS_PER_JOB).map(
         (setsChunk) =>
           new Promise<boolean>((resolve, reject) => {
             return this.queueBlsWork({

--- a/packages/beacon-node/src/chain/bls/multithread/utils.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/utils.ts
@@ -17,3 +17,14 @@ export function chunkifyMaximizeChunkSize<T>(arr: T[], minPerChunk: number): T[]
 
   return arrArr;
 }
+
+/**
+ * Splits an array into chunks that do not exceed a maximum size.
+ */
+export function chunkifyMaxChunkSize<T>(arr: T[], maxPerChunk: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < arr.length; i += maxPerChunk) {
+    chunks.push(arr.slice(i, i + maxPerChunk));
+  }
+  return chunks;
+}

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -31,8 +31,7 @@ import {RegistryMetricCreator} from "../utils/registryMetricCreator.js";
 
 export type LodestarMetrics = ReturnType<typeof createLodestarMetrics>;
 
-type BlsMetricBoolean = "true" | "false";
-type BlsJobOutcome = "valid" | "invalid" | "error";
+type BlsJobOutcome = "valid" | "invalid" | "prepError" | "verifyError" | "workerError";
 type BlsBufferFlushReason = "size" | "timeout";
 type BlsVerificationCallOperation = "general_batch" | "general_direct" | "general_fallback" | "same_message";
 
@@ -421,25 +420,17 @@ export function createLodestarMetrics(
         name: "lodestar_bls_thread_pool_error_jobs_signature_sets_count",
         help: "Count of signature sets that ended in an input, binding, or worker error",
       }),
-      jobWaitTime: register.histogram<{
-        type: JobQueueItemType;
-        priority: BlsMetricBoolean;
-        batchable: BlsMetricBoolean;
-      }>({
+      jobWaitTime: register.histogram<{type: JobQueueItemType}>({
         name: "lodestar_bls_thread_pool_queue_job_wait_time_seconds",
         help: "Time from adding a BLS job until it is selected for a worker dispatch group",
-        labelNames: ["type", "priority", "batchable"],
-        buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60],
+        labelNames: ["type"],
+        buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 2],
       }),
-      jobDuration: register.histogram<{
-        type: JobQueueItemType;
-        priority: BlsMetricBoolean;
-        batchable: BlsMetricBoolean;
-      }>({
+      jobDuration: register.histogram<{type: JobQueueItemType}>({
         name: "lodestar_bls_thread_pool_job_duration_seconds",
         help: "End-to-end duration of a BLS job from submission through completion",
-        labelNames: ["type", "priority", "batchable"],
-        buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60],
+        labelNames: ["type"],
+        buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 2],
       }),
       jobResults: register.counter<{type: JobQueueItemType; outcome: BlsJobOutcome}>({
         name: "lodestar_bls_thread_pool_job_results_total",
@@ -496,12 +487,12 @@ export function createLodestarMetrics(
       latencyToWorker: register.histogram({
         name: "lodestar_bls_thread_pool_latency_to_worker",
         help: "Time from sending the job to the worker and the worker receiving it",
-        buckets: [0.001, 0.003, 0.01, 0.03, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60],
+        buckets: [0.001, 0.003, 0.01, 0.03, 0.1, 0.25, 0.5, 1, 2],
       }),
       latencyFromWorker: register.histogram({
         name: "lodestar_bls_thread_pool_latency_from_worker",
         help: "Time from the worker sending the result and the main thread receiving it",
-        buckets: [0.001, 0.003, 0.01, 0.03, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60],
+        buckets: [0.001, 0.003, 0.01, 0.03, 0.1, 0.25, 0.5, 1, 2],
       }),
       mainThreadDurationInThreadPool: register.histogram({
         name: "lodestar_bls_thread_pool_main_thread_time_seconds",
@@ -518,16 +509,13 @@ export function createLodestarMetrics(
       workRequestPreparationDuration: register.histogram({
         name: "lodestar_bls_thread_pool_work_request_preparation_duration_seconds",
         help: "Main-thread time spent converting one worker dispatch group to binding inputs",
-        buckets: [
-          0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30,
-          60,
-        ],
+        buckets: [0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2],
       }),
       verificationCallDuration: register.histogram<{operation: BlsVerificationCallOperation}>({
         name: "lodestar_bls_thread_pool_verification_call_duration_seconds",
         help: "Duration of one worker-side lodestar-z verification binding call, including input conversion",
         labelNames: ["operation"],
-        buckets: [0.00025, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60],
+        buckets: [0.00025, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2],
       }),
       verificationCallSignatureSets: register.counter<{operation: BlsVerificationCallOperation}>({
         name: "lodestar_bls_thread_pool_verification_call_signature_sets_total",

--- a/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
@@ -5,6 +5,7 @@ import {testLogger} from "@lodestar/logger/test-utils";
 import {ISignatureSet, SignatureSetType} from "@lodestar/state-transition";
 import {VerifySignatureOpts} from "../../../../src/chain/bls/interface.js";
 import {BlsMultiThreadWorkerPool} from "../../../../src/chain/bls/multithread/index.js";
+import {WorkResultCode} from "../../../../src/chain/bls/multithread/types.js";
 import {createMetricsTest} from "../../../unit/metrics/utils.js";
 
 describe("chain / bls / multithread queue", () => {
@@ -137,14 +138,87 @@ describe("chain / bls / multithread queue", () => {
     const jobResults = await metrics.register.getSingleMetricAsString("lodestar_bls_thread_pool_job_results_total");
     expect(jobResults).toContain('type="default",outcome="valid"');
     expect(jobResults).toContain('type="default",outcome="invalid"');
-    expect(jobResults).toContain('type="default",outcome="error"');
+    expect(jobResults).toContain('type="default",outcome="prepError"');
     expect(jobResults).toContain('type="same_message",outcome="valid"');
+
+    const jobWaitTime = await metrics.register.getSingleMetricAsString(
+      "lodestar_bls_thread_pool_queue_job_wait_time_seconds"
+    );
+    expect(jobWaitTime).toContain('lodestar_bls_thread_pool_queue_job_wait_time_seconds_count{type="default"}');
+    expect(jobWaitTime).not.toContain("priority=");
+    expect(jobWaitTime).not.toContain("batchable=");
+
+    for (const metricName of [
+      "lodestar_bls_thread_pool_queue_job_wait_time_seconds",
+      "lodestar_bls_thread_pool_job_duration_seconds",
+      "lodestar_bls_thread_pool_latency_to_worker",
+      "lodestar_bls_thread_pool_latency_from_worker",
+      "lodestar_bls_thread_pool_work_request_preparation_duration_seconds",
+      "lodestar_bls_thread_pool_verification_call_duration_seconds",
+    ]) {
+      const metric = await metrics.register.getSingleMetricAsString(metricName);
+      expect(metric).toContain('le="2"');
+      expect(metric).not.toContain('le="5"');
+    }
 
     const bufferFlushes = await metrics.register.getSingleMetricAsString(
       "lodestar_bls_thread_pool_buffer_flushes_total"
     );
     expect(bufferFlushes).toContain('reason="timeout"');
     expect(bufferFlushes).toContain('reason="size"');
+  });
+
+  it("Should distinguish verifier and worker result errors", async () => {
+    const metrics = createMetricsTest();
+    const pool = new BlsMultiThreadWorkerPool({}, {logger, metrics});
+    afterEachCallbacks.push(() => pool.close());
+    await pool["waitTillInitialized"]();
+
+    for (const worker of pool["workers"]) {
+      if (!("workerApi" in worker.status)) {
+        throw Error("BLS worker did not initialize");
+      }
+
+      worker.status.workerApi.verifyManySignatureSets = async () => {
+        const now = process.hrtime();
+        return {
+          workerId: 0,
+          batchRetries: 0,
+          batchSigsSuccess: 0,
+          verificationCalls: [],
+          workerStartTime: now,
+          workerEndTime: now,
+          results: [{code: WorkResultCode.error, error: Error("verification failed")}],
+        };
+      };
+    }
+
+    await expect(pool.verifySignatureSets([sets[0]])).rejects.toThrow("verification failed");
+
+    for (const worker of pool["workers"]) {
+      if (!("workerApi" in worker.status)) {
+        throw Error("BLS worker did not initialize");
+      }
+
+      worker.status.workerApi.verifyManySignatureSets = async () => {
+        const now = process.hrtime();
+        return {
+          workerId: 0,
+          batchRetries: 0,
+          batchSigsSuccess: 0,
+          verificationCalls: [],
+          workerStartTime: now,
+          workerEndTime: now,
+          results: [{code: WorkResultCode.success, result: []}],
+        };
+      };
+    }
+
+    await expect(pool.verifySignatureSets([sets[0]])).rejects.toThrow("Invalid BLS worker result length");
+
+    const jobResults = await metrics.register.getSingleMetricAsString("lodestar_bls_thread_pool_job_results_total");
+    expect(jobResults).toContain('type="default",outcome="verifyError"');
+    expect(jobResults).toContain('type="default",outcome="workerError"');
   });
 
   for (const priority of [true, false]) {
@@ -225,18 +299,21 @@ describe("chain / bls / multithread queue", () => {
       };
     }
 
-    const smallJob = pool.verifySignatureSets([sets[0], sets[1]], {batchable: true});
-    const largeJob = pool.verifySignatureSets(
-      Array.from({length: 127}, () => sets[2]),
+    const firstJob = pool.verifySignatureSets(
+      Array.from({length: 128}, () => sets[0]),
+      {batchable: true}
+    );
+    const secondJob = pool.verifySignatureSets(
+      Array.from({length: 128}, () => sets[2]),
       {batchable: true}
     );
 
     try {
-      await vi.waitFor(() => expect(startedWorkerCalls).toBe(2));
+      await vi.waitFor(() => expect(startedWorkerCalls).toBe(1));
     } finally {
       releaseWorkers();
     }
 
-    await expect(Promise.all([smallJob, largeJob])).resolves.toEqual([true, true]);
+    await expect(Promise.all([firstJob, secondJob])).resolves.toEqual([true, true]);
   });
 });

--- a/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
@@ -276,6 +276,26 @@ describe("chain / bls / multithread queue", () => {
     expect(retries).toContain("lodestar_bls_thread_pool_batch_retries_total 0");
   });
 
+  it("Should keep every dispatched job within the verifier bound", async () => {
+    const pool = await initializePool();
+    const dispatchedJobSizes: number[] = [];
+
+    for (const worker of pool["workers"]) {
+      if (!("workerApi" in worker.status)) {
+        throw Error("BLS worker did not initialize");
+      }
+
+      const verifyManySignatureSets = worker.status.workerApi.verifyManySignatureSets.bind(worker.status.workerApi);
+      worker.status.workerApi.verifyManySignatureSets = async (workReqs) => {
+        dispatchedJobSizes.push(...workReqs.map((workReq) => workReq.sets.length));
+        return verifyManySignatureSets(workReqs);
+      };
+    }
+
+    await expect(pool.verifySignatureSets(Array.from({length: 257}, () => sets[0]))).resolves.toBe(true);
+    expect(Math.max(...dispatchedJobSizes)).toBeLessThanOrEqual(256);
+  });
+
   it("Should dispatch bounded packages to idle workers", async () => {
     const pool = await initializePool();
     await new Promise((resolve) => setTimeout(resolve, 0));


### PR DESCRIPTION
## Summary

- raise the worker package limit to 256 signature sets, matching Lodestar-Z's verifier bound
- reduce BLS job latency metric cardinality and cap scheduler duration buckets at 2 seconds
- distinguish preparation, verification, and worker result failures in job outcome metrics
- add regressions for 256-set dispatches, metric dimensions/buckets, and error outcomes

## Verification

- `pnpm vitest run --project e2e packages/beacon-node/test/e2e/chain/bls/multithread.test.ts` (12 passed)
- `pnpm --filter @lodestar/beacon-node build`
- `pnpm --filter @lodestar/beacon-node check-types`
- `pnpm biome check packages/beacon-node/src/metrics/metrics/lodestar.ts packages/beacon-node/src/chain/bls/multithread/index.ts packages/beacon-node/test/e2e/chain/bls/multithread.test.ts`

Follow-up for #9820 review feedback from @twoeths.
