### PR TITLE
fix: always add api attestations to the pool

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -100,17 +100,21 @@ export function getBeaconPoolApi({
             const {indexedAttestation, subnet, attDataRootHex, committeeIndex, validatorCommitteeIndex, committeeSize} =
               await validateGossipFnRetryUnknownRoot(validateFn, network, chain, slot, beaconBlockRoot);
 
-            if (network.shouldAggregate(subnet, slot)) {
-              const insertOutcome = chain.attestationPool.add(
-                committeeIndex,
-                attestation,
-                attDataRootHex,
-                validatorCommitteeIndex,
-                committeeSize,
-                priority
-              );
-              metrics?.opPool.attestationPool.apiInsertOutcome.inc({insertOutcome});
-            }
+            // Always add api attestations to the pool, regardless of whether an aggregator duty is registered
+            // for this (subnet, slot). The `is_aggregator` flag of `prepareBeaconCommitteeSubnet` only governs
+            // whether we announce the subnet subscription and aggregate attestations *received on that subnet*
+            // via gossip, it does not apply to attestations handed to us directly by an attached validator client.
+            // Gating on it means we cannot serve `getAggregatedAttestation` for our own validators if the VC
+            // does not set the flag, see https://github.com/ChainSafe/lodestar/issues/7548
+            const insertOutcome = chain.attestationPool.add(
+              committeeIndex,
+              attestation,
+              attDataRootHex,
+              validatorCommitteeIndex,
+              committeeSize,
+              priority
+            );
+            metrics?.opPool.attestationPool.apiInsertOutcome.inc({insertOutcome});
 
             if (isForkPostElectra(fork)) {
               chain.emitter.emit(

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -115,7 +115,7 @@ export function getBeaconPoolApi({
             } catch (e) {
               // The pool is a local optimization, failing to insert must not stop us from publishing a
               // validated attestation, which the route requires us to do. Same handling as the gossip path
-              logger.error("Error adding unaggregated attestation to pool", {subnet}, e as Error);
+              logger.debug("Error adding unaggregated attestation to pool", {subnet}, e as Error);
             }
 
             if (isForkPostElectra(fork)) {

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -100,21 +100,27 @@ export function getBeaconPoolApi({
             const {indexedAttestation, subnet, attDataRootHex, committeeIndex, validatorCommitteeIndex, committeeSize} =
               await validateGossipFnRetryUnknownRoot(validateFn, network, chain, slot, beaconBlockRoot);
 
-            // Always add api attestations to the pool, regardless of whether an aggregator duty is registered
-            // for this (subnet, slot). The `is_aggregator` flag of `prepareBeaconCommitteeSubnet` only governs
-            // whether we announce the subnet subscription and aggregate attestations *received on that subnet*
-            // via gossip, it does not apply to attestations handed to us directly by an attached validator client.
-            // Gating on it means we cannot serve `getAggregatedAttestation` for our own validators if the VC
-            // does not set the flag, see https://github.com/ChainSafe/lodestar/issues/7548
-            const insertOutcome = chain.attestationPool.add(
-              committeeIndex,
-              attestation,
-              attDataRootHex,
-              validatorCommitteeIndex,
-              committeeSize,
-              priority
-            );
-            metrics?.opPool.attestationPool.apiInsertOutcome.inc({insertOutcome});
+            try {
+              // Always add api attestations to the pool, regardless of whether an aggregator duty is registered
+              // for this (subnet, slot). The `is_aggregator` flag of `prepareBeaconCommitteeSubnet` only governs
+              // whether we announce the subnet subscription and aggregate attestations *received on that subnet*
+              // via gossip, it does not apply to attestations handed to us directly by an attached validator client.
+              // Gating on it means we cannot serve `getAggregatedAttestation` for our own validators if the VC
+              // does not set the flag, see https://github.com/ChainSafe/lodestar/issues/7548
+              const insertOutcome = chain.attestationPool.add(
+                committeeIndex,
+                attestation,
+                attDataRootHex,
+                validatorCommitteeIndex,
+                committeeSize,
+                priority
+              );
+              metrics?.opPool.attestationPool.apiInsertOutcome.inc({insertOutcome});
+            } catch (e) {
+              // The pool is a local optimization, failing to insert must not stop us from publishing a
+              // validated attestation, which the route requires us to do. Same handling as the gossip path
+              logger.error("Error adding unaggregated attestation to pool", {subnet}, e as Error);
+            }
 
             if (isForkPostElectra(fork)) {
               chain.emitter.emit(

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -101,12 +101,8 @@ export function getBeaconPoolApi({
               await validateGossipFnRetryUnknownRoot(validateFn, network, chain, slot, beaconBlockRoot);
 
             try {
-              // Always add api attestations to the pool, regardless of whether an aggregator duty is registered
-              // for this (subnet, slot). The `is_aggregator` flag of `prepareBeaconCommitteeSubnet` only governs
-              // whether we announce the subnet subscription and aggregate attestations *received on that subnet*
-              // via gossip, it does not apply to attestations handed to us directly by an attached validator client.
-              // Gating on it means we cannot serve `getAggregatedAttestation` for our own validators if the VC
-              // does not set the flag, see https://github.com/ChainSafe/lodestar/issues/7548
+              // `is_aggregator` only covers aggregating what we receive on the subnet via gossip, not what
+              // a validator client hands us directly, see https://github.com/ChainSafe/lodestar/issues/7548
               const insertOutcome = chain.attestationPool.add(
                 committeeIndex,
                 attestation,

--- a/packages/beacon-node/test/unit/api/impl/beacon/pool/submitPoolAttestations.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/pool/submitPoolAttestations.test.ts
@@ -3,7 +3,8 @@ import {createChainForkConfig} from "@lodestar/config";
 import {config as configDef} from "@lodestar/config/default";
 import {ssz} from "@lodestar/types";
 import {getBeaconPoolApi} from "../../../../../../src/api/impl/beacon/pool/index.js";
-import {InsertOutcome} from "../../../../../../src/chain/opPools/types.js";
+import {InsertOutcome, OpPoolError, OpPoolErrorCode} from "../../../../../../src/chain/opPools/types.js";
+import {AttestationValidationResult} from "../../../../../../src/chain/validation/attestation.js";
 import {ApiTestModules, getApiTestModules} from "../../../../../utils/api.js";
 
 vi.mock("../../../../../../src/network/processor/gossipHandlers.js", async (importActual) => {
@@ -37,14 +38,16 @@ describe("api - beacon - submitPoolAttestationsV2", () => {
     // `is_aggregator: true` in `prepareBeaconCommitteeSubnet`
     modules.network.shouldAggregate = vi.fn().mockReturnValue(false);
 
-    vi.mocked(validateGossipFnRetryUnknownRoot).mockResolvedValue({
+    const validationResult: AttestationValidationResult = {
+      attestation: ssz.electra.SingleAttestation.defaultValue(),
       indexedAttestation: ssz.electra.IndexedAttestation.defaultValue(),
       subnet,
       attDataRootHex: "0x00",
       committeeIndex: 0,
       validatorCommitteeIndex: 0,
       committeeSize: 64,
-    } as any);
+    };
+    vi.mocked(validateGossipFnRetryUnknownRoot<AttestationValidationResult>).mockResolvedValue(validationResult);
 
     api = getBeaconPoolApi(modules);
   });
@@ -57,6 +60,17 @@ describe("api - beacon - submitPoolAttestationsV2", () => {
     expect(attestationPool.add).toHaveBeenCalledOnce();
     // api attestations are always inserted with priority so they are not rejected for being late
     expect(attestationPool.add).toHaveBeenCalledWith(0, attestation, "0x00", 0, 64, true);
+  });
+
+  it("still publishes the attestation if it can not be added to the pool", async () => {
+    const attestation = ssz.electra.SingleAttestation.defaultValue();
+    attestationPool.add.mockImplementation(() => {
+      throw new OpPoolError({code: OpPoolErrorCode.REACHED_MAX_PER_SLOT});
+    });
+
+    await expect(api.submitPoolAttestationsV2({signedAttestations: [attestation]})).resolves.not.toThrow();
+
+    expect(modules.network.publishBeaconAttestation).toHaveBeenCalledWith(attestation, subnet);
   });
 
   it("publishes the attestation on the subnet", async () => {

--- a/packages/beacon-node/test/unit/api/impl/beacon/pool/submitPoolAttestations.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/pool/submitPoolAttestations.test.ts
@@ -1,0 +1,69 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {createChainForkConfig} from "@lodestar/config";
+import {config as configDef} from "@lodestar/config/default";
+import {ssz} from "@lodestar/types";
+import {getBeaconPoolApi} from "../../../../../../src/api/impl/beacon/pool/index.js";
+import {InsertOutcome} from "../../../../../../src/chain/opPools/types.js";
+import {ApiTestModules, getApiTestModules} from "../../../../../utils/api.js";
+
+vi.mock("../../../../../../src/network/processor/gossipHandlers.js", async (importActual) => {
+  const mod = await importActual<typeof import("../../../../../../src/network/processor/gossipHandlers.js")>();
+  return {...mod, validateGossipFnRetryUnknownRoot: vi.fn()};
+});
+
+const {validateGossipFnRetryUnknownRoot} = await import("../../../../../../src/network/processor/gossipHandlers.js");
+
+describe("api - beacon - submitPoolAttestationsV2", () => {
+  const config = createChainForkConfig({
+    ...configDef,
+    ALTAIR_FORK_EPOCH: 0,
+    BELLATRIX_FORK_EPOCH: 0,
+    CAPELLA_FORK_EPOCH: 0,
+    DENEB_FORK_EPOCH: 0,
+    ELECTRA_FORK_EPOCH: 0,
+  });
+  const subnet = 7;
+
+  let modules: ApiTestModules;
+  let api: ReturnType<typeof getBeaconPoolApi>;
+  let attestationPool: {add: ReturnType<typeof vi.fn>};
+
+  beforeEach(() => {
+    modules = getApiTestModules({config});
+    attestationPool = {add: vi.fn().mockReturnValue(InsertOutcome.NewData)};
+    Object.defineProperty(modules.chain, "attestationPool", {value: attestationPool});
+    modules.network.publishBeaconAttestation = vi.fn().mockResolvedValue(1);
+    // No aggregator duty registered for this (subnet, slot), ie. the validator client did not send
+    // `is_aggregator: true` in `prepareBeaconCommitteeSubnet`
+    modules.network.shouldAggregate = vi.fn().mockReturnValue(false);
+
+    vi.mocked(validateGossipFnRetryUnknownRoot).mockResolvedValue({
+      indexedAttestation: ssz.electra.IndexedAttestation.defaultValue(),
+      subnet,
+      attDataRootHex: "0x00",
+      committeeIndex: 0,
+      validatorCommitteeIndex: 0,
+      committeeSize: 64,
+    } as any);
+
+    api = getBeaconPoolApi(modules);
+  });
+
+  it("adds the attestation to the pool even if we have no aggregator duty", async () => {
+    const attestation = ssz.electra.SingleAttestation.defaultValue();
+
+    await api.submitPoolAttestationsV2({signedAttestations: [attestation]});
+
+    expect(attestationPool.add).toHaveBeenCalledOnce();
+    // api attestations are always inserted with priority so they are not rejected for being late
+    expect(attestationPool.add).toHaveBeenCalledWith(0, attestation, "0x00", 0, 64, true);
+  });
+
+  it("publishes the attestation on the subnet", async () => {
+    const attestation = ssz.electra.SingleAttestation.defaultValue();
+
+    await api.submitPoolAttestationsV2({signedAttestations: [attestation]});
+
+    expect(modules.network.publishBeaconAttestation).toHaveBeenCalledWith(attestation, subnet);
+  });
+});


### PR DESCRIPTION
**Motivation**

`submitPoolAttestationsV2` only inserts an api-submitted attestation into the attestation pool when
`network.shouldAggregate(subnet, slot)` is true, which is only the case if a validator client sent
`is_aggregator: true` for that `(slot, committee_index)` via `prepareBeaconCommitteeSubnet`.

That condition does not belong on this path. Per
[beacon-APIs](https://github.com/ethereum/beacon-APIs/blob/master/apis/validator/beacon_committee_subscriptions.yaml),
`is_aggregator` gates two things: announcing the subnet topic subscription on gossipsub, and aggregating
attestations *received on that subnet*. An attestation handed to us directly by an attached VC is neither. We
keep the same gate on the gossip path in `gossipHandlers`, where it is correct and saves CPU and RAM on
long-lived subnets we are not aggregating for.

The practical effect is that we cannot serve `getAggregatedAttestation` for our own validators if the VC does not
set the flag, which is #7548. #7553 fixed the lateness half of that issue by inserting api attestations with
`priority`, but the insert is still gated.

This is reachable today: a Nimbus VC never sets `is_aggregator: true`
(status-im/nimbus-eth2#8923), so on a devnet of Lodestar BNs paired with Nimbus VCs no attnet subscription
happens at all, no aggregate is ever produced, and no attestation is included in any block. Other beacon nodes
pool api attestations unconditionally, which is why only Lodestar is affected.

**Description**

- always insert api-submitted attestations into the attestation pool, regardless of whether an aggregator duty
  is registered for the `(subnet, slot)`

The pool is already bounded independently of this (`SLOTS_RETAINED = 3`, `MAX_ATTESTATIONS_PER_SLOT = 16_384`)
and every attestation is validated by `validateApiAttestation` before it is inserted, so this does not open up a
new DoS surface.

Adds a unit test for the api path, which fails on `unstable` and passes here.

Follow-up to #7553, which addressed the lateness half of #7548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
