### PR TITLE
refactor(bls): route remaining checks through verifier

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1090,7 +1090,7 @@ export class BeaconChain implements IBeaconChain {
       RegenCaller.produceBlock
     );
     const proposerIndex = state.getBeaconProposer(slot);
-    const proposerPubKey = this.pubkeyCache.getOrThrow(proposerIndex).toBytes();
+    const proposerPubKey = this.pubkeyCache.getPubkeyBytesOrThrow(proposerIndex);
 
     const {body, produceResult, executionPayloadValue, shouldOverrideBuilder} = await produceBlockBody.call(
       this,

--- a/packages/state-transition/src/block/processDeposit.ts
+++ b/packages/state-transition/src/block/processDeposit.ts
@@ -1,4 +1,9 @@
-import {PublicKey, Signature, verify, verifyMultipleAggregateSignatures} from "@chainsafe/lodestar-z/blst";
+import {
+  BLS_VERIFIER_MAX_BATCH_SIZE,
+  BLS_VERIFIER_SET_TYPE,
+  type BlsSignatureSet,
+  verifySignatureSets,
+} from "@chainsafe/lodestar-z/bls-verifier";
 import {BeaconConfig} from "@lodestar/config";
 import {
   DEPOSIT_CONTRACT_TREE_DEPTH,
@@ -187,54 +192,34 @@ export function verifyDepositSignatures(config: BeaconConfig, deposits: electra.
   // fork-agnostic domain since deposits are valid across forks, matching isValidDepositSignature
   const domain = computeDomain(DOMAIN_DEPOSIT, config.GENESIS_FORK_VERSION, ZERO_HASH);
 
-  const signatureSets: {pk: PublicKey; msg: Uint8Array; sig: Signature}[] = [];
-  const signatureSetDepositIndices: number[] = [];
-  for (let i = 0; i < deposits.length; i++) {
-    const {pubkey, withdrawalCredentials, amount, signature} = deposits[i];
-    let pk: PublicKey;
-    let sig: Signature;
+  const signatureSets: BlsSignatureSet[] = deposits.map(({pubkey, withdrawalCredentials, amount, signature}) => ({
+    type: BLS_VERIFIER_SET_TYPE.single,
+    pubkey,
+    message: computeSigningRoot(ssz.phase0.DepositMessage, {pubkey, withdrawalCredentials, amount}, domain),
+    signature,
+  }));
+
+  for (let chunkStart = 0; chunkStart < signatureSets.length; chunkStart += BLS_VERIFIER_MAX_BATCH_SIZE) {
+    const chunk = signatureSets.slice(chunkStart, chunkStart + BLS_VERIFIER_MAX_BATCH_SIZE);
+    let chunkValid: boolean;
     try {
-      // Parse without group/infinity checks; deferred to the verify call below so it can be
-      // batched across all sets.
-      pk = PublicKey.fromBytes(pubkey);
-      sig = Signature.fromBytes(signature);
+      chunkValid = verifySignatureSets(chunk);
     } catch (_) {
-      // Malformed pubkey or signature bytes - invalid deposit, results[i] stays false
+      chunkValid = false;
+    }
+
+    if (chunkValid) {
+      results.fill(true, chunkStart, chunkStart + chunk.length);
       continue;
     }
-    const msg = computeSigningRoot(ssz.phase0.DepositMessage, {pubkey, withdrawalCredentials, amount}, domain);
-    signatureSets.push({pk, msg, sig});
-    signatureSetDepositIndices.push(i);
-  }
 
-  if (signatureSets.length === 0) {
-    return results;
-  }
-
-  // Deposit pubkeys and signatures are untrusted, so group + infinity checks are required.
-  // The trailing (true, true) args delegate those checks to blst, amortized across the batch.
-  let batchValid: boolean;
-  try {
-    batchValid =
-      signatureSets.length >= 2
-        ? verifyMultipleAggregateSignatures(signatureSets, true, true)
-        : verify(signatureSets[0].msg, signatureSets[0].pk, signatureSets[0].sig, true, true);
-  } catch (_) {
-    batchValid = false;
-  }
-
-  if (batchValid) {
-    for (const depositIndex of signatureSetDepositIndices) {
-      results[depositIndex] = true;
-    }
-  } else {
-    for (let s = 0; s < signatureSets.length; s++) {
+    for (let i = 0; i < chunk.length; i++) {
       try {
-        if (verify(signatureSets[s].msg, signatureSets[s].pk, signatureSets[s].sig, true, true)) {
-          results[signatureSetDepositIndices[s]] = true;
+        if (verifySignatureSets([chunk[i]])) {
+          results[chunkStart + i] = true;
         }
       } catch (_) {
-        // invalid point / malformed → invalid signature, results[i] stays false
+        // Invalid point or malformed bytes leave this deposit false.
       }
     }
   }

--- a/packages/state-transition/src/block/processExecutionPayloadBid.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadBid.ts
@@ -1,4 +1,3 @@
-import {PublicKey, Signature, verify} from "@chainsafe/lodestar-z/blst";
 import {
   BUILDER_INDEX_SELF_BUILD,
   ForkSeq,
@@ -12,7 +11,13 @@ import {G2_POINT_AT_INFINITY} from "../constants/constants.js";
 import {getExecutionPayloadBidSigningRoot} from "../signatureSets/executionPayloadBid.js";
 import {CachedBeaconStateGloas, CachedBeaconStateHeze} from "../types.js";
 import {canBuilderCoverBid, isActiveBuilder} from "../util/gloas.js";
-import {getBlockRootAtSlot, getCurrentEpoch, getRandaoMix} from "../util/index.js";
+import {
+  createSingleSignatureSetFromComponents,
+  getBlockRootAtSlot,
+  getCurrentEpoch,
+  getRandaoMix,
+  verifySignatureSet,
+} from "../util/index.js";
 
 export function processExecutionPayloadBid(
   state: CachedBeaconStateGloas | CachedBeaconStateHeze,
@@ -123,10 +128,7 @@ function verifyExecutionPayloadBidSignature(
   const signingRoot = getExecutionPayloadBidSigningRoot(state.config, signedBid.message);
 
   try {
-    const publicKey = PublicKey.fromBytes(pubkey);
-    const signature = Signature.fromBytes(signedBid.signature, true);
-
-    return verify(signingRoot, publicKey, signature);
+    return verifySignatureSet(createSingleSignatureSetFromComponents(pubkey, signingRoot, signedBid.signature));
   } catch (_e) {
     return false; // Catch all BLS errors: failed key validation, failed signature validation, invalid signature
   }

--- a/packages/state-transition/src/rewards/syncCommitteeRewards.ts
+++ b/packages/state-transition/src/rewards/syncCommitteeRewards.ts
@@ -2,6 +2,7 @@ import {type PubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {BeaconConfig} from "@lodestar/config";
 import {ForkName, SYNC_COMMITTEE_SIZE} from "@lodestar/params";
 import {BeaconBlock, ValidatorIndex, altair, rewards} from "@lodestar/types";
+import {toPubkeyHex} from "@lodestar/utils";
 import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../cache/stateCache.js";
 
 export async function computeSyncCommitteeRewards(
@@ -48,7 +49,8 @@ export async function computeSyncCommitteeRewards(
   if (validatorIds.length) {
     const filtersSet = new Set(validatorIds);
     return rewards.filter((reward) => {
-      const pubkeyHex = pubkeyCache.get(reward.validatorIndex)?.toHex();
+      const pubkey = pubkeyCache.getPubkeyBytes(reward.validatorIndex);
+      const pubkeyHex = pubkey === undefined ? undefined : toPubkeyHex(pubkey);
       return filtersSet.has(reward.validatorIndex) || (pubkeyHex !== undefined && filtersSet.has(pubkeyHex));
     });
   }

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -1,4 +1,3 @@
-import {PublicKey, Signature, verify} from "@chainsafe/lodestar-z/blst";
 import {BeaconConfig} from "@lodestar/config";
 import {
   BUILDER_INDEX_FLAG,
@@ -23,6 +22,7 @@ import {computeEpochAtSlot} from "./epoch.js";
 import {computeEpochShuffling} from "./epochShuffling.js";
 import {RootCache} from "./rootCache.js";
 import {computePayloadTimelinessCommitteesForEpoch} from "./seed.js";
+import {createSingleSignatureSetFromComponents, verifySignatureSet} from "./signatureSets.js";
 import {computeSigningRoot} from "./signingRoot.js";
 import {getActiveValidatorIndices} from "./validator.js";
 
@@ -339,9 +339,7 @@ export function isValidBuilderDepositSignature(
   const domain = computeDomain(DOMAIN_BUILDER_DEPOSIT, config.GENESIS_FORK_VERSION, ZERO_HASH);
   const signingRoot = computeSigningRoot(ssz.phase0.DepositMessage, depositMessage, domain);
   try {
-    const publicKey = PublicKey.fromBytes(pubkey, true);
-    const sig = Signature.fromBytes(signature, true);
-    return verify(signingRoot, publicKey, sig);
+    return verifySignatureSet(createSingleSignatureSetFromComponents(pubkey, signingRoot, signature));
   } catch (_e) {
     return false;
   }

--- a/packages/state-transition/test/unit/block/processDeposit.blsVerifier.test.ts
+++ b/packages/state-transition/test/unit/block/processDeposit.blsVerifier.test.ts
@@ -1,0 +1,55 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {BLS_VERIFIER_SET_TYPE, type BlsSignatureSet} from "@chainsafe/lodestar-z/bls-verifier";
+import {createBeaconConfig} from "@lodestar/config";
+import {getConfig} from "@lodestar/config/test-utils";
+import {ForkName} from "@lodestar/params";
+
+const verifySignatureSetsMock = vi.hoisted(() => vi.fn<(sets: BlsSignatureSet[]) => boolean>());
+
+vi.mock("@chainsafe/lodestar-z/bls-verifier", () => ({
+  BLS_VERIFIER_MAX_BATCH_SIZE: 256,
+  BLS_VERIFIER_SET_TYPE: {indexed: 0, aggregate: 1, single: 2},
+  verifySignatureSets: verifySignatureSetsMock,
+}));
+
+import {verifyDepositSignatures} from "../../../src/block/processDeposit.js";
+import {generateBuilderPendingDeposits} from "../../../src/testUtils/util.js";
+
+const config = createBeaconConfig(getConfig(ForkName.fulu), Buffer.alloc(32));
+
+describe("verifyDepositSignatures Lodestar-Z verifier routing", () => {
+  beforeEach(() => {
+    verifySignatureSetsMock.mockReset();
+  });
+
+  it("routes deposit bytes through verifySignatureSets", () => {
+    const [deposit] = generateBuilderPendingDeposits(config, 1, 4000);
+    verifySignatureSetsMock.mockReturnValue(true);
+
+    expect(verifyDepositSignatures(config, [deposit])).toEqual([true]);
+    expect(verifySignatureSetsMock).toHaveBeenCalledWith([
+      {
+        type: BLS_VERIFIER_SET_TYPE.single,
+        pubkey: deposit.pubkey,
+        message: expect.any(Uint8Array),
+        signature: deposit.signature,
+      },
+    ]);
+  });
+
+  it("falls back to individual verifier calls when a chunk is invalid", () => {
+    const deposits = generateBuilderPendingDeposits(config, 2, 5000);
+    verifySignatureSetsMock.mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+    expect(verifyDepositSignatures(config, deposits)).toEqual([true, false]);
+    expect(verifySignatureSetsMock.mock.calls.map(([sets]) => sets.length)).toEqual([2, 1, 1]);
+  });
+
+  it("keeps verifier calls within the native batch limit", () => {
+    const deposits = generateBuilderPendingDeposits(config, 257, 6000);
+    verifySignatureSetsMock.mockReturnValue(true);
+
+    expect(verifyDepositSignatures(config, deposits)).toEqual(new Array<boolean>(257).fill(true));
+    expect(verifySignatureSetsMock.mock.calls.map(([sets]) => sets.length)).toEqual([256, 1]);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid materializing `PublicKey` wrappers for block production and sync reward filtering
- route execution bid, builder deposit, and batched deposit verification through `@chainsafe/lodestar-z/bls-verifier`
- preserve per-deposit results and bound verifier chunks to the native 256-set limit

## Verification
- `pnpm --filter @lodestar/state-transition build`
- `pnpm --filter @lodestar/beacon-node build`
- `pnpm --filter @lodestar/state-transition check-types`
- `pnpm --filter @lodestar/beacon-node check-types`
- `pnpm vitest run --project unit packages/state-transition/test/unit` (42 files, 336 tests)
- Biome on all changed files
