### PR TITLE
feat: add `blockV2` event with new `builderIndex` and `blockHash` fields

### DIFF
--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -94,6 +94,11 @@ export enum EventType {
   headV2 = "head_v2",
   /** The node has received a block (from P2P or API) that is successfully imported on the fork-choice `on_block` handler */
   block = "block",
+  /**
+   * The node has received a gloas block (from P2P or API) that is successfully imported on the fork-choice `on_block` handler
+   * and includes signed execution payload
+   */
+  blockV2 = "block_v2",
   /** The node has received a block (from P2P or API) that passes validation rules of the `beacon_block` topic */
   blockGossip = "block_gossip",
   /** The node has received a valid attestation (from P2P or API) */
@@ -144,6 +149,7 @@ export const eventTypes: {[K in EventType]: K} = {
   [EventType.head]: EventType.head,
   [EventType.headV2]: EventType.headV2,
   [EventType.block]: EventType.block,
+  [EventType.blockV2]: EventType.blockV2,
   [EventType.blockGossip]: EventType.blockGossip,
   [EventType.attestation]: EventType.attestation,
   [EventType.singleAttestation]: EventType.singleAttestation,
@@ -185,6 +191,13 @@ export type EventData = {
   [EventType.block]: {
     slot: Slot;
     block: RootHex;
+    executionOptimistic: boolean;
+  };
+  [EventType.blockV2]: {
+    slot: Slot;
+    block: RootHex;
+    blockHash: RootHex;
+    builderIndex: BuilderIndex;
     executionOptimistic: boolean;
   };
   [EventType.blockGossip]: {
@@ -334,6 +347,16 @@ export function getTypeByEvent(config: ChainForkConfig): {[K in EventType]: Type
       {
         slot: ssz.Slot,
         block: stringType,
+        executionOptimistic: ssz.Boolean,
+      },
+      {jsonCase: "eth2"}
+    ),
+    [EventType.blockV2]: new ContainerType(
+      {
+        slot: ssz.Slot,
+        block: stringType,
+        blockHash: stringType,
+        builderIndex: ssz.BuilderIndex,
         executionOptimistic: ssz.Boolean,
       },
       {jsonCase: "eth2"}

--- a/packages/api/test/unit/beacon/testData/events.ts
+++ b/packages/api/test/unit/beacon/testData/events.ts
@@ -48,6 +48,13 @@ export const eventTestData: EventData = {
     block: "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf",
     executionOptimistic: false,
   },
+  [EventType.blockV2]: {
+    slot: 10,
+    block: "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf",
+    builderIndex: 42,
+    blockHash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    executionOptimistic: false,
+  },
   [EventType.blockGossip]: {
     slot: 10,
     block: "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf",

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -535,6 +535,15 @@ export async function importBlock(
           executionOptimistic: blockSummary != null && isOptimisticBlock(blockSummary),
         });
       }
+      if (this.emitter.listenerCount(routes.events.EventType.blockV2) && isGloasBeaconBlock(block.message)) {
+        this.emitter.emit(routes.events.EventType.blockV2, {
+          block: blockRootHex,
+          slot: blockSlot,
+          blockHash: toRootHex(block.message.body.signedExecutionPayloadBid.message.blockHash),
+          builderIndex: block.message.body.signedExecutionPayloadBid.message.builderIndex,
+          executionOptimistic: blockSummary != null && isOptimisticBlock(blockSummary),
+        });
+      }
       if (this.emitter.listenerCount(routes.events.EventType.voluntaryExit)) {
         for (const voluntaryExit of block.message.body.voluntaryExits) {
           this.emitter.emit(routes.events.EventType.voluntaryExit, voluntaryExit);


### PR DESCRIPTION
**Motivation**

Introduce a new `block_v2` event that has new fields `blockHash` and `builderIndex`, emits on Gloas block import.

**Description**
Fourth solution type, next to https://github.com/ChainSafe/lodestar/pull/9876, https://github.com/ChainSafe/lodestar/pull/9875 and https://github.com/ChainSafe/lodestar/pull/9854.
This time 2 new fields (`blockHash` and `builderIndex`) in a new event (`block_v2`).