### PR TITLE
test: cover malformed pubkeys in the batch deposit signature helper

### DIFF
--- a/packages/state-transition/test/unit/block/processDeposit.test.ts
+++ b/packages/state-transition/test/unit/block/processDeposit.test.ts
@@ -3,6 +3,7 @@ import {createBeaconConfig} from "@lodestar/config";
 import {getConfig} from "@lodestar/config/test-utils";
 import {ForkName} from "@lodestar/params";
 import {electra} from "@lodestar/types";
+import {fromHex} from "@lodestar/utils";
 import {verifyDepositSignatures} from "../../../src/block/processDeposit.js";
 import {generateBuilderPendingDeposits} from "../../../src/testUtils/util.js";
 
@@ -23,6 +24,37 @@ describe("verifyDepositSignatures", () => {
     // c as valid rather than marking the whole chunk invalid.
     const invalidB: electra.PendingDeposit = {...b, signature: a.signature};
     expect(verifyDepositSignatures(config, [a, invalidB, c])).toEqual([true, false, true]);
+  });
+
+  // BLS KeyValidate edge cases from consensus-specs#5541. Those spec tests exercise
+  // process_deposit / apply_pending_deposit / process_builder_deposit_request, which all route
+  // through isValidDepositSignature() — the single-deposit path that parses with validation.
+  // verifyDepositSignatures() is a separate batch helper (used by the pre-Gloas scanner) that
+  // parses without validation, so the spec tests never reach it. Cover it here.
+  const keyValidatePubkeys = {
+    "outside the prime-order subgroup": "0x80" + "00".repeat(46) + "04",
+    "the point at infinity": "0xc0" + "00".repeat(47),
+    "not on the curve": "0x80" + "00".repeat(46) + "01",
+    "failing G1 decompression": "0xc010" + "00".repeat(46),
+  };
+
+  for (const [what, pubkey] of Object.entries(keyValidatePubkeys)) {
+    it(`marks a pubkey ${what} invalid without affecting valid deposits`, () => {
+      const [a, b] = generateBuilderPendingDeposits(config, 2, 4000);
+      const malformed: electra.PendingDeposit = {...b, pubkey: fromHex(pubkey)};
+      expect(verifyDepositSignatures(config, [a, malformed])).toEqual([true, false]);
+    });
+  }
+
+  it("marks the infinity pubkey invalid even paired with the infinity signature", () => {
+    // The degenerate pair a naive implementation can accept against any message.
+    const [a, b] = generateBuilderPendingDeposits(config, 2, 5000);
+    const malformed: electra.PendingDeposit = {
+      ...b,
+      pubkey: fromHex("0xc0" + "00".repeat(47)),
+      signature: fromHex("0xc0" + "00".repeat(95)),
+    };
+    expect(verifyDepositSignatures(config, [a, malformed])).toEqual([true, false]);
   });
 
   it("marks a malformed signature invalid without affecting valid deposits", () => {

--- a/packages/state-transition/test/unit/block/processDeposit.test.ts
+++ b/packages/state-transition/test/unit/block/processDeposit.test.ts
@@ -33,9 +33,12 @@ describe("verifyDepositSignatures", () => {
   // asserted here is the batch one: a malformed entry fails on its own and leaves its neighbours'
   // results intact, rather than invalidating the whole chunk.
   //
-  // These do not prove KeyValidate is applied. blst rejects infinity and non-subgroup pubkeys
-  // whether or not the validation flags are passed, and each case also carries a signature over a
-  // different DepositMessage, so it would fail for any substituted pubkey.
+  // Note what these four do and don't isolate: each carries a signature over a different
+  // DepositMessage (the pubkey is part of the signed message), so it would fail for any substituted
+  // pubkey, malformed or not. Only the not-on-curve and failed-decompression vectors are rejected by
+  // deserialization itself; subgroup and infinity are accepted by PublicKey.fromBytes() unless it is
+  // asked to validate. The deposit path doesn't call that API directly — it hands raw bytes to
+  // verifySignatureSets() — so the case that actually pins infinity checking is the one below.
   const keyValidatePubkeys = {
     "outside the prime-order subgroup": "0x80" + "00".repeat(46) + "04",
     "the point at infinity": "0xc0" + "00".repeat(47),

--- a/packages/state-transition/test/unit/block/processDeposit.test.ts
+++ b/packages/state-transition/test/unit/block/processDeposit.test.ts
@@ -42,7 +42,7 @@ describe("verifyDepositSignatures", () => {
     it(`marks a pubkey ${what} invalid without affecting valid deposits`, () => {
       const [a, b] = generateBuilderPendingDeposits(config, 2, 4000);
       const malformed: electra.PendingDeposit = {...b, pubkey: fromHex(pubkey)};
-      expect(verifyDepositSignatures(config, [a, malformed])).toEqual([true, false]);
+      expect(verifyDepositSignatures(config, [a, malformed]), `pubkey ${what}`).toEqual([true, false]);
     });
   }
 

--- a/packages/state-transition/test/unit/block/processDeposit.test.ts
+++ b/packages/state-transition/test/unit/block/processDeposit.test.ts
@@ -26,11 +26,16 @@ describe("verifyDepositSignatures", () => {
     expect(verifyDepositSignatures(config, [a, invalidB, c])).toEqual([true, false, true]);
   });
 
-  // BLS KeyValidate edge cases from consensus-specs#5541. Those spec tests exercise
-  // process_deposit / apply_pending_deposit / process_builder_deposit_request, which all route
-  // through isValidDepositSignature() — the single-deposit path that parses with validation.
-  // verifyDepositSignatures() is a separate batch helper (used by the pre-Gloas scanner) that
-  // parses without validation, so the spec tests never reach it. Cover it here.
+  // Malformed pubkeys from consensus-specs#5541. Those spec tests exercise process_deposit /
+  // apply_pending_deposit / process_builder_deposit_request, which all route through
+  // isValidDepositSignature() — the single-deposit path. verifyDepositSignatures() is a separate
+  // batch helper (used by the pre-Gloas scanner) that the spec tests never reach, so the property
+  // asserted here is the batch one: a malformed entry fails on its own and leaves its neighbours'
+  // results intact, rather than invalidating the whole chunk.
+  //
+  // These do not prove KeyValidate is applied. blst rejects infinity and non-subgroup pubkeys
+  // whether or not the validation flags are passed, and each case also carries a signature over a
+  // different DepositMessage, so it would fail for any substituted pubkey.
   const keyValidatePubkeys = {
     "outside the prime-order subgroup": "0x80" + "00".repeat(46) + "04",
     "the point at infinity": "0xc0" + "00".repeat(47),


### PR DESCRIPTION
**Motivation**

`verifyDepositSignatures()` is a batch helper used by the pre-Gloas scanner to warm the
deposit signature cache. Nothing in the spec vectors reaches it: consensus-specs#5541's
malformed-pubkey cases drive `process_deposit`, `apply_pending_deposit` and
`process_builder_deposit_request`, which all route through `isValidDepositSignature()` —
the single-deposit path.

The batch path has a failure mode the single-deposit path doesn't. When the aggregate
verify fails it falls back to checking entries individually, so one malformed entry must
fail on its own without taking its neighbours down with it. Its existing tests cover a
valid batch, a wrong-message signature and a malformed *signature* — none covers a
malformed *pubkey*, which is the input that makes parsing itself fail.

**Description**

- add the four #5541 pubkeys, each batched with a valid deposit, asserting the malformed
  one is `false` and the neighbour still verifies
- add the infinity pubkey paired with the infinity signature, the degenerate pair a naive
  implementation can accept against any message

Test-only, no behaviour change.

To be explicit about what these do *not* do: the four table cases don't isolate key
validation. The pubkey is part of the signed `DepositMessage`, so each carries a signature
over a different message and would fail for any substituted pubkey, malformed or not.
Constructing a vector that verifies only when subgroup validation is skipped would need a
signature under a small-subgroup point. The property they pin is the batch-isolation one
above.

The infinity pair is the exception and is worth keeping on those grounds: infinity pubkey
with infinity signature satisfies the pairing equation for *any* message, so an
implementation that skips the infinity check accepts it. That one fails for the right
reason.

For the record, since deserialization behaviour is easy to assume: only not-on-curve and
failed-decompression are rejected unconditionally. `PublicKey.fromBytes()` accepts
subgroup and infinity keys unless asked to validate —

```
vector            pkValidate=true   pkValidate=false   (omitted)
subgroup          rejected          ACCEPTED           ACCEPTED
infinity          rejected          ACCEPTED           ACCEPTED
not-on-curve      rejected          rejected           rejected
bad-decompress    rejected          rejected           rejected
```

— identical under `@chainsafe/blst@2.2.0` and the `@chainsafe/lodestar-z@1.0.0` binding
that replaced it in #8900, so the swap didn't move this. The deposit path doesn't call
that API anyway; it hands raw bytes to `verifySignatureSets()`, which rejects all four.