### PR TITLE
feat(bls): suggestion for bls metrics

### DIFF
--- a/dashboards/lodestar_bls_thread_pool.json
+++ b/dashboards/lodestar_bls_thread_pool.json
@@ -1152,11 +1152,41 @@
           },
           "expr": "sum by (instance, operation) (rate(lodestar_bls_thread_pool_verification_call_signature_sets_total[$rate_interval])) / sum by (instance, operation) (rate(lodestar_bls_thread_pool_verification_call_duration_seconds_count[$rate_interval]))",
           "interval": "",
-          "legendFormat": "{{operation}} sets/verification call",
+          "legendFormat": "sets/call: {{operation}}",
           "refId": "B"
         }
       ],
       "title": "BLS dispatch and verification call width",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "general_batch",
+            "renamePattern": "combined standard jobs"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "general_single",
+            "renamePattern": "single job"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "general_fallback",
+            "renamePattern": "jobs retried after batch failure"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "same_message",
+            "renamePattern": "shared-message jobs"
+          }
+        }
+      ],
       "type": "timeseries"
     },
     {
@@ -1234,7 +1264,7 @@
           "editorMode": "code",
           "expr": "sum by (instance, operation) (rate(lodestar_bls_thread_pool_verification_call_duration_seconds_sum[$rate_interval])) / sum by (instance, operation) (rate(lodestar_bls_thread_pool_verification_call_duration_seconds_count[$rate_interval]))",
           "instant": false,
-          "legendFormat": "mean call {{operation}}",
+          "legendFormat": "mean call: {{operation}}",
           "range": true,
           "refId": "A"
         },
@@ -1247,13 +1277,43 @@
           "expr": "sum by (instance, operation) (rate(lodestar_bls_thread_pool_verification_call_duration_seconds_sum[$rate_interval])) / sum by (instance, operation) (rate(lodestar_bls_thread_pool_verification_call_signature_sets_total[$rate_interval]))",
           "hide": false,
           "instant": false,
-          "legendFormat": "per set {{operation}}",
+          "legendFormat": "per set: {{operation}}",
           "range": true,
           "refId": "B"
         }
       ],
       "description": "Mean duration per synchronous lodestar-z binding call and total binding-call time amortized per signature set, grouped by verification path.",
       "title": "Worker lodestar-z verification cost",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "general_batch",
+            "renamePattern": "combined standard jobs"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "general_single",
+            "renamePattern": "single job"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "general_fallback",
+            "renamePattern": "jobs retried after batch failure"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "same_message",
+            "renamePattern": "shared-message jobs"
+          }
+        }
+      ],
       "type": "timeseries"
     },
     {

--- a/dashboards/lodestar_bls_thread_pool.json
+++ b/dashboards/lodestar_bls_thread_pool.json
@@ -879,7 +879,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Signature sets carried by each semantic job and each intentional batching-buffer flush.",
+      "description": "Average signature sets per BLS job, grouped by job type.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -954,19 +954,9 @@
           "interval": "",
           "legendFormat": "{{type}} sets/job",
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "sum by (instance) (rate(lodestar_bls_thread_pool_buffered_signature_sets_sum[$rate_interval])) / sum by (instance) (rate(lodestar_bls_thread_pool_buffered_signature_sets_count[$rate_interval]))",
-          "interval": "",
-          "legendFormat": "sets/buffer flush",
-          "refId": "B"
         }
       ],
