### PR TITLE
perf(state-transition): batch inactivity score updates

### DIFF
--- a/packages/state-transition/src/epoch/processInactivityUpdates.ts
+++ b/packages/state-transition/src/epoch/processInactivityUpdates.ts
@@ -37,6 +37,7 @@ export function processInactivityUpdates(state: CachedBeaconStateAltair, cache: 
 
   inactivityScoresArr.length = state.validators.length;
   inactivityScores.getAll(inactivityScoresArr);
+  let shouldSetInactivityScores = false;
 
   for (let i = 0; i < flags.length; i++) {
     const flag = flags[i];
@@ -53,8 +54,14 @@ export function processInactivityUpdates(state: CachedBeaconStateAltair, cache: 
         inactivityScore -= Math.min(INACTIVITY_SCORE_RECOVERY_RATE, inactivityScore);
       }
       if (inactivityScore !== prevInactivityScore) {
-        inactivityScores.set(i, inactivityScore);
+        inactivityScoresArr[i] = inactivityScore;
+        shouldSetInactivityScores = true;
       }
     }
+  }
+
+  if (shouldSetInactivityScores) {
+    // Rebuilding the full view is slightly slower than individual sets only when very few scores change.
+    state.inactivityScores = state.type.fields.inactivityScores.toViewDU(inactivityScoresArr);
   }
 }

--- a/packages/state-transition/test/perf/epoch/processInactivityUpdates.test.ts
+++ b/packages/state-transition/test/perf/epoch/processInactivityUpdates.test.ts
@@ -1,54 +1,40 @@
 import {bench, describe} from "@chainsafe/benchmark";
+import {getConfig} from "@lodestar/config/test-utils";
+import {ForkName, MIN_EPOCHS_TO_INACTIVITY_PENALTY} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
 import {processInactivityUpdates} from "../../../src/epoch/processInactivityUpdates.js";
-import {generatePerfTestCachedStateAltair, numValidators} from "../../../src/testUtils/util.js";
-import {StateAltairEpoch} from "../types.js";
-import {mutateInactivityScores} from "./util.js";
-import {FlagFactors, generateBalanceDeltasEpochTransitionCache} from "./utilPhase0.js";
+import {upgradeStateToFulu} from "../../../src/slot/upgradeStateToFulu.js";
+import {upgradeStateToGloas} from "../../../src/slot/upgradeStateToGloas.js";
+import {createCachedBeaconStateTest} from "../../../src/testUtils/state.js";
+import {generatePerfTestCachedStateElectra, numValidators} from "../../../src/testUtils/util.js";
+import {CachedBeaconStateAltair} from "../../../src/types.js";
+import {FLAG_ELIGIBLE_ATTESTER, FLAG_UNSLASHED} from "../../../src/util/attesterStatus.js";
+import {StateEpoch} from "../types.js";
+import {generateBalanceDeltasEpochTransitionCache} from "./utilPhase0.js";
 
