### PR TITLE
fix(state-transition): use shared pubkey cache in Gloas tests

### DIFF
--- a/packages/state-transition/test/unit/slot/upgradeStateToGloasCacheHit.test.ts
+++ b/packages/state-transition/test/unit/slot/upgradeStateToGloasCacheHit.test.ts
@@ -128,7 +128,7 @@ describe("upgradeStateToGloas - builder-deposit signature cache", () => {
 
     const fuluState = createCachedBeaconState(
       stateView,
-      {config, pubkeyCache: createPubkeyCache()},
+      {config, pubkeyCache},
       {skipSyncCommitteeCache: true, skipSyncPubkeys: true}
     ) as CachedBeaconStateFulu;
 

--- a/packages/state-transition/test/unit/util/gloas.test.ts
+++ b/packages/state-transition/test/unit/util/gloas.test.ts
@@ -1,9 +1,10 @@
 import {describe, expect, it} from "vitest";
+import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {createBeaconConfig} from "@lodestar/config";
 import {getConfig} from "@lodestar/config/test-utils";
 import {FAR_FUTURE_EPOCH, ForkName, MIN_DEPOSIT_AMOUNT, PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
-import {createCachedBeaconState, createPubkeyCache} from "../../../src/index.js";
+import {createCachedBeaconState} from "../../../src/index.js";
 import {CachedBeaconStateGloas} from "../../../src/types.js";
 import {
   addBuilderToRegistry,
@@ -25,7 +26,7 @@ function buildGloasState(slot = 0): CachedBeaconStateGloas {
     view,
     {
       config: createBeaconConfig(config, view.genesisValidatorsRoot),
-      pubkeyCache: createPubkeyCache(),
+      pubkeyCache,
     },
     {skipSyncCommitteeCache: true}
   ) as CachedBeaconStateGloas;


### PR DESCRIPTION
## Summary

- fix Gloas tests after the latest `bing/blst-z` merge removed `createPubkeyCache`
- use the shared Lodestar-Z `pubkeyCache`, matching the current state-transition cache API

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm check-types`
- `pnpm vitest run --project unit packages/state-transition/test/unit/util/gloas.test.ts packages/state-transition/test/unit/slot/upgradeStateToGloasCacheHit.test.ts` (14 passed)

Follow-up for #9820 after the latest base merge caused the Lint and Type Checks jobs to fail.