### PR TITLE
ci: cache perf-state interop pubkeys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: packages/state-transition/test-cache/interop-pubkeys.pkix
-          key: interop-pubkeys-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'packages/state-transition/src/testUtils/interopPubkeyCache.ts') }}
+          key: interop-pubkeys-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'packages/state-transition/src/testUtils/interopPubkeyCache.ts', 'packages/state-transition/src/testUtils/util.ts', 'packages/state-transition/src/util/interop.ts') }}
           restore-keys: |
             interop-pubkeys-${{ runner.os }}-
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,15 @@ jobs:
         with:
           node: ${{ matrix.node }}
 
+      - name: Restore interop pubkey cache
+        id: interop-pubkey-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: packages/state-transition/test-cache/interop-pubkeys.pkix
+          key: interop-pubkeys-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'packages/state-transition/src/testUtils/interopPubkeyCache.ts') }}
+          restore-keys: |
+            interop-pubkeys-${{ runner.os }}-
+
       # Cache validator slashing protection data tests
       - name: Restore spec tests cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -111,6 +120,13 @@ jobs:
         # Rever to "pnpm test:unit" when finished debugging core dumps
         # run: sudo sh -c "ulimit -c unlimited && /usr/bin/node-with-debug $(which pnpm) test:unit"
         run: pnpm vitest run --project unit --project unit-minimal --coverage
+
+      - name: Save interop pubkey cache
+        if: ${{ always() && steps.interop-pubkey-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: packages/state-transition/test-cache/interop-pubkeys.pkix
+          key: ${{ steps.interop-pubkey-cache.outputs.cache-primary-key }}
 
       # # Remove when finished debugging core dumps
       # - uses: './.github/actions/core-dump'

--- a/packages/state-transition/test/unit/sanityCheck.test.ts
+++ b/packages/state-transition/test/unit/sanityCheck.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../../src/testUtils/util.js";
 
 describe("Perf test sanity check", () => {
-  vi.setConfig({testTimeout: 90 * 1000});
+  vi.setConfig({testTimeout: 120 * 1000});
 
   if (ACTIVE_PRESET !== PresetName.mainnet) {
     throw Error(`ACTIVE_PRESET '${ACTIVE_PRESET}' must be mainnet`);


### PR DESCRIPTION
## Summary

Keep the canonical 250,000-validator perf fixture, but avoid deriving the same unique interop pubkeys from scratch on every CI run.

- restore/save the validated PKIX snapshot around the unit-test job
- key snapshots by OS, dependency lockfile, and snapshot helper implementation
- retain an OS-prefix fallback; the loader rejects stale ABI or non-interop contents and regenerates safely
- raise the file-local timeout from 90 to 120 seconds for cold-cache and runner-pressure headroom

The current 90-second timeout is marginal after #8900 switched the fixture to unique native-cache interop pubkeys:

- #9905 attempt 1: 92.953s, timed out
- attempt 2: 91.829s, timed out
- attempt 3: 85.155s, passed unchanged
- the same timeout occurred on at least six unrelated PR runs after #8900

A local coverage run measured the phase0 test at 75.722s with no snapshot and 46.903s with the snapshot, a 38.1% reduction. The linked #9905 run passed unchanged on its third attempt, so this is not attributed to that PR.