### PR TITLE
fix: contain errors thrown while sending events to a client

### DIFF
--- a/packages/beacon-node/src/api/impl/events/index.ts
+++ b/packages/beacon-node/src/api/impl/events/index.ts
@@ -4,7 +4,8 @@ import {ApiModules} from "../types.js";
 
 export function getEventsApi({
   chain,
-}: Pick<ApiModules, "chain" | "config">): ApplicationMethods<routes.events.Endpoints> {
+  logger,
+}: Pick<ApiModules, "chain" | "config" | "logger">): ApplicationMethods<routes.events.Endpoints> {
   return {
     async eventstream({topics, signal, onEvent}) {
       const onAbortFns: (() => void)[] = [];
@@ -12,9 +13,14 @@ export function getEventsApi({
       for (const topic of topics) {
         // biome-ignore lint/suspicious/noExplicitAny: We need to use `any` type here
         const handler = (data: any): void => {
-          // TODO: What happens if this handler throws? Does it break the other chain.emitter listeners?
-
-          onEvent({type: topic, message: data});
+          try {
+            onEvent({type: topic, message: data});
+          } catch (e) {
+            // `chain.emitter` emits synchronously, a throwing listener would propagate the error to
+            // whoever emitted the event, e.g. a gossip handler, and skip the remaining listeners.
+            // A single misbehaving event or client must not affect the node or other subscribers.
+            logger.error("Error sending event to client", {topic}, e as Error);
+          }
         };
 
         chain.emitter.on(topic, handler);

--- a/packages/beacon-node/src/api/impl/events/index.ts
+++ b/packages/beacon-node/src/api/impl/events/index.ts
@@ -19,7 +19,7 @@ export function getEventsApi({
             // `chain.emitter` emits synchronously, a throwing listener would propagate the error to
             // whoever emitted the event, e.g. a gossip handler, and skip the remaining listeners.
             // A single misbehaving event or client must not affect the node or other subscribers.
-            logger.error("Error sending event to client", {topic}, e as Error);
+            logger.warn("Error sending event to client", {topic}, e as Error);
           }
         };
 

--- a/packages/beacon-node/test/unit/api/impl/events/events.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/events/events.test.ts
@@ -88,22 +88,6 @@ describe("Events api impl", () => {
       expect(() => chainEventEmmitter.emit(routes.events.EventType.head, headEventData)).not.toThrow();
     });
 
-    it("should keep sending events to other clients if one of them throws", async () => {
-      void api.eventstream({
-        topics: [routes.events.EventType.head],
-        signal: controller.signal,
-        onEvent: () => {
-          throw new Error("failed to send event");
-        },
-      });
-      const events = getEvents([routes.events.EventType.head]);
-
-      chainEventEmmitter.emit(routes.events.EventType.head, headEventData);
-
-      expect(events).toHaveLength(1);
-      expect(events[0].type).toBe(routes.events.EventType.head);
-    });
-
     it("should emit data_column_sidecar event", async () => {
       const events = getEvents([routes.events.EventType.dataColumnSidecar]);
 

--- a/packages/beacon-node/test/unit/api/impl/events/events.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/events/events.test.ts
@@ -1,6 +1,7 @@
 import {MockedObject, afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {routes} from "@lodestar/api";
 import {config} from "@lodestar/config/default";
+import {testLogger} from "@lodestar/logger/test-utils";
 import {ssz} from "@lodestar/types";
 import {toHex} from "@lodestar/utils";
 import {getEventsApi} from "../../../../../src/api/impl/events/index.js";
@@ -33,7 +34,7 @@ describe("Events api impl", () => {
     beforeEach(() => {
       chainStub = vi.mocked(new BeaconChain({} as any, {} as any), {partial: true, deep: false});
       chainEventEmmitter = chainStub.emitter;
-      api = getEventsApi({config, chain: chainStub});
+      api = getEventsApi({config, chain: chainStub, logger: testLogger()});
       controller = new AbortController();
     });
 
@@ -70,6 +71,37 @@ describe("Events api impl", () => {
       expect(events).toHaveLength(1);
       expect(events[0].type).toBe(routes.events.EventType.head);
       expect(events[0].message).not.toBeNull();
+    });
+
+    it("should not propagate an error thrown while sending an event", async () => {
+      const error = new Error("failed to send event");
+      void api.eventstream({
+        topics: [routes.events.EventType.head],
+        signal: controller.signal,
+        onEvent: () => {
+          throw error;
+        },
+      });
+
+      // `chainEventEmmitter` emits synchronously, a throwing subscriber must not surface the error
+      // to the emitting code, e.g. a gossip handler
+      expect(() => chainEventEmmitter.emit(routes.events.EventType.head, headEventData)).not.toThrow();
+    });
+
+    it("should keep sending events to other clients if one of them throws", async () => {
+      void api.eventstream({
+        topics: [routes.events.EventType.head],
+        signal: controller.signal,
+        onEvent: () => {
+          throw new Error("failed to send event");
+        },
+      });
+      const events = getEvents([routes.events.EventType.head]);
+
+      chainEventEmmitter.emit(routes.events.EventType.head, headEventData);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe(routes.events.EventType.head);
     });
 
     it("should emit data_column_sidecar event", async () => {


### PR DESCRIPTION
**Motivation**

Resolves the existing TODO in the event stream handler.

```ts
// TODO: What happens if this handler throws? Does it break the other chain.emitter listeners?
```

It does. `chain.emitter` emits synchronously, so an error thrown while sending an event to a client
propagates to whoever emitted it, e.g. a gossip handler, and skips the remaining subscribers.

**Description**

- contain and log errors thrown while sending an event to a client, a single event or client must not affect
  the node or other subscribers
