### PR TITLE
refactor(state-transition): use Lodestar-Z signature verifier

### DIFF
--- a/packages/beacon-node/src/chain/bls/multithread/jobItem.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/jobItem.ts
@@ -1,6 +1,5 @@
-import {ISignatureSet} from "@lodestar/state-transition";
+import {ISignatureSet, toBlsSignatureSet} from "@lodestar/state-transition";
 import {SameMessageSignatureSet, VerifySignatureOpts} from "../interface.js";
-import {toBlsSignatureSet} from "../utils.js";
 import {BlsWorkReq, JobQueueItemType} from "./types.js";
 
 export type JobQueueItem = JobQueueItemDefault | JobQueueItemSameMessage;

--- a/packages/beacon-node/src/chain/bls/utils.ts
+++ b/packages/beacon-node/src/chain/bls/utils.ts
@@ -1,52 +1,10 @@
 import {
   BLS_VERIFIER_MAX_BATCH_SIZE,
   BLS_VERIFIER_MAX_SAME_MESSAGE_BATCH_SIZE,
-  BLS_VERIFIER_SET_TYPE,
-  type BlsSignatureSet,
   verifySignatureSets,
 } from "@chainsafe/lodestar-z/bls-verifier";
-import {ISignatureSet, SignatureSetType} from "@lodestar/state-transition";
+import {ISignatureSet, SignatureSetType, toBlsSignatureSet} from "@lodestar/state-transition";
 import {SameMessageSignatureSet} from "./interface.js";
