### PR TITLE
fix: prune prefinalized pending items in BlockInputSync

### DIFF
--- a/packages/beacon-node/src/sync/types.ts
+++ b/packages/beacon-node/src/sync/types.ts
@@ -77,8 +77,7 @@ export type PendingPayloadInput = {
 export type PendingPayloadRootHex = {
   status: PendingPayloadInputStatus.pending | PendingPayloadInputStatus.fetching;
   rootHex: RootHex;
-  // message slot hint, may be missing when resolving a parent payload
-  slot?: Slot;
+  slot: Slot;
   timeAddedSec: number;
   timeSyncedSec?: number;
   peerIdStrings: Set<string>;
@@ -125,7 +124,7 @@ export function getPayloadSyncCacheItemRootHex(payload: PayloadSyncCacheItem): R
   return payload.rootHex;
 }
 
-export function getPayloadSyncCacheItemSlot(payload: PayloadSyncCacheItem): Slot | string {
+export function getPayloadSyncCacheItemSlot(payload: PayloadSyncCacheItem): Slot {
   if (isPendingPayloadInput(payload)) {
     return payload.payloadInput.slot;
   }
@@ -134,5 +133,5 @@ export function getPayloadSyncCacheItemSlot(payload: PayloadSyncCacheItem): Slot
     return payload.envelope.message.payload.slotNumber;
   }
 
-  return payload.slot ?? "unknown";
+  return payload.slot;
 }

--- a/packages/beacon-node/src/sync/types.ts
+++ b/packages/beacon-node/src/sync/types.ts
@@ -77,7 +77,10 @@ export type PendingPayloadInput = {
 export type PendingPayloadRootHex = {
   status: PendingPayloadInputStatus.pending | PendingPayloadInputStatus.fetching;
   rootHex: RootHex;
-  slot: Slot;
+  // Trusted slot only (fork choice / validated data), may be missing until resolved. NOT the gossip
+  // message slot from ChainEvent.unknownEnvelopeBlockRoot, which is untrusted and not necessarily the
+  // payload/block slot. See BlockInputSync.resolvePayloadSlot.
+  slot?: Slot;
   timeAddedSec: number;
   timeSyncedSec?: number;
   peerIdStrings: Set<string>;
@@ -124,7 +127,7 @@ export function getPayloadSyncCacheItemRootHex(payload: PayloadSyncCacheItem): R
   return payload.rootHex;
 }
 
-export function getPayloadSyncCacheItemSlot(payload: PayloadSyncCacheItem): Slot {
+export function getPayloadSyncCacheItemSlot(payload: PayloadSyncCacheItem): Slot | string {
   if (isPendingPayloadInput(payload)) {
     return payload.payloadInput.slot;
   }
@@ -133,5 +136,5 @@ export function getPayloadSyncCacheItemSlot(payload: PayloadSyncCacheItem): Slot
     return payload.envelope.message.payload.slotNumber;
   }
 
-  return payload.slot;
+  return payload.slot ?? "unknown";
 }

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -1,5 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
+import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {ForkSeq, isForkPostGloas} from "@lodestar/params";
 import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
 import {computeTimeAtSlot} from "@lodestar/state-transition";
@@ -154,6 +155,7 @@ export class BlockInputSync {
       this.chain.emitter.on(ChainEvent.incompleteBlockInput, this.onIncompleteBlockInput);
       this.chain.emitter.on(ChainEvent.incompletePayloadEnvelope, this.onIncompletePayloadEnvelope);
       this.chain.emitter.on(ChainEvent.blockUnknownParent, this.onUnknownParent);
+      this.chain.emitter.on(ChainEvent.forkChoiceFinalized, this.pruneFinalized);
       this.chain.emitter.on(routes.events.EventType.block, this.onBlockImported);
       this.chain.emitter.on(routes.events.EventType.executionPayload, this.onPayloadImported);
       this.network.events.on(NetworkEvent.peerConnected, this.onPeerConnected);
@@ -170,6 +172,7 @@ export class BlockInputSync {
     this.chain.emitter.off(ChainEvent.incompleteBlockInput, this.onIncompleteBlockInput);
     this.chain.emitter.off(ChainEvent.incompletePayloadEnvelope, this.onIncompletePayloadEnvelope);
     this.chain.emitter.off(ChainEvent.blockUnknownParent, this.onUnknownParent);
+    this.chain.emitter.off(ChainEvent.forkChoiceFinalized, this.pruneFinalized);
     this.chain.emitter.off(routes.events.EventType.block, this.onBlockImported);
     this.chain.emitter.off(routes.events.EventType.executionPayload, this.onPayloadImported);
     this.network.events.off(NetworkEvent.peerConnected, this.onPeerConnected);
@@ -215,7 +218,7 @@ export class BlockInputSync {
 
   private onUnknownEnvelopeBlockRoot = (data: ChainEventData[ChainEvent.unknownEnvelopeBlockRoot]): void => {
     try {
-      this.addByPayloadRootHex(data.rootHex, data.peer, data.slot);
+      this.addByPayloadRootHex(data.rootHex, data.slot, data.peer);
       this.triggerUnknownBlockSearch();
       this.metrics?.blockInputSync.requests.inc({type: PendingBlockType.UNKNOWN_PAYLOAD_BLOCK_ROOT});
       this.metrics?.blockInputSync.payloadSource.inc({source: data.source});
@@ -258,7 +261,7 @@ export class BlockInputSync {
       }
 
       if (missingDependency.kind === "parentPayload") {
-        this.addByPayloadRootHex(missingDependency.rootHex, data.peer);
+        this.addByPayloadRootHex(missingDependency.rootHex, missingDependency.slot, data.peer);
       } else if (missingDependency.kind === "parentBlock") {
         this.addByRootHex(missingDependency.rootHex, data.peer);
       }
@@ -282,6 +285,43 @@ export class BlockInputSync {
   }: routes.events.EventData[routes.events.EventType.executionPayload]): void => {
     this.pendingPayloads.delete(blockRoot);
     this.triggerUnknownBlockSearch();
+  };
+
+  /**
+   * Drop pending payloads and blocks that fell below the finalized slot.
+   * See https://github.com/ChainSafe/lodestar/issues/9800
+   */
+  private pruneFinalized = (checkpoint: CheckpointWithHex): void => {
+    // Use the actual finalized block slot, not computeStartSlotAtEpoch(checkpoint.epoch)
+    // because the payload at the finalized block is not finalized
+    const finalizedSlot = this.chain.forkChoice.getFinalizedBlock().slot;
+
+    let deletedPayloads = 0;
+    for (const [rootHex, payload] of this.pendingPayloads) {
+      if (getPayloadSyncCacheItemSlot(payload) < finalizedSlot) {
+        this.pendingPayloads.delete(rootHex);
+        deletedPayloads++;
+      }
+    }
+
+    let deletedBlocks = 0;
+    for (const [rootHex, block] of this.pendingBlocks) {
+      const slot = getBlockInputSyncCacheItemSlot(block);
+      if (typeof slot === "number" && slot < finalizedSlot) {
+        this.pendingBlocks.delete(rootHex);
+        deletedBlocks++;
+      }
+    }
+
+    if (deletedPayloads > 0 || deletedBlocks > 0) {
+      this.metrics?.blockInputSync.removedBlocks.inc(deletedPayloads + deletedBlocks);
+      this.logger.debug("BlockInputSync.pruneFinalized dropped pre-finalized pending items", {
+        finalizedSlot,
+        finalizedRoot: checkpoint.rootHex,
+        deletedPayloads,
+        deletedBlocks,
+      });
+    }
   };
 
   private addByRootHex = (rootHex: RootHex, peerIdStr?: PeerIdStr): boolean => {
@@ -349,7 +389,7 @@ export class BlockInputSync {
     }
   };
 
-  private addByPayloadRootHex = (rootHex: RootHex, peerIdStr?: PeerIdStr, slot?: Slot): boolean => {
+  private addByPayloadRootHex = (rootHex: RootHex, slot: Slot, peerIdStr?: PeerIdStr): boolean => {
     let pendingPayload = this.pendingPayloads.get(rootHex);
     let added = false;
     if (!pendingPayload) {
@@ -364,8 +404,8 @@ export class BlockInputSync {
       added = true;
 
       this.logger.verbose("Added new payload rootHex to BlockInputSync.pendingPayloads", {
-        slot: slot ?? "unknown",
-        delaySec: slot != null ? this.chain.clock.secFromSlot(slot) : "unknown",
+        slot,
+        delaySec: this.chain.clock.secFromSlot(slot),
         root: rootHex,
         peerIdStr: peerIdStr ?? "unknown peer",
       });
@@ -436,10 +476,12 @@ export class BlockInputSync {
     blockInput: IBlockInput
   ):
     | {kind: "ready"}
-    | {kind: "block" | "parentBlock" | "parentPayload"; rootHex: RootHex}
+    | {kind: "block" | "parentBlock"; rootHex: RootHex}
+    | {kind: "parentPayload"; rootHex: RootHex; slot: Slot}
     | {kind: "invalidParentPayload"; parentRootHex: RootHex; parentBlockHashHex: RootHex} {
     const parentRootHex = blockInput.parentRootHex;
-    if (!this.chain.forkChoice.hasBlockHex(parentRootHex)) {
+    const parentBlock = this.chain.forkChoice.getBlockHexDefaultStatus(parentRootHex);
+    if (!parentBlock) {
       return {kind: "parentBlock", rootHex: parentRootHex};
     }
 
@@ -464,13 +506,13 @@ export class BlockInputSync {
     const parentPayloadInput = this.chain.seenPayloadEnvelopeInputCache.get(parentRootHex);
     if (parentPayloadInput) {
       if (parentPayloadInput.getBlockHashHex() === parentBlockHashHex) {
-        return {kind: "parentPayload", rootHex: parentRootHex};
+        return {kind: "parentPayload", rootHex: parentRootHex, slot: parentBlock.slot};
       }
 
       return {kind: "invalidParentPayload", parentRootHex, parentBlockHashHex};
     }
 
-    return {kind: "parentPayload", rootHex: parentRootHex};
+    return {kind: "parentPayload", rootHex: parentRootHex, slot: parentBlock.slot};
   }
 
   private advancePendingBlock(pendingBlock: PendingBlockInput): AdvancePendingBlockResult {
@@ -493,9 +535,9 @@ export class BlockInputSync {
       }
 
       case "parentPayload": {
-        let added = this.addByPayloadRootHex(missingDependency.rootHex);
+        let added = this.addByPayloadRootHex(missingDependency.rootHex, missingDependency.slot);
         for (const peerIdStr of pendingBlock.peerIdStrings) {
-          added = this.addByPayloadRootHex(missingDependency.rootHex, peerIdStr) || added;
+          added = this.addByPayloadRootHex(missingDependency.rootHex, missingDependency.slot, peerIdStr) || added;
         }
         return added ? "queued_parent_payload" : "blocked";
       }
@@ -928,6 +970,7 @@ export class BlockInputSync {
         const pendingPayloadByRoot: PendingPayloadRootHex = {
           status: PendingPayloadInputStatus.pending,
           rootHex,
+          slot: pendingPayload.envelope.message.payload.slotNumber,
           timeAddedSec: pendingPayload.timeAddedSec,
           peerIdStrings: new Set(pendingPayload.peerIdStrings),
         };

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -218,7 +218,7 @@ export class BlockInputSync {
 
   private onUnknownEnvelopeBlockRoot = (data: ChainEventData[ChainEvent.unknownEnvelopeBlockRoot]): void => {
     try {
-      this.addByPayloadRootHex(data.rootHex, data.slot, data.peer);
+      this.addByPayloadRootHex(data.rootHex, data.peer, this.resolvePayloadSlot(data.rootHex));
       this.triggerUnknownBlockSearch();
       this.metrics?.blockInputSync.requests.inc({type: PendingBlockType.UNKNOWN_PAYLOAD_BLOCK_ROOT});
       this.metrics?.blockInputSync.payloadSource.inc({source: data.source});
@@ -261,7 +261,7 @@ export class BlockInputSync {
       }
 
       if (missingDependency.kind === "parentPayload") {
-        this.addByPayloadRootHex(missingDependency.rootHex, missingDependency.slot, data.peer);
+        this.addByPayloadRootHex(missingDependency.rootHex, data.peer, missingDependency.slot);
       } else if (missingDependency.kind === "parentBlock") {
         this.addByRootHex(missingDependency.rootHex, data.peer);
       }
@@ -297,8 +297,24 @@ export class BlockInputSync {
     const finalizedSlot = this.chain.forkChoice.getFinalizedBlock().slot;
 
     let deletedPayloads = 0;
+    let unresolvedSlotPayloads = 0;
     for (const [rootHex, payload] of this.pendingPayloads) {
-      if (getPayloadSyncCacheItemSlot(payload) < finalizedSlot) {
+      // Last-effort resolve for a slot-less PendingPayloadRootHex, and store it back for later passes.
+      if (!isPendingPayloadInput(payload) && !isPendingPayloadEnvelope(payload) && payload.slot === undefined) {
+        payload.slot = this.resolvePayloadSlot(rootHex);
+      }
+
+      const slot = getPayloadSyncCacheItemSlot(payload);
+      if (typeof slot !== "number") {
+        unresolvedSlotPayloads++;
+        this.logger.debug("BlockInputSync.pruneFinalized: pending payload with unresolved slot", {
+          root: rootHex,
+          finalizedSlot,
+        });
+        continue;
+      }
+
+      if (slot < finalizedSlot) {
         this.pendingPayloads.delete(rootHex);
         deletedPayloads++;
       }
@@ -315,13 +331,15 @@ export class BlockInputSync {
 
     if (deletedPayloads > 0 || deletedBlocks > 0) {
       this.metrics?.blockInputSync.removedBlocks.inc(deletedPayloads + deletedBlocks);
-      this.logger.debug("BlockInputSync.pruneFinalized dropped pre-finalized pending items", {
-        finalizedSlot,
-        finalizedRoot: checkpoint.rootHex,
-        deletedPayloads,
-        deletedBlocks,
-      });
     }
+
+    this.logger.debug("BlockInputSync.pruneFinalized dropped pre-finalized pending items", {
+      finalizedSlot,
+      finalizedRoot: checkpoint.rootHex,
+      deletedPayloads,
+      deletedBlocks,
+      unresolvedSlotPayloads,
+    });
   };
 
   private addByRootHex = (rootHex: RootHex, peerIdStr?: PeerIdStr): boolean => {
@@ -389,7 +407,7 @@ export class BlockInputSync {
     }
   };
 
-  private addByPayloadRootHex = (rootHex: RootHex, slot: Slot, peerIdStr?: PeerIdStr): boolean => {
+  private addByPayloadRootHex = (rootHex: RootHex, peerIdStr?: PeerIdStr, slot?: Slot): boolean => {
     let pendingPayload = this.pendingPayloads.get(rootHex);
     let added = false;
     if (!pendingPayload) {
@@ -404,8 +422,8 @@ export class BlockInputSync {
       added = true;
 
       this.logger.verbose("Added new payload rootHex to BlockInputSync.pendingPayloads", {
-        slot,
-        delaySec: this.chain.clock.secFromSlot(slot),
+        slot: slot ?? "unknown",
+        delaySec: slot != null ? this.chain.clock.secFromSlot(slot) : "unknown",
         root: rootHex,
         peerIdStr: peerIdStr ?? "unknown peer",
       });
@@ -421,6 +439,29 @@ export class BlockInputSync {
     }
     return added;
   };
+
+  /**
+   * Resolve the block slot for a payload root.
+   */
+  private resolvePayloadSlot(rootHex: RootHex): Slot | undefined {
+    // a pending block of the same root
+    const pendingBlock = this.pendingBlocks.get(rootHex);
+    if (pendingBlock) {
+      const pendingBlockSlot = getBlockInputSyncCacheItemSlot(pendingBlock);
+      if (typeof pendingBlockSlot === "number") {
+        return pendingBlockSlot;
+      }
+    }
+
+    // the block is in fork choice
+    const forkChoiceSlot = this.chain.forkChoice.getBlockHexDefaultStatus(rootHex)?.slot;
+    if (forkChoiceSlot !== undefined) {
+      return forkChoiceSlot;
+    }
+
+    // a seen payload envelope input
+    return this.chain.seenPayloadEnvelopeInputCache.get(rootHex)?.slot;
+  }
 
   private addByPayloadInput = (
     payloadInput: PayloadEnvelopeInput,
@@ -535,9 +576,9 @@ export class BlockInputSync {
       }
 
       case "parentPayload": {
-        let added = this.addByPayloadRootHex(missingDependency.rootHex, missingDependency.slot);
+        let added = this.addByPayloadRootHex(missingDependency.rootHex, undefined, missingDependency.slot);
         for (const peerIdStr of pendingBlock.peerIdStrings) {
-          added = this.addByPayloadRootHex(missingDependency.rootHex, missingDependency.slot, peerIdStr) || added;
+          added = this.addByPayloadRootHex(missingDependency.rootHex, peerIdStr, missingDependency.slot) || added;
         }
         return added ? "queued_parent_payload" : "blocked";
       }
@@ -1008,6 +1049,10 @@ export class BlockInputSync {
 
     if (payload.status !== PendingPayloadInputStatus.pending) {
       return;
+    }
+
+    if (!isPendingPayloadInput(payload) && payload.slot === undefined) {
+      payload.slot = this.resolvePayloadSlot(rootHex);
     }
 
     const payloadSlot = getPayloadSyncCacheItemSlot(payload);

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -1153,9 +1153,11 @@ export class BlockInputSync {
           );
         }
 
-        throw Error(
-          `Error fetching payload by root slot=${slot} root=${rootHex} after ${i}: cannot find peer with needed columns=${prettyPrintIndices(Array.from(pendingColumns))}`
-        );
+        const reason =
+          pendingColumns.size > 0
+            ? `cannot find peer with needed columns=${prettyPrintIndices(Array.from(pendingColumns))}`
+            : "no peer available to download pending payload";
+        throw Error(`Error fetching payload by root slot=${slot} root=${rootHex} after ${i}: ${reason}`);
       }
 
       const {peerId, client: peerClient} = peerMeta;

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -1025,7 +1025,13 @@ export class BlockInputSync {
     const res = await wrapError(this.fetchPayloadInput(payload));
     if (!res.err) {
       const pendingPayload = res.result;
-      this.pendingPayloads.set(getPayloadSyncCacheItemRootHex(pendingPayload), pendingPayload);
+      const resultRootHex = getPayloadSyncCacheItemRootHex(pendingPayload);
+      // finalization may have deleted this entry while we were awaiting the network, do not resurrect it via the set below
+      if (!this.pendingPayloads.has(resultRootHex)) {
+        this.logger.verbose("Dropping downloaded payload, entry pruned during fetch", logCtx);
+        return;
+      }
+      this.pendingPayloads.set(resultRootHex, pendingPayload);
 
       if (isPendingPayloadEnvelope(pendingPayload)) {
         await this.reconcilePayloadEnvelope(pendingPayload);

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -932,6 +932,67 @@ describe("UnknownBlockSync", () => {
       expect(payloadInput.hasAllData()).toBe(true);
     });
 
+    it("does not resurrect a payload entry pruned while its download was in flight", async () => {
+      const peer = await getRandPeerIdStr();
+      const {blockRootHex, payloadInput, envelope, columnSidecars} = buildPayloadFixture({
+        blobCount: 1,
+        sampledColumns: [0],
+        slot: 1,
+      });
+
+      const processExecutionPayload = vi.fn().mockResolvedValue(undefined);
+
+      let pendingPayloads: Map<string, PayloadSyncCacheItem> | undefined;
+      // Simulate pruneFinalized deleting the entry while the network fetch is in flight.
+      const sendExecutionPayloadEnvelopesByRoot = vi.fn().mockImplementation(async () => {
+        pendingPayloads?.delete(blockRootHex);
+        return [envelope];
+      });
+      const sendDataColumnSidecarsByRoot = vi.fn().mockResolvedValue(columnSidecars);
+
+      const {emitter} = setupPayloadSyncTest({
+        chainOverrides: {
+          processExecutionPayload,
+          seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
+            get: vi.fn().mockImplementation((root: string) => (root === blockRootHex ? payloadInput : undefined)),
+            prune: vi.fn(),
+          } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
+          forkChoice: {
+            hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
+            hasBlockHex: vi.fn().mockImplementation((root: string) => root === blockRootHex),
+            getBlockHexDefaultStatus: vi
+              .fn()
+              .mockImplementation((root: string) => (root === blockRootHex ? ({slot: 0} as ProtoBlock) : null)),
+            getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
+          } as unknown as IForkChoice,
+        },
+        custodyConfig: {sampledColumns: [0], sampleGroups: [[0]]} as unknown as CustodyConfig,
+        networkOverrides: {
+          sendExecutionPayloadEnvelopesByRoot,
+          sendDataColumnSidecarsByRoot,
+        },
+        peers: [{peerId: peer, custodyColumns: [0]}],
+      });
+
+      pendingPayloads = (service as unknown as {pendingPayloads: Map<string, PayloadSyncCacheItem>}).pendingPayloads;
+
+      emitter.emit(ChainEvent.unknownEnvelopeBlockRoot, {
+        rootHex: blockRootHex,
+        slot: 0,
+        peer,
+        source: BlockInputSource.gossip,
+      });
+
+      await sleep(50);
+
+      expect(sendExecutionPayloadEnvelopesByRoot).toHaveBeenCalledTimes(1);
+      // Entry deleted mid-fetch must not be resurrected by the post-await set...
+      expect(pendingPayloads.has(blockRootHex)).toBe(false);
+      // ...and the pruned payload must not be processed.
+      expect(processExecutionPayload).not.toHaveBeenCalled();
+    });
+
     it("continues fetching sampled columns across peers until payload input is complete", async () => {
       const peerA = await getRandPeerIdStr();
       const peerB = await getRandPeerIdStr();

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -1608,6 +1608,59 @@ describe("UnknownBlockSync", () => {
       );
     });
 
+    it("resolvePayloadSlot prefers pending block (S2), then fork choice (S3), then seen cache (S4)", () => {
+      const getBlockHexDefaultStatus = vi.fn().mockReturnValue(null);
+      const seenGet = vi.fn().mockReturnValue(undefined);
+      setupPayloadSyncTest({
+        chainOverrides: {
+          seenPayloadEnvelopeInputCache: {
+            add: vi.fn(),
+            get: seenGet,
+            prune: vi.fn(),
+          } as unknown as IBeaconChain["seenPayloadEnvelopeInputCache"],
+          forkChoice: {
+            hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
+            hasBlockHex: vi.fn().mockReturnValue(false),
+            getBlockHexDefaultStatus,
+            getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
+          } as unknown as IForkChoice,
+        },
+      });
+
+      const svc = service as unknown as {
+        resolvePayloadSlot: (rootHex: string) => number | undefined;
+        pendingBlocks: Map<string, BlockInputSyncCacheItem>;
+      };
+      const rootHex = toRootHex(Buffer.alloc(32, 0xe1));
+
+      // no trusted source -> undefined
+      expect(svc.resolvePayloadSlot(rootHex)).toBeUndefined();
+
+      // S4: seen payload envelope cache
+      seenGet.mockReturnValue({slot: 50});
+      expect(svc.resolvePayloadSlot(rootHex)).toBe(50);
+
+      // S3: fork choice overrides S4
+      getBlockHexDefaultStatus.mockReturnValue({slot: 40} as ProtoBlock);
+      expect(svc.resolvePayloadSlot(rootHex)).toBe(40);
+
+      // S2: a pending block of the same root overrides S3
+      const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+      block.message.slot = 30;
+      svc.pendingBlocks.set(rootHex, {
+        status: PendingBlockInputStatus.downloaded,
+        blockInput: createGloasBlockInput({
+          block,
+          blockRootHex: rootHex,
+          seenTimestampSec: 0,
+          source: BlockInputSource.gossip,
+        }),
+        timeAddedSec: 0,
+        peerIdStrings: new Set(),
+      });
+      expect(svc.resolvePayloadSlot(rootHex)).toBe(30);
+    });
+
     it("prunes pending payloads and blocks below the finalized block slot on ChainEvent.forkChoiceFinalized", () => {
       const finalizedEpoch = 4;
       // Simulate a skipped epoch boundary: the finalized block sits below computeStartSlotAtEpoch(epoch).
@@ -1616,12 +1669,20 @@ describe("UnknownBlockSync", () => {
       const epochBoundarySlot = computeStartSlotAtEpoch(finalizedEpoch);
       const finalizedBlockSlot = epochBoundarySlot - 2;
 
+      // A slot-less payload whose block is in fork choice (S3) below finality -> resolved + pruned.
+      const rootHexResolvable = toRootHex(Buffer.alloc(32, 0xa5));
+      const resolvableSlot = finalizedBlockSlot - 4;
+
       const {emitter} = setupPayloadSyncTest({
         chainOverrides: {
           forkChoice: {
             hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
             hasBlockHex: vi.fn().mockReturnValue(false),
-            getBlockHexDefaultStatus: vi.fn().mockReturnValue(null),
+            getBlockHexDefaultStatus: vi
+              .fn()
+              .mockImplementation((root: string) =>
+                root === rootHexResolvable ? ({slot: resolvableSlot} as ProtoBlock) : null
+              ),
             getFinalizedBlock: vi.fn().mockReturnValue({slot: finalizedBlockSlot} as ProtoBlock),
           } as unknown as IForkChoice,
         },
@@ -1689,7 +1750,24 @@ describe("UnknownBlockSync", () => {
         peerIdStrings: new Set(),
       });
 
-      expect(pendingPayloads.size).toBe(5);
+      // slot-less PendingPayloadRootHex, resolved from fork choice (S3) at prune time -> pruned
+      pendingPayloads.set(rootHexResolvable, {
+        status: PendingPayloadInputStatus.pending,
+        rootHex: rootHexResolvable,
+        timeAddedSec: 0,
+        peerIdStrings: new Set(),
+      });
+
+      // slot-less PendingPayloadRootHex with no trusted source -> unresolved, retained (logged)
+      const rootHexUnresolvable = toRootHex(Buffer.alloc(32, 0xa6));
+      pendingPayloads.set(rootHexUnresolvable, {
+        status: PendingPayloadInputStatus.pending,
+        rootHex: rootHexUnresolvable,
+        timeAddedSec: 0,
+        peerIdStrings: new Set(),
+      });
+
+      expect(pendingPayloads.size).toBe(7);
 
       // PendingBlockInput below finality -> pruned (slot resolved from blockInput.slot)
       const blockBelow = ssz.gloas.SignedBeaconBlock.defaultValue();
@@ -1744,9 +1822,11 @@ describe("UnknownBlockSync", () => {
       expect(pendingPayloads.has(rootHexBelow)).toBe(false);
       expect(pendingPayloads.has(inputRootHex)).toBe(false);
       expect(pendingPayloads.has(envelopeRootHex)).toBe(false);
+      expect(pendingPayloads.has(rootHexResolvable)).toBe(false);
       expect(pendingPayloads.has(rootHexAtFinalized)).toBe(true);
       expect(pendingPayloads.has(rootHexBetween)).toBe(true);
-      expect(pendingPayloads.size).toBe(2);
+      expect(pendingPayloads.has(rootHexUnresolvable)).toBe(true);
+      expect(pendingPayloads.size).toBe(3);
 
       expect(pendingBlocks.has(blockBelowRootHex)).toBe(false);
       expect(pendingBlocks.has(blockAtFinalizedRootHex)).toBe(true);

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -3,10 +3,11 @@ import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {routes} from "@lodestar/api";
 import {createBeaconConfig} from "@lodestar/config";
 import {config as minimalConfig} from "@lodestar/config/default";
-import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
+import {CheckpointWithHex, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {ForkName} from "@lodestar/params";
 import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
+import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {SignedBeaconBlock, gloas, ssz} from "@lodestar/types";
 import {notNullish, sleep, toRootHex} from "@lodestar/utils";
 import {BlockInputNoData, BlockInputPreData} from "../../../src/chain/blocks/blockInput/blockInput.js";
@@ -24,7 +25,12 @@ import {ExecutionPayloadStatus} from "../../../src/execution/index.js";
 import {INetwork, NetworkEvent, NetworkEventBus} from "../../../src/network/index.js";
 import {PeerSyncMeta} from "../../../src/network/peers/peersData.js";
 import {defaultSyncOptions} from "../../../src/sync/options.js";
-import {BlockInputSyncCacheItem, PendingBlockInputStatus} from "../../../src/sync/types.js";
+import {
+  BlockInputSyncCacheItem,
+  PayloadSyncCacheItem,
+  PendingBlockInputStatus,
+  PendingPayloadInputStatus,
+} from "../../../src/sync/types.js";
 import {BlockInputSync, UnknownBlockPeerBalancer} from "../../../src/sync/unknownBlock.js";
 import {CustodyConfig} from "../../../src/util/dataColumns.js";
 import {PeerIdStr} from "../../../src/util/peerId.js";
@@ -394,10 +400,16 @@ describe("sync by UnknownBlockSync", {timeout: 20_000}, () => {
       const forkChoiceKnownPayloadHashes = new Map([[blockRootHex0, toRootHex(blockHash0)]]);
       const forkChoice: Pick<
         IForkChoice,
-        "getBlockHexAndBlockHash" | "getFinalizedBlock" | "hasBlock" | "hasBlockHex" | "hasPayloadHexUnsafe"
+        | "getBlockHexAndBlockHash"
+        | "getBlockHexDefaultStatus"
+        | "getFinalizedBlock"
+        | "hasBlock"
+        | "hasBlockHex"
+        | "hasPayloadHexUnsafe"
       > = {
         hasBlock: (root) => forkChoiceKnownRoots.has(toRootHex(root)),
         hasBlockHex: (rootHex) => forkChoiceKnownRoots.has(rootHex),
+        getBlockHexDefaultStatus: (rootHex) => (forkChoiceKnownRoots.has(rootHex) ? ({slot: 0} as ProtoBlock) : null),
         hasPayloadHexUnsafe: (rootHex) => forkChoiceKnownPayloadHashes.has(rootHex),
         getBlockHexAndBlockHash: (rootHex, blockHashHex) =>
           forkChoiceKnownPayloadHashes.get(rootHex) === blockHashHex ? ({slot: 0} as ProtoBlock) : null,
@@ -685,6 +697,9 @@ describe("UnknownBlockSync", () => {
           clock: new ClockStopped(0),
           forkChoice: {
             hasBlockHex: vi.fn().mockImplementation((root: string) => root === parentRootHex),
+            getBlockHexDefaultStatus: vi
+              .fn()
+              .mockImplementation((root: string) => (root === parentRootHex ? ({slot: 0} as ProtoBlock) : null)),
             hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
             getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
           } as unknown as IForkChoice,
@@ -813,6 +828,7 @@ describe("UnknownBlockSync", () => {
         forkChoice: {
           hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
           hasBlockHex: vi.fn().mockReturnValue(false),
+          getBlockHexDefaultStatus: vi.fn().mockReturnValue(null),
           getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
         } as unknown as IForkChoice,
         ...chainOverrides,
@@ -881,6 +897,9 @@ describe("UnknownBlockSync", () => {
           forkChoice: {
             hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
             hasBlockHex: vi.fn().mockImplementation((root: string) => root === blockRootHex),
+            getBlockHexDefaultStatus: vi
+              .fn()
+              .mockImplementation((root: string) => (root === blockRootHex ? ({slot: 0} as ProtoBlock) : null)),
             getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
           } as unknown as IForkChoice,
         },
@@ -952,6 +971,9 @@ describe("UnknownBlockSync", () => {
           forkChoice: {
             hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
             hasBlockHex: vi.fn().mockImplementation((root: string) => root === blockRootHex),
+            getBlockHexDefaultStatus: vi
+              .fn()
+              .mockImplementation((root: string) => (root === blockRootHex ? ({slot: 0} as ProtoBlock) : null)),
             getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
           } as unknown as IForkChoice,
         },
@@ -1038,6 +1060,9 @@ describe("UnknownBlockSync", () => {
           forkChoice: {
             hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
             hasBlockHex: vi.fn().mockImplementation((root: string) => knownRoots.has(root)),
+            getBlockHexDefaultStatus: vi
+              .fn()
+              .mockImplementation((root: string) => (knownRoots.has(root) ? ({slot: 0} as ProtoBlock) : null)),
             getBlockHexAndBlockHash: vi
               .fn()
               .mockImplementation((root: string, hash: string) =>
@@ -1139,6 +1164,9 @@ describe("UnknownBlockSync", () => {
           forkChoice: {
             hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
             hasBlockHex: vi.fn().mockImplementation((root: string) => knownRoots.has(root)),
+            getBlockHexDefaultStatus: vi
+              .fn()
+              .mockImplementation((root: string) => (knownRoots.has(root) ? ({slot: 0} as ProtoBlock) : null)),
             getBlockHexAndBlockHash: vi
               .fn()
               .mockImplementation((root: string, hash: string) =>
@@ -1234,6 +1262,9 @@ describe("UnknownBlockSync", () => {
           forkChoice: {
             hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
             hasBlockHex: vi.fn().mockImplementation((root: string) => knownRoots.has(root)),
+            getBlockHexDefaultStatus: vi
+              .fn()
+              .mockImplementation((root: string) => (knownRoots.has(root) ? ({slot: 0} as ProtoBlock) : null)),
             getBlockHexAndBlockHash: vi
               .fn()
               .mockImplementation((root: string, hash: string) =>
@@ -1309,6 +1340,9 @@ describe("UnknownBlockSync", () => {
           forkChoice: {
             hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
             hasBlockHex: vi.fn().mockImplementation((root: string) => root === blockRootHex),
+            getBlockHexDefaultStatus: vi
+              .fn()
+              .mockImplementation((root: string) => (root === blockRootHex ? ({slot: 0} as ProtoBlock) : null)),
             getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
           } as unknown as IForkChoice,
         },
@@ -1402,6 +1436,11 @@ describe("UnknownBlockSync", () => {
           forkChoice: {
             hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
             hasBlockHex: vi.fn().mockImplementation((root: string) => root === payloadInput.blockRootHex),
+            getBlockHexDefaultStatus: vi
+              .fn()
+              .mockImplementation((root: string) =>
+                root === payloadInput.blockRootHex ? ({slot: 0} as ProtoBlock) : null
+              ),
             getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
           } as unknown as IForkChoice,
         },
@@ -1508,6 +1547,152 @@ describe("UnknownBlockSync", () => {
       );
     });
 
+    it("prunes pending payloads and blocks below the finalized block slot on ChainEvent.forkChoiceFinalized", () => {
+      const finalizedEpoch = 4;
+      // Simulate a skipped epoch boundary: the finalized block sits below computeStartSlotAtEpoch(epoch).
+      // The prune must use the actual finalized block slot, not the epoch boundary, otherwise it would
+      // wrongly drop the finalized block's own payload and payloads in the (finalizedBlockSlot, boundary) gap.
+      const epochBoundarySlot = computeStartSlotAtEpoch(finalizedEpoch);
+      const finalizedBlockSlot = epochBoundarySlot - 2;
+
+      const {emitter} = setupPayloadSyncTest({
+        chainOverrides: {
+          forkChoice: {
+            hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
+            hasBlockHex: vi.fn().mockReturnValue(false),
+            getBlockHexDefaultStatus: vi.fn().mockReturnValue(null),
+            getFinalizedBlock: vi.fn().mockReturnValue({slot: finalizedBlockSlot} as ProtoBlock),
+          } as unknown as IForkChoice,
+        },
+      });
+
+      const pendingPayloads = (service as unknown as {pendingPayloads: Map<string, PayloadSyncCacheItem>})
+        .pendingPayloads;
+      const pendingBlocks = (service as unknown as {pendingBlocks: Map<string, BlockInputSyncCacheItem>}).pendingBlocks;
+
+      // PendingPayloadRootHex just below the finalized block slot -> pruned
+      const rootHexBelow = toRootHex(Buffer.alloc(32, 0xa1));
+      pendingPayloads.set(rootHexBelow, {
+        status: PendingPayloadInputStatus.pending,
+        rootHex: rootHexBelow,
+        slot: finalizedBlockSlot - 1,
+        timeAddedSec: 0,
+        peerIdStrings: new Set(),
+      });
+
+      // PendingPayloadRootHex at the finalized block slot -> retained (its payload may still be needed by a
+      // not-yet-imported successor; prune is strict `<`)
+      const rootHexAtFinalized = toRootHex(Buffer.alloc(32, 0xa2));
+      pendingPayloads.set(rootHexAtFinalized, {
+        status: PendingPayloadInputStatus.pending,
+        rootHex: rootHexAtFinalized,
+        slot: finalizedBlockSlot,
+        timeAddedSec: 0,
+        peerIdStrings: new Set(),
+      });
+
+      // PendingPayloadRootHex in the (finalizedBlockSlot, epochBoundarySlot) gap -> retained. Regression guard:
+      // an epoch-boundary cutoff would wrongly prune this.
+      const rootHexBetween = toRootHex(Buffer.alloc(32, 0xa3));
+      pendingPayloads.set(rootHexBetween, {
+        status: PendingPayloadInputStatus.pending,
+        rootHex: rootHexBetween,
+        slot: finalizedBlockSlot + 1,
+        timeAddedSec: 0,
+        peerIdStrings: new Set(),
+      });
+
+      // PendingPayloadInput below finality -> pruned (slot resolved from payloadInput.slot)
+      const {blockRootHex: inputRootHex, payloadInput} = buildPayloadFixture({
+        blobCount: 0,
+        sampledColumns: [],
+        slot: finalizedBlockSlot - 2,
+      });
+      pendingPayloads.set(inputRootHex, {
+        status: PendingPayloadInputStatus.pending,
+        payloadInput,
+        timeAddedSec: 0,
+        peerIdStrings: new Set(),
+      });
+
+      // PendingPayloadEnvelope below finality -> pruned (slot resolved from envelope slotNumber)
+      const {blockRootHex: envelopeRootHex, envelope} = buildPayloadFixture({
+        blobCount: 0,
+        sampledColumns: [],
+        slot: finalizedBlockSlot - 3,
+      });
+      pendingPayloads.set(envelopeRootHex, {
+        status: PendingPayloadInputStatus.waitingForBlock,
+        envelope,
+        timeAddedSec: 0,
+        peerIdStrings: new Set(),
+      });
+
+      expect(pendingPayloads.size).toBe(5);
+
+      // PendingBlockInput below finality -> pruned (slot resolved from blockInput.slot)
+      const blockBelow = ssz.gloas.SignedBeaconBlock.defaultValue();
+      blockBelow.message.slot = finalizedBlockSlot - 1;
+      const blockBelowRootHex = toRootHex(getGloasBlockRoot(blockBelow));
+      pendingBlocks.set(blockBelowRootHex, {
+        status: PendingBlockInputStatus.downloaded,
+        blockInput: createGloasBlockInput({
+          block: blockBelow,
+          blockRootHex: blockBelowRootHex,
+          seenTimestampSec: 0,
+          source: BlockInputSource.gossip,
+        }),
+        timeAddedSec: 0,
+        peerIdStrings: new Set(),
+      });
+
+      // PendingBlockInput at the finalized block slot -> retained
+      const blockAtFinalized = ssz.gloas.SignedBeaconBlock.defaultValue();
+      blockAtFinalized.message.slot = finalizedBlockSlot;
+      const blockAtFinalizedRootHex = toRootHex(getGloasBlockRoot(blockAtFinalized));
+      pendingBlocks.set(blockAtFinalizedRootHex, {
+        status: PendingBlockInputStatus.downloaded,
+        blockInput: createGloasBlockInput({
+          block: blockAtFinalized,
+          blockRootHex: blockAtFinalizedRootHex,
+          seenTimestampSec: 0,
+          source: BlockInputSource.gossip,
+        }),
+        timeAddedSec: 0,
+        peerIdStrings: new Set(),
+      });
+
+      // PendingRootHex has no slot -> retained (cannot be compared to the finalized slot)
+      const rootOnlyHex = toRootHex(Buffer.alloc(32, 0xb1));
+      pendingBlocks.set(rootOnlyHex, {
+        status: PendingBlockInputStatus.pending,
+        rootHex: rootOnlyHex,
+        timeAddedSec: 0,
+        peerIdStrings: new Set(),
+      });
+
+      expect(pendingBlocks.size).toBe(3);
+
+      const checkpoint: CheckpointWithHex = {
+        epoch: finalizedEpoch,
+        root: Buffer.alloc(32, 0xcc),
+        rootHex: toRootHex(Buffer.alloc(32, 0xcc)),
+      };
+      emitter.emit(ChainEvent.forkChoiceFinalized, checkpoint);
+
+      expect(pendingPayloads.has(rootHexBelow)).toBe(false);
+      expect(pendingPayloads.has(inputRootHex)).toBe(false);
+      expect(pendingPayloads.has(envelopeRootHex)).toBe(false);
+      expect(pendingPayloads.has(rootHexAtFinalized)).toBe(true);
+      expect(pendingPayloads.has(rootHexBetween)).toBe(true);
+      expect(pendingPayloads.size).toBe(2);
+
+      expect(pendingBlocks.has(blockBelowRootHex)).toBe(false);
+      expect(pendingBlocks.has(blockAtFinalizedRootHex)).toBe(true);
+      expect(pendingBlocks.has(rootOnlyHex)).toBe(true);
+      expect(pendingBlocks.size).toBe(2);
+    });
+
     it("drops a child block when its parent payload hash conflicts with the known parent block", async () => {
       const peer = await getRandPeerIdStr();
 
@@ -1558,6 +1743,9 @@ describe("UnknownBlockSync", () => {
           forkChoice: {
             hasPayloadHexUnsafe: vi.fn().mockReturnValue(false),
             hasBlockHex: vi.fn().mockImplementation((root: string) => root === parentRootHex),
+            getBlockHexDefaultStatus: vi
+              .fn()
+              .mockImplementation((root: string) => (root === parentRootHex ? ({slot: 0} as ProtoBlock) : null)),
             getBlockHexAndBlockHash: vi.fn().mockReturnValue(null),
             getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
           } as unknown as IForkChoice,
@@ -1711,6 +1899,9 @@ describe("UnknownBlockSync", () => {
       forkChoice: {
         getFinalizedBlock: vi.fn().mockReturnValue({slot: 0} as ProtoBlock),
         hasBlockHex: vi.fn().mockImplementation((rootHex: string) => rootHex === parentRootHex),
+        getBlockHexDefaultStatus: vi
+          .fn()
+          .mockImplementation((rootHex: string) => (rootHex === parentRootHex ? ({slot: 0} as ProtoBlock) : null)),
         getBlockHexAndBlockHash: vi
           .fn()
           .mockImplementation((rootHex: string, blockHashHex: string) =>


### PR DESCRIPTION
**Motivation**

- Beacon node keep downloading orphaned/missing payloads, even through their slots are finalized

**Description**

- track slot in `PendingPayloadRootHex`
- implement `pruneFinalized()`
- log messages correctly to avoid the confusion in #9801

Closes #9800
Closes #9801

**AI Assistance Disclosure**

- created with the help of Claude