-// PERF: Cost = iterate over an array of size $VALIDATOR_COUNT + 'proportional' to how many validtors are inactive or
-// have been inactive in the past, i.e. that require an update to their inactivityScore. Worst case = all validators
-// need to update their non-zero `inactivityScore`.
-//
-// On normal mainnet conditions
-//   - prevTargetAttester: 96%
-//   - unslashed:          100%
-//   - eligibleAttester:   98%
-//  TODO: Compute from altair testnet inactivityScores updates on average
-//
-// On worst case:
-//   - status = 0xff
-//   - all inactivityScores > 0
-
-describe("altair processInactivityUpdates", () => {
+describe("gloas processInactivityUpdates", () => {
   const vc = numValidators;
+  const eligibleMissedTargetFlags = FLAG_ELIGIBLE_ATTESTER | FLAG_UNSLASHED;
 
-  const testCases: {id: string; isInInactivityLeak: boolean; flagFactors: FlagFactors; factorWithPositive: number}[] = [
-    {
-      id: "normalcase",
-      isInInactivityLeak: false,
-      flagFactors: 0xff,
-      factorWithPositive: 0.04,
+  bench<StateEpoch, StateEpoch>({
+    id: `gloas processInactivityUpdates - ${vc} inactivity leak all eligible missed target`,
+    yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
+    before: () => {
+      const upgraded = upgradeStateToGloas(
+        upgradeStateToFulu(generatePerfTestCachedStateElectra({goBackOneSlot: true}))
+      );
+      upgraded.commit();
+      const state = createCachedBeaconStateTest(
+        ssz.gloas.BeaconState.getViewDU(upgraded.node),
+        getConfig(ForkName.gloas),
+        {skipSyncPubkeys: true}
+      );
+      state.finalizedCheckpoint.epoch = state.epochCtx.epoch - MIN_EPOCHS_TO_INACTIVITY_PENALTY - 2;
+      state.commit();
+      const cache = generateBalanceDeltasEpochTransitionCache(state, true, eligibleMissedTargetFlags);
+      return {state, cache};
     },
-    {
-      id: "worstcase",
-      isInInactivityLeak: true,
-      flagFactors: 0xff,
-      factorWithPositive: 0.04,
-    },
-  ];
-
-  for (const {id, isInInactivityLeak, flagFactors, factorWithPositive} of testCases) {
-    bench<StateAltairEpoch, StateAltairEpoch>({
-      id: `altair processInactivityUpdates - ${vc} ${id}`,
-      yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
-      before: () => {
-        const state = generatePerfTestCachedStateAltair({goBackOneSlot: true});
-        const cache = generateBalanceDeltasEpochTransitionCache(state, isInInactivityLeak, flagFactors);
-        mutateInactivityScores(state, factorWithPositive);
-        return {state, cache};
-      },
-      beforeEach: ({state, cache}) => ({state: state.clone(), cache}),
-      fn: ({state, cache}) => processInactivityUpdates(state, cache),
-    });
-  }
+    beforeEach: ({state, cache}) => ({state: state.clone(), cache}),
+    fn: ({state, cache}) => processInactivityUpdates(state as CachedBeaconStateAltair, cache),
+  });
 });

--- a/packages/state-transition/test/perf/epoch/utilPhase0.ts
+++ b/packages/state-transition/test/perf/epoch/utilPhase0.ts
@@ -1,5 +1,5 @@
 import {AttesterFlags, toAttesterFlags} from "../../../src/index.js";
-import {CachedBeaconStateAltair, CachedBeaconStatePhase0, EpochTransitionCache} from "../../../src/types.js";
+import {CachedBeaconStateAllForks, EpochTransitionCache} from "../../../src/types.js";
 
 /**
  * Generate an incomplete EpochTransitionCache to simulate any network condition relevant to getAttestationDeltas
@@ -7,7 +7,7 @@ import {CachedBeaconStateAltair, CachedBeaconStatePhase0, EpochTransitionCache} 
  * @param flagFactors factor (0,1) of validators that have that flag set to true
  */
 export function generateBalanceDeltasEpochTransitionCache(
-  state: CachedBeaconStatePhase0 | CachedBeaconStateAltair,
+  state: CachedBeaconStateAllForks,
   isInInactivityLeak: boolean,
   flagFactors: FlagFactors
 ): EpochTransitionCache {


### PR DESCRIPTION
## Motivation

`processInactivityUpdates()` may update many validator scores in the same epoch. Updating the Gloas progressive list one index at a time repeatedly rebuilds tree paths and caused the epoch-transition slowdown reported in #9865.

## Description

- Reuse the materialized inactivity score array and publish it as one SSZ view when any score changes.
- Keep the zero-change path from rebuilding the state field.
- Replace the legacy Altair benchmark cases with one Gloas inactivity-leak benchmark whose runtime type, config, epoch context, and cache input are all Gloas.

Closes #9865.
