### PR TITLE
feat: add `block_hash` and `builder_index` to block event

### DIFF
--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -75,7 +75,7 @@ const blockBase = new ContainerType(
     block: stringType,
     executionOptimistic: ssz.Boolean,
   },
-  {jsonCase: "eth2"}
+  {typeName: "Block", jsonCase: "eth2"}
 );
 const blockGloas = new ContainerType(
   {
@@ -85,7 +85,7 @@ const blockGloas = new ContainerType(
     builderIndex: ssz.BuilderIndex,
     executionOptimistic: ssz.Boolean,
   },
-  {jsonCase: "eth2"}
+  {typeName: "BlockGloas", jsonCase: "eth2"}
 );
 type FuluDataColumnSidecarSSE = ValueOf<typeof fuluDataColumnSidecarSSE>;
 type GloasDataColumnSidecarSSE = ValueOf<typeof gloasDataColumnSidecarSSE>;

--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -1,6 +1,6 @@
 import {ContainerType, ListBasicType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, MAX_BLOB_COMMITMENTS_PER_BLOCK, isForkPostGloas} from "@lodestar/params";
+import {ForkName, ForkSeq, MAX_BLOB_COMMITMENTS_PER_BLOCK, isForkPostGloas} from "@lodestar/params";
 import {
   Attestation,
   AttesterSlashing,
@@ -68,6 +68,24 @@ const headV2 = new ContainerType(
     executionOptimistic: ssz.Boolean,
   },
   {typeName: "HeadV2", jsonCase: "eth2"}
+);
+const blockBase = new ContainerType(
+  {
+    slot: ssz.Slot,
+    block: stringType,
+    executionOptimistic: ssz.Boolean,
+  },
+  {jsonCase: "eth2"}
+);
+const blockGloas = new ContainerType(
+  {
+    slot: ssz.Slot,
+    block: stringType,
+    executionOptimistic: ssz.Boolean,
+    blockHash: stringType,
+    builderIndex: ssz.BuilderIndex,
+  },
+  {jsonCase: "eth2"}
 );
 type FuluDataColumnSidecarSSE = ValueOf<typeof fuluDataColumnSidecarSSE>;
 type GloasDataColumnSidecarSSE = ValueOf<typeof gloasDataColumnSidecarSSE>;
@@ -186,6 +204,8 @@ export type EventData = {
     slot: Slot;
     block: RootHex;
     executionOptimistic: boolean;
+    blockHash?: RootHex;
+    builderIndex?: BuilderIndex;
   };
   [EventType.blockGossip]: {
     slot: Slot;
@@ -330,14 +350,17 @@ export function getTypeByEvent(config: ChainForkConfig): {[K in EventType]: Type
     ),
     [EventType.headV2]: WithVersion(() => headV2),
 
-    [EventType.block]: new ContainerType(
-      {
-        slot: ssz.Slot,
-        block: stringType,
-        executionOptimistic: ssz.Boolean,
+    [EventType.block]: {
+      toJson: (val) => {
+        if (config.getForkSeq(val.slot) < ForkSeq.gloas) return blockBase.toJson(val);
+        if (val.blockHash === undefined || val.builderIndex === undefined) {
+          throw Error(`Missing block hash or builder index for block at ${val.slot}`);
+        }
+        return blockGloas.toJson({...val, blockHash: val.blockHash, builderIndex: val.builderIndex});
       },
-      {jsonCase: "eth2"}
-    ),
+      fromJson: (json) =>
+        (config.getForkSeq((json as {slot: Slot}).slot) >= ForkSeq.gloas ? blockGloas : blockBase).fromJson(json),
+    },
     [EventType.blockGossip]: new ContainerType(
       {
         slot: ssz.Slot,

--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -81,9 +81,9 @@ const blockGloas = new ContainerType(
   {
     slot: ssz.Slot,
     block: stringType,
-    executionOptimistic: ssz.Boolean,
     blockHash: stringType,
     builderIndex: ssz.BuilderIndex,
+    executionOptimistic: ssz.Boolean,
   },
   {jsonCase: "eth2"}
 );
@@ -203,9 +203,9 @@ export type EventData = {
   [EventType.block]: {
     slot: Slot;
     block: RootHex;
-    executionOptimistic: boolean;
     blockHash?: RootHex;
     builderIndex?: BuilderIndex;
+    executionOptimistic: boolean;
   };
   [EventType.blockGossip]: {
     slot: Slot;

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -76,6 +76,7 @@ const ignoredTopics: string[] = [
   // TODO: unskip once the spec release adds `current_slot` to the fast_confirmation event
   // (tracked in https://github.com/ethereum/beacon-APIs/pull/598)
   "fast_confirmation",
+  "block"
 ];
 
 // eventstream types are defined as comments in the description of "examples".

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -76,7 +76,7 @@ const ignoredTopics: string[] = [
   // TODO: unskip once the spec release adds `current_slot` to the fast_confirmation event
   // (tracked in https://github.com/ethereum/beacon-APIs/pull/598)
   "fast_confirmation",
-  "block"
+  "block",
 ];
 
 // eventstream types are defined as comments in the description of "examples".

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -76,6 +76,8 @@ const ignoredTopics: string[] = [
   // TODO: unskip once the spec release adds `current_slot` to the fast_confirmation event
   // (tracked in https://github.com/ethereum/beacon-APIs/pull/598)
   "fast_confirmation",
+  // TODO: unskip once the spec release adds `builder_index` and `block_hash` to the block event
+  // (tracked in https://github.com/ethereum/beacon-APIs/issues/599)
   "block",
 ];
 

--- a/packages/api/test/unit/beacon/testData/events.ts
+++ b/packages/api/test/unit/beacon/testData/events.ts
@@ -47,6 +47,8 @@ export const eventTestData: EventData = {
     slot: 10,
     block: "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf",
     executionOptimistic: false,
+    blockHash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    builderIndex: 1,
   },
   [EventType.blockGossip]: {
     slot: 10,

--- a/packages/api/test/unit/beacon/testData/events.ts
+++ b/packages/api/test/unit/beacon/testData/events.ts
@@ -46,9 +46,9 @@ export const eventTestData: EventData = {
   [EventType.block]: {
     slot: 10,
     block: "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf",
-    executionOptimistic: false,
     blockHash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     builderIndex: 1,
+    executionOptimistic: false,
   },
   [EventType.blockGossip]: {
     slot: 10,

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -10,6 +10,7 @@ import {
   getSafeExecutionBlockHash,
 } from "@lodestar/fork-choice";
 import {
+  BUILDER_INDEX_SELF_BUILD,
   ForkPostAltair,
   ForkPostElectra,
   ForkSeq,
@@ -25,7 +26,17 @@ import {
   isStatePostAltair,
   isStatePostBellatrix,
 } from "@lodestar/state-transition";
-import {Attestation, BeaconBlock, altair, capella, electra, isGloasBeaconBlock, phase0, ssz} from "@lodestar/types";
+import {
+  Attestation,
+  BeaconBlock,
+  BuilderIndex,
+  altair,
+  capella,
+  electra,
+  isGloasBeaconBlock,
+  phase0,
+  ssz,
+} from "@lodestar/types";
 import {isErrorAborted, toRootHex} from "@lodestar/utils";
 import {GENESIS_SLOT, ZERO_HASH_HEX} from "../../constants/index.js";
 import {callInNextEventLoop} from "../../util/eventLoop.js";
@@ -529,12 +540,16 @@ export async function importBlock(
     callInNextEventLoop(() => {
       // NOTE: Skip emitting if there are no listeners from the API
       if (this.emitter.listenerCount(routes.events.EventType.block)) {
-        const gloasFields = isGloasBeaconBlock(block.message)
-          ? {
+        let gloasFields: undefined | {blockHash: string; builderIndex: BuilderIndex};
+        if (isGloasBeaconBlock(block.message)) {
+          const builderIndex = block.message.body.signedExecutionPayloadBid.message.builderIndex;
+          if (builderIndex !== BUILDER_INDEX_SELF_BUILD) {
+            gloasFields = {
               blockHash: toRootHex(block.message.body.signedExecutionPayloadBid.message.blockHash),
-              builderIndex: block.message.body.signedExecutionPayloadBid.message.builderIndex,
-            }
-          : {};
+              builderIndex,
+            };
+          }
+        }
         this.emitter.emit(routes.events.EventType.block, {
           block: blockRootHex,
           slot: blockSlot,

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -529,10 +529,17 @@ export async function importBlock(
     callInNextEventLoop(() => {
       // NOTE: Skip emitting if there are no listeners from the API
       if (this.emitter.listenerCount(routes.events.EventType.block)) {
+        const gloasFields = isGloasBeaconBlock(block.message)
+          ? {
+              blockHash: toRootHex(block.message.body.signedExecutionPayloadBid.message.blockHash),
+              builderIndex: block.message.body.signedExecutionPayloadBid.message.builderIndex,
+            }
+          : {};
         this.emitter.emit(routes.events.EventType.block, {
           block: blockRootHex,
           slot: blockSlot,
           executionOptimistic: blockSummary != null && isOptimisticBlock(blockSummary),
+          ...gloasFields,
         });
       }
       if (this.emitter.listenerCount(routes.events.EventType.voluntaryExit)) {


### PR DESCRIPTION
**Motivation**

Adapting block event for Gloas PoC.

**Description**

Introduces 2 new fields, `block_hash` and `builder_index` to the block event.
Related wiring and test adaptation.
Skipping oapi spec test for `block` event until spec tests are updated with new event fields.

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Used Claude to audit the changes.
