### PR TITLE
perf: resolve builder top-ups by index at the fork transition

### DIFF
--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -11,7 +11,7 @@ import {
   ValueOf,
 } from "@chainsafe/ssz";
 import {BUILDER_INDEX_SELF_BUILD, PAYLOAD_BUILDER_VERSION, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
-import {ssz} from "@lodestar/types";
+import {BuilderIndex, ssz} from "@lodestar/types";
 import {toPubkeyHex} from "@lodestar/utils";
 import {isValidDepositSignature} from "../block/processDeposit.js";
 import {getCachedBeaconState} from "../cache/stateCache.js";
@@ -197,9 +197,10 @@ function onboardBuildersFromPendingDeposits(
   let sigFromCache = 0;
   let sigVerified = 0;
 
-  // Track pubkeys of new builders added when applying deposits. `state.builders` starts empty
-  // at the fork, so every builder pubkey here is one added in an earlier iteration.
-  const builderPubkeys = new Set<string>();
+  // Track pubkeys of new builders added when applying deposits, mapped to their registry
+  // index. `state.builders` starts empty at the fork and this loop only ever appends, so the
+  // index is stable and a top-up can go straight to it instead of scanning.
+  const builderIndexByPubkey = new Map<string, BuilderIndex>();
 
   const pendingDeposits = ssz.gloas.PendingDeposits.defaultViewDU();
   const pendingDepositsLookup = PendingDepositsLookup.buildEmpty();
@@ -218,15 +219,10 @@ function onboardBuildersFromPendingDeposits(
       continue;
     }
 
-    if (builderPubkeys.has(pubkeyHex)) {
+    const builderIndex = builderIndexByPubkey.get(pubkeyHex);
+    if (builderIndex !== undefined) {
       // Top up an already-onboarded builder
-      // TODO GLOAS: linear search; consider builder pubkey cache when we drop the upgrade-time set
-      for (let j = 0; j < state.builders.length; j++) {
-        if (toPubkeyHex(state.builders.getReadonly(j).pubkey) === pubkeyHex) {
-          state.builders.get(j).balance += deposit.amount;
-          break;
-        }
-      }
+      state.builders.get(builderIndex).balance += deposit.amount;
       topups++;
       continue;
     }
@@ -282,7 +278,8 @@ function onboardBuildersFromPendingDeposits(
       deposit.amount,
       deposit.slot
     );
-    builderPubkeys.add(pubkeyHex);
+    // appendBuilderToRegistry() pushes, so the new builder is the last entry
+    builderIndexByPubkey.set(pubkeyHex, state.builders.length - 1);
     onboarded++;
   }
 


### PR DESCRIPTION
**Motivation**

`onboardBuildersFromPendingDeposits()` scans `state.builders` on every top-up:

```ts
// TODO GLOAS: linear search; consider builder pubkey cache when we drop the upgrade-time set
for (let j = 0; j < state.builders.length; j++) {
  if (toPubkeyHex(state.builders.getReadonly(j).pubkey) === pubkeyHex) {
```

After #9840 removed the O(n^2) from the onboarding path, this is the last superlinear path
left in the fork transition. A deposit for an already-onboarded builder costs O(index),
with a `toPubkeyHex()` allocation per element scanned, ~1.7us per element measured on a
12-core box. `N` top-ups behind a builder at index `i` cost `i * N * 1.7us`, so a few
hundred top-ups against a registry of ~10k builders is seconds of fork transition.

This is cheap to reach on a live network: a deposit whose pubkey is already an onboarded
builder takes this branch before any credential or signature check, so top-ups need no
valid signature at all. glamsterdam-devnet-8 currently has ~10k builder deposits queued
for the fork.

**Description**

- `builderPubkeys` already tracks exactly the right pubkeys, it just discards the index,
  so make it a `Map<string, BuilderIndex>` and let a top-up go straight to the entry
- safe because `state.builders` starts empty at the fork and `appendBuilderToRegistry()`
  only pushes, so a newly appended builder is at `length - 1` and never moves
- removes the last `toPubkeyHex()` call from the loop

Net -3 lines. Covered by the existing metrics test, which asserts the top-up lands on the
onboarded builder's balance rather than just that it runs.
