### PR TITLE
fix: rate limit repeated peer score penalties

### DIFF
--- a/packages/beacon-node/src/network/core/metrics.ts
+++ b/packages/beacon-node/src/network/core/metrics.ts
@@ -221,6 +221,16 @@ export function createNetworkCoreMetrics(register: RegistryMetricCreator) {
         help: "Total peer relevance checks on Status, labeled by result (relevant or irrelevant reason code)",
         labelNames: ["result"],
       }),
+      /**
+       * Penalties dropped by the REPEAT_PENALTY_COOLDOWN_MS rate limit, labeled by action name.
+       * A sustained rate here means a failure source is firing far faster than once per cooldown,
+       * i.e. the peer set would have been scored down on a single incident without the limit.
+       */
+      penaltiesSuppressed: register.counter<{reason: string}>({
+        name: "lodestar_peer_penalties_suppressed_total",
+        help: "Total peer score penalties suppressed by the repeat penalty cooldown, labeled by action name",
+        labelNames: ["reason"],
+      }),
     },
     leakedConnectionsCount: register.gauge({
       name: "lodestar_peer_manager_leaked_connections_count",

--- a/packages/beacon-node/src/network/peers/score/constants.ts
+++ b/packages/beacon-node/src/network/peers/score/constants.ts
@@ -28,6 +28,14 @@ export const COOL_DOWN_BEFORE_DECAY_MS = 30 * 60 * 1000;
  * genuinely misbehaving peer still reaches MIN_SCORE_BEFORE_BAN within a minute.
  */
 export const REPEAT_PENALTY_COOLDOWN_MS = 10 * 1000;
+/**
+ * Limit of action names tracked per peer for the repeat penalty cooldown.
+ *
+ * Action names are usually a bounded set of error codes, but `LodestarError` allows a custom
+ * message, so the set is not guaranteed bounded. Pruning is fail-open, a dropped entry only means
+ * the next penalty for that action is applied rather than suppressed.
+ */
+export const MAX_PENALTY_ACTIONS_PER_PEER = 32;
 /** Limit of entries in the scores map */
 export const MAX_ENTRIES = 1000;
 /** Const that gets returned when no cool-down is applied */

--- a/packages/beacon-node/src/network/peers/score/constants.ts
+++ b/packages/beacon-node/src/network/peers/score/constants.ts
@@ -29,7 +29,7 @@ export const COOL_DOWN_BEFORE_DECAY_MS = 30 * 60 * 1000;
  */
 export const REPEAT_PENALTY_COOLDOWN_MS = 10 * 1000;
 /**
- * Limit of action names tracked per peer for the repeat penalty cooldown.
+ * Limit of action + action name pairs tracked per peer for the repeat penalty cooldown.
  *
  * Action names are usually a bounded set of error codes, but `LodestarError` allows a custom
  * message, so the set is not guaranteed bounded. Pruning is fail-open, a dropped entry only means

--- a/packages/beacon-node/src/network/peers/score/constants.ts
+++ b/packages/beacon-node/src/network/peers/score/constants.ts
@@ -20,6 +20,14 @@ export const SCORE_HALFLIFE_MS = 10 * 60 * 1000;
 export const HALFLIFE_DECAY_MS = -Math.log(2) / SCORE_HALFLIFE_MS;
 /** The number of milliseconds we ban a peer for before their score begins to decay */
 export const COOL_DOWN_BEFORE_DECAY_MS = 30 * 60 * 1000;
+/**
+ * The minimum time between two penalties for the same action on the same peer.
+ *
+ * Repeated identical failures in a burst are one incident, not N. Without this a request loop
+ * retrying at a high rate compounds a single transient into a ban. 10s is short enough that a
+ * genuinely misbehaving peer still reaches MIN_SCORE_BEFORE_BAN within a minute.
+ */
+export const REPEAT_PENALTY_COOLDOWN_MS = 10 * 1000;
 /** Limit of entries in the scores map */
 export const MAX_ENTRIES = 1000;
 /** Const that gets returned when no cool-down is applied */

--- a/packages/beacon-node/src/network/peers/score/store.ts
+++ b/packages/beacon-node/src/network/peers/score/store.ts
@@ -7,6 +7,7 @@ import {prettyPrintPeerId} from "../../util.js";
 import {
   DEFAULT_SCORE,
   MAX_ENTRIES,
+  MAX_PENALTY_ACTIONS_PER_PEER,
   MAX_SCORE,
   MIN_SCORE,
   REPEAT_PENALTY_COOLDOWN_MS,
@@ -81,6 +82,7 @@ export class PeerRpcScoreStore implements IPeerRpcScoreStore {
         return;
       }
       lastPenalties.set(actionName, nowMs);
+      pruneSetToMax(lastPenalties, MAX_PENALTY_ACTIONS_PER_PEER);
     }
 
     const peerScore = this.scores.getOrDefault(peerIdStr);

--- a/packages/beacon-node/src/network/peers/score/store.ts
+++ b/packages/beacon-node/src/network/peers/score/store.ts
@@ -32,7 +32,7 @@ const peerActionScore: Record<PeerAction, number> = {
  */
 export class PeerRpcScoreStore implements IPeerRpcScoreStore {
   private readonly scores: MapDef<PeerIdStr, IPeerScore>;
-  /** Time the last penalty was applied per peer, per action name, to rate limit repeats */
+  /** Time the last penalty was applied per peer, per action + action name, to rate limit repeats */
   private readonly lastPenaltyMs: MapDef<PeerIdStr, Map<string, number>>;
   private readonly metrics: NetworkCoreMetrics | null;
   private readonly logger: Logger | null;
@@ -76,12 +76,16 @@ export class PeerRpcScoreStore implements IPeerRpcScoreStore {
     if (action !== PeerAction.Fatal) {
       const nowMs = Date.now();
       const lastPenalties = this.lastPenaltyMs.getOrDefault(peerIdStr);
-      const lastMs = lastPenalties.get(actionName);
+      // Key on the action too, not just its name. The same error code maps to different severities
+      // depending on method (e.g. RESP_TIMEOUT is Mid for block methods but Low for ping/status), so
+      // keying on the name alone would let whichever arrived first mask a stronger penalty.
+      const penaltyKey = `${action}:${actionName}`;
+      const lastMs = lastPenalties.get(penaltyKey);
       if (lastMs !== undefined && nowMs - lastMs < REPEAT_PENALTY_COOLDOWN_MS) {
         this.metrics?.peerManager.penaltiesSuppressed.inc({reason: actionName});
         return;
       }
-      lastPenalties.set(actionName, nowMs);
+      lastPenalties.set(penaltyKey, nowMs);
       pruneSetToMax(lastPenalties, MAX_PENALTY_ACTIONS_PER_PEER);
     }
 

--- a/packages/beacon-node/src/network/peers/score/store.ts
+++ b/packages/beacon-node/src/network/peers/score/store.ts
@@ -4,7 +4,14 @@ import {GoodByeReasonCode} from "../../../constants/network.js";
 import {PeerIdStr} from "../../../util/peerId.js";
 import {NetworkCoreMetrics} from "../../core/metrics.js";
 import {prettyPrintPeerId} from "../../util.js";
-import {DEFAULT_SCORE, MAX_ENTRIES, MAX_SCORE, MIN_SCORE, SCORE_THRESHOLD} from "./constants.js";
+import {
+  DEFAULT_SCORE,
+  MAX_ENTRIES,
+  MAX_SCORE,
+  MIN_SCORE,
+  REPEAT_PENALTY_COOLDOWN_MS,
+  SCORE_THRESHOLD,
+} from "./constants.js";
 import {IPeerRpcScoreStore, IPeerScore, PeerAction, PeerRpcScoreOpts, PeerScoreStats, ScoreState} from "./interface.js";
 import {MaxScore, RealScore} from "./score.js";
 import {scoreToState} from "./utils.js";
@@ -24,6 +31,8 @@ const peerActionScore: Record<PeerAction, number> = {
  */
 export class PeerRpcScoreStore implements IPeerRpcScoreStore {
   private readonly scores: MapDef<PeerIdStr, IPeerScore>;
+  /** Time the last penalty was applied per peer, per action name, to rate limit repeats */
+  private readonly lastPenaltyMs: MapDef<PeerIdStr, Map<string, number>>;
   private readonly metrics: NetworkCoreMetrics | null;
   private readonly logger: Logger | null;
 
@@ -35,6 +44,7 @@ export class PeerRpcScoreStore implements IPeerRpcScoreStore {
     this.scores = opts.disablePeerScoring
       ? new MapDef(() => new MaxScore())
       : new MapDef(() => new RealScore(this.metrics));
+    this.lastPenaltyMs = new MapDef(() => new Map());
   }
 
   getScore(peer: PeerId): number {
@@ -58,7 +68,22 @@ export class PeerRpcScoreStore implements IPeerRpcScoreStore {
   }
 
   applyAction(peer: PeerId, action: PeerAction, actionName: string): void {
-    const peerScore = this.scores.getOrDefault(peer.toString());
+    const peerIdStr = peer.toString();
+
+    // Rate limit repeats of the same action so a high-frequency failure source cannot compound a
+    // single incident into a ban. Fatal is a deliberate immediate ban and is never suppressed.
+    if (action !== PeerAction.Fatal) {
+      const nowMs = Date.now();
+      const lastPenalties = this.lastPenaltyMs.getOrDefault(peerIdStr);
+      const lastMs = lastPenalties.get(actionName);
+      if (lastMs !== undefined && nowMs - lastMs < REPEAT_PENALTY_COOLDOWN_MS) {
+        this.metrics?.peerManager.penaltiesSuppressed.inc({reason: actionName});
+        return;
+      }
+      lastPenalties.set(actionName, nowMs);
+    }
+
+    const peerScore = this.scores.getOrDefault(peerIdStr);
     const scoreChange = peerActionScore[action];
     const newScore = peerScore.add(scoreChange);
 
@@ -81,6 +106,7 @@ export class PeerRpcScoreStore implements IPeerRpcScoreStore {
 
     // Bound size of data structures
     pruneSetToMax(this.scores, MAX_ENTRIES);
+    pruneSetToMax(this.lastPenaltyMs, MAX_ENTRIES);
 
     for (const [peerIdStr, peerScore] of this.scores) {
       const newScore = peerScore.update();

--- a/packages/beacon-node/test/unit/network/peers/score.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/score.test.ts
@@ -135,6 +135,15 @@ describe("peer score penalty rate limiting", () => {
     expect(lastPenalties?.size).toBe(MAX_PENALTY_ACTIONS_PER_PEER);
   });
 
+  it("Should not let a weaker action mask a stronger one with the same name", () => {
+    const scoreStore = new PeerRpcScoreStore();
+    // same actionName, different severity: RESP_TIMEOUT is Mid for block methods, Low for ping
+    scoreStore.applyAction(peer, PeerAction.MidToleranceError, "REQUEST_ERROR_RESP_TIMEOUT");
+    scoreStore.applyAction(peer, PeerAction.LowToleranceError, "REQUEST_ERROR_RESP_TIMEOUT");
+
+    expect(scoreStore.getScore(peer)).toBe(-15);
+  });
+
   it("Should never suppress Fatal", () => {
     const scoreStore = new PeerRpcScoreStore();
     scoreStore.applyAction(peer, PeerAction.LowToleranceError, actionName);

--- a/packages/beacon-node/test/unit/network/peers/score.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/score.test.ts
@@ -1,6 +1,9 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {MapDef} from "@lodestar/utils";
-import {REPEAT_PENALTY_COOLDOWN_MS} from "../../../../src/network/peers/score/constants.js";
+import {
+  MAX_PENALTY_ACTIONS_PER_PEER,
+  REPEAT_PENALTY_COOLDOWN_MS,
+} from "../../../../src/network/peers/score/constants.js";
 import {
   PeerAction,
   PeerRpcScoreStore,
@@ -120,6 +123,16 @@ describe("peer score penalty rate limiting", () => {
     }
 
     expect(scoreStore.getScoreState(peer)).toBe(ScoreState.Banned);
+  });
+
+  it("Should bound tracked action names per peer", () => {
+    const scoreStore = new PeerRpcScoreStore();
+    for (let i = 0; i < MAX_PENALTY_ACTIONS_PER_PEER * 2; i++) {
+      scoreStore.applyAction(peer, PeerAction.HighToleranceError, `action-${i}`);
+    }
+    const lastPenalties = (scoreStore["lastPenaltyMs"] as MapDef<string, Map<string, number>>).get(peer.toString());
+
+    expect(lastPenalties?.size).toBe(MAX_PENALTY_ACTIONS_PER_PEER);
   });
 
   it("Should never suppress Fatal", () => {

--- a/packages/beacon-node/test/unit/network/peers/score.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/score.test.ts
@@ -1,5 +1,6 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {MapDef} from "@lodestar/utils";
+import {REPEAT_PENALTY_COOLDOWN_MS} from "../../../../src/network/peers/score/constants.js";
 import {
   PeerAction,
   PeerRpcScoreStore,
@@ -45,9 +46,15 @@ describe("simple block provider score tracking", () => {
 
   for (const [peerAction, times] of timesToBan)
     it(`Should ban peer after ${times} ${peerAction}`, async () => {
+      vi.useFakeTimers();
       const {scoreStore} = mockStore();
-      for (let i = 0; i < times; i++) scoreStore.applyAction(peer, peerAction, actionName);
+      for (let i = 0; i < times; i++) {
+        scoreStore.applyAction(peer, peerAction, actionName);
+        // repeats of the same action are rate limited, space them beyond the cooldown
+        vi.advanceTimersByTime(REPEAT_PENALTY_COOLDOWN_MS);
+      }
       expect(scoreStore.getScoreState(peer)).toBe(ScoreState.Banned);
+      vi.useRealTimers();
     });
 
   const factorForJsBadMath = 1.1;
@@ -74,6 +81,53 @@ describe("simple block provider score tracking", () => {
     scoreStore.applyAction(peer, PeerAction.Fatal, actionName);
     scoreStore.applyAction(peer, PeerAction.Fatal, actionName);
     expect(scoreStore.getScore(peer)).toBeGreaterThanOrEqual(MIN_SCORE);
+  });
+});
+
+describe("peer score penalty rate limiting", () => {
+  const peer = peerIdFromString("Qma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi");
+  const actionName = "REQUEST_ERROR_DIAL_TIMEOUT";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("Should apply the same action only once per cooldown", () => {
+    const scoreStore = new PeerRpcScoreStore();
+    for (let i = 0; i < 20; i++) scoreStore.applyAction(peer, PeerAction.LowToleranceError, actionName);
+
+    expect(scoreStore.getScore(peer)).toBe(-10);
+    expect(scoreStore.getScoreState(peer)).toBe(ScoreState.Healthy);
+  });
+
+  it("Should apply the same action again after the cooldown", () => {
+    const scoreStore = new PeerRpcScoreStore();
+    scoreStore.applyAction(peer, PeerAction.LowToleranceError, actionName);
+    vi.advanceTimersByTime(REPEAT_PENALTY_COOLDOWN_MS);
+    scoreStore.applyAction(peer, PeerAction.LowToleranceError, actionName);
+
+    expect(scoreStore.getScore(peer)).toBe(-20);
+  });
+
+  it("Should not rate limit distinct actions", () => {
+    const scoreStore = new PeerRpcScoreStore();
+    for (const reason of ["a", "b", "c", "d", "e"]) {
+      scoreStore.applyAction(peer, PeerAction.LowToleranceError, reason);
+    }
+
+    expect(scoreStore.getScoreState(peer)).toBe(ScoreState.Banned);
+  });
+
+  it("Should never suppress Fatal", () => {
+    const scoreStore = new PeerRpcScoreStore();
+    scoreStore.applyAction(peer, PeerAction.LowToleranceError, actionName);
+    scoreStore.applyAction(peer, PeerAction.Fatal, actionName);
+
+    expect(scoreStore.getScoreState(peer)).toBe(ScoreState.Banned);
   });
 });
 


### PR DESCRIPTION
**Motivation**

`applyAction` has no rate limit, every call is an unconditional `add(scoreChange)`. A failure source firing faster than the score decays therefore compounds one incident into an unbounded number of penalties, so the score ends up measuring our own request volume rather than the peer's behavior.

On glamsterdam-devnet-8 a 60s transient produced 162 `execution_payload_envelopes_by_root` dial timeouts on `lodestar-besu-2` in one minute. At -10 each that banned 48 of its 64 peers:

```
       13:56  peers=64  DIAL_TIMEOUT=174/min
       13:57  peers=8   goodbye{Peer score too low}=48/min
```

The trap is self-sustaining. With only a handful of peers left, each subsequent burst concentrates more penalties per peer, not fewer, so the node kept banning what little it rediscovered. Two hours later it was still banning ~1.8 peers per peer-slot per 10 min against a healthy node's 0.08, holding 2-11 peers and never climbing, with the original request loop long since idle:

```
                     14:30 14:40 ... 15:50 16:00 16:10 16:20 16:30
besu-2  peers            5     9        11     2     3     6     4
        bans/10m        20    16         8    18     6     9     7
geth-1  peers           26    22        45    49    54    41    41
        bans/10m         3     5         3     1     1     5     1
```

Neither node recovered on its own.

**Description**

Apply the same action to the same peer at most once per `REPEAT_PENALTY_COOLDOWN_MS` (10s). Repeated identical failures in a burst are one incident, not N.

- distinct actions still stack, so several different failures are still scored independently
- `Fatal` is a deliberate immediate ban and is never suppressed
- a genuinely misbehaving peer still reaches `MIN_SCORE_BEFORE_BAN` within a minute
- `lodestar_peer_penalties_suppressed_total{reason}` counts what the limit dropped; a sustained rate there means a failure source is firing far faster than once per cooldown

This is complementary to #9877, which lowers the per-event penalty for dial failures. That bounds the cost of one event, this bounds how many events one incident can charge. Either alone would have prevented the peer wipe above, together they also cover whatever high-frequency method comes next.

The existing "ban after N actions" tests applied N penalties in a tight loop, so they now advance the clock between actions, which is the behavior change made explicit. 16/16 pass, full `test/unit/network` suite 290/290, biome and tsc clean.

Notes and full metric reconstruction: https://gist.github.com/nflaig/1e4e053beca1e747096e5112a9ba7e9c

**Scope**

The cooldown applies to every `reportPeer` path, not only reqresp dial errors. Callers with a fixed action name are affected most:

- `gossipHandlers.ts`: `BadGossipBlock`, `BadGossipPayload`, `ExecutionEngineInvalid`
- `backfill.ts`: `BadSyncBlocks`
- `range/chain.ts`: `SyncChainInvalidBatchSelf`/`SyncChainInvalidBatchOther`

So a peer flooding invalid gossip blocks is now banned in ~50s rather than after ~5 blocks. That is the main behavior change to weigh. It seems an acceptable trade for bounding the burst case: gossipsub scoring penalizes such a peer independently, and 50s is still prompt against a peer that has to keep misbehaving for the whole window to earn it.

Action names are not guaranteed to be a bounded set, `LodestarError` allows a custom message and `range/chain.ts` reports peers with `res.err.message`, so the per-peer map is pruned to `MAX_PENALTY_ACTIONS_PER_PEER`. Pruning is fail-open, a dropped entry only means the next penalty for that action is applied rather than suppressed.
