### PR TITLE
chore(bls): expose pubkey cache metrics

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1577,6 +1577,8 @@ export class BeaconChain implements IBeaconChain {
     // syncContributionAndProofPool tracks metrics on its own
     metrics.opPool.blsToExecutionChangePoolSize.set(this.opPool.blsToExecutionChangeSize);
     metrics.chain.blacklistedBlocks.set(this.blacklistedBlocks.size);
+    metrics.bls.pubkeyCacheSize.set(this.pubkeyCache.size);
+    metrics.bls.pubkeyCacheCapacity.set(this.pubkeyCache.capacity);
 
     const headState = this.getHeadState();
     if (isStatePostElectra(headState)) {

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -404,6 +404,14 @@ export function createLodestarMetrics(
         name: "lodestar_bls_aggregated_pubkeys_total",
         help: "Total validator public keys used as inputs to aggregate signature sets",
       }),
+      pubkeyCacheSize: register.gauge({
+        name: "lodestar_bls_pubkey_cache_size",
+        help: "Current number of validator public keys in the native cache",
+      }),
+      pubkeyCacheCapacity: register.gauge({
+        name: "lodestar_bls_pubkey_cache_capacity",
+        help: "Number of validator public keys the native cache can hold without growing",
+      }),
     },
 
     blsThreadPool: {

--- a/packages/beacon-node/test/unit/chain/pubkeyCacheMetrics.test.ts
+++ b/packages/beacon-node/test/unit/chain/pubkeyCacheMetrics.test.ts
@@ -1,0 +1,46 @@
+import {describe, expect, it, vi} from "vitest";
+import {ForkName} from "@lodestar/params";
+import {BeaconChain} from "../../../src/chain/chain.js";
+import {Metrics} from "../../../src/metrics/index.js";
+
+describe("BeaconChain pubkey cache metrics", () => {
+  it("reports the current pubkey cache size and capacity on scrape", () => {
+    const size = {set: vi.fn()};
+    const capacity = {set: vi.fn()};
+    const set = vi.fn();
+    const metrics = {
+      bls: {pubkeyCacheSize: size, pubkeyCacheCapacity: capacity},
+      opPool: {
+        attestationPool: {size: {set}},
+        attesterSlashingPoolSize: {set},
+        proposerSlashingPoolSize: {set},
+        voluntaryExitPoolSize: {set},
+        syncCommitteeMessagePoolSize: {set},
+        payloadAttestationPool: {size: {set}},
+        executionPayloadBidPool: {size: {set}},
+        blsToExecutionChangePoolSize: {set},
+      },
+      chain: {blacklistedBlocks: {set}},
+    } as unknown as Metrics;
+    const chain = {
+      attestationPool: {getAttestationCount: () => 0},
+      opPool: {
+        attesterSlashingsSize: 0,
+        proposerSlashingsSize: 0,
+        voluntaryExitsSize: 0,
+        blsToExecutionChangeSize: 0,
+      },
+      syncCommitteeMessagePool: {size: 0},
+      payloadAttestationPool: {size: 0},
+      executionPayloadBidPool: {size: 0},
+      blacklistedBlocks: new Map(),
+      pubkeyCache: {size: 123, capacity: 456},
+      getHeadState: () => ({forkName: ForkName.phase0}),
+    } as unknown as BeaconChain;
+
+    BeaconChain.prototype["onScrapeMetrics"].call(chain, metrics);
+
+    expect(size.set).toHaveBeenCalledWith(123);
+    expect(capacity.set).toHaveBeenCalledWith(456);
+  });
+});

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -79,9 +79,9 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       wsCheckpoint,
     } = await initBeaconState(args, beaconPaths.dataDir, config, db, logger);
     const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
-    // Growing the native cache reallocates its memory which is not safe while other threads
-    // read it. Reserve 3 months of worst-case registry growth (MAX_PENDING_DEPOSITS_PER_EPOCH
-    // per epoch), over a year at organic rates. If exceeded, the native cache grows by the same step.
+    // Reserve 3 months of worst-case registry growth (MAX_PENDING_DEPOSITS_PER_EPOCH per epoch),
+    // over a year at organic rates, to avoid routine cache reallocations. Cache growth is protected
+    // by its native lock; if this headroom is exceeded, it grows by the same fixed step.
     const headroomEpochs = (90 * 24 * 60 * 60) / (config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH);
     const pubkeyCacheHeadroom = MAX_PENDING_DEPOSITS_PER_EPOCH * Math.ceil(headroomEpochs);
     pubkeyCache.ensureCapacity(anchorState.validators.length + pubkeyCacheHeadroom);


### PR DESCRIPTION
## Summary

- expose native pubkey cache size and capacity gauges
- collect both values from `BeaconChain.onScrapeMetrics()`
- correct the startup headroom comment now that cache growth is lock-protected
- add a focused scrape regression

## Verification

- `pnpm vitest run --project unit test/unit/chain/pubkeyCacheMetrics.test.ts`
- `pnpm build` in `packages/beacon-node`
- `pnpm build` in `packages/cli`
- `pnpm exec biome check packages/beacon-node/src/chain/chain.ts packages/beacon-node/src/metrics/metrics/lodestar.ts packages/beacon-node/test/unit/chain/pubkeyCacheMetrics.test.ts packages/cli/src/cmds/beacon/handler.ts`
