### PR TITLE
fix: treat dial timeouts as HighToleranceError for all methods

### DIFF
--- a/packages/beacon-node/src/network/reqresp/score.ts
+++ b/packages/beacon-node/src/network/reqresp/score.ts
@@ -44,17 +44,11 @@ export function onOutgoingReqRespError(e: RequestError, method: ReqRespMethod): 
         // failure, so keep the stronger penalty (Fatal for Ping, as before).
         return method === ReqRespMethod.Ping ? PeerAction.Fatal : PeerAction.LowToleranceError;
       }
-      switch (method) {
-        // Ping and Status are liveness probes; their dial timeouts are dominated by transient
-        // network congestion rather than peer misbehavior, so penalize leniently to avoid
-        // self-inflicted peer starvation (https://github.com/ChainSafe/lodestar/issues/9562),
-        // while still applying some penalty so genuinely dead peers eventually free the slot.
-        case ReqRespMethod.Ping:
-        case ReqRespMethod.Status:
-          return PeerAction.HighToleranceError;
-        default:
-          return PeerAction.LowToleranceError;
-      }
+      // A dial failure means we could not open a stream. That is evidence about the transport, not
+      // about the peer's behavior, and it is dominated by transient congestion on our side, so
+      // penalize leniently for every method to avoid self-inflicted peer starvation (#9562). A
+      // genuinely dead peer still accumulates penalty and is eventually evicted, freeing the slot.
+      return PeerAction.HighToleranceError;
     // TODO: Detect SSZDecodeError and return PeerAction.Fatal
 
     case RequestErrorCode.RESP_TIMEOUT:

--- a/packages/beacon-node/test/unit/network/reqresp/score.test.ts
+++ b/packages/beacon-node/test/unit/network/reqresp/score.test.ts
@@ -15,8 +15,8 @@ describe("beacon-node / network / reqresp / score / onOutgoingReqRespError", () 
     new RequestError({code: RequestErrorCode.DIAL_ERROR, error: new Error(innerMessage)});
 
   const testCases: {id: string; method: ReqRespMethod; error: RequestError; expected: PeerAction | null}[] = [
-    // Ping/Status dial timeouts are dominated by transient network congestion, not misbehavior,
-    // so they get the lenient HighToleranceError to avoid self-inflicted peer starvation. See #9562.
+    // Dial timeouts are dominated by transient network congestion, not misbehavior, so every method
+    // gets the lenient HighToleranceError to avoid self-inflicted peer starvation. See #9562.
     {
       id: "Ping DIAL_TIMEOUT -> HighToleranceError",
       method: ReqRespMethod.Ping,
@@ -62,19 +62,26 @@ describe("beacon-node / network / reqresp / score / onOutgoingReqRespError", () 
       error: dialError(PROTOCOL_SELECTION_FAILED),
       expected: PeerAction.LowToleranceError,
     },
-    // Non-liveness methods keep the stronger LowToleranceError penalty on dial timeouts;
-    // the #9562 evidence only supports loosening Ping/Status.
+    // Sync methods are issued far more often than the liveness probes, so a single transient
+    // produces most of its penalties here. They must be lenient too, otherwise a request loop
+    // retrying at a high rate bans the whole peer set in seconds.
     {
-      id: "BeaconBlocksByRange DIAL_TIMEOUT -> LowToleranceError",
+      id: "BeaconBlocksByRange DIAL_TIMEOUT -> HighToleranceError",
       method: ReqRespMethod.BeaconBlocksByRange,
       error: dialTimeout(),
-      expected: PeerAction.LowToleranceError,
+      expected: PeerAction.HighToleranceError,
     },
     {
-      id: "Metadata DIAL_TIMEOUT -> LowToleranceError",
+      id: "ExecutionPayloadEnvelopesByRoot DIAL_TIMEOUT -> HighToleranceError",
+      method: ReqRespMethod.ExecutionPayloadEnvelopesByRoot,
+      error: dialTimeout(),
+      expected: PeerAction.HighToleranceError,
+    },
+    {
+      id: "Metadata DIAL_TIMEOUT -> HighToleranceError",
       method: ReqRespMethod.Metadata,
       error: dialTimeout(),
-      expected: PeerAction.LowToleranceError,
+      expected: PeerAction.HighToleranceError,
     },
   ];
 


### PR DESCRIPTION
**Motivation**

#9707 made ping/status dial timeouts lenient per #9562, but left every other method on `LowToleranceError` (-10), so 5 failed dials still cross `MIN_SCORE_BEFORE_BAN` (-50) and ban a peer.

Sync methods are issued far more often than the liveness probes, so a single transient produces most of its penalties there. On glamsterdam-devnet-8, `lodestar-besu-2` took 162 `execution_payload_envelopes_by_root` dial timeouts in one minute and banned 48 of its 64 peers:

```
       13:56  peers=64  DIAL_TIMEOUT=174/min  (162 execution_payload_envelopes_by_root, 12 ping)
       13:57  peers=8   goodbye{Peer score too low}=48/min
```

Every lodestar node saw the same blip and the damage scaled with each node's own dial timeout count, i.e. with how many requests it happened to have in flight:

| node | DIAL_TIMEOUT peak/min | bans | peers | outcome |
|---|---|---|---|---|
| besu-2 | 174 | 48 | 64 → 8 | stuck |
| nethermind-2 | 52 | 10 | 61 → 2 | stuck |
| reth-2 | 96 | 20 | 63 → 30 | survived |
| besu-1 | 40 | 2 | 42 → 36 | survived |
| geth-1 | 8 | 2 | 50 → 46 | survived |

Both stuck nodes fell far enough behind that gossip and unknown block sync unsubscribe, leaving range sync as the only path forward, which does not work on ~5 peers. Neither recovered on its own. Host CPU was ~0.3 and `node_network_receive_drop_total` was 0 throughout, so nothing local was saturated.

**Description**

Return `HighToleranceError` (-1) for `DIAL_TIMEOUT`/`DIAL_ERROR` on every method rather than only ping/status. A dial failure means we could not open a stream, which is evidence about the transport rather than the peer's behavior. A genuinely dead peer still accumulates penalty and is eventually evicted, freeing the slot.

`protocol selection failed` is a real protocol incompatibility rather than a transient failure and keeps its existing penalty (`Fatal` for ping, `LowToleranceError` otherwise).

This bounds the per-event penalty but not the number of events; a peer can still be banned by a sufficiently long burst. Rate limiting repeated penalties is a separate change.

Extends the existing `onOutgoingReqRespError` unit tests, 10/10 pass, biome and tsc clean.

Notes and full metric reconstruction: https://gist.github.com/nflaig/1e4e053beca1e747096e5112a9ba7e9c