### PR TITLE
fix: keep event stream alive if an event can not be serialized

### DIFF
--- a/packages/api/src/beacon/server/events.ts
+++ b/packages/api/src/beacon/server/events.ts
@@ -42,10 +42,15 @@ export function getRoutes(config: ChainForkConfig, methods: ApplicationMethods<E
               topics: req.query.topics,
               signal: controller.signal,
               onEvent: (event) => {
+                // Serialization is per event and must not tear down the stream. Throwing here is
+                // handled by the caller which logs it and keeps the subscription alive, the client
+                // only misses this single event instead of silently losing the whole stream.
+                const data = eventSerdes.toJson(event);
+
                 try {
-                  const data = eventSerdes.toJson(event);
                   res.raw.write(serializeSSEEvent({event: event.type, data}));
                 } catch (e) {
+                  // The connection itself is broken, there is no way to recover it
                   reject(e);
                 }
               },
@@ -58,10 +63,12 @@ export function getRoutes(config: ChainForkConfig, methods: ApplicationMethods<E
             req.socket.once("close", () => resolve());
             req.socket.once("end", () => resolve());
           });
-
-          // api.eventstream will never stop, so no need to ever call `res.raw.end();`
         } finally {
           controller.abort();
+          // Always end the response. If an error is thrown after the headers were sent, fastify can
+          // no longer write a status code and would leave the socket open, the client then waits
+          // forever on a stream that will never emit another event.
+          if (!res.raw.writableEnded && !res.raw.destroyed) res.raw.end();
         }
       },
     },

--- a/packages/api/test/unit/beacon/genericServerTest/events.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/events.test.ts
@@ -1,6 +1,7 @@
 import {FastifyInstance} from "fastify";
 import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
 import {config} from "@lodestar/config/default";
+import {ForkName} from "@lodestar/params";
 import {sleep} from "@lodestar/utils";
 import {getClient} from "../../../../src/beacon/client/events.js";
 import {BeaconEvent, Endpoints, EventType, getDefinitions} from "../../../../src/beacon/routes/events.js";
@@ -77,5 +78,45 @@ describe("beacon / events", () => {
     });
 
     expect(eventsReceived).toEqual(eventsToSend);
+  });
+
+  it("Keep the stream alive if an event can not be serialized", async () => {
+    // Emitting an event whose `version` does not match its type is a bug on the emitting side and
+    // must not happen, it is only used here to force a serialization failure. What matters is that
+    // a single event that can not be serialized does not take the whole stream down with it.
+    const invalidEvent = {
+      type: EventType.proposerPreferences,
+      message: {...eventTestData[EventType.proposerPreferences], version: ForkName.fulu},
+    } as BeaconEvent;
+    const eventHead: BeaconEvent = {
+      type: EventType.head,
+      message: eventTestData[EventType.head],
+    };
+    const eventsReceived: BeaconEvent[] = [];
+
+    await new Promise<void>((resolve, reject) => {
+      mockApi.eventstream.mockImplementation(async ({onEvent}) => {
+        try {
+          // The error is surfaced to the caller instead of tearing down the connection
+          expect(() => onEvent(invalidEvent)).toThrow();
+          await sleep(5);
+          onEvent(eventHead);
+        } catch (e) {
+          reject(e);
+        }
+      });
+
+      const client = getClient(config, baseUrl);
+      void client.eventstream({
+        topics: [EventType.head, EventType.proposerPreferences],
+        signal: controller.signal,
+        onEvent: (event) => {
+          eventsReceived.push(event);
+          resolve();
+        },
+      });
+    });
+
+    expect(eventsReceived).toEqual([eventHead]);
   });
 });

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -104,6 +104,13 @@ export class RestApiServer {
 
     // To parse our ApiError -> statusCode
     server.setErrorHandler<FastifyError | Error>((err, _req, res) => {
+      if (res.raw.headersSent) {
+        // A status code can no longer be written, e.g. if a long-lived SSE stream failed mid-flight.
+        // End the response instead, else the socket is left open and the client never notices.
+        if (!res.raw.writableEnded && !res.raw.destroyed) res.raw.end();
+        return;
+      }
+
       const stacktraces = opts.stacktraces ? err.stack?.split("\n") : undefined;
       if ("validation" in err && err.validation) {
         const {instancePath = "unknown", message} = err.validation?.[0] ?? {};


### PR DESCRIPTION
**Motivation**

On glamsterdam-devnet-8 a single event that failed to serialize took down the entire `/eth/v1/events`
connection

```
Req req-4 eventstream error - Invalid fork=fulu for post-gloas fork types
Req req-4 eventstream error - Cannot write headers after they are sent to the client
```

`onEvent` rejected the connection-level promise, and since the headers were already sent fastify could not
write a status code, which left the socket open. The client saw no EOF and no error and never reconnected.
xatu-sentry received 3 proposer preference events before the error and 0 in the following 272 minutes,
without a single resubscribe attempt. The builder paired with a Lodestar beacon warned
`No proposer preferences for slot` from the next slot on and stopped submitting bids entirely.

**Description**

- do not tear down the event stream if a single event fails to serialize, only drop that event
- always end the response, so a client of a stream that fails after the headers were sent sees the
  connection close and reconnects
- return early from the error handler once the headers are sent, a status code can no longer be written

Stacked on #9871, which contains the error the first change now surfaces to the caller.