-      "title": "BLS batching width",
+      "title": "Signature sets per BLS job",
       "type": "timeseries"
     },
     {

--- a/dashboards/lodestar_bls_thread_pool.json
+++ b/dashboards/lodestar_bls_thread_pool.json
@@ -855,7 +855,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (instance) (rate(lodestar_bls_thread_pool_batch_retries_total[$rate_interval])) / sum by (instance) (rate(lodestar_bls_thread_pool_verification_call_duration_seconds_count{operation=\"general_batch\"}[$rate_interval]))",
+          "expr": "sum by (instance) (rate(lodestar_bls_thread_pool_batch_retries_total[$rate_interval])) / sum by (instance) (rate(lodestar_bls_thread_pool_verification_call_duration_seconds_count{operation=\"batch\"}[$rate_interval]))",
           "interval": "",
           "legendFormat": "failed batches",
           "refId": "A"
@@ -865,7 +865,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (instance) (rate(lodestar_bls_thread_pool_verification_call_signature_sets_total{operation=\"general_fallback\"}[$rate_interval])) / sum by (instance) (rate(lodestar_bls_thread_pool_verification_call_signature_sets_total{operation=\"general_batch\"}[$rate_interval]))",
+          "expr": "sum by (instance) (rate(lodestar_bls_thread_pool_verification_call_signature_sets_total{operation=\"fallback\"}[$rate_interval])) / sum by (instance) (rate(lodestar_bls_thread_pool_verification_call_signature_sets_total{operation=\"batch\"}[$rate_interval]))",
           "interval": "",
           "legendFormat": "signature sets checked again",
           "refId": "B"
@@ -1157,36 +1157,6 @@
         }
       ],
       "title": "BLS dispatch and verification call width",
-      "transformations": [
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "general_batch",
-            "renamePattern": "combined standard jobs"
-          }
-        },
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "general_single",
-            "renamePattern": "single job"
-          }
-        },
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "general_fallback",
-            "renamePattern": "jobs retried after batch failure"
-          }
-        },
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "same_message",
-            "renamePattern": "shared-message jobs"
-          }
-        }
-      ],
       "type": "timeseries"
     },
     {
@@ -1284,36 +1254,6 @@
       ],
       "description": "Mean duration per synchronous lodestar-z binding call and total binding-call time amortized per signature set, grouped by verification path.",
       "title": "Worker lodestar-z verification cost",
-      "transformations": [
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "general_batch",
-            "renamePattern": "combined standard jobs"
-          }
-        },
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "general_single",
-            "renamePattern": "single job"
-          }
-        },
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "general_fallback",
-            "renamePattern": "jobs retried after batch failure"
-          }
-        },
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "same_message",
-            "renamePattern": "shared-message jobs"
-          }
-        }
-      ],
       "type": "timeseries"
     },
     {

--- a/dashboards/lodestar_bls_thread_pool.json
+++ b/dashboards/lodestar_bls_thread_pool.json
@@ -779,7 +779,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Outcome of signature sets submitted to combined general-verification calls. Fast-path sets complete in the combined call; fallback sets are reverified at their original request boundary.",
+      "description": "Percentage of combined batch checks that failed and percentage of signature sets checked again after those failures.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -819,6 +819,8 @@
             }
           },
           "mappings": [],
+          "max": 1,
+          "min": 0,
           "unit": "percentunit"
         },
         "overrides": []
@@ -853,9 +855,9 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (instance) (rate(lodestar_bls_thread_pool_batch_sigs_success_total[$rate_interval])) / sum by (instance) (rate(lodestar_bls_thread_pool_verification_call_signature_sets_total{operation=\"general_batch\"}[$rate_interval]))",
+          "expr": "sum by (instance) (rate(lodestar_bls_thread_pool_batch_retries_total[$rate_interval])) / sum by (instance) (rate(lodestar_bls_thread_pool_verification_call_duration_seconds_count{operation=\"general_batch\"}[$rate_interval]))",
           "interval": "",
-          "legendFormat": "fast path",
+          "legendFormat": "failed batches",
           "refId": "A"
         },
         {
@@ -865,11 +867,11 @@
           },
           "expr": "sum by (instance) (rate(lodestar_bls_thread_pool_verification_call_signature_sets_total{operation=\"general_fallback\"}[$rate_interval])) / sum by (instance) (rate(lodestar_bls_thread_pool_verification_call_signature_sets_total{operation=\"general_batch\"}[$rate_interval]))",
           "interval": "",
-          "legendFormat": "fallback",
+          "legendFormat": "signature sets checked again",
           "refId": "B"
         }
       ],