-
-export function toBlsSignatureSet(signatureSet: ISignatureSet): BlsSignatureSet {
-  switch (signatureSet.type) {
-    case SignatureSetType.single:
-      return {
-        type: BLS_VERIFIER_SET_TYPE.single,
-        pubkey: signatureSet.pubkey,
-        message: signatureSet.signingRoot,
-        signature: signatureSet.signature,
-      };
-
-    case SignatureSetType.indexed:
-      return {
-        type: BLS_VERIFIER_SET_TYPE.indexed,
-        index: signatureSet.index,
-        message: signatureSet.signingRoot,
-        signature: signatureSet.signature,
-      };
-
-    case SignatureSetType.aggregate: {
-      const indices = new Uint32Array(signatureSet.indices.length);
-      for (const [i, index] of signatureSet.indices.entries()) {
-        if (!Number.isInteger(index) || index < 0 || index > 0xffffffff) {
-          throw new RangeError(`Invalid validator index ${index}`);
-        }
-        indices[i] = index;
-      }
-
-      return {
-        type: BLS_VERIFIER_SET_TYPE.aggregate,
-        indices,
-        message: signatureSet.signingRoot,
-        signature: signatureSet.signature,
-      };
-    }
-
-    default:
-      throw Error("Unknown signature set type");
-  }
-}
 
 export function verifySignatureSetsInBatches(signatureSets: ISignatureSet[]): boolean {
   if (signatureSets.length === 0) {

--- a/packages/beacon-node/src/chain/validation/attesterSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/attesterSlashing.ts
@@ -44,14 +44,7 @@ export async function validateAttesterSlashing(
   // [REJECT] All of the conditions within process_attester_slashing pass validation.
   try {
     // verifySignature = false, verified in batch below
-    assertValidAttesterSlashing(
-      chain.config,
-      chain.pubkeyCache,
-      state.slot,
-      state.validatorCount,
-      attesterSlashing,
-      false
-    );
+    assertValidAttesterSlashing(chain.config, state.slot, state.validatorCount, attesterSlashing, false);
   } catch (e) {
     throw new AttesterSlashingError(GossipAction.REJECT, {
       code: AttesterSlashingErrorCode.INVALID,

--- a/packages/beacon-node/src/chain/validation/proposerSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/proposerSlashing.ts
@@ -37,7 +37,7 @@ async function validateProposerSlashing(
   try {
     const proposer = state.getValidator(proposerSlashing.signedHeader1.message.proposerIndex);
     // verifySignature = false, verified in batch below
-    assertValidProposerSlashing(chain.config, chain.pubkeyCache, state.slot, proposerSlashing, proposer, false);
+    assertValidProposerSlashing(chain.config, state.slot, proposerSlashing, proposer, false);
   } catch (e) {
     throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID,

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -1,4 +1,3 @@
-import {type PubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq, MAX_COMMITTEES_PER_SLOT, MAX_VALIDATORS_PER_COMMITTEE} from "@lodestar/params";
 import {IndexedAttestation, IndexedAttestationBigint, Slot} from "@lodestar/types";
@@ -10,7 +9,6 @@ import {verifySignatureSet} from "../util/index.js";
  */
 export function isValidIndexedAttestation(
   config: BeaconConfig,
-  _pubkeyCache: PubkeyCache,
   stateSlot: Slot,
   validatorsLen: number,
   indexedAttestation: IndexedAttestation,
@@ -28,7 +26,6 @@ export function isValidIndexedAttestation(
 
 export function isValidIndexedAttestationBigint(
   config: BeaconConfig,
-  _pubkeyCache: PubkeyCache,
   stateSlot: Slot,
   validatorsLen: number,
   indexedAttestation: IndexedAttestationBigint,

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -10,7 +10,7 @@ import {verifySignatureSet} from "../util/index.js";
  */
 export function isValidIndexedAttestation(
   config: BeaconConfig,
-  pubkeyCache: PubkeyCache,
+  _pubkeyCache: PubkeyCache,
   stateSlot: Slot,
   validatorsLen: number,
   indexedAttestation: IndexedAttestation,
@@ -21,14 +21,14 @@ export function isValidIndexedAttestation(
   }
 
   if (verifySignature) {
-    return verifySignatureSet(getIndexedAttestationSignatureSet(config, stateSlot, indexedAttestation), pubkeyCache);
+    return verifySignatureSet(getIndexedAttestationSignatureSet(config, stateSlot, indexedAttestation));
   }
   return true;
 }
 
 export function isValidIndexedAttestationBigint(
   config: BeaconConfig,
-  pubkeyCache: PubkeyCache,
+  _pubkeyCache: PubkeyCache,
   stateSlot: Slot,
   validatorsLen: number,
   indexedAttestation: IndexedAttestationBigint,
@@ -39,10 +39,7 @@ export function isValidIndexedAttestationBigint(
   }
 
   if (verifySignature) {
-    return verifySignatureSet(
-      getIndexedAttestationBigintSignatureSet(config, stateSlot, indexedAttestation),
-      pubkeyCache
-    );
+    return verifySignatureSet(getIndexedAttestationBigintSignatureSet(config, stateSlot, indexedAttestation));
   }
   return true;
 }

--- a/packages/state-transition/src/block/isValidIndexedPayloadAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedPayloadAttestation.ts
@@ -16,10 +16,7 @@ export function isValidIndexedPayloadAttestation(
   }
 
   if (verifySignature) {
-    return verifySignatureSet(
-      getIndexedPayloadAttestationSignatureSet(state.config, indexedPayloadAttestation),
-      state.epochCtx.pubkeyCache
-    );
+    return verifySignatureSet(getIndexedPayloadAttestationSignatureSet(state.config, indexedPayloadAttestation));
   }
 
   return true;

--- a/packages/state-transition/src/block/processAttestationPhase0.ts
+++ b/packages/state-transition/src/block/processAttestationPhase0.ts
@@ -53,7 +53,6 @@ export function processAttestationPhase0(
   if (
     !isValidIndexedAttestation(
       state.config,
-      epochCtx.pubkeyCache,
       state.slot,
       state.validators.length,
       epochCtx.getIndexedAttestation(ForkSeq.phase0, attestation),

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -67,7 +67,7 @@ export function processAttestationsAltair(
     // we can verify only that and nothing else.
     if (verifySignature) {
       const sigSet = getAttestationWithIndicesSignatureSet(state.config, state.slot, attestation, attestingIndices);
-      if (!verifySignatureSet(sigSet, state.epochCtx.pubkeyCache)) {
+      if (!verifySignatureSet(sigSet)) {
         throw new Error("Attestation signature is not valid");
       }
     }

--- a/packages/state-transition/src/block/processAttesterSlashing.ts
+++ b/packages/state-transition/src/block/processAttesterSlashing.ts
@@ -1,4 +1,3 @@
-import {type PubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq} from "@lodestar/params";
 import {AttesterSlashing, Slot} from "@lodestar/types";
@@ -20,14 +19,7 @@ export function processAttesterSlashing(
   verifySignatures = true
 ): void {
   const {epochCtx} = state;
-  assertValidAttesterSlashing(
-    state.config,
-    epochCtx.pubkeyCache,
-    state.slot,
-    state.validators.length,
-    attesterSlashing,
-    verifySignatures
-  );
+  assertValidAttesterSlashing(state.config, state.slot, state.validators.length, attesterSlashing, verifySignatures);
 
   const intersectingIndices = getAttesterSlashableIndices(attesterSlashing);
 
@@ -48,7 +40,6 @@ export function processAttesterSlashing(
 
 export function assertValidAttesterSlashing(
   config: BeaconConfig,
-  pubkeyCache: PubkeyCache,
   stateSlot: Slot,
   validatorsLen: number,
   attesterSlashing: AttesterSlashing,
@@ -65,9 +56,7 @@ export function assertValidAttesterSlashing(
   // be higher than the clock and the slashing would still be valid. Same applies to attestation data index, which
   // can be any arbitrary value. Must use bigint variants to hash correctly to all possible values
   for (const [i, attestation] of [attestation1, attestation2].entries()) {
-    if (
-      !isValidIndexedAttestationBigint(config, pubkeyCache, stateSlot, validatorsLen, attestation, verifySignatures)
-    ) {
+    if (!isValidIndexedAttestationBigint(config, stateSlot, validatorsLen, attestation, verifySignatures)) {
       throw new Error(`AttesterSlashing attestation${i} is invalid`);
     }
   }

--- a/packages/state-transition/src/block/processDeposit.ts
+++ b/packages/state-transition/src/block/processDeposit.ts
@@ -13,7 +13,14 @@ import {BLSPubkey, Bytes32, UintNum64, electra, phase0, ssz} from "@lodestar/typ
 import {verifyMerkleBranch} from "@lodestar/utils";
 import {ZERO_HASH} from "../constants/index.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateAltair, CachedBeaconStateElectra} from "../types.js";
-import {computeDomain, computeSigningRoot, getMaxEffectiveBalance, increaseBalance} from "../util/index.js";
+import {
+  computeDomain,
+  computeSigningRoot,
+  createSingleSignatureSetFromComponents,
+  getMaxEffectiveBalance,
+  increaseBalance,
+  verifySignatureSet,
+} from "../util/index.js";
 
 /**
  * Process a Deposit operation. Potentially adds a new validator to the registry. Mutates the validators and balances
@@ -159,11 +166,7 @@ export function isValidDepositSignature(
   const domain = computeDomain(DOMAIN_DEPOSIT, config.GENESIS_FORK_VERSION, ZERO_HASH);
   const signingRoot = computeSigningRoot(ssz.phase0.DepositMessage, depositMessage, domain);
   try {
-    // Pubkeys must be checked for group + inf. This must be done only once when the validator deposit is processed
-    const publicKey = PublicKey.fromBytes(pubkey, true);
-    const signature = Signature.fromBytes(depositSignature, true);
-
-    return verify(signingRoot, publicKey, signature);
+    return verifySignatureSet(createSingleSignatureSetFromComponents(pubkey, signingRoot, depositSignature));
   } catch (_e) {
     return false; // Catch all BLS errors: failed key validation, failed signature validation, invalid signature
   }

--- a/packages/state-transition/src/block/processProposerSlashing.ts
+++ b/packages/state-transition/src/block/processProposerSlashing.ts
@@ -62,7 +62,7 @@ export function processProposerSlashing(
 
 export function assertValidProposerSlashing(
   config: BeaconConfig,
-  pubkeyCache: PubkeyCache,
+  _pubkeyCache: PubkeyCache,
   stateSlot: Slot,
   proposerSlashing: phase0.ProposerSlashing,
   proposer: Validator,
@@ -99,7 +99,7 @@ export function assertValidProposerSlashing(
   if (verifySignatures) {
     const signatureSets = getProposerSlashingSignatureSets(config, stateSlot, proposerSlashing);
     for (let i = 0; i < signatureSets.length; i++) {
-      if (!verifySignatureSet(signatureSets[i], pubkeyCache)) {
+      if (!verifySignatureSet(signatureSets[i])) {
         throw new Error(`ProposerSlashing header${i + 1} signature invalid`);
       }
     }

--- a/packages/state-transition/src/block/processProposerSlashing.ts
+++ b/packages/state-transition/src/block/processProposerSlashing.ts
@@ -1,4 +1,3 @@
-import {type PubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Slot, phase0, ssz} from "@lodestar/types";
@@ -22,14 +21,7 @@ export function processProposerSlashing(
   verifySignatures = true
 ): void {
   const proposer = state.validators.getReadonly(proposerSlashing.signedHeader1.message.proposerIndex);
-  assertValidProposerSlashing(
-    state.config,
-    state.epochCtx.pubkeyCache,
-    state.slot,
-    proposerSlashing,
-    proposer,
-    verifySignatures
-  );
+  assertValidProposerSlashing(state.config, state.slot, proposerSlashing, proposer, verifySignatures);
 
   if (fork >= ForkSeq.gloas) {
     // Remove the BuilderPendingPayment corresponding to this proposal if it is still in the
@@ -62,7 +54,6 @@ export function processProposerSlashing(
 
 export function assertValidProposerSlashing(
   config: BeaconConfig,
-  _pubkeyCache: PubkeyCache,
   stateSlot: Slot,
   proposerSlashing: phase0.ProposerSlashing,
   proposer: Validator,

--- a/packages/state-transition/src/block/processRandao.ts
+++ b/packages/state-transition/src/block/processRandao.ts
@@ -17,7 +17,7 @@ export function processRandao(state: CachedBeaconStateAllForks, block: BeaconBlo
   const randaoReveal = block.body.randaoReveal;
 
   // verify RANDAO reveal
-  if (verifySignature && !verifyRandaoSignature(config, epochCtx.pubkeyCache, block)) {
+  if (verifySignature && !verifyRandaoSignature(config, block)) {
     throw new Error("RANDAO reveal is an invalid signature");
   }
 

--- a/packages/state-transition/src/block/processSyncCommittee.ts
+++ b/packages/state-transition/src/block/processSyncCommittee.ts
@@ -32,7 +32,7 @@ export function processSyncAggregate(
       participantIndices
     );
     // When there's no participation we consider the signature valid and just ignore it
-    if (signatureSet !== null && !verifySignatureSet(signatureSet, state.epochCtx.pubkeyCache)) {
+    if (signatureSet !== null && !verifySignatureSet(signatureSet)) {
       throw Error("Sync committee signature invalid");
     }
   }

--- a/packages/state-transition/src/block/processVoluntaryExit.ts
+++ b/packages/state-transition/src/block/processVoluntaryExit.ts
@@ -93,10 +93,7 @@ function getValidatorVoluntaryExitValidity(
   }
 
   // Verify signature
-  if (
-    verifySignature &&
-    !verifyVoluntaryExitSignature(config, epochCtx.pubkeyCache, new BeaconStateView(state), signedVoluntaryExit)
-  ) {
+  if (verifySignature && !verifyVoluntaryExitSignature(config, new BeaconStateView(state), signedVoluntaryExit)) {
     return VoluntaryExitValidity.invalidSignature;
   }
 

--- a/packages/state-transition/src/signatureSets/proposer.ts
+++ b/packages/state-transition/src/signatureSets/proposer.ts
@@ -7,11 +7,11 @@ import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../util/signa
 
 export function verifyProposerSignature(
   config: BeaconConfig,
-  pubkeyCache: PubkeyCache,
+  _pubkeyCache: PubkeyCache,
   signedBlock: SignedBeaconBlock | SignedBlindedBeaconBlock
 ): boolean {
   const signatureSet = getBlockProposerSignatureSet(config, signedBlock);
-  return verifySignatureSet(signatureSet, pubkeyCache);
+  return verifySignatureSet(signatureSet);
 }
 
 export function getBlockProposerSignatureSet(

--- a/packages/state-transition/src/signatureSets/proposer.ts
+++ b/packages/state-transition/src/signatureSets/proposer.ts
@@ -1,4 +1,3 @@
-import {type PubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_PROPOSER} from "@lodestar/params";
 import {SignedBeaconBlock, SignedBlindedBeaconBlock, Slot, isBlindedBeaconBlock, phase0, ssz} from "@lodestar/types";
@@ -7,7 +6,6 @@ import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../util/signa
 
 export function verifyProposerSignature(
   config: BeaconConfig,
-  _pubkeyCache: PubkeyCache,
   signedBlock: SignedBeaconBlock | SignedBlindedBeaconBlock
 ): boolean {
   const signatureSet = getBlockProposerSignatureSet(config, signedBlock);

--- a/packages/state-transition/src/signatureSets/randao.ts
+++ b/packages/state-transition/src/signatureSets/randao.ts
@@ -10,8 +10,8 @@ import {
   verifySignatureSet,
 } from "../util/index.js";
 
-export function verifyRandaoSignature(config: BeaconConfig, pubkeyCache: PubkeyCache, block: BeaconBlock): boolean {
-  return verifySignatureSet(getRandaoRevealSignatureSet(config, block), pubkeyCache);
+export function verifyRandaoSignature(config: BeaconConfig, _pubkeyCache: PubkeyCache, block: BeaconBlock): boolean {
+  return verifySignatureSet(getRandaoRevealSignatureSet(config, block));
 }
 
 /**

--- a/packages/state-transition/src/signatureSets/randao.ts
+++ b/packages/state-transition/src/signatureSets/randao.ts
@@ -1,4 +1,3 @@
-import {type PubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_RANDAO} from "@lodestar/params";
 import {BeaconBlock, ssz} from "@lodestar/types";
@@ -10,7 +9,7 @@ import {
   verifySignatureSet,
 } from "../util/index.js";
 
-export function verifyRandaoSignature(config: BeaconConfig, _pubkeyCache: PubkeyCache, block: BeaconBlock): boolean {
+export function verifyRandaoSignature(config: BeaconConfig, block: BeaconBlock): boolean {
   return verifySignatureSet(getRandaoRevealSignatureSet(config, block));
 }
 

--- a/packages/state-transition/src/signatureSets/voluntaryExits.ts
+++ b/packages/state-transition/src/signatureSets/voluntaryExits.ts
@@ -15,11 +15,11 @@ import {
 
 export function verifyVoluntaryExitSignature(
   config: BeaconConfig,
-  pubkeyCache: PubkeyCache,
+  _pubkeyCache: PubkeyCache,
   state: IBeaconStateView,
   signedVoluntaryExit: phase0.SignedVoluntaryExit
 ): boolean {
-  return verifySignatureSet(getVoluntaryExitSignatureSet(config, state, signedVoluntaryExit), pubkeyCache);
+  return verifySignatureSet(getVoluntaryExitSignatureSet(config, state, signedVoluntaryExit));
 }
 
 /**

--- a/packages/state-transition/src/signatureSets/voluntaryExits.ts
+++ b/packages/state-transition/src/signatureSets/voluntaryExits.ts
@@ -1,4 +1,3 @@
-import {type PubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq} from "@lodestar/params";
 import {SignedBeaconBlock, Slot, phase0, ssz} from "@lodestar/types";
@@ -15,7 +14,6 @@ import {
 
 export function verifyVoluntaryExitSignature(
   config: BeaconConfig,
-  _pubkeyCache: PubkeyCache,
   state: IBeaconStateView,
   signedVoluntaryExit: phase0.SignedVoluntaryExit
 ): boolean {

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -113,7 +113,7 @@ export function stateTransition(
   postState = processSlotsWithTransientCache(postState, blockSlot, options, {metrics, validatorMonitor});
 
   // Verify proposer signature only
-  if (verifyProposer && !verifyProposerSignature(postState.config, postState.epochCtx.pubkeyCache, signedBlock)) {
+  if (verifyProposer && !verifyProposerSignature(postState.config, signedBlock)) {
     throw new Error("Invalid block signature");
   }
 

--- a/packages/state-transition/src/util/signatureSets.ts
+++ b/packages/state-transition/src/util/signatureSets.ts
@@ -1,4 +1,4 @@
-import {PublicKey, Signature, aggregatePublicKeys, fastAggregateVerify, verify} from "@chainsafe/lodestar-z/blst";
+import {PublicKey, Signature, fastAggregateVerify, verify} from "@chainsafe/lodestar-z/blst";
 import {type PubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {Root} from "@lodestar/types";
 
@@ -61,10 +61,7 @@ export function getSignatureSetPubkey(signatureSet: ISignatureSet, pubkeyCache: 
     }
 
     case SignatureSetType.aggregate: {
-      const pubkeys = signatureSet.indices.map((i) => {
-        return pubkeyCache.getOrThrow(i);
-      });
-      return aggregatePublicKeys(pubkeys);
+      return pubkeyCache.aggregate(signatureSet.indices);
     }
 
     default:

--- a/packages/state-transition/src/util/signatureSets.ts
+++ b/packages/state-transition/src/util/signatureSets.ts
@@ -47,28 +47,6 @@ export type AggregatedSignatureSet = {
 
 export type ISignatureSet = SingleSignatureSet | IndexedSignatureSet | AggregatedSignatureSet;
 
-/**
- * Get the pubkey for a signature set, performing aggregation if necessary.
- * Requires pubkeyCache for indexed and aggregate sets.
- */
-export function getSignatureSetPubkey(signatureSet: ISignatureSet, pubkeyCache: PubkeyCache): PublicKey {
-  switch (signatureSet.type) {
-    case SignatureSetType.single:
-      return PublicKey.fromBytes(signatureSet.pubkey, true);
-
-    case SignatureSetType.indexed: {
-      return pubkeyCache.getOrThrow(signatureSet.index);
-    }
-
-    case SignatureSetType.aggregate: {
-      return pubkeyCache.aggregate(signatureSet.indices);
-    }
-
-    default:
-      throw Error("Unknown signature set type");
-  }
-}
-
 export function verifySignatureSet(signatureSet: SingleSignatureSet, pubkeyCache?: PubkeyCache): boolean;
 export function verifySignatureSet(signatureSet: IndexedSignatureSet, pubkeyCache: PubkeyCache): boolean;
 export function verifySignatureSet(signatureSet: AggregatedSignatureSet, pubkeyCache: PubkeyCache): boolean;

--- a/packages/state-transition/src/util/signatureSets.ts
+++ b/packages/state-transition/src/util/signatureSets.ts
@@ -1,5 +1,4 @@
-import {PublicKey, Signature, fastAggregateVerify, verify} from "@chainsafe/lodestar-z/blst";
-import {type PubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
+import {BLS_VERIFIER_SET_TYPE, type BlsSignatureSet, verifySignatureSets} from "@chainsafe/lodestar-z/bls-verifier";
 import {Root} from "@lodestar/types";
 
 export enum SignatureSetType {
@@ -47,39 +46,48 @@ export type AggregatedSignatureSet = {
 
 export type ISignatureSet = SingleSignatureSet | IndexedSignatureSet | AggregatedSignatureSet;
 
-export function verifySignatureSet(signatureSet: SingleSignatureSet, pubkeyCache?: PubkeyCache): boolean;
-export function verifySignatureSet(signatureSet: IndexedSignatureSet, pubkeyCache: PubkeyCache): boolean;
-export function verifySignatureSet(signatureSet: AggregatedSignatureSet, pubkeyCache: PubkeyCache): boolean;
-export function verifySignatureSet(signatureSet: ISignatureSet, pubkeyCache: PubkeyCache): boolean;
-export function verifySignatureSet(signatureSet: ISignatureSet, pubkeyCache?: PubkeyCache): boolean {
-  // All signatures are not trusted and must be group checked (p2.subgroup_check)
-  const signature = Signature.fromBytes(signatureSet.signature, true);
-
+export function toBlsSignatureSet(signatureSet: ISignatureSet): BlsSignatureSet {
   switch (signatureSet.type) {
     case SignatureSetType.single:
-      return verify(signatureSet.signingRoot, PublicKey.fromBytes(signatureSet.pubkey, true), signature);
+      return {
+        type: BLS_VERIFIER_SET_TYPE.single,
+        pubkey: signatureSet.pubkey,
+        message: signatureSet.signingRoot,
+        signature: signatureSet.signature,
+      };
 
-    case SignatureSetType.indexed: {
-      if (!pubkeyCache) {
-        throw Error("pubkeyCache required for indexed signature set");
-      }
-      const pubkey = pubkeyCache.getOrThrow(signatureSet.index);
-      return verify(signatureSet.signingRoot, pubkey, signature);
-    }
+    case SignatureSetType.indexed:
+      return {
+        type: BLS_VERIFIER_SET_TYPE.indexed,
+        index: signatureSet.index,
+        message: signatureSet.signingRoot,
+        signature: signatureSet.signature,
+      };
 
     case SignatureSetType.aggregate: {
-      if (!pubkeyCache) {
-        throw Error("pubkeyCache required for aggregate signature set");
+      const indices = new Uint32Array(signatureSet.indices.length);
+      for (const [i, index] of signatureSet.indices.entries()) {
+        if (!Number.isInteger(index) || index < 0 || index > 0xffffffff) {
+          throw new RangeError(`Invalid validator index ${index}`);
+        }
+        indices[i] = index;
       }
-      const pubkeys = signatureSet.indices.map((i) => {
-        return pubkeyCache.getOrThrow(i);
-      });
-      return fastAggregateVerify(signatureSet.signingRoot, pubkeys, signature);
+
+      return {
+        type: BLS_VERIFIER_SET_TYPE.aggregate,
+        indices,
+        message: signatureSet.signingRoot,
+        signature: signatureSet.signature,
+      };
     }
 
     default:
       throw Error("Unknown signature set type");
   }
+}
+
+export function verifySignatureSet(signatureSet: ISignatureSet): boolean {
+  return verifySignatureSets([toBlsSignatureSet(signatureSet)]);
 }
 
 export function createSingleSignatureSetFromComponents(

--- a/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
+++ b/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
@@ -56,14 +56,7 @@ describe("validate indexed attestation", () => {
       signature: EMPTY_SIGNATURE,
     };
     expect(
-      isValidIndexedAttestation(
-        state.config,
-        state.epochCtx.pubkeyCache,
-        state.slot,
-        state.validators.length,
-        indexedAttestation,
-        false
-      )
+      isValidIndexedAttestation(state.config, state.slot, state.validators.length, indexedAttestation, false)
     ).toBe(expectedValue);
   });
 });

--- a/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import {describe, expect, it} from "vitest";
 import {SecretKey} from "@chainsafe/lodestar-z/blst";
+import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {BitArray} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
 import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE} from "@lodestar/params";
@@ -9,11 +10,52 @@ import {ZERO_HASH} from "../../../src/constants/index.js";
 import {BeaconStateView} from "../../../src/index.js";
 import {getBlockSignatureSets} from "../../../src/signatureSets/index.js";
 import {generateCachedState} from "../../../src/testUtils/state.js";
+import {SignatureSetType, toBlsSignatureSet, verifySignatureSet} from "../../../src/util/signatureSets.js";
 import {generateValidators} from "../../utils/validator.js";
 
 const EMPTY_SIGNATURE = Buffer.alloc(96);
 
 describe("signatureSets", () => {
+  it("converts aggregate indices to the Lodestar-Z verifier representation", () => {
+    const set = toBlsSignatureSet({
+      type: SignatureSetType.aggregate,
+      indices: [1, 2],
+      signingRoot: Buffer.alloc(32, 3),
+      signature: Buffer.alloc(96, 4),
+    });
+
+    expect(set).toMatchObject({indices: new Uint32Array([1, 2]), message: Buffer.alloc(32, 3)});
+  });
+
+  it("rejects aggregate validator indices outside uint32", () => {
+    for (const index of [-1, 0.5, 2 ** 32]) {
+      expect(() =>
+        toBlsSignatureSet({
+          type: SignatureSetType.aggregate,
+          indices: [index],
+          signingRoot: Buffer.alloc(32),
+          signature: Buffer.alloc(96),
+        })
+      ).toThrow(`Invalid validator index ${index}`);
+    }
+  });
+
+  it("verifies indexed sets through the shared Lodestar-Z cache", () => {
+    pubkeyCache.reset();
+    const secretKey = SecretKey.fromKeygen(Buffer.alloc(32, 42));
+    const signingRoot = Buffer.alloc(32, 7);
+    pubkeyCache.append(0, secretKey.toPublicKey().toBytes());
+
+    expect(
+      verifySignatureSet({
+        type: SignatureSetType.indexed,
+        index: 0,
+        signingRoot,
+        signature: secretKey.sign(signingRoot).toBytes(),
+      })
+    ).toBe(true);
+  });
+
   it("should aggregate all signatures from a block", () => {
     const emptyBlockBody = ssz.capella.BeaconBlockBody.defaultValue();
     const block: capella.BeaconBlock = {

--- a/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -1,7 +1,6 @@
 import crypto from "node:crypto";
-import {afterEach, describe, expect, it, vi} from "vitest";
+import {describe, expect, it} from "vitest";
 import {SecretKey} from "@chainsafe/lodestar-z/blst";
-import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {BitArray} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
 import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE} from "@lodestar/params";
@@ -10,33 +9,11 @@ import {ZERO_HASH} from "../../../src/constants/index.js";
 import {BeaconStateView} from "../../../src/index.js";
 import {getBlockSignatureSets} from "../../../src/signatureSets/index.js";
 import {generateCachedState} from "../../../src/testUtils/state.js";
-import {SignatureSetType, getSignatureSetPubkey} from "../../../src/util/signatureSets.js";
 import {generateValidators} from "../../utils/validator.js";
 
 const EMPTY_SIGNATURE = Buffer.alloc(96);
 
 describe("signatureSets", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("delegates aggregate pubkey resolution to PubkeyCache", () => {
-    const indices = [1, 2, 3];
-    const expected = SecretKey.fromKeygen(Buffer.alloc(32, 1)).toPublicKey();
-    const aggregate = vi.spyOn(pubkeyCache, "aggregate").mockReturnValue(expected);
-    const getOrThrow = vi.spyOn(pubkeyCache, "getOrThrow").mockReturnValue(expected);
-
-    const actual = getSignatureSetPubkey(
-      {type: SignatureSetType.aggregate, indices, signingRoot: ZERO_HASH, signature: EMPTY_SIGNATURE},
-      pubkeyCache
-    );
-
-    expect(actual).toBe(expected);
-    expect(aggregate).toHaveBeenCalledOnce();
-    expect(aggregate).toHaveBeenCalledWith(indices);
-    expect(getOrThrow).not.toHaveBeenCalled();
-  });
-
   it("should aggregate all signatures from a block", () => {
     const emptyBlockBody = ssz.capella.BeaconBlockBody.defaultValue();
     const block: capella.BeaconBlock = {

--- a/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
-import {describe, expect, it} from "vitest";
+import {afterEach, describe, expect, it, vi} from "vitest";
 import {SecretKey} from "@chainsafe/lodestar-z/blst";
+import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {BitArray} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
 import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE} from "@lodestar/params";
@@ -9,11 +10,33 @@ import {ZERO_HASH} from "../../../src/constants/index.js";
 import {BeaconStateView} from "../../../src/index.js";
 import {getBlockSignatureSets} from "../../../src/signatureSets/index.js";
 import {generateCachedState} from "../../../src/testUtils/state.js";
+import {SignatureSetType, getSignatureSetPubkey} from "../../../src/util/signatureSets.js";
 import {generateValidators} from "../../utils/validator.js";
 
 const EMPTY_SIGNATURE = Buffer.alloc(96);
 
 describe("signatureSets", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delegates aggregate pubkey resolution to PubkeyCache", () => {
+    const indices = [1, 2, 3];
+    const expected = SecretKey.fromKeygen(Buffer.alloc(32, 1)).toPublicKey();
+    const aggregate = vi.spyOn(pubkeyCache, "aggregate").mockReturnValue(expected);
+    const getOrThrow = vi.spyOn(pubkeyCache, "getOrThrow").mockReturnValue(expected);
+
+    const actual = getSignatureSetPubkey(
+      {type: SignatureSetType.aggregate, indices, signingRoot: ZERO_HASH, signature: EMPTY_SIGNATURE},
+      pubkeyCache
+    );
+
+    expect(actual).toBe(expected);
+    expect(aggregate).toHaveBeenCalledOnce();
+    expect(aggregate).toHaveBeenCalledWith(indices);
+    expect(getOrThrow).not.toHaveBeenCalled();
+  });
+
   it("should aggregate all signatures from a block", () => {
     const emptyBlockBody = ssz.capella.BeaconBlockBody.defaultValue();
     const block: capella.BeaconBlock = {


### PR DESCRIPTION
## Summary

- route state-transition signature-set verification through `@chainsafe/lodestar-z/bls-verifier`
- move `toBlsSignatureSet()` into state-transition and reuse it from beacon-node worker paths
- use the shared Lodestar-Z cache for indexed and aggregate verification
- route single deposit proof-of-possession checks through the same native verifier
- remove the unused `getSignatureSetPubkey` helper and its `aggregatePublicKeys` import

## Verification

- `pnpm --filter @lodestar/state-transition check-types`
- `pnpm --filter @lodestar/beacon-node check-types`
- `pnpm --filter @lodestar/state-transition build`
- `pnpm vitest run --project unit packages/state-transition/test/unit` (41 files, 331 tests passed)
- `pnpm vitest run --project unit packages/beacon-node/test/unit/chain/bls/bls.test.ts` (22 tests passed)
- Biome check on all 13 changed files

Follow-up to https://github.com/ChainSafe/lodestar/pull/9820#pullrequestreview-4980327284
