### PR TITLE
chore: restore pre-Fulu proposer shuffling check

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {MIN_SEED_LOOKAHEAD, SLOTS_PER_EPOCH, isForkPostGloas} from "@lodestar/params";
+import {MIN_SEED_LOOKAHEAD, SLOTS_PER_EPOCH, isForkPostFulu, isForkPostGloas} from "@lodestar/params";
 import {
   DataAvailabilityStatus,
   EffectiveBalanceIncrements,
@@ -2084,6 +2084,11 @@ export class ForkChoice implements IForkChoice {
     const isHeadLate = !headBlock.timeliness;
     if (!isHeadLate) {
       return {prelimProposerHead, prelimNotReorgedReason: NotReorgedReason.HeadBlockIsTimely};
+    }
+
+    const isShufflingStable = isForkPostFulu(this.config.getForkName(slot)) || slot % SLOTS_PER_EPOCH !== 0;
+    if (!isShufflingStable) {
+      return {prelimProposerHead, prelimNotReorgedReason: NotReorgedReason.NotShufflingStable};
     }
 
     // No reorg if headBlock and parentBlock are not ffg competitive

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -54,6 +54,7 @@ export enum NotReorgedReason {
   HeadBlockIsTimely = "headBlockIsTimely",
   ParentBlockNotAvailable = "parentBlockNotAvailable",
   ProposerBoostReorgDisabled = "proposerBoostReorgDisabled",
+  NotShufflingStable = "notShufflingStable",
   NotFFGCompetitive = "notFFGCompetitive",
   ChainLongUnfinality = "chainLongUnfinality",
   ParentBlockDistanceMoreThanOneSlot = "parentBlockDistanceMoreThanOneSlot",

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -1,5 +1,6 @@
 import {beforeEach, describe, expect, it} from "vitest";
 import {fromHexString} from "@chainsafe/ssz";
+import {ChainForkConfig, createChainForkConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
 import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {DataAvailabilityStatus} from "@lodestar/state-transition";
@@ -26,6 +27,14 @@ describe("Forkchoice / GetProposerHead", () => {
   const parentSlot = genesisSlot + 1;
   const headSlot = genesisSlot + 2;
   const validatorCount = 100;
+  const fuluConfig = createChainForkConfig({
+    ALTAIR_FORK_EPOCH: 0,
+    BELLATRIX_FORK_EPOCH: 0,
+    CAPELLA_FORK_EPOCH: 0,
+    DENEB_FORK_EPOCH: 0,
+    ELECTRA_FORK_EPOCH: 0,
+    FULU_FORK_EPOCH: 0,
+  });
 
   let protoArr: ProtoArray;
 
@@ -109,6 +118,22 @@ describe("Forkchoice / GetProposerHead", () => {
     payloadStatus: PayloadStatus.FULL,
   };
 
+  const epochBoundaryParentBlock = {
+    ...baseParentHeadBlock,
+    slot: SLOTS_PER_EPOCH * 2 - 2,
+    stateRoot: getStateRoot(SLOTS_PER_EPOCH * 2 - 2),
+    blockRoot: getBlockRoot(SLOTS_PER_EPOCH * 2 - 2),
+    targetRoot: getBlockRoot(SLOTS_PER_EPOCH),
+  };
+  const epochBoundaryHeadBlock = {
+    ...baseHeadBlock,
+    slot: SLOTS_PER_EPOCH * 2 - 1,
+    stateRoot: getStateRoot(SLOTS_PER_EPOCH * 2 - 1),
+    parentRoot: getBlockRoot(SLOTS_PER_EPOCH * 2 - 2),
+    blockRoot: getBlockRoot(SLOTS_PER_EPOCH * 2 - 1),
+    targetRoot: getBlockRoot(SLOTS_PER_EPOCH),
+  };
+
   const fcStore: IForkChoiceStore = {
     currentSlot: genesisSlot + 1,
     justified: {
@@ -173,6 +198,7 @@ describe("Forkchoice / GetProposerHead", () => {
     currentSlot?: Slot;
     secFromSlot?: number;
     expectedNotReorgedReason?: NotReorgedReason;
+    config?: ChainForkConfig;
   }[] = [
     {
       id: "Case that meets all conditions to be re-orged",
@@ -188,24 +214,20 @@ describe("Forkchoice / GetProposerHead", () => {
       expectedNotReorgedReason: NotReorgedReason.HeadBlockIsTimely,
     },
     {
-      id: "Reorg when currentSlot is at epoch boundary",
-      parentBlock: {
-        ...baseParentHeadBlock,
-        slot: SLOTS_PER_EPOCH * 2 - 2,
-        stateRoot: getStateRoot(SLOTS_PER_EPOCH * 2 - 2),
-        blockRoot: getBlockRoot(SLOTS_PER_EPOCH * 2 - 2),
-        targetRoot: getBlockRoot(SLOTS_PER_EPOCH),
-      },
-      headBlock: {
-        ...baseHeadBlock,
-        slot: SLOTS_PER_EPOCH * 2 - 1,
-        stateRoot: getStateRoot(SLOTS_PER_EPOCH * 2 - 1),
-        parentRoot: getBlockRoot(SLOTS_PER_EPOCH * 2 - 2),
-        blockRoot: getBlockRoot(SLOTS_PER_EPOCH * 2 - 1),
-        targetRoot: getBlockRoot(SLOTS_PER_EPOCH),
-      },
+      id: "No reorg when proposer shuffling is not stable",
+      parentBlock: epochBoundaryParentBlock,
+      headBlock: epochBoundaryHeadBlock,
+      expectReorg: false,
+      currentSlot: SLOTS_PER_EPOCH * 2,
+      expectedNotReorgedReason: NotReorgedReason.NotShufflingStable,
+    },
+    {
+      id: "Reorg when currentSlot is at a post-Fulu epoch boundary",
+      parentBlock: epochBoundaryParentBlock,
+      headBlock: epochBoundaryHeadBlock,
       expectReorg: true,
       currentSlot: SLOTS_PER_EPOCH * 2,
+      config: fuluConfig,
     },
     {
       id: "No reorg when the blocks are not ffg competitive",
@@ -280,6 +302,7 @@ describe("Forkchoice / GetProposerHead", () => {
     currentSlot: proposalSlot,
     secFromSlot,
     expectedNotReorgedReason,
+    config: forkChoiceConfig,
   } of testCases) {
     it(`${id}`, async () => {
       protoArr.onBlock(parentBlock, parentBlock.slot, null);
@@ -297,7 +320,7 @@ describe("Forkchoice / GetProposerHead", () => {
         currentSlot,
       });
 
-      const forkChoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null, {
+      const forkChoice = new ForkChoice(forkChoiceConfig ?? config, fcStore, protoArr, validatorCount, null, {
         proposerBoost: true,
         proposerBoostReorg: true,
       });

--- a/packages/fork-choice/test/unit/forkChoice/shouldOverrideForkChoiceUpdate.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/shouldOverrideForkChoiceUpdate.test.ts
@@ -1,5 +1,6 @@
 import {beforeEach, describe, expect, it} from "vitest";
 import {fromHexString} from "@chainsafe/ssz";
+import {ChainForkConfig, createChainForkConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {DataAvailabilityStatus} from "@lodestar/state-transition";
@@ -26,6 +27,14 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
   const parentSlot = genesisSlot + 1;
   const headSlot = genesisSlot + 2;
   const validatorCount = 100;
+  const fuluConfig = createChainForkConfig({
+    ALTAIR_FORK_EPOCH: 0,
+    BELLATRIX_FORK_EPOCH: 0,
+    CAPELLA_FORK_EPOCH: 0,
+    DENEB_FORK_EPOCH: 0,
+    ELECTRA_FORK_EPOCH: 0,
+    FULU_FORK_EPOCH: 0,
+  });
 
   let protoArr: ProtoArray;
 
@@ -109,6 +118,22 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
     payloadStatus: PayloadStatus.FULL,
   };
 
+  const epochBoundaryParentBlock = {
+    ...baseParentHeadBlock,
+    slot: SLOTS_PER_EPOCH * 2 - 2,
+    stateRoot: getStateRoot(SLOTS_PER_EPOCH * 2 - 2),
+    blockRoot: getBlockRoot(SLOTS_PER_EPOCH * 2 - 2),
+    targetRoot: getBlockRoot(SLOTS_PER_EPOCH),
+  };
+  const epochBoundaryHeadBlock = {
+    ...baseHeadBlock,
+    slot: SLOTS_PER_EPOCH * 2 - 1,
+    stateRoot: getStateRoot(SLOTS_PER_EPOCH * 2 - 1),
+    parentRoot: getBlockRoot(SLOTS_PER_EPOCH * 2 - 2),
+    blockRoot: getBlockRoot(SLOTS_PER_EPOCH * 2 - 1),
+    targetRoot: getBlockRoot(SLOTS_PER_EPOCH),
+  };
+
   const fcStore: IForkChoiceStore = {
     currentSlot: genesisSlot + 1,
     justified: {
@@ -171,6 +196,7 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
     expectReorg: boolean;
     currentSlot?: Slot;
     expectedNotReorgedReason?: NotReorgedReason;
+    config?: ChainForkConfig;
   }[] = [
     {
       id: "Case that meets all conditions to be re-orged",
@@ -186,23 +212,18 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
       expectedNotReorgedReason: NotReorgedReason.HeadBlockIsTimely,
     },
     {
-      id: "Reorg when proposal slot is at epoch boundary",
-      parentBlock: {
-        ...baseParentHeadBlock,
-        slot: SLOTS_PER_EPOCH * 2 - 2,
-        stateRoot: getStateRoot(SLOTS_PER_EPOCH * 2 - 2),
-        blockRoot: getBlockRoot(SLOTS_PER_EPOCH * 2 - 2),
-        targetRoot: getBlockRoot(SLOTS_PER_EPOCH),
-      },
-      headBlock: {
-        ...baseHeadBlock,
-        slot: SLOTS_PER_EPOCH * 2 - 1,
-        stateRoot: getStateRoot(SLOTS_PER_EPOCH * 2 - 1),
-        parentRoot: getBlockRoot(SLOTS_PER_EPOCH * 2 - 2),
-        blockRoot: getBlockRoot(SLOTS_PER_EPOCH * 2 - 1),
-        targetRoot: getBlockRoot(SLOTS_PER_EPOCH),
-      },
+      id: "No reorg when proposer shuffling is not stable",
+      parentBlock: epochBoundaryParentBlock,
+      headBlock: epochBoundaryHeadBlock,
+      expectReorg: false,
+      expectedNotReorgedReason: NotReorgedReason.NotShufflingStable,
+    },
+    {
+      id: "Reorg when proposal slot is at a post-Fulu epoch boundary",
+      parentBlock: epochBoundaryParentBlock,
+      headBlock: epochBoundaryHeadBlock,
       expectReorg: true,
+      config: fuluConfig,
     },
     {
       id: "No reorg when the blocks are not ffg competitive",
@@ -246,6 +267,7 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
     expectReorg,
     currentSlot: blockSeenSlot,
     expectedNotReorgedReason,
+    config: forkChoiceConfig,
   } of testCases) {
     it(id, async () => {
       protoArr.onBlock(parentBlock, parentBlock.slot, null);
@@ -253,7 +275,7 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
 
       const secFromSlot = 0;
       const currentSlot = blockSeenSlot ?? headBlock.slot;
-      const forkChoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null, {
+      const forkChoice = new ForkChoice(forkChoiceConfig ?? config, fcStore, protoArr, validatorCount, null, {
         proposerBoost: true,
         proposerBoostReorg: true,
       });


### PR DESCRIPTION
The shuffling stability check was removed for all forks in #9769, but the spec only removes it from Fulu.

Keep the check through Electra and allow epoch-boundary reorgs from Fulu.

Tested with the targeted unit tests and minimal/mainnet `get_proposer_head/epoch_boundary` spec tests.