### PR TITLE
refactor: rename ethereumSszSpecsTests key to sszSpecTests

### DIFF
--- a/packages/beacon-node/test/spec/downloadTests.ts
+++ b/packages/beacon-node/test/spec/downloadTests.ts
@@ -2,10 +2,10 @@ import path from "node:path";
 import {config} from "dotenv";
 import {downloadNightlyTests} from "@lodestar/spec-test-util/downloadNightlyTests";
 import {downloadTests} from "@lodestar/spec-test-util/downloadTests";
-import {blsSpecTests, ethereumConsensusSpecsTests, ethereumSszSpecsTests} from "./specTestVersioning.js";
+import {blsSpecTests, ethereumConsensusSpecsTests, sszSpecTests} from "./specTestVersioning.js";
 
 const [date, repo, branch] = process.argv.slice(2);
-const downloads = [downloadTests(blsSpecTests, console.log), downloadTests(ethereumSszSpecsTests, console.log)];
+const downloads = [downloadTests(blsSpecTests, console.log), downloadTests(sszSpecTests, console.log)];
 
 if (date) {
   config({path: path.join(import.meta.dirname, "../../../../.env")});

--- a/packages/beacon-node/test/spec/general/ssz.test.ts
+++ b/packages/beacon-node/test/spec/general/ssz.test.ts
@@ -12,7 +12,7 @@ import {
   Type,
   fromHexString,
 } from "@chainsafe/ssz";
-import {ethereumSszSpecsTests} from "../specTestVersioning.js";
+import {sszSpecTests} from "../specTestVersioning.js";
 import {runValidSszTest} from "../utils/runValidSszTest.js";
 import {getSszSpecTestType} from "./ssz_types.js";
 
@@ -25,7 +25,7 @@ type SszFixture = {
   rejectionReason?: string;
 };
 
-const fixturesDir = path.join(ethereumSszSpecsTests.outputDir, "fixtures", "ssz", "ssz");
+const fixturesDir = path.join(sszSpecTests.outputDir, "fixtures", "ssz", "ssz");
 
 for (const testSuite of fs.readdirSync(fixturesDir)) {
   const testSuiteDir = path.join(fixturesDir, testSuite);

--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -9,9 +9,9 @@ export const ethereumConsensusSpecsTests = {
   outputDir: path.join(__dirname, "../../", specTestVersions.ethereumConsensusSpecsTests.outputDirBase),
 };
 
-export const ethereumSszSpecsTests = {
-  ...specTestVersions.ethereumSszSpecsTests,
-  outputDir: path.join(__dirname, "../../", specTestVersions.ethereumSszSpecsTests.outputDirBase),
+export const sszSpecTests = {
+  ...specTestVersions.sszSpecTests,
+  outputDir: path.join(__dirname, "../../", specTestVersions.sszSpecTests.outputDirBase),
 };
 
 export const blsSpecTests = {

--- a/spec-tests-version.json
+++ b/spec-tests-version.json
@@ -9,7 +9,7 @@
       "minimal"
     ]
   },
-  "ethereumSszSpecsTests": {
+  "sszSpecTests": {
     "specVersion": "v0.0.1.dev2",
     "specTestsRepoUrl": "https://github.com/ethereum/ssz-specs",
     "outputDirBase": "spec-tests-ssz",


### PR DESCRIPTION
Per @wemeetagain's review on #9859, renames the `ethereumSszSpecsTests` entry in `spec-tests-version.json` (plus its exported const in `specTestVersioning.ts` and all usages) to `sszSpecTests`.

Mechanical rename only, no behavior change. The output dir (`spec-tests-ssz`) is intentionally left unchanged; only the config key + code symbol are renamed. Touches 4 files (`spec-tests-version.json`, `specTestVersioning.ts`, `downloadTests.ts`, `ssz.test.ts`), 8 sites.

Targets `agent/ssz-spec-tests` as requested (https://github.com/ChainSafe/lodestar/pull/9859#discussion_r3830515331).

> This PR was written with AI assistance (Claude Code).
