### PR TITLE
fix: keep event stream alive if an event can not be serialized

### DIFF
--- a/packages/api/src/beacon/server/events.ts
+++ b/packages/api/src/beacon/server/events.ts
@@ -42,10 +42,15 @@ export function getRoutes(config: ChainForkConfig, methods: ApplicationMethods<E
               topics: req.query.topics,
               signal: controller.signal,
               onEvent: (event) => {
+                // Serialization is per event and must not tear down the stream. Throwing here is
+                // handled by the caller which logs it and keeps the subscription alive, the client
+                // only misses this single event instead of silently losing the whole stream.
+                const data = eventSerdes.toJson(event);
+
                 try {
-                  const data = eventSerdes.toJson(event);
                   res.raw.write(serializeSSEEvent({event: event.type, data}));
                 } catch (e) {
+                  // The connection itself is broken, there is no way to recover it
                   reject(e);
                 }
               },
@@ -58,10 +63,12 @@ export function getRoutes(config: ChainForkConfig, methods: ApplicationMethods<E
             req.socket.once("close", () => resolve());
             req.socket.once("end", () => resolve());
           });
-
-          // api.eventstream will never stop, so no need to ever call `res.raw.end();`
         } finally {
           controller.abort();
+          // Always end the response. If an error is thrown after the headers were sent, fastify can
+          // no longer write a status code and would leave the socket open, the client then waits
+          // forever on a stream that will never emit another event.
+          if (!res.raw.writableEnded && !res.raw.destroyed) res.raw.end();
         }
       },
     },

--- a/packages/api/test/unit/beacon/genericServerTest/events.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/events.test.ts
@@ -1,6 +1,7 @@
 import {FastifyInstance} from "fastify";
 import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
 import {config} from "@lodestar/config/default";
+import {ForkName} from "@lodestar/params";
 import {sleep} from "@lodestar/utils";
 import {getClient} from "../../../../src/beacon/client/events.js";
 import {BeaconEvent, Endpoints, EventType, getDefinitions} from "../../../../src/beacon/routes/events.js";
@@ -77,5 +78,44 @@ describe("beacon / events", () => {
     });
 
     expect(eventsReceived).toEqual(eventsToSend);
+  });
+
+  it("Keep the stream alive if an event can not be serialized", async () => {
+    // `version` does not match the Gloas-only type of the event, as observed on a devnet where a
+    // peer gossiped proposer preferences for a proposal slot that was still pre-Gloas
+    const invalidEvent = {
+      type: EventType.proposerPreferences,
+      message: {...eventTestData[EventType.proposerPreferences], version: ForkName.fulu},
+    } as BeaconEvent;
+    const eventHead: BeaconEvent = {
+      type: EventType.head,
+      message: eventTestData[EventType.head],
+    };
+    const eventsReceived: BeaconEvent[] = [];
+
+    await new Promise<void>((resolve, reject) => {
+      mockApi.eventstream.mockImplementation(async ({onEvent}) => {
+        try {
+          // The error is surfaced to the caller instead of tearing down the connection
+          expect(() => onEvent(invalidEvent)).toThrow();
+          await sleep(5);
+          onEvent(eventHead);
+        } catch (e) {
+          reject(e);
+        }
+      });
+
+      const client = getClient(config, baseUrl);
+      void client.eventstream({
+        topics: [EventType.head, EventType.proposerPreferences],
+        signal: controller.signal,
+        onEvent: (event) => {
+          eventsReceived.push(event);
+          resolve();
+        },
+      });
+    });
+
+    expect(eventsReceived).toEqual([eventHead]);
   });
 });

