### PR TITLE
test(builder): handler tests

### DIFF
--- a/packages/cli/test/unit/cmds/builder/handler.test.ts
+++ b/packages/cli/test/unit/cmds/builder/handler.test.ts
@@ -1,0 +1,39 @@
+import {describe, expect, it} from "vitest";
+import {chainConfig} from "@lodestar/config/default";
+import {LogLevel} from "@lodestar/utils";
+import {builderHandler} from "../../../../src/cmds/builder/handler.js";
+import {IBuilderCliArgs} from "../../../../src/cmds/builder/options.js";
+import {GlobalArgs} from "../../../../src/options/index.js";
+import {testFilesDir} from "../../../utils.js";
+
+describe("cmds / builder / args handler", () => {
+  const ZERO_ADDRESS = "0x" + "0".repeat(40);
+  const VALID_FEE_RECIPIENT = "0x" + "1".repeat(40);
+
+  async function runBuilderHandler(
+    args: Partial<IBuilderCliArgs & GlobalArgs> & Record<string, unknown>
+  ): Promise<void> {
+    return builderHandler({
+      logLevel: LogLevel.info,
+      logFileLevel: LogLevel.debug,
+      dataDir: testFilesDir,
+      executionFeeRecipient: VALID_FEE_RECIPIENT,
+      ...args,
+    } as unknown as IBuilderCliArgs & GlobalArgs);
+  }
+
+  it("Should reject unscheduled Gloas", async () => {
+    await expect(runBuilderHandler({})).rejects.toThrow("Gloas must be scheduled via GLOAS_FORK_EPOCH");
+  });
+
+  it("Should reject zero executionFeeRecipient", async () => {
+    // Rejecting with the fee recipient error rather than the Gloas error also proves the
+    // fork guard read the epoch merged in from CLI args, not from the default config
+    await expect(
+      runBuilderHandler({
+        "params.GLOAS_FORK_EPOCH": String(chainConfig.FULU_FORK_EPOCH + 1),
+        executionFeeRecipient: ZERO_ADDRESS,
+      })
+    ).rejects.toThrow("Cannot put zero address as an executionFeeRecipient");
+  });
+});


### PR DESCRIPTION
**Motivation**

Add meaningful tests for builder handler in cli package.

**Description**

This should cover two most important cases:
- Throw when Gloas fork epoch is not scheduled
- Throw on zero address executionFeeRecipient

These are the only breaking conditions we introduced, an improper shape of `executionFeeRecipient` would be taken care of by `parseFeeRecipient` function which is tested in validator cli tests.

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Used Claude to ping-pong on which tests are necessary and generate tests. Tests were thoroughly inspected and tidied up manually.
