### PR TITLE
fix: emit gloas events with the fork of the topic

### DIFF
--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1282,8 +1282,11 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         payloadAttestationMessage.data.blobDataAvailable
       );
 
+      // The event version must match the fork the message was deserialized with, which is the
+      // fork of the topic. It can be ahead of the fork of the message slot as the Gloas topics
+      // are subscribed one epoch before the fork.
       chain.emitter.emit(routes.events.EventType.payloadAttestationMessage, {
-        version: config.getForkName(payloadAttestationMessage.data.slot),
+        version: topic.boundary.fork,
         data: payloadAttestationMessage,
       });
     },
@@ -1310,8 +1313,11 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
 
       chain.validatorMonitor?.registerExecutionPayloadBid(OpSource.gossip, proposerIndex, executionPayloadBid.message);
 
+      // The event version must match the fork the message was deserialized with, which is the
+      // fork of the topic. It can be ahead of the fork of the message slot as the Gloas topics
+      // are subscribed one epoch before the fork.
       chain.emitter.emit(routes.events.EventType.executionPayloadBid, {
-        version: config.getForkName(executionPayloadBid.message.slot),
+        version: topic.boundary.fork,
         data: executionPayloadBid,
       });
     },
@@ -1323,8 +1329,11 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       const signedProposerPreferences = sszDeserialize(topic, serializedData);
       await validateGossipProposerPreferences(chain, signedProposerPreferences);
 
+      // The event version must match the fork the message was deserialized with, which is the
+      // fork of the topic. It can be ahead of the fork of the message slot as the Gloas topics
+      // are subscribed one epoch before the fork.
       chain.emitter.emit(routes.events.EventType.proposerPreferences, {
-        version: config.getForkName(signedProposerPreferences.message.proposalSlot),
+        version: topic.boundary.fork,
         data: signedProposerPreferences,
       });
     },


### PR DESCRIPTION
**Motivation**

The Gloas-only gossip handlers derive the event version from the message slot. The message was deserialized
with the fork of the topic, and since Gloas topics are subscribed one epoch before the fork, the two can
disagree for the duration of that epoch. `getPostGloasForkTypes` then throws when the event is serialized.

Observed on glamsterdam-devnet-8 via `proposer_preferences`, but reachable the same way via
`execution_payload_bid` and `payload_attestation_message`.

**Description**

- emit Gloas-only events with the fork of the topic, which is the fork the message was deserialized with,
  instead of the fork of the message slot