--- a/packages/beacon-node/src/api/impl/events/index.ts
+++ b/packages/beacon-node/src/api/impl/events/index.ts
@@ -4,7 +4,8 @@ import {ApiModules} from "../types.js";
 
 export function getEventsApi({
   chain,
-}: Pick<ApiModules, "chain" | "config">): ApplicationMethods<routes.events.Endpoints> {
+  logger,
+}: Pick<ApiModules, "chain" | "config" | "logger">): ApplicationMethods<routes.events.Endpoints> {
   return {
     async eventstream({topics, signal, onEvent}) {
       const onAbortFns: (() => void)[] = [];
@@ -12,9 +13,14 @@ export function getEventsApi({
       for (const topic of topics) {
         // biome-ignore lint/suspicious/noExplicitAny: We need to use `any` type here
         const handler = (data: any): void => {
-          // TODO: What happens if this handler throws? Does it break the other chain.emitter listeners?
-
-          onEvent({type: topic, message: data});
+          try {
+            onEvent({type: topic, message: data});
+          } catch (e) {
+            // `chain.emitter` emits synchronously, a throwing listener would propagate the error to
+            // whoever emitted the event, e.g. a gossip handler, and skip the remaining listeners.
+            // A single misbehaving event or client must not affect the node or other subscribers.
+            logger.error("Error sending event to client", {topic}, e as Error);
+          }
         };
 
         chain.emitter.on(topic, handler);

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -104,6 +104,13 @@ export class RestApiServer {
 
     // To parse our ApiError -> statusCode
     server.setErrorHandler<FastifyError | Error>((err, _req, res) => {
+      if (res.raw.headersSent) {
+        // A status code can no longer be written, e.g. if a long-lived SSE stream failed mid-flight.
+        // End the response instead, else the socket is left open and the client never notices.
+        if (!res.raw.writableEnded && !res.raw.destroyed) res.raw.end();
+        return;
+      }
+
       const stacktraces = opts.stacktraces ? err.stack?.split("\n") : undefined;
       if ("validation" in err && err.validation) {
         const {instancePath = "unknown", message} = err.validation?.[0] ?? {};

--- a/packages/beacon-node/src/chain/errors/proposerPreferences.ts
+++ b/packages/beacon-node/src/chain/errors/proposerPreferences.ts
@@ -1,7 +1,9 @@
+import {ForkName} from "@lodestar/params";
 import {Epoch, RootHex, Slot, ValidatorIndex} from "@lodestar/types";
 import {GossipActionError} from "./gossipValidation.js";
 
 export enum ProposerPreferencesErrorCode {
+  PRE_GLOAS_PROPOSAL_SLOT = "PROPOSER_PREFERENCES_ERROR_PRE_GLOAS_PROPOSAL_SLOT",
   INVALID_EPOCH = "PROPOSER_PREFERENCES_ERROR_INVALID_EPOCH",
   PROPOSAL_SLOT_PASSED = "PROPOSER_PREFERENCES_ERROR_PROPOSAL_SLOT_PASSED",
   UNKNOWN_DEPENDENT_ROOT = "PROPOSER_PREFERENCES_ERROR_UNKNOWN_DEPENDENT_ROOT",
@@ -13,6 +15,11 @@ export enum ProposerPreferencesErrorCode {
 }
 
 export type ProposerPreferencesErrorType =
+  | {
+      code: ProposerPreferencesErrorCode.PRE_GLOAS_PROPOSAL_SLOT;
+      proposalSlot: Slot;
+      proposalFork: ForkName;
+    }
   | {
       code: ProposerPreferencesErrorCode.INVALID_EPOCH;
       proposalSlot: Slot;

--- a/packages/beacon-node/src/chain/validation/proposerPreferences.ts
+++ b/packages/beacon-node/src/chain/validation/proposerPreferences.ts
@@ -1,5 +1,5 @@
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
-import {GENESIS_EPOCH, GENESIS_SLOT, MIN_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {GENESIS_EPOCH, GENESIS_SLOT, MIN_SEED_LOOKAHEAD, SLOTS_PER_EPOCH, isForkPostGloas} from "@lodestar/params";
 import {
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
@@ -23,6 +23,21 @@ export async function validateGossipProposerPreferences(
   const {proposalSlot, validatorIndex, dependentRoot} = preferences;
   const dependentRootHex = toRootHex(dependentRoot);
   const proposalEpoch = computeEpochAtSlot(proposalSlot);
+
+  // [IGNORE] `preferences.proposal_slot` is in a Gloas or later fork.
+  //
+  // Not a spec condition. The Gloas topics are subscribed one epoch ahead of the fork, so for that
+  // epoch the lookahead check below accepts a `proposal_slot` that is still pre-Gloas. Preferences
+  // for such a slot are meaningless as there is no bid auction before Gloas, and consumers that
+  // derive the fork from `proposal_slot` cannot represent them with a Gloas-only type.
+  const proposalFork = chain.config.getForkName(proposalSlot);
+  if (!isForkPostGloas(proposalFork)) {
+    throw new ProposerPreferencesError(GossipAction.IGNORE, {
+      code: ProposerPreferencesErrorCode.PRE_GLOAS_PROPOSAL_SLOT,
+      proposalSlot,
+      proposalFork,
+    });
+  }
 
   // [IGNORE] `preferences.proposal_slot` is within the proposer lookahead,
   // allowing for `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1282,8 +1282,11 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         payloadAttestationMessage.data.blobDataAvailable
       );
 
+      // The event version must match the fork the message was deserialized with, which is the
+      // fork of the topic. It can be ahead of the fork of the message slot as the Gloas topics
+      // are subscribed one epoch before the fork.
       chain.emitter.emit(routes.events.EventType.payloadAttestationMessage, {
-        version: config.getForkName(payloadAttestationMessage.data.slot),
+        version: topic.boundary.fork,
         data: payloadAttestationMessage,
       });
     },
@@ -1310,8 +1313,11 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
 
       chain.validatorMonitor?.registerExecutionPayloadBid(OpSource.gossip, proposerIndex, executionPayloadBid.message);
 
+      // The event version must match the fork the message was deserialized with, which is the
+      // fork of the topic. It can be ahead of the fork of the message slot as the Gloas topics
+      // are subscribed one epoch before the fork.
       chain.emitter.emit(routes.events.EventType.executionPayloadBid, {
-        version: config.getForkName(executionPayloadBid.message.slot),
+        version: topic.boundary.fork,
         data: executionPayloadBid,
       });
     },
@@ -1323,8 +1329,11 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       const signedProposerPreferences = sszDeserialize(topic, serializedData);
       await validateGossipProposerPreferences(chain, signedProposerPreferences);
 
+      // The event version must match the fork the message was deserialized with, which is the
+      // fork of the topic. It can be ahead of the fork of the message slot as the Gloas topics
+      // are subscribed one epoch before the fork.
       chain.emitter.emit(routes.events.EventType.proposerPreferences, {
-        version: config.getForkName(signedProposerPreferences.message.proposalSlot),
+        version: topic.boundary.fork,
         data: signedProposerPreferences,
       });
     },

--- a/packages/beacon-node/test/unit/api/impl/events/events.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/events/events.test.ts
@@ -1,6 +1,7 @@
 import {MockedObject, afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {routes} from "@lodestar/api";
 import {config} from "@lodestar/config/default";
+import {testLogger} from "@lodestar/logger/test-utils";
 import {ssz} from "@lodestar/types";
 import {toHex} from "@lodestar/utils";
 import {getEventsApi} from "../../../../../src/api/impl/events/index.js";
@@ -33,7 +34,7 @@ describe("Events api impl", () => {
     beforeEach(() => {
       chainStub = vi.mocked(new BeaconChain({} as any, {} as any), {partial: true, deep: false});
       chainEventEmmitter = chainStub.emitter;
-      api = getEventsApi({config, chain: chainStub});
+      api = getEventsApi({config, chain: chainStub, logger: testLogger()});
       controller = new AbortController();
     });
 
@@ -70,6 +71,37 @@ describe("Events api impl", () => {
       expect(events).toHaveLength(1);
       expect(events[0].type).toBe(routes.events.EventType.head);
       expect(events[0].message).not.toBeNull();
+    });
+
+    it("should not propagate an error thrown while sending an event", async () => {
+      const error = new Error("failed to send event");
+      void api.eventstream({
+        topics: [routes.events.EventType.head],
+        signal: controller.signal,
+        onEvent: () => {
+          throw error;
+        },
+      });
+
+      // `chainEventEmmitter` emits synchronously, a throwing subscriber must not surface the error
+      // to the emitting code, e.g. a gossip handler
+      expect(() => chainEventEmmitter.emit(routes.events.EventType.head, headEventData)).not.toThrow();
+    });
+
+    it("should keep sending events to other clients if one of them throws", async () => {
+      void api.eventstream({
+        topics: [routes.events.EventType.head],
+        signal: controller.signal,
+        onEvent: () => {
+          throw new Error("failed to send event");
+        },
+      });
+      const events = getEvents([routes.events.EventType.head]);
+
+      chainEventEmmitter.emit(routes.events.EventType.head, headEventData);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe(routes.events.EventType.head);
     });
 
     it("should emit data_column_sidecar event", async () => {

--- a/packages/beacon-node/test/unit/chain/validation/proposerPreferences.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/proposerPreferences.test.ts
@@ -1,0 +1,52 @@
+import {describe, it} from "vitest";
+import {ChainConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {Slot, ssz} from "@lodestar/types";
+import {ProposerPreferencesErrorCode} from "../../../../src/chain/errors/index.js";
+import {IBeaconChain} from "../../../../src/chain/index.js";
+import {validateGossipProposerPreferences} from "../../../../src/chain/validation/proposerPreferences.js";
+import {expectRejectedWithLodestarError} from "../../../utils/errors.js";
+
+describe("validate proposer preferences", () => {
+  const GLOAS_FORK_EPOCH = 2;
+  const config = createChainForkConfig({
+    ...defaultChainConfig,
+    ALTAIR_FORK_EPOCH: 0,
+    BELLATRIX_FORK_EPOCH: 0,
+    CAPELLA_FORK_EPOCH: 0,
+    DENEB_FORK_EPOCH: 0,
+    ELECTRA_FORK_EPOCH: 0,
+    FULU_FORK_EPOCH: 1,
+    GLOAS_FORK_EPOCH,
+  } as Partial<ChainConfig>);
+  const gloasStartSlot = GLOAS_FORK_EPOCH * SLOTS_PER_EPOCH;
+
+  function getChainStub(currentSlot: Slot): IBeaconChain {
+    return {config, clock: {currentSlotWithGossipDisparity: currentSlot}} as Partial<IBeaconChain> as IBeaconChain;
+  }
+
+  function getProposerPreferences(
+    proposalSlot: Slot
+  ): ReturnType<typeof ssz.gloas.SignedProposerPreferences.defaultValue> {
+    const signedProposerPreferences = ssz.gloas.SignedProposerPreferences.defaultValue();
+    signedProposerPreferences.message.proposalSlot = proposalSlot;
+    return signedProposerPreferences;
+  }
+
+  // The Gloas topics are subscribed one epoch before the fork, a peer may publish preferences for a
+  // proposal slot that is still pre-Gloas on that topic
+  it("should ignore preferences for a pre-gloas proposal slot", async () => {
+    await expectRejectedWithLodestarError(
+      validateGossipProposerPreferences(getChainStub(gloasStartSlot - 2), getProposerPreferences(gloasStartSlot - 1)),
+      ProposerPreferencesErrorCode.PRE_GLOAS_PROPOSAL_SLOT
+    );
+  });
+
+  it("should not ignore preferences for a gloas proposal slot", async () => {
+    // Fails on the lookahead check instead, which is the check right after the fork guard
+    await expectRejectedWithLodestarError(
+      validateGossipProposerPreferences(getChainStub(0), getProposerPreferences(gloasStartSlot)),
+      ProposerPreferencesErrorCode.INVALID_EPOCH
+    );
+  });
+});


### PR DESCRIPTION
**Motivation**

At the first slot of the epoch before the Gloas fork on glamsterdam-devnet-8, all Lodestar nodes logged

```
Req req-4 eventstream error - Invalid fork=fulu for post-gloas fork types
Req req-4 eventstream error - Cannot write headers after they are sent to the client
```

A peer gossiped `proposer_preferences` for a `proposal_slot` that was still pre-Gloas. Gloas topics are
subscribed one epoch ahead of the fork and the lookahead check accepts any `proposal_slot` up to the end
of `current_epoch + MIN_SEED_LOOKAHEAD`, so during that epoch it spans the fork boundary. The handler then
emits the event with `version = getForkName(proposal_slot)` = `fulu` and `getPostGloasForkTypes` throws.

That single event took down the whole `/eth/v1/events` connection, and since the headers were already sent
fastify could not write a status code, leaving the socket open. The client saw no EOF and no error and never
reconnected. The builder on `buildoor-lodestar-ethrex-1` cached seven preferences before the error, warned
`No proposer preferences for slot` from the next slot on, and submitted no bids for the following two hours.

**Description**

- ignore gossiped proposer preferences for a pre-Gloas `proposal_slot`, there is no bid auction before Gloas
- emit Gloas-only events with the fork of the topic, which is the fork the message was deserialized with,
  instead of the fork of the message slot. The same crash was reachable via `execution_payload_bid` and
  `payload_attestation_message`
- do not tear down the event stream if a single event fails to serialize, only drop that event
- always end the response, so a client of a stream that fails after the headers were sent sees the connection
  close and reconnects
- contain errors thrown while sending an event to a client. `chain.emitter` emits synchronously, so those
  would otherwise propagate to the gossip handler that emitted the event and skip the remaining subscribers

The pre-Gloas `proposal_slot` check is not a spec condition, the p2p spec has no rule restricting
`proposal_slot` to the Gloas fork.
