### PR TITLE
test: align benchmark pubkeys with lodestar-z global pubkey cache

### DIFF
--- a/packages/state-transition/test/perf/block/util.ts
+++ b/packages/state-transition/test/perf/block/util.ts
@@ -1,4 +1,3 @@
-import {SecretKey} from "@chainsafe/lodestar-z/blst";
 import {Tree, toGindex} from "@chainsafe/persistent-merkle-tree";
 import {BitArray} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
@@ -14,6 +13,7 @@ import {
   getBlockRoot,
   getBlockRootAtSlot,
 } from "../../../src/index.js";
+import {interopSecretKey} from "../../../src/util/interop.js";
 
 export type BlockOpts = {
   proposerSlashingLen: number;
@@ -211,7 +211,8 @@ function getDeposits(preState: CachedBeaconStateAllForks, count: number): phase0
   depositRootViewDU["dirtyLength"] = true;
 
   for (let i = 0; i < count; i++) {
-    const sk = SecretKey.fromBytes(Buffer.alloc(32, i + 1));
+    // Keep synthetic deposits aligned with their future validator index in the global pubkey cache.
+    const sk = interopSecretKey(depositCount + i);
     const pubkey = sk.toPublicKey().toBytes();
     const depositMessage: phase0.DepositMessage = {pubkey, withdrawalCredentials, amount: 32e9};
     // Sign with disposable keys

--- a/packages/state-transition/test/perf/util/loadState/loadState.test.ts
+++ b/packages/state-transition/test/perf/util/loadState/loadState.test.ts
@@ -1,7 +1,7 @@
 import {bench, describe} from "@chainsafe/benchmark";
 import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {createCachedBeaconState} from "../../../../src/cache/stateCache.js";
-import {generatePerfTestCachedStateAltair, getPubkeys} from "../../../../src/testUtils/util.js";
+import {generatePerfTestCachedStateAltair} from "../../../../src/testUtils/util.js";
 import {loadState} from "../../../../src/util/loadState/loadState.js";
 
 /**
@@ -20,7 +20,12 @@ describe("loadState", () => {
       id: `migrate state ${seedValidators} validators, ${numModifiedValidators} modified, ${numNewValidators} new`,
       before: () => {
         const seedState = generatePerfTestCachedStateAltair({vc: seedValidators, goBackOneSlot: false});
-        const {pubkeys} = getPubkeys(seedValidators + numNewValidators);
+        // Only read the appended keys directly from the pubkey cache. Requesting the full
+        // `seedValidators + numNewValidators` set would materialize a second ~seedValidators-sized
+        // array (the seed set is already cached at `seedValidators`) and spike peak memory.
+        const newPubkeys = Array.from({length: numNewValidators}, (_, i) =>
+          pubkeyCache.getPubkeyBytesOrThrow(seedValidators + i)
+        );
         // cache all HashObjects
         seedState.hashTreeRoot();
         const newState = seedState.clone();
@@ -34,7 +39,7 @@ describe("loadState", () => {
         for (let i = 0; i < numNewValidators; i++) {
           // New validators must have distinct pubkeys for lodestar-z's process-wide pubkey cache.
           const validator = seedState.validators.get(0).clone();
-          validator.pubkey = pubkeys[seedValidators + i];
+          validator.pubkey = newPubkeys[i];
           newState.validators.push(validator);
           newState.inactivityScores.push(seedState.inactivityScores.get(0));
           newState.balances.push(seedState.balances.get(0));

--- a/packages/state-transition/test/perf/util/loadState/loadState.test.ts
+++ b/packages/state-transition/test/perf/util/loadState/loadState.test.ts
@@ -1,7 +1,7 @@
 import {bench, describe} from "@chainsafe/benchmark";
 import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {createCachedBeaconState} from "../../../../src/cache/stateCache.js";
-import {generatePerfTestCachedStateAltair} from "../../../../src/testUtils/util.js";
+import {generatePerfTestCachedStateAltair, getPubkeys} from "../../../../src/testUtils/util.js";
 import {loadState} from "../../../../src/util/loadState/loadState.js";
 
 /**
@@ -20,6 +20,7 @@ describe("loadState", () => {
       id: `migrate state ${seedValidators} validators, ${numModifiedValidators} modified, ${numNewValidators} new`,
       before: () => {
         const seedState = generatePerfTestCachedStateAltair({vc: seedValidators, goBackOneSlot: false});
+        const {pubkeys} = getPubkeys(seedValidators + numNewValidators);
         // cache all HashObjects
         seedState.hashTreeRoot();
         const newState = seedState.clone();
@@ -31,7 +32,10 @@ describe("loadState", () => {
         }
 
         for (let i = 0; i < numNewValidators; i++) {
-          newState.validators.push(seedState.validators.get(0).clone());
+          // New validators must have distinct pubkeys for lodestar-z's process-wide pubkey cache.
+          const validator = seedState.validators.get(0).clone();
+          validator.pubkey = pubkeys[seedValidators + i];
+          newState.validators.push(validator);
           newState.inactivityScores.push(seedState.inactivityScores.get(0));
           newState.balances.push(seedState.balances.get(0));
         }


### PR DESCRIPTION
## Motivation

After the `blst-z` merge (unstable `931ecbec`), `@chainsafe/lodestar-z` uses a **process-wide** pubkey cache. Three perf benchmarks in the [failing CI job](https://github.com/ChainSafe/lodestar/actions/runs/32494170992) crash against it:

- **processBlock worstcase deposits** -> `ConflictingPubkey`
- **loadState migrate (new validators)** -> `DuplicatePubkey`

## Description

Test-only changes; no production cache behavior is affected.

**`test/perf/block/util.ts` - `getDeposits()`**
Old code minted deposit pubkeys from arbitrary bytes (`SecretKey.fromBytes(Buffer.alloc(32, i + 1))`). Those don't match the interop pubkey the global cache expects at the deposit's future validator index (`depositCount + i`), so the cache throws `ConflictingPubkey`. Switched to `interopSecretKey(depositCount + i)` so each synthetic deposit registers the correct pubkey at its own index. `depositCount === validators.length` by construction (both derive from `pubkeys.length` in `buildPerformanceState*`), so the new indices never overlap existing validators.

**`test/perf/util/loadState/loadState.test.ts`**
Synthetic new validators were clones of validator `0`, so they all shared one pubkey -> `DuplicatePubkey`. Assign each appended validator the distinct interop pubkey for index `seedValidators + i`. The code reads only the appended keys directly from `pubkeyCache.getPubkeyBytesOrThrow(...)`, avoiding a second full `seedValidators + numNewValidators` array for the 1.5M-validator benchmark case.

## Verification

Local run of the three previously-failing targets plus `pnpm lint`, `pnpm check-types`, `pnpm build` - all pass. GitHub CI is running on the follow-up commit.

🤖 Generated with AI assistance