### PR TITLE
feat: add api submitted attestations to fork choice

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -118,6 +118,16 @@ export function getBeaconPoolApi({
               logger.debug("Error adding unaggregated attestation to pool", {subnet}, e as Error);
             }
 
+            try {
+              // An attestation submitted by an attached validator client is a vote like any other, our own
+              // fork choice should count it. Not doing so leaves the vote out of our store until a block or
+              // someone else's aggregate carries it back, `emitSelf` is off so what we publish does not
+              // loop back to us
+              chain.forkChoice.onAttestation(indexedAttestation, attDataRootHex);
+            } catch (e) {
+              logger.debug("Error adding api unaggregated attestation to forkchoice", {subnet}, e as Error);
+            }
+
             if (isForkPostElectra(fork)) {
               chain.emitter.emit(
                 routes.events.EventType.singleAttestation,

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1623,6 +1623,14 @@ export function getValidatorApi(
             );
             metrics?.opPool.aggregatedAttestationPool.apiInsertOutcome.inc({insertOutcome});
 
+            try {
+              // Same as the gossip path, an aggregate submitted through the api carries votes our own fork
+              // choice should count
+              chain.forkChoice.onAttestation(indexedAttestation, attDataRootHex);
+            } catch (e) {
+              logger.debug("Error adding api aggregated attestation to forkchoice", {slot}, e as Error);
+            }
+
             const sentPeers = await network.publishBeaconAggregateAndProof(signedAggregateAndProof);
             chain.validatorMonitor?.onPoolSubmitAggregatedAttestation(seenTimestampSec, indexedAttestation, sentPeers);
           } catch (e) {

--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -77,6 +77,7 @@ vi.mock("@lodestar/fork-choice", async (importActual) => {
       hasBlockHex: vi.fn(),
       getBlockSummariesAtSlot: vi.fn(),
       notifyPtcMessages: vi.fn(),
+      onAttestation: vi.fn(),
       shouldBuildOnFull: vi.fn(),
       getCanonicalPayloadCounts: vi.fn(),
     };

--- a/packages/beacon-node/test/unit/api/impl/beacon/pool/submitPoolAttestations.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/pool/submitPoolAttestations.test.ts
@@ -28,6 +28,7 @@ describe("api - beacon - submitPoolAttestationsV2", () => {
   let modules: ApiTestModules;
   let api: ReturnType<typeof getBeaconPoolApi>;
   let attestationPool: {add: ReturnType<typeof vi.fn>};
+  let validationResult: AttestationValidationResult;
 
   beforeEach(() => {
     modules = getApiTestModules({config});
@@ -38,7 +39,7 @@ describe("api - beacon - submitPoolAttestationsV2", () => {
     // `is_aggregator: true` in `prepareBeaconCommitteeSubnet`
     modules.network.shouldAggregate = vi.fn().mockReturnValue(false);
 
-    const validationResult: AttestationValidationResult = {
+    validationResult = {
       attestation: ssz.electra.SingleAttestation.defaultValue(),
       indexedAttestation: ssz.electra.IndexedAttestation.defaultValue(),
       subnet,
@@ -66,6 +67,25 @@ describe("api - beacon - submitPoolAttestationsV2", () => {
     const attestation = ssz.electra.SingleAttestation.defaultValue();
     attestationPool.add.mockImplementation(() => {
       throw new OpPoolError({code: OpPoolErrorCode.REACHED_MAX_PER_SLOT});
+    });
+
+    await expect(api.submitPoolAttestationsV2({signedAttestations: [attestation]})).resolves.not.toThrow();
+
+    expect(modules.network.publishBeaconAttestation).toHaveBeenCalledWith(attestation, subnet);
+  });
+
+  it("adds the attestation to fork choice", async () => {
+    const attestation = ssz.electra.SingleAttestation.defaultValue();
+
+    await api.submitPoolAttestationsV2({signedAttestations: [attestation]});
+
+    expect(modules.forkChoice.onAttestation).toHaveBeenCalledWith(validationResult.indexedAttestation, "0x00");
+  });
+
+  it("still publishes the attestation if fork choice rejects it", async () => {
+    const attestation = ssz.electra.SingleAttestation.defaultValue();
+    modules.forkChoice.onAttestation.mockImplementation(() => {
+      throw new Error("Unknown target root");
     });
 
     await expect(api.submitPoolAttestationsV2({signedAttestations: [attestation]})).resolves.not.toThrow();


### PR DESCRIPTION
> Stacked on #9886, review that one first. Base will change to `unstable` once it lands.

**Motivation**

`forkChoice.onAttestation` is called from `importBlock` and from the two gossip handlers, and nowhere
else. Neither api submission route feeds it:

- `submitPoolAttestationsV2` validates, pools and publishes
- `publishAggregateAndProofsV2` validates, pools and publishes

`emitSelf` is not set on our gossipsub instance so it defaults to off, which means what we publish is
not delivered back to us, and if a peer echoes it the seen cache drops it. An attestation submitted by
an attached validator client therefore never reaches our own fork choice, it only lands once a block or
somebody else's aggregate carries it back.

Most of the time this is invisible, our validators attest to the head we handed them, so applying the
vote would not change the head we already picked. It matters in two cases:

- the attestation data came from a different beacon node in a multi node VC setup, the case
  `submitPoolAttestationsV2` already has a comment about (#5098)
- across slots, since fork choice latest messages are sticky, so our validators are missing from our own
  store during a reorg race

Lighthouse applies both, `apply_attestation_to_fork_choice` runs on the unaggregated route in
[`publish_attestations.rs`](https://github.com/sigp/lighthouse/blob/unstable/beacon_node/http_api/src/publish_attestations.rs)
and on the aggregate route in `http_api/src/validator/mod.rs`, in both cases after the message has been
sent to the network.

**Description**

- call `chain.forkChoice.onAttestation` on both api routes, right after the pool insert, mirroring the
  order the gossip handlers use
- contain the error and log at debug, same as the gossip handlers. A vote we can not apply must not stop
  us from publishing a validated attestation

Not gated on `network.dontSendGossipAttestationsToForkchoice`. That flag is about the gossip firehose, as
its name says, and api attestations are our own validators' and low volume. Happy to reconsider if the
preference is for one switch covering both.

`onAttestation` was missing from the shared fork choice mock, added it there rather than per test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
