### PR TITLE
fix: optimize proposer boost dependent root check

### DIFF
--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -102,11 +102,6 @@ export const defaultSkipOpts: SkipOpts = {
     // TODO-GLOAS: re-enable after gloas light client is implemented
     /\/gloas_fork$/,
     /\/heze_fork$/,
-    // TODO GLOAS: Proposer-boost dependent-root gate uses stale cached head across epoch-boundary ticks;
-    // boost wrongly denied. Fails identically on every pre-gloas fork.
-    // Enable this after https://github.com/ChainSafe/lodestar/issues/9666 is resolved
-    // The case name embeds the generation seed, so it changes whenever comptests are regenerated.
-    /fork_choice_compliance\/block_tree_test\/pyspec_tests\/block_tree_test_17_381675768_1$/,
     // TODO GLOAS: gloas/heze take ~23-24s on the mainnet preset (~7.5x pre-gloas) because every
     // post-gloas slot writes into the SLOTS_PER_HISTORICAL_ROOT-wide executionPayloadAvailability
     // bitvector, and this suite steps 8192 slots. That is 76-81% of the 30s sanity/slots timeout,

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -764,7 +764,7 @@ export class ForkChoice implements IForkChoice {
       isTimely &&
       // only boost the first block we see
       this.proposerBoostRoot === null &&
-      this.isProposerBoostSameDependentRoot(this.head.blockRoot, parentRootHex);
+      this.isProposerBoostSameDependentRoot(parentRootHex);
     // Candidate boost root used for protoArray.onBlock's best-child weighting. Committed to the
     // store only after the insertion succeeds.
     const proposerBoostRoot = isProposerBoostBlock ? blockRootHex : this.proposerBoostRoot;
@@ -1565,7 +1565,7 @@ export class ForkChoice implements IForkChoice {
    * The block is not yet in the proto-array when this runs, so its dependent root is traced from
    * its parent
    */
-  private isProposerBoostSameDependentRoot(headRootHex: RootHex, blockParentRootHex: RootHex): boolean {
+  private isProposerBoostSameDependentRoot(blockParentRootHex: RootHex): boolean {
     const epoch = computeEpochAtSlot(this.fcStore.currentSlot);
     // Genesis block parent
     if (epoch <= MIN_SEED_LOOKAHEAD) {
@@ -1573,9 +1573,17 @@ export class ForkChoice implements IForkChoice {
     }
 
     const dependentSlot = computeStartSlotAtEpoch(epoch - MIN_SEED_LOOKAHEAD) - 1;
+    const justifiedRootHex = this.fcStore.justified.checkpoint.rootHex;
+    const justifiedBlock = this.protoArray.getNodeDefaultStatus(justifiedRootHex);
+    // Every viable head descends from the justified checkpoint. If that block is at or after the
+    // dependent slot, its dependent root is canonical without recomputing fork choice.
+    const headRootHex =
+      justifiedBlock !== undefined && justifiedBlock.slot >= dependentSlot
+        ? justifiedRootHex
+        : this.updateHead().blockRoot;
     const headDependentRoot = this.protoArray.getAncestorOrNull(headRootHex, dependentSlot)?.blockRoot;
     const blockDependentRoot = this.protoArray.getAncestorOrNull(blockParentRootHex, dependentSlot)?.blockRoot;
-    // On lookup failure, we lean on the conservative side and withold the boost
+    // On lookup failure, we lean on the conservative side and withhold the boost
     if (headDependentRoot === undefined || blockDependentRoot === undefined) {
       return false;
     }


### PR DESCRIPTION
An epoch-boundary checkpoint update can stale the cached head before the first block is imported. Recomputing head unconditionally fixes that, but adds a second fork-choice run to the normal import path. The justified checkpoint provides the same dependent root whenever it is at or after the dependent slot, with a fresh-head fallback for exceptional cases.

- Use the justified checkpoint as the proposer boost dependent-root anchor when it proves the canonical root.
- Recompute fork choice only when the justified block is older than the dependent slot.
- Re-enable the affected compliance case.