### PR TITLE
test(perf): populate appended load-state pubkeys

### DIFF
--- a/packages/state-transition/test/perf/util/loadState/loadState.test.ts
+++ b/packages/state-transition/test/perf/util/loadState/loadState.test.ts
@@ -1,6 +1,7 @@
 import {bench, describe} from "@chainsafe/benchmark";
 import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {createCachedBeaconState} from "../../../../src/cache/stateCache.js";
+import {ensureInteropPubkeyCache} from "../../../../src/testUtils/interopPubkeyCache.js";
 import {generatePerfTestCachedStateAltair} from "../../../../src/testUtils/util.js";
 import {loadState} from "../../../../src/util/loadState/loadState.js";
 
@@ -20,6 +21,7 @@ describe("loadState", () => {
       id: `migrate state ${seedValidators} validators, ${numModifiedValidators} modified, ${numNewValidators} new`,
       before: () => {
         const seedState = generatePerfTestCachedStateAltair({vc: seedValidators, goBackOneSlot: false});
+        ensureInteropPubkeyCache(seedValidators + numNewValidators);
         // Only read the appended keys directly from the pubkey cache. Requesting the full
         // `seedValidators + numNewValidators` set would materialize a second ~seedValidators-sized
         // array (the seed set is already cached at `seedValidators`) and spike peak memory.


### PR DESCRIPTION
## Summary

The follow-up unstable benchmark run after #9893 still failed in `loadState.test.ts` with `pubkeyCache: index 1500000 not found`. The benchmark read the 2,000 synthetic new-validator pubkeys before anything had populated those cache indices.

Extend the interop pubkey cache through `seedValidators + numNewValidators` before reading that appended range. This preserves #9893's bounded 2,000-entry array rather than materializing another 1.5M-entry array.

Locally, the exact failing benchmark changed from 0 passing / 1 failed to 1 passing / 0 failed. The combined three-file reproduction from the original incident now reports 7 passing / 0 failed. Biome and the state-transition build also pass.