### PR TITLE
docs: correct pre-verify scanner capacity with measured throughput

### DIFF
--- a/packages/state-transition/src/util/preVerifyBuilderDeposits.ts
+++ b/packages/state-transition/src/util/preVerifyBuilderDeposits.ts
@@ -10,8 +10,15 @@ export const BUILDER_DEPOSIT_BATCH_SIZE = 32;
 
 /**
  * Per-tick cap on builder deposits the prepareForNextSlot scanner will verify.
- * ~2.7s for 10_000 BLS verifications on a typical server — fits within the slot budget while the
- * pre-window (see GLOAS_PREVERIFY_WINDOW_EPOCHS) covers up to ~620k deposits over its duration.
+ *
+ * Note this cap is not what actually bounds a tick: the caller also passes a duration budget of
+ * BUILDER_PREVERIFY_LIMIT_BPS (20% of a slot, ~2.4s at 12s slots), and 10_000 verifications do not
+ * fit in it. Measured at the glamsterdam-devnet-8 gloas fork, the scanner cleared 16_306 deposits
+ * in 12.43s across 62 ticks — ~1_300/s, so ~3_000 per tick and on the order of 200k over the
+ * GLOAS_PREVERIFY_WINDOW_EPOCHS window, not the ~620k this count implies.
+ *
+ * Anything not cached in time is verified inline during the fork transition, so treat ~200k as the
+ * practical ceiling until the budget is raised.
  */
 export const MAX_BUILDER_DEPOSITS_PER_SLOT = 10_000;
 


### PR DESCRIPTION
**Motivation**

`MAX_BUILDER_DEPOSITS_PER_SLOT` documents the scanner as covering "~620k deposits" over
the pre-fork window. That is `10_000 x ~62 ticks`, i.e. the count cap — but the count cap
is not what bounds a tick. `prepareNextSlot` also passes a duration budget of
`BUILDER_PREVERIFY_LIMIT_BPS` (20% of a slot, ~2.4s at 12s slots), and by the comment's own
figure 10_000 verifications take ~2.7s, so a tick runs out of time before it runs out of
count.

Measured at the glamsterdam-devnet-8 gloas fork:

```
lodestar_builder_deposit_preverify_cached_deposits       16306
lodestar_builder_deposit_preverify_duration_seconds_sum  12.43   (62 ticks)
```

~1_300 verifications/s, so ~3_000 per tick and on the order of 200k over the window —
roughly 3x below the documented figure. The queue that day was 16_306 and warmed
comfortably (`signature_checks{source="verified"} = 0` at the transition), but scenarios
being discussed for these devnets go to 262_144, which sits above the real ceiling while
appearing well inside the documented one. Anything not cached in time is verified inline
during the fork transition.

**Description**

- correct the comment to state the duration budget as the binding constraint, with the
  measured throughput and the resulting ~200k practical ceiling

Comment only, no behaviour change. Raising the ceiling is a separate judgement about how
much slot time to spend pre-verifying — either widening `GLOAS_PREVERIFY_WINDOW_EPOCHS` or
`BUILDER_PREVERIFY_LIMIT_BPS` — so I have left the constants alone rather than pick a
number here.

Context: https://gist.github.com/nflaig/c02c00714d07df076bed23200805d2d6