### PR TITLE
fix(metrics): add BLS dashboard coverage

### DIFF
--- a/dashboards/lodestar_bls_thread_pool.json
+++ b/dashboards/lodestar_bls_thread_pool.json
@@ -285,7 +285,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Average sync time to validate a single signature set. Note that the set may have been verified in batch. In most normal hardware this value should be ~1-2ms",
+      "description": "Average sync time to validate a single signature set. Note that the set may have been verified in batch. In most normal hardware this value should be ~1-2ms. worker_thread and single_thread show the same per-sigset average from the thread pool worker's own histogram and from the single-thread fallback path, respectively, so the fallback path is observable alongside the thread pool.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -363,6 +363,26 @@
           "interval": "",
           "legendFormat": "pool",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(lodestar_bls_worker_thread_time_per_sigset_seconds_sum[$rate_interval])/rate(lodestar_bls_worker_thread_time_per_sigset_seconds_count[$rate_interval])",
+          "interval": "",
+          "legendFormat": "worker_thread",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(lodestar_bls_single_thread_time_per_sigset_seconds_sum[$rate_interval])/rate(lodestar_bls_single_thread_time_per_sigset_seconds_count[$rate_interval])",
+          "interval": "",
+          "legendFormat": "single_thread",
+          "refId": "C"
         }
       ],
       "title": "BLS thread pool - sig set verification time / set",
@@ -373,7 +393,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Raw throughput of the thread pool. How many individual signature sets are successfully validated per second",
+      "description": "Raw throughput of the thread pool. How many individual signature sets are successfully validated per second. Also plots sig_sets_total (all signature sets entering the pool, before success/error split), prioritized_sig_sets and batchable_sig_sets (how the incoming sets were categorized before verification).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -451,6 +471,36 @@
           "interval": "",
           "legendFormat": "pool",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(lodestar_bls_thread_pool_sig_sets_total[$rate_interval])",
+          "interval": "",
+          "legendFormat": "sig_sets_total",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(lodestar_bls_thread_pool_prioritized_sig_sets_total[$rate_interval])",
+          "interval": "",
+          "legendFormat": "prioritized_sig_sets",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(lodestar_bls_thread_pool_batchable_sig_sets_total[$rate_interval])",
+          "interval": "",
+          "legendFormat": "batchable_sig_sets",
+          "refId": "D"
         }
       ],
       "title": "BLS thread pool - sig sets / sec",
@@ -909,7 +959,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "How many individual signature sets are invalid vs (valid + invalid). We don't control this number since peers may send us invalid signatures. This number should be very low since we should ban bad peers. If it's too high the batch optimization may not be worth it.",
+      "description": "How many individual signature sets are invalid vs (valid + invalid). We don't control this number since peers may send us invalid signatures. This number should be very low since we should ban bad peers. If it's too high the batch optimization may not be worth it. aggregate_error_{{type}} counts errors while aggregating pubkeys or signatures for a job (distinct from the per-signature-set validation errors above), broken down by job type. This should also stay near zero; a sustained non-zero rate points to malformed input or a bug in the aggregation path rather than an adversarial peer.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1013,6 +1063,22 @@
                 "value": "right"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "aggregate_error_.*"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ops"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
           }
         ]
       },
@@ -1083,6 +1149,18 @@
           "interval": "",
           "legendFormat": "same_message_set_retries",
           "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": false,
+          "expr": "rate(lodestar_bls_thread_pool_error_aggregate_signature_sets_count[$rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "aggregate_error_{{type}}",
+          "refId": "E"
         }
       ],
       "title": "BLS thread pool - Error rates",
@@ -1264,10 +1342,24 @@
           "legendFormat": "pubkey_aggregation",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(lodestar_bls_single_thread_time_seconds_sum[$rate_interval]) * 384",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "single_thread",
