### PR TITLE
test: harden e2e child process cleanup

### DIFF
--- a/packages/cli/test/e2e/runDevCmd.test.ts
+++ b/packages/cli/test/e2e/runDevCmd.test.ts
@@ -5,14 +5,26 @@ import {spawnCliCommand, stopChildProcess} from "@lodestar/test-utils";
 import {retry} from "@lodestar/utils";
 
 describe("Run dev command", () => {
-  vi.setConfig({testTimeout: 30_000});
+  vi.setConfig({testTimeout: 30_000, hookTimeout: 30_000});
 
   it("Run dev command with no --dataDir until beacon api is listening", async () => {
     const beaconPort = 39011;
+    const p2pPort = 39021;
+    const discoveryPort = 39022;
+    const quicPort = 39023;
 
     const devProc = await spawnCliCommand(
       "packages/cli/bin/lodestar.js",
-      ["dev", "--reset", "--startValidators=0..7", `--rest.port=${beaconPort}`],
+      [
+        "dev",
+        "--reset",
+        "--startValidators=0..7",
+        "--listenAddress=127.0.0.1",
+        `--port=${p2pPort}`,
+        `--discoveryPort=${discoveryPort}`,
+        `--quicPort=${quicPort}`,
+        `--rest.port=${beaconPort}`,
+      ],
       {pipeStdioToParent: true, logPrefix: "dev"}
     );
     onTestFinished(async () => {

--- a/packages/test-utils/src/childProcess.ts
+++ b/packages/test-utils/src/childProcess.ts
@@ -2,7 +2,7 @@ import childProcess, {ChildProcess, ChildProcessWithoutNullStreams} from "node:c
 import fs from "node:fs";
 import path from "node:path";
 import stream from "node:stream";
-import {Logger, prettyMsToTime, retry, sleep} from "@lodestar/utils";
+import {Logger, prettyMsToTime, retry} from "@lodestar/utils";
 
 export type ChildProcessLogOptions = {
   /**
@@ -92,25 +92,55 @@ export function isPidRunning(pid: number): boolean {
 
 export const stopChildProcess = async (
   childProcess: childProcess.ChildProcess,
-  signal: NodeJS.Signals | number = "SIGTERM"
+  signal: NodeJS.Signals | number = "SIGTERM",
+  timeoutMs = 5000
 ): Promise<void> => {
-  if (childProcess.killed || childProcess.exitCode !== null || childProcess.signalCode !== null) {
+  if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
     return;
   }
 
   const pid = childProcess.pid;
+  const waitForExit = async (): Promise<"exited" | "timeout"> => {
+    if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
+      return "exited";
+    }
 
-  await new Promise((resolve, reject) => {
-    childProcess.once("error", reject);
-    // We use `exit` instead of `close` as multiple processes can share same `stdio`
-    childProcess.once("exit", resolve);
-    childProcess.kill(signal);
-  });
+    return new Promise((resolve, reject) => {
+      let timeout: NodeJS.Timeout | undefined;
+      const cleanup = (): void => {
+        if (timeout !== undefined) {
+          clearTimeout(timeout);
+        }
+        childProcess.off("error", onError);
+        childProcess.off("exit", onExit);
+      };
+      const onError = (error: Error): void => {
+        cleanup();
+        reject(error);
+      };
+      const onExit = (): void => {
+        cleanup();
+        resolve("exited");
+      };
 
-  if (pid != null && isPidRunning(pid)) {
-    // Wait for sometime and try to kill this time
-    await sleep(500);
-    await stopChildProcess(childProcess, "SIGKILL");
+      childProcess.once("error", onError);
+      // We use `exit` instead of `close` as multiple processes can share same `stdio`
+      childProcess.once("exit", onExit);
+      timeout = setTimeout(() => {
+        cleanup();
+        resolve("timeout");
+      }, timeoutMs);
+    });
+  };
+
+  childProcess.kill(signal);
+  if ((await waitForExit()) === "exited") {
+    return;
+  }
+
+  childProcess.kill("SIGKILL");
+  if ((await waitForExit()) === "timeout" && pid != null && isPidRunning(pid)) {
+    throw Error(`Failed to stop child process pid=${pid} with SIGKILL after ${timeoutMs}ms`);
   }
 };
 
@@ -125,23 +155,7 @@ export const gracefullyStopChildProcess = async (
   childProcess: childProcess.ChildProcess,
   timeoutMs = 3000
 ): Promise<void> => {
-  if (childProcess.killed || childProcess.exitCode !== null || childProcess.signalCode !== null) {
-    return;
-  }
-
-  // Send signal to child process to gracefully stop
-  childProcess.kill("SIGINT");
-
-  // Wait for process to exit or timeout
-  const result = await Promise.race([
-    new Promise((resolve) => childProcess.once("exit", resolve)).then(() => "exited"),
-    sleep(timeoutMs).then(() => "timeout"),
-  ]);
-
-  // If process is timeout kill it
-  if (result === "timeout") {
-    await stopChildProcess(childProcess, "SIGKILL");
-  }
+  await stopChildProcess(childProcess, "SIGINT", timeoutMs);
 };
 
 export enum ChildProcessResolve {

--- a/packages/test-utils/src/childProcess.ts
+++ b/packages/test-utils/src/childProcess.ts
@@ -100,7 +100,7 @@ export const stopChildProcess = async (
   }
 
   const pid = childProcess.pid;
-  const waitForExit = async (): Promise<"exited" | "timeout"> => {
+  const killAndWaitForExit = async (killSignal: NodeJS.Signals | number): Promise<"exited" | "timeout"> => {
     if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
       return "exited";
     }
@@ -130,16 +130,24 @@ export const stopChildProcess = async (
         cleanup();
         resolve("timeout");
       }, timeoutMs);
+
+      // Send the signal only after the `error`/`exit` listeners are armed. `kill()` can emit
+      // `error` synchronously (e.g. EPERM) or throw (e.g. EINVAL); arming afterwards would miss
+      // a synchronous `error` and leave the wait hanging until it times out.
+      try {
+        childProcess.kill(killSignal);
+      } catch (e) {
+        cleanup();
+        reject(e as Error);
+      }
     });
   };
 
-  childProcess.kill(signal);
-  if ((await waitForExit()) === "exited") {
+  if ((await killAndWaitForExit(signal)) === "exited") {
     return;
   }
 
-  childProcess.kill("SIGKILL");
-  if ((await waitForExit()) === "timeout" && pid != null && isPidRunning(pid)) {
+  if ((await killAndWaitForExit("SIGKILL")) === "timeout" && pid != null && isPidRunning(pid)) {
     throw Error(`Failed to stop child process pid=${pid} with SIGKILL after ${timeoutMs}ms`);
   }
 };


### PR DESCRIPTION
## Problem

Recent E2E failures are timing out during test cleanup rather than failing assertions. The recurring symptom is the `runDevCmd.test.ts` teardown waiting for `stopChildProcess(devProc)` while GitHub later reaps orphan `MainThread` / docker processes.

The helper already intended to fall back to `SIGKILL`, but that fallback was unreachable when the initial signal did not produce an `exit` event: it awaited the first `exit` before checking whether the PID was still alive.

## Solution

- Make `stopChildProcess()` bound the wait after the requested signal.
- Send `SIGKILL` if the child has not exited before that timeout, then bound that wait too.
- Treat `childProcess.killed` as "a signal was sent", not as proof that the process has exited.
- Reuse the hardened helper from `gracefullyStopChildProcess()`.
- Give `runDevCmd.test.ts` explicit P2P/discovery/QUIC ports and a larger hook timeout, so the test does not depend on default networking ports or Vitest's default 10s hook budget.

## Verification

- `pnpm lint`
- `pnpm --filter @lodestar/test-utils build`
- `pnpm exec biome check packages/test-utils/src/childProcess.ts packages/cli/test/e2e/runDevCmd.test.ts`
- `git diff --check`
- `pnpm exec vitest run --project e2e packages/cli/test/e2e/runDevCmd.test.ts` passed 4 local runs total: one single run plus a 3-run loop
- Direct smoke check: spawned a child that ignores `SIGTERM`; `stopChildProcess(child, "SIGTERM", 100)` forced `SIGKILL` in ~100ms

## AI Assistance

Created with AI assistance from OpenAI Codex.
