### PR TITLE
fix(cli): remove progress abort listener after completion

### DIFF
--- a/packages/cli/src/util/progress.ts
+++ b/packages/cli/src/util/progress.ts
@@ -18,6 +18,15 @@ export function showProgress({
   let lastProcessTime: number = Date.now();
   let progressIntervalId: NodeJS.Timeout;
 
+  const cleanup = (): void => {
+    clearInterval(progressIntervalId);
+    signal.removeEventListener("abort", onAbort);
+  };
+
+  const onAbort = (): void => {
+    cleanup();
+  };
+
   const needle: NeedleFunc = (needle: number) => {
     // zero is considered first index in the range
     current = needle + 1;
@@ -42,7 +51,7 @@ export function showProgress({
     lastProcessTime = currentTime;
 
     if (current >= total) {
-      clearInterval(progressIntervalId);
+      cleanup();
     }
   };
 
@@ -50,9 +59,11 @@ export function showProgress({
     progressIntervalId = setInterval(processProgress, frequencyMs);
   }
 
-  signal.addEventListener("abort", () => {
-    clearInterval(progressIntervalId);
-  });
+  signal.addEventListener("abort", onAbort, {once: true});
+
+  if (total === 0) {
+    cleanup();
+  }
 
   return needle;
 }

--- a/packages/cli/test/unit/util/progress.test.ts
+++ b/packages/cli/test/unit/util/progress.test.ts
@@ -64,6 +64,19 @@ describe("progress", () => {
       expect(progress).nthCalledWith(1, {total, current: total, ratePerSec: 0, percentage: 100});
     });
 
+    it("should remove the abort listener when total is reached", () => {
+      const progress = vi.fn();
+      const controller = new AbortController();
+      const addEventListener = vi.spyOn(controller.signal, "addEventListener");
+      const removeEventListener = vi.spyOn(controller.signal, "removeEventListener");
+      const needle = showProgress({total: 1, signal: controller.signal, frequencyMs: 50, progress});
+
+      needle(0);
+
+      expect(addEventListener).toHaveBeenCalledTimes(1);
+      expect(removeEventListener).toHaveBeenCalledWith("abort", addEventListener.mock.calls[0][1]);
+    });
+
     it("should not call progress when initiated with zero total", () => {
       const progress = vi.fn();
       const frequencyMs = 50;


### PR DESCRIPTION
**Motivation**

<!-- Why does this PR exist? What are the goals of the pull request? -->

`showProgress()` did not remove its abort listener when progress completed normally. Reusing a long-lived `AbortController` across multiple tasks could accumulate listener closures and retain unnecessary references.



**Description**

<!-- A clear and concise general description of the changes of this pull request. -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

- Added a named `onAbort` listener.
- Added a shared `cleanup()` function that clears the interval and removes the abort listener.
- Cleanup now runs when progress reaches its total, when the signal aborts, and when `total === 0`.
- Registered the abort listener with `{once: true}`.
- Added a unit test that spies on `addEventListener` and `removeEventListener` and verifies that the same listener is removed.




Closes https://github.com/ChainSafe/lodestar/issues/9856

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

I use codex for review and self-test.
<!-- Insert any AI assistance disclosure here -->