+          "range": true,
+          "refId": "C"
         }
       ],
       "title": "BLS jobItemWorkReq cpu time per epoch",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "CPU time per epoch spent on work normally offloaded to BLS worker threads, extrapolated from a per-second rate (* 384, the seconds in one epoch). aggregate_with_randomness and pubkey_aggregation run on the main thread by design. single_thread is different: it's the whole BLS thread pool falling back to verifying signatures on the main thread (e.g. on single-core machines), so it should stay at or near zero whenever the worker thread pool is available; a sustained non-zero value means the node is missing out on the thread pool's parallelism and verification is slower than expected."
     },
     {
       "datasource": {

--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -217,6 +217,14 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
     message: Uint8Array,
     opts: Omit<VerifySignatureOpts, "verifyOnMainThread"> = {}
   ): Promise<boolean[]> {
+    this.metrics?.blsThreadPool.totalSigSets.inc(sets.length);
+    if (opts.priority) {
+      this.metrics?.blsThreadPool.prioritizedSigSets.inc(sets.length);
+    }
+    if (opts.batchable) {
+      this.metrics?.blsThreadPool.batchableSigSets.inc(sets.length);
+    }
+
     // chunkify so that it reduce the risk of retrying when there is at least one invalid signature
     const results = await Promise.all(
       chunkifyMaximizeChunkSize(sets, MAX_SIGNATURE_SETS_PER_JOB).map(

--- a/packages/beacon-node/src/chain/bls/singleThread.ts
+++ b/packages/beacon-node/src/chain/bls/singleThread.ts
@@ -25,11 +25,16 @@ export class BlsSingleThreadVerifier implements IBlsVerifier {
 
     // Count time after aggregating
     const timer = this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.startTimer();
+    const singleThreadTimer = this.metrics?.blsSingleThread.singleThreadDuration.startTimer();
     const isValid = verifySignatureSetsMaybeBatch(setsAggregated);
 
     // Don't use a try/catch, only count run without exceptions
     if (timer) {
       timer();
+    }
+    const duration = singleThreadTimer?.();
+    if (duration !== undefined && sets.length > 0) {
+      this.metrics?.blsSingleThread.timePerSigSet.observe(duration / sets.length);
     }
 
     return isValid;
@@ -40,6 +45,7 @@ export class BlsSingleThreadVerifier implements IBlsVerifier {
     message: Uint8Array
   ): Promise<boolean[]> {
     const timer = this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.startTimer();
+    const singleThreadTimer = this.metrics?.blsSingleThread.singleThreadDuration.startTimer();
     const pubkey = aggregatePublicKeys(sets.map((set) => set.publicKey));
     let isAllValid = true;
     // validate signature = true
@@ -73,6 +79,10 @@ export class BlsSingleThreadVerifier implements IBlsVerifier {
 
     if (timer) {
       timer();
+    }
+    const duration = singleThreadTimer?.();
+    if (duration !== undefined && sets.length > 0) {
+      this.metrics?.blsSingleThread.timePerSigSet.observe(duration / sets.length);
     }
 
     return result;

--- a/packages/beacon-node/test/unit/chain/bls/bls.test.ts
+++ b/packages/beacon-node/test/unit/chain/bls/bls.test.ts
@@ -118,4 +118,29 @@ describe("BlsVerifier ", () => {
       metrics.close();
     });
   });
+
+  describe("BlsMultiThreadWorkerPool metrics", () => {
+    it("should count same-message signature sets in the incoming metrics", async () => {
+      const metrics = createMetricsTest();
+      const verifier = new BlsMultiThreadWorkerPool({}, {metrics, logger: testLogger(), pubkeyCache});
+      const signingRoot = Buffer.alloc(32, 100);
+      const sets = secretKeys.map((secretKey) => ({
+        publicKey: secretKey.toPublicKey(),
+        signature: secretKey.sign(signingRoot).toBytes(),
+      }));
+
+      await verifier.verifySignatureSetsSameMessage(sets, signingRoot, {priority: true, batchable: true});
+
+      for (const metricName of [
+        "lodestar_bls_thread_pool_sig_sets_total",
+        "lodestar_bls_thread_pool_prioritized_sig_sets_total",
+        "lodestar_bls_thread_pool_batchable_sig_sets_total",
+      ]) {
+        await expect(metrics.register.getSingleMetricAsString(metricName)).resolves.toContain(`${metricName} 3`);
+      }
+
+      await verifier.close();
+      metrics.close();
+    });
+  });
 });

--- a/packages/beacon-node/test/unit/chain/bls/bls.test.ts
+++ b/packages/beacon-node/test/unit/chain/bls/bls.test.ts
@@ -4,6 +4,7 @@ import {testLogger} from "@lodestar/logger/test-utils";
 import {ISignatureSet, SignatureSetType, createPubkeyCache} from "@lodestar/state-transition";
 import {BlsMultiThreadWorkerPool} from "../../../../src/chain/bls/multithread/index.js";
 import {BlsSingleThreadVerifier} from "../../../../src/chain/bls/singleThread.js";
+import {createMetricsTest} from "../../metrics/utils.js";
 
 describe("BlsVerifier ", () => {
   // take time for creating thread pool
@@ -88,4 +89,33 @@ describe("BlsVerifier ", () => {
       });
     });
   }
+
+  describe("BlsSingleThreadVerifier metrics", () => {
+    it("should record verification duration metrics", async () => {
+      const metrics = createMetricsTest();
+      const verifier = new BlsSingleThreadVerifier({metrics, pubkeyCache});
+      const sets = secretKeys.map((secretKey, i) => {
+        const signingRoot = Buffer.alloc(32, i);
+        return {
+          type: SignatureSetType.single,
+          pubkey: secretKey.toPublicKey(),
+          signingRoot,
+          signature: secretKey.sign(signingRoot).toBytes(),
+        };
+      });
+
+      await verifier.verifySignatureSets(sets);
+
+      const singleThreadTime = "lodestar_bls_single_thread_time_seconds";
+      const singleThreadTimePerSigSet = "lodestar_bls_single_thread_time_per_sigset_seconds";
+      await expect(metrics.register.getSingleMetricAsString(singleThreadTime)).resolves.toContain(
+        `${singleThreadTime}_count 1`
+      );
+      await expect(metrics.register.getSingleMetricAsString(singleThreadTimePerSigSet)).resolves.toContain(
+        `${singleThreadTimePerSigSet}_count 1`
+      );
+
+      metrics.close();
+    });
+  });
 });


### PR DESCRIPTION
**Motivation**

The BLS thread pool dashboard does not show several metrics that are already defined and emitted by the beacon node. This makes the incoming signature-set mix, aggregation errors, and single-thread verification path difficult to inspect.

**Description**

- Add the remaining BLS thread pool metrics to the relevant Grafana panels.
- Record single-thread verification duration and per-signature-set duration in the single-thread verifier.
- Add a unit test covering the new single-thread duration metrics.

Closes #9408

**Validation**

- `pnpm --filter @lodestar/beacon-node build`
- `pnpm --filter @lodestar/beacon-node test:unit`
- `pnpm --filter @lodestar/beacon-node lint`
- `node scripts/lint-grafana-dashboards.mjs ./dashboards`
- `git diff --check`

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

AI assistance was used during repository review and drafting. I reviewed the implementation and ran the validation commands listed above.