-      "title": "Combined batch outcomes",
+      "title": "Batch verification fallback",
       "type": "timeseries"
     },
     {

--- a/packages/beacon-node/src/chain/bls/multithread/types.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/types.ts
@@ -31,9 +31,9 @@ export enum WorkResultCode {
 }
 
 export enum VerificationCallOperation {
-  generalBatch = "general_batch",
-  generalSingle = "general_single",
-  generalFallback = "general_fallback",
+  batch = "batch",
+  single = "single",
+  fallback = "fallback",
   sameMessage = "same_message",
 }
 

--- a/packages/beacon-node/src/chain/bls/multithread/types.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/types.ts
@@ -32,7 +32,7 @@ export enum WorkResultCode {
 
 export enum VerificationCallOperation {
   generalBatch = "general_batch",
-  generalDirect = "general_direct",
+  generalSingle = "general_single",
   generalFallback = "general_fallback",
   sameMessage = "same_message",
 }

--- a/packages/beacon-node/src/chain/bls/multithread/worker.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/worker.ts
@@ -49,7 +49,7 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
   const nonBatchableSets: {
     idx: number;
     sets: BlsSignatureSet[];
-    operation: VerificationCallOperation.generalDirect | VerificationCallOperation.generalFallback;
+    operation: VerificationCallOperation.generalSingle | VerificationCallOperation.generalFallback;
   }[] = [];
 
   // Split sets between batchable and non-batchable preserving their original index in the req array
@@ -61,7 +61,7 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
         if (workReq.opts.batchable) {
           batchableSets.push({idx: i, sets});
         } else {
-          nonBatchableSets.push({idx: i, sets, operation: VerificationCallOperation.generalDirect});
+          nonBatchableSets.push({idx: i, sets, operation: VerificationCallOperation.generalSingle});
         }
         break;
       }

--- a/packages/beacon-node/src/chain/bls/multithread/worker.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/worker.ts
@@ -49,7 +49,7 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
   const nonBatchableSets: {
     idx: number;
     sets: BlsSignatureSet[];
-    operation: VerificationCallOperation.generalSingle | VerificationCallOperation.generalFallback;
+    operation: VerificationCallOperation.single | VerificationCallOperation.fallback;
   }[] = [];
 
   // Split sets between batchable and non-batchable preserving their original index in the req array
@@ -61,7 +61,7 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
         if (workReq.opts.batchable) {
           batchableSets.push({idx: i, sets});
         } else {
-          nonBatchableSets.push({idx: i, sets, operation: VerificationCallOperation.generalSingle});
+          nonBatchableSets.push({idx: i, sets, operation: VerificationCallOperation.single});
         }
         break;
       }
@@ -95,11 +95,8 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
 
       try {
         // Attempt to verify multiple sets at once
-        const isValid = recordVerificationCall(
-          verificationCalls,
-          VerificationCallOperation.generalBatch,
-          allSets.length,
-          () => verifySignatureSets(allSets)
+        const isValid = recordVerificationCall(verificationCalls, VerificationCallOperation.batch, allSets.length, () =>
+          verifySignatureSets(allSets)
         );
 
         if (isValid) {
@@ -115,7 +112,7 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
             ...batchableChunk.map(({idx, sets}) => ({
               idx,
               sets,
-              operation: VerificationCallOperation.generalFallback as const,
+              operation: VerificationCallOperation.fallback as const,
             }))
           );
         }
@@ -128,7 +125,7 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
           ...batchableChunk.map(({idx, sets}) => ({
             idx,
             sets,
-            operation: VerificationCallOperation.generalFallback as const,
+            operation: VerificationCallOperation.fallback as const,
           }))
         );
       }

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -489,7 +489,7 @@ export function createLodestarMetrics(
       bufferedSignatureSets: register.histogram({
         name: "lodestar_bls_thread_pool_buffered_signature_sets",
         help: "Count of signature sets included in each batching-buffer flush",
-        buckets: [1, 2, 4, 8, 16, 24, 32, 48, 64, 128],
+        buckets: [1, 8, 16, 24, 28, 32, 36, 40, 44, 48, 64, 128],
       }),
       // To measure the time cost of main thread <-> worker message passing
       latencyToWorker: register.histogram({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -33,7 +33,7 @@ export type LodestarMetrics = ReturnType<typeof createLodestarMetrics>;
 
 type BlsJobOutcome = "valid" | "invalid" | "prepError" | "verifyError" | "workerError";
 type BlsBufferFlushReason = "size" | "timeout";
-type BlsVerificationCallOperation = "general_batch" | "general_direct" | "general_fallback" | "same_message";
+type BlsVerificationCallOperation = "general_batch" | "general_single" | "general_fallback" | "same_message";
 
 /**
  * Extra Lodestar custom metrics

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -33,7 +33,7 @@ export type LodestarMetrics = ReturnType<typeof createLodestarMetrics>;
 
 type BlsJobOutcome = "valid" | "invalid" | "prepError" | "verifyError" | "workerError";
 type BlsBufferFlushReason = "size" | "timeout";
-type BlsVerificationCallOperation = "general_batch" | "general_single" | "general_fallback" | "same_message";
+type BlsVerificationCallOperation = "batch" | "single" | "fallback" | "same_message";
 
 /**
  * Extra Lodestar custom metrics

--- a/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
@@ -116,7 +116,7 @@ describe("chain / bls / multithread queue", () => {
     const verificationCallDuration = await metrics.register.getSingleMetricAsString(
       "lodestar_bls_thread_pool_verification_call_duration_seconds"
     );
-    for (const operation of ["general_batch", "general_direct", "general_fallback", "same_message"]) {
+    for (const operation of ["general_batch", "general_single", "general_fallback", "same_message"]) {
       expect(verificationCallDuration).toContain(`operation="${operation}"`);
     }
 

--- a/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
@@ -116,7 +116,7 @@ describe("chain / bls / multithread queue", () => {
     const verificationCallDuration = await metrics.register.getSingleMetricAsString(
       "lodestar_bls_thread_pool_verification_call_duration_seconds"
     );
-    for (const operation of ["general_batch", "general_single", "general_fallback", "same_message"]) {
+    for (const operation of ["batch", "single", "fallback", "same_message"]) {
       expect(verificationCallDuration).toContain(`operation="${operation}"`);
     }
 
@@ -124,10 +124,10 @@ describe("chain / bls / multithread queue", () => {
       "lodestar_bls_thread_pool_verification_call_signature_sets_total"
     );
     expect(verificationCallSignatureSets).toContain(
-      'lodestar_bls_thread_pool_verification_call_signature_sets_total{operation="general_batch"} 4'
+      'lodestar_bls_thread_pool_verification_call_signature_sets_total{operation="batch"} 4'
     );
     expect(verificationCallSignatureSets).toContain(
-      'lodestar_bls_thread_pool_verification_call_signature_sets_total{operation="general_fallback"} 1'
+      'lodestar_bls_thread_pool_verification_call_signature_sets_total{operation="fallback"} 1'
     );
 
     const invalidInput: ISignatureSet = {...sets[0], type: SignatureSetType.aggregate, indices: [-1]};


### PR DESCRIPTION
**Motivation**

Changes some of metrics related review that i did [here](https://github.com/ChainSafe/lodestar/pull/9820#pullrequestreview-4991318264)

**Description**

## Changes

### changes the 'combined batch outcomes' to batch retries instead and cap it to 100%

The main reason is I think it doesn't make sense to log the positive case, it's a minor issue but seems more natural to track the negative cases and cap it from 0-100% rather than have a weird 100% band

See [original comment](https://github.com/ChainSafe/lodestar/pull/9820#discussion_r3828660389)

Before:

<img width="865" height="449" alt="Screenshot 2026-08-21 at 5 12 09 PM" src="https://github.com/user-attachments/assets/ac3f6632-6365-4638-b8fe-38f59842bfcb" />

After:

<img width="777" height="522" alt="Screenshot 2026-08-21 at 5 12 36 PM" src="https://github.com/user-attachments/assets/fd9c4991-ed24-487c-be46-555db0fe3893" />


### Address vague verification work names

There's no point in having a 'general' prefix in our `VerificationCallOperation` enum, because anything that is not `sameMessage` is by definition a 'general' call, so we just remove it. The 'direct' name also doesn't make sense, all the calls are 'direct' so to speak, what we want is 'single' instead of direct

see [original comment](https://github.com/ChainSafe/lodestar/pull/9820#discussion_r3828784891)

Change:

```ts
export enum VerificationCallOperation {
  generalBatch = "general_batch",
  generalDirect = "general_direct",
  generalFallback = "general_fallback",
  sameMessage = "same_message",
}
```

to:

```ts
export enum VerificationCallOperation {
  batch = "batch",
  single = "single",
  fallback = "fallback",
}
```

Before:

<img width="880" height="323" alt="Screenshot 2026-08-21 at 5 15 19 PM" src="https://github.com/user-attachments/assets/4ebbcfb1-8bdc-43ab-9400-fb5a4c657377" />

After:

<img width="1713" height="634" alt="Screenshot 2026-08-21 at 5 32 59 PM" src="https://github.com/user-attachments/assets/e5e24f9c-beaa-4a94-aa04-7b9bac6b77ae" />

###  De-dup buffered sets per flush metric

 The sets/buffer flush was already tracked in the histogram in another metric:
<img width="1012" height="656" alt="Screenshot 2026-08-21 at 5 59 48 PM" src="https://github.com/user-attachments/assets/e64b613d-099e-463f-a463-58752009be0b" />

see [original comment](https://github.com/ChainSafe/lodestar/pull/9820#discussion_r3828699971).

Before: 
<img width="883" height="313" alt="Screenshot 2026-08-21 at 5 25 25 PM" src="https://github.com/user-attachments/assets/0886afd2-59da-4e15-908d-05e146efd3ad" />

After:
<img width="861" height="383" alt="Screenshot 2026-08-21 at 5 25 45 PM" src="https://github.com/user-attachments/assets/345cefd2-f252-4751-a36a-ae1524cfe91e" />

