### PR TITLE
refactor: assert BeaconEvent type in eventstream handler

### DIFF
--- a/packages/beacon-node/src/api/impl/events/index.ts
+++ b/packages/beacon-node/src/api/impl/events/index.ts
@@ -14,6 +14,8 @@ export function getEventsApi({
         // biome-ignore lint/suspicious/noExplicitAny: We need to use `any` type here
         const handler = (data: any): void => {
           try {
+            // TS only relates `{type, message}` to the `BeaconEvent` discriminated union while
+            // `EventType` stays within its ~25-member cap; without the cast, adding events trips TS2345.
             onEvent({type: topic, message: data} as routes.events.BeaconEvent);
           } catch (e) {
             // `chain.emitter` emits synchronously, a throwing listener would propagate the error to

--- a/packages/beacon-node/src/api/impl/events/index.ts
+++ b/packages/beacon-node/src/api/impl/events/index.ts
@@ -14,7 +14,7 @@ export function getEventsApi({
         // biome-ignore lint/suspicious/noExplicitAny: We need to use `any` type here
         const handler = (data: any): void => {
           try {
-            onEvent({type: topic, message: data});
+            onEvent({type: topic, message: data} as routes.events.BeaconEvent);
           } catch (e) {
             // `chain.emitter` emits synchronously, a throwing listener would propagate the error to
             // whoever emitted the event, e.g. a gossip handler, and skip the remaining listeners.


### PR DESCRIPTION
## Motivation

Split out from the block / builder event PRs (#9854, #9875, #9876) as a standalone change, as suggested by @markolazic01.

The `eventstream` handler in `getEventsApi` forwards every emitter event through a single `onEvent({type: topic, message: data})` call, where `topic` is the full `EventType` union and `data` (and therefore `message`) is `any`. That object literal only type-checks via TypeScript's discriminated-union distribution path (`typeRelatedToDiscriminatedType`), which bails out once the number of source discriminant combinations exceeds 25.

`EventType` currently has exactly **25** members, so it compiles today. Adding a **26th** event tips it over the cap and fails with:

```
TS2345: Argument of type '{ type: EventType; message: any; }' is not assignable to parameter of type 'BeaconEvent'.
  Types of property 'type' are incompatible.
    Type 'EventType' is not assignable to type 'EventType.<lastMember>'.
```

which is why each new-event PR currently has to add this cast. Landing it once here unblocks those PRs without each carrying the change.

## Description

Assert `routes.events.BeaconEvent` at the `onEvent` call. The cast only makes explicit the type erasure that already exists at this `chain.emitter` boundary — `message` is `any`, so the topic/message pairing was never verified by the compiler regardless. The only cast-free alternative would be to construct the event per-topic instead of funneling every topic through one union-typed `onEvent({type, message})` call, which is a larger refactor not worth it here.

**No runtime or current-compile behavior change** on `unstable` (25 `EventType` members).

---
🤖 Generated with AI assistance
