### PR TITLE
refactor(network): resolve zero peers publish policy per topic

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -401,7 +401,7 @@ export function getBeaconBlockApi({
       for (let i = 0; i < dataColumnSidecars.length; i++) {
         // + 1 because we publish to beacon_block first
         const {sentPeers, alreadyPublished} = sentPeersArr[i + 1] as {sentPeers: number; alreadyPublished: boolean};
-        // sent peers could be 0 as we set `allowPublishToZeroTopicPeers=true` in network.publishDataColumnSidecar()
+        // sent peers could be 0, data_column_sidecar opts out of the zero peers publish error, see gossipTopicAllowPublishToZeroPeers
         metrics?.dataColumns.sentPeersPerSubnet.observe(sentPeers);
         // A duplicate publish (alreadyPublished=true) means the column is already propagating on the network —
         // expected in self-build flows where peers gossip columns back to us before we publish the envelope.

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -423,15 +423,16 @@ export const gossipTopicIgnoreDuplicatePublishError: Record<GossipType, boolean>
  * validator client. That is the right default: a message that reached nobody is a failed broadcast, and a
  * VC configured with several beacon nodes can fall back to another one.
  *
- * Only topics that have a concrete reason to tolerate it opt out here. Note this is applied per publish,
- * a topic set to `false` still honors the global `--network.allowPublishToZeroPeers` flag.
+ * Only topics that have a concrete reason to tolerate it opt out here, ie. are set to `true`, and the
+ * reason is named on the entry. Everything else is `false` and keeps raising. Note this is applied per
+ * publish, a topic set to `false` still honors the global `--network.allowPublishToZeroPeers` flag.
  */
 export const gossipTopicAllowPublishToZeroPeers: Record<GossipType, boolean> = {
   [GossipType.beacon_block]: false,
   [GossipType.blob_sidecar]: false,
-  // We ensure having all topic peers via prioritizePeers(). Even with 0 peers on the topic the overall
-  // publish can still succeed, because a supernode rebuilds and publishes the missing columns for us,
-  // so track sent peers as 0 instead of raising
+  // data_column_sidecar: we ensure having all topic peers via prioritizePeers(). Even with 0 peers on the
+  // topic the overall publish can still succeed, because a supernode rebuilds and publishes the missing
+  // columns for us, so track sent peers as 0 instead of raising
   [GossipType.data_column_sidecar]: true,
   [GossipType.beacon_aggregate_and_proof]: false,
   [GossipType.beacon_attestation]: false,
@@ -440,7 +441,9 @@ export const gossipTopicAllowPublishToZeroPeers: Record<GossipType, boolean> = {
   [GossipType.attester_slashing]: false,
   [GossipType.sync_committee_contribution_and_proof]: false,
   [GossipType.sync_committee]: false,
-  // Non-mandatory route on most of the network, there may be no peer subscribed to it at all
+  // light_client_finality_update and light_client_optimistic_update: non-mandatory route on most of the
+  // network as of Oct 2022, there may be no peer subscribed to the topic at all. Reason carried over from
+  // the handlers in network.ts, which used to swallow the error instead
   [GossipType.light_client_finality_update]: true,
   [GossipType.light_client_optimistic_update]: true,
   [GossipType.bls_to_execution_change]: false,

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -414,3 +414,38 @@ export const gossipTopicIgnoreDuplicatePublishError: Record<GossipType, boolean>
   [GossipType.execution_payload_bid]: true,
   [GossipType.proposer_preferences]: true,
 };
+
+/**
+ * Whether a publish that reached zero subscribed peers is an acceptable outcome for a topic.
+ *
+ * Publishing to a topic with no subscribed peers throws `PublishError.NoPeersSubscribedToTopic`, which
+ * propagates to the caller and, for messages submitted through the beacon API, is surfaced to the
+ * validator client. That is the right default: a message that reached nobody is a failed broadcast, and a
+ * VC configured with several beacon nodes can fall back to another one.
+ *
+ * Only topics that have a concrete reason to tolerate it opt out here. Note this is applied per publish,
+ * a topic set to `false` still honors the global `--network.allowPublishToZeroPeers` flag.
+ */
+export const gossipTopicAllowPublishToZeroPeers: Record<GossipType, boolean> = {
+  [GossipType.beacon_block]: false,
+  [GossipType.blob_sidecar]: false,
+  // We ensure having all topic peers via prioritizePeers(). Even with 0 peers on the topic the overall
+  // publish can still succeed, because a supernode rebuilds and publishes the missing columns for us,
+  // so track sent peers as 0 instead of raising
+  [GossipType.data_column_sidecar]: true,
+  [GossipType.beacon_aggregate_and_proof]: false,
+  [GossipType.beacon_attestation]: false,
+  [GossipType.voluntary_exit]: false,
+  [GossipType.proposer_slashing]: false,
+  [GossipType.attester_slashing]: false,
+  [GossipType.sync_committee_contribution_and_proof]: false,
+  [GossipType.sync_committee]: false,
+  // Non-mandatory route on most of the network, there may be no peer subscribed to it at all
+  [GossipType.light_client_finality_update]: true,
+  [GossipType.light_client_optimistic_update]: true,
+  [GossipType.bls_to_execution_change]: false,
+  [GossipType.execution_payload]: false,
+  [GossipType.payload_attestation_message]: false,
+  [GossipType.execution_payload_bid]: false,
+  [GossipType.proposer_preferences]: false,
+};

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -49,7 +49,12 @@ import {INetworkCore, NetworkCore, WorkerNetworkCore} from "./core/index.js";
 import {INetworkEventBus, NetworkEvent, NetworkEventBus, NetworkEventData} from "./events.js";
 import {getActiveForkBoundaries} from "./forks.js";
 import {GossipHandlers, GossipTopicMap, GossipType, GossipTypeMap} from "./gossip/index.js";
-import {getGossipSSZType, gossipTopicIgnoreDuplicatePublishError, stringifyGossipTopic} from "./gossip/topic.js";
+import {
+  getGossipSSZType,
+  gossipTopicAllowPublishToZeroPeers,
+  gossipTopicIgnoreDuplicatePublishError,
+  stringifyGossipTopic,
+} from "./gossip/topic.js";
 import {INetwork} from "./interface.js";
 import {NetworkOptions} from "./options.js";
 import {PeerAction, PeerScoreStats} from "./peers/index.js";
@@ -65,7 +70,7 @@ import {
 } from "./reqresp/utils/collect.js";
 import {collectSequentialBlocksInRange} from "./reqresp/utils/collectSequentialBlocksInRange.js";
 import {CommitteeSubscription} from "./subnets/index.js";
-import {isPublishDuplicateError, isPublishToZeroPeersError, prettyPrintPeerIdStr} from "./util.js";
+import {isPublishDuplicateError, prettyPrintPeerIdStr} from "./util.js";
 
 type NetworkModules = {
   opts: NetworkOptions;
@@ -352,9 +357,7 @@ export class Network implements INetwork {
     const epoch = computeEpochAtSlot(signedBlock.message.slot);
     const boundary = this.config.getForkBoundaryAtEpoch(epoch);
 
-    return this.publishGossip<GossipType.beacon_block>({type: GossipType.beacon_block, boundary}, signedBlock, {
-      ignoreDuplicatePublishError: true,
-    });
+    return this.publishGossip<GossipType.beacon_block>({type: GossipType.beacon_block, boundary}, signedBlock);
   }
 
   async publishBlobSidecar(blobSidecar: deneb.BlobSidecar): Promise<number> {
@@ -363,9 +366,7 @@ export class Network implements INetwork {
 
     const subnet = blobSidecar.index;
 
-    return this.publishGossip<GossipType.blob_sidecar>({type: GossipType.blob_sidecar, boundary, subnet}, blobSidecar, {
-      ignoreDuplicatePublishError: true,
-    });
+    return this.publishGossip<GossipType.blob_sidecar>({type: GossipType.blob_sidecar, boundary, subnet}, blobSidecar);
   }
 
   async publishDataColumnSidecar(
@@ -381,14 +382,7 @@ export class Network implements INetwork {
     try {
       const sentPeers = await this.publishGossip<GossipType.data_column_sidecar>(
         {type: GossipType.data_column_sidecar, boundary, subnet},
-        dataColumnSidecar,
-        {
-          // we ensure having all topic peers via prioritizePeers() function
-          // in the worse case, if there is 0 peer on the topic, the overall publish operation could be still a success
-          // because supernode will rebuild and publish missing data column sidecars for us
-          // hence we want to track sent peers as 0 instead of an error
-          allowPublishToZeroTopicPeers: true,
-        }
+        dataColumnSidecar
       );
       return {sentPeers, alreadyPublished: false};
     } catch (e) {
@@ -405,8 +399,7 @@ export class Network implements INetwork {
 
     return this.publishGossip<GossipType.beacon_aggregate_and_proof>(
       {type: GossipType.beacon_aggregate_and_proof, boundary},
-      aggregateAndProof,
-      {ignoreDuplicatePublishError: true}
+      aggregateAndProof
     );
   }
 
@@ -416,8 +409,7 @@ export class Network implements INetwork {
 
     return this.publishGossip<GossipType.beacon_attestation>(
       {type: GossipType.beacon_attestation, boundary, subnet},
-      attestation,
-      {ignoreDuplicatePublishError: true}
+      attestation
     );
   }
 
@@ -425,9 +417,7 @@ export class Network implements INetwork {
     const epoch = voluntaryExit.message.epoch;
     const boundary = this.config.getForkBoundaryAtEpoch(epoch);
 
-    return this.publishGossip<GossipType.voluntary_exit>({type: GossipType.voluntary_exit, boundary}, voluntaryExit, {
-      ignoreDuplicatePublishError: true,
-    });
+    return this.publishGossip<GossipType.voluntary_exit>({type: GossipType.voluntary_exit, boundary}, voluntaryExit);
   }
 
   async publishBlsToExecutionChange(blsToExecutionChange: capella.SignedBLSToExecutionChange): Promise<number> {
@@ -438,8 +428,7 @@ export class Network implements INetwork {
       if (fork >= ForkSeq.capella) {
         const publishPromise = this.publishGossip<GossipType.bls_to_execution_change>(
           {type: GossipType.bls_to_execution_change, boundary},
-          blsToExecutionChange,
-          {ignoreDuplicatePublishError: true}
+          blsToExecutionChange
         );
         publishChanges.push(publishPromise);
       }
@@ -457,8 +446,7 @@ export class Network implements INetwork {
 
     return this.publishGossip<GossipType.proposer_slashing>(
       {type: GossipType.proposer_slashing, boundary},
-      proposerSlashing,
-      {ignoreDuplicatePublishError: true}
+      proposerSlashing
     );
   }
 
@@ -478,10 +466,7 @@ export class Network implements INetwork {
 
     return this.publishGossip<GossipType.sync_committee>(
       {type: GossipType.sync_committee, boundary, subnet},
-      signature,
-      {
-        ignoreDuplicatePublishError: true,
-      }
+      signature
     );
   }
 
@@ -491,8 +476,7 @@ export class Network implements INetwork {
 
     return this.publishGossip<GossipType.sync_committee_contribution_and_proof>(
       {type: GossipType.sync_committee_contribution_and_proof, boundary},
-      contributionAndProof,
-      {ignoreDuplicatePublishError: true}
+      contributionAndProof
     );
   }
 
@@ -522,8 +506,7 @@ export class Network implements INetwork {
 
     return this.publishGossip<GossipType.execution_payload>(
       {type: GossipType.execution_payload, boundary},
-      signedEnvelope,
-      {ignoreDuplicatePublishError: true}
+      signedEnvelope
     );
   }
 
@@ -533,8 +516,7 @@ export class Network implements INetwork {
 
     return this.publishGossip<GossipType.execution_payload_bid>(
       {type: GossipType.execution_payload_bid, boundary},
-      signedBid,
-      {ignoreDuplicatePublishError: true}
+      signedBid
     );
   }
 
@@ -544,8 +526,7 @@ export class Network implements INetwork {
 
     return this.publishGossip<GossipType.payload_attestation_message>(
       {type: GossipType.payload_attestation_message, boundary},
-      payloadAttestationMessage,
-      {ignoreDuplicatePublishError: true}
+      payloadAttestationMessage
     );
   }
 
@@ -555,22 +536,21 @@ export class Network implements INetwork {
 
     return this.publishGossip<GossipType.proposer_preferences>(
       {type: GossipType.proposer_preferences, boundary},
-      signedProposerPreferences,
-      {ignoreDuplicatePublishError: true}
+      signedProposerPreferences
     );
   }
 
   private async publishGossip<K extends GossipType>(
     topic: GossipTopicMap[K],
-    object: GossipTypeMap[K],
-    opts?: PublishOpts | undefined
+    object: GossipTypeMap[K]
   ): Promise<number> {
     const topicStr = stringifyGossipTopic(this.config, topic);
     const sszType = getGossipSSZType(topic);
     const messageData = (sszType.serialize as (object: GossipTypeMap[GossipType]) => Uint8Array)(object);
-    opts = {
-      ...opts,
+    const opts: PublishOpts = {
       ignoreDuplicatePublishError: gossipTopicIgnoreDuplicatePublishError[topic.type],
+      // Leave undefined unless the topic opts out, so `--network.allowPublishToZeroPeers` still applies
+      allowPublishToZeroTopicPeers: gossipTopicAllowPublishToZeroPeers[topic.type] ? true : undefined,
     };
     const sentPeers = await this.core.publishGossip(topicStr, messageData, opts);
 
@@ -813,11 +793,7 @@ export class Network implements INetwork {
       await this.waitForSyncMessageCutoff(finalityUpdate.signatureSlot);
       await this.publishLightClientFinalityUpdate(finalityUpdate);
     } catch (e) {
-      // Non-mandatory route on most of network as of Oct 2022. May not have found any peers on topic yet
-      // Remove once https://github.com/ChainSafe/js-libp2p-gossipsub/issues/367
-      if (!isPublishToZeroPeersError(e as Error)) {
-        this.logger.debug("Error on BeaconGossipHandler.onLightclientFinalityUpdate", {}, e as Error);
-      }
+      this.logger.debug("Error on BeaconGossipHandler.onLightclientFinalityUpdate", {}, e as Error);
     }
   };
 
@@ -830,11 +806,7 @@ export class Network implements INetwork {
       await this.waitForSyncMessageCutoff(optimisticUpdate.signatureSlot);
       await this.publishLightClientOptimisticUpdate(optimisticUpdate);
     } catch (e) {
-      // Non-mandatory route on most of network as of Oct 2022. May not have found any peers on topic yet
-      // Remove once https://github.com/ChainSafe/js-libp2p-gossipsub/issues/367
-      if (!isPublishToZeroPeersError(e as Error)) {
-        this.logger.debug("Error on BeaconGossipHandler.onLightclientOptimisticUpdate", {}, e as Error);
-      }
+      this.logger.debug("Error on BeaconGossipHandler.onLightclientOptimisticUpdate", {}, e as Error);
     }
   };
 

--- a/packages/beacon-node/src/network/util.ts
+++ b/packages/beacon-node/src/network/util.ts
@@ -24,11 +24,6 @@ export function getConnection(libp2p: Libp2p, peerIdStr: string): Connection | u
 }
 
 // https://github.com/libp2p/js-libp2p/blob/f87cba928991736d9646b3e054c367f55cab315c/packages/gossipsub/src/gossipsub.ts#L2076
-export function isPublishToZeroPeersError(e: Error): boolean {
-  return e.message.includes("PublishError.NoPeersSubscribedToTopic");
-}
-
-// https://github.com/libp2p/js-libp2p/blob/f87cba928991736d9646b3e054c367f55cab315c/packages/gossipsub/src/gossipsub.ts#L2076
 export function isPublishDuplicateError(e: Error): boolean {
   return e.message.includes("PublishError.Duplicate");
 }

--- a/packages/beacon-node/test/unit/network/gossip/topic.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/topic.test.ts
@@ -20,6 +20,7 @@ import {
   getCoreTopicsAtFork,
   getGossipSSZMaxSize,
   getGossipSSZType,
+  gossipTopicAllowPublishToZeroPeers,
   parseGossipTopic,
   stringifyGossipTopic,
 } from "../../../../src/network/gossip/topic.js";
@@ -404,6 +405,28 @@ describe("network / gossip / topic", () => {
       expect(allowedTopics.has("/eth2/ffffffff/beacon_attestation_5/ssz_snappy")).toBe(false);
       // Garbage
       expect(allowedTopics.has("/attacker/garbage/topic")).toBe(false);
+    });
+  });
+
+  describe("gossipTopicAllowPublishToZeroPeers", () => {
+    it("has an entry for every gossip type", () => {
+      for (const gossipType of Object.values(GossipType)) {
+        expect(gossipTopicAllowPublishToZeroPeers[gossipType]).toBeTypeOf("boolean");
+      }
+    });
+
+    it("only opts out for topics that tolerate reaching no peer", () => {
+      const allowed = Object.values(GossipType).filter((type) => gossipTopicAllowPublishToZeroPeers[type]);
+
+      // A publish that reached no peer is a failed broadcast and must surface to the caller. Adding a
+      // topic here silently turns that failure into a success, so it should be a deliberate change.
+      expect(allowed.sort()).toEqual(
+        [
+          GossipType.data_column_sidecar,
+          GossipType.light_client_finality_update,
+          GossipType.light_client_optimistic_update,
+        ].sort()
+      );
     });
   });
 });


### PR DESCRIPTION
**Motivation**

`PublishError.NoPeersSubscribedToTopic` is handled three different ways depending on the topic:

- swallowed in the handler for light client updates, via `isPublishToZeroPeersError`
- pre-empted for data column sidecars, by passing `allowPublishToZeroTopicPeers: true` at the call site
- propagated to the caller for everything else, so for messages submitted through the beacon API it
  surfaces to the validator client

The behaviour per topic is defensible, the three mechanisms are not. There is already a per-topic table for
exactly this kind of publish policy, `gossipTopicIgnoreDuplicatePublishError`, applied centrally in
`publishGossip`, so the zero peers case can live next to it.

While moving it I noticed the per call site publish opts have no effect. `publishGossip` did

```ts
opts = {
  ...opts,
  ignoreDuplicatePublishError: gossipTopicIgnoreDuplicatePublishError[topic.type],
};
```

so the table always overwrote what the caller passed. All 13 `{ignoreDuplicatePublishError: true}` args were
dead, including `proposer_slashing` where the call site says `true` and the table says `false`.

**Description**

- add `gossipTopicAllowPublishToZeroPeers` and resolve it in `publishGossip`, next to the existing
  duplicate publish table
- only three topics opt out, each with the reason recorded on the entry: `data_column_sidecar` because a
  supernode rebuilds and publishes the missing columns for us, and the two light client update topics
  because they are a non-mandatory route with often nothing subscribed
- drop the per call site publish opts, they were overwritten and had no effect
- remove `isPublishToZeroPeersError`, no longer used

Effective behaviour per topic is unchanged. A publish that reached no peer stays an error unless the topic has
a reason to tolerate it, so a VC configured with several beacon nodes can still fall back to another one on a
failed broadcast. Whether `beacon_attestation` should keep erroring is now a one line change in a table
rather than a decision buried in a `try/catch`.

The flag is only set when a topic opts out and left `undefined` otherwise. gossipsub resolves it as
`opts?.allowPublishToZeroTopicPeers ?? this.opts.allowPublishToZeroTopicPeers`, so passing an explicit
`false` per topic would have silently disabled `--network.allowPublishToZeroPeers`.

`Record<GossipType, boolean>` already forces a new topic to make a choice at compile time, the added test
pins the opt-out set so widening it is deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
