### PR TITLE
feat: prepare for epoch boundary reorg

### DIFF
--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -151,23 +151,38 @@ export class PrepareNextSlotScheduler {
         const proposerIndex = await getProposerIndex();
         feeRecipient = this.chain.beaconProposerCache.get(proposerIndex);
 
-        if (feeRecipient) {
-          // If we are proposing next slot, we need to predict if we can proposer-boost-reorg or not
+        // Predict the proposer head of the next slot when either:
+        //  - we are proposing the next slot (single-slot proposer-boost-reorg), or
+        //  - this is an epoch transition: post-Fulu the next proposer may reorg a weak
+        //    last-block-of-epoch and build slot 0 on the strong parent (epoch-boundary reorg),
+        //    so we should dial the strong parent through the boundary instead of the weak head.
+        if (feeRecipient || isEpochTransition) {
           const proposerHead = this.chain.predictProposerHead(clockSlot);
           const {slot: proposerHeadSlot, blockRoot: proposerHeadRoot} = proposerHead;
 
-          // If we predict we can reorg, we build on the proposer head (parent) block instead
+          // If we predict a reorg, we build the epoch transition on the proposer head (parent) instead
           if (proposerHeadRoot !== headRoot || proposerHeadSlot !== headSlot) {
-            this.logger.verbose("Weak head detected. May build on parent block instead", {
+            // feeRecipient set => WE propose the next slot and may reorg it out ourselves;
+            // otherwise it's a predicted reorg by another proposer (epoch-boundary reorg).
+            const logMessage = feeRecipient
+              ? "Weak head detected. We may build on parent block instead"
+              : "Weak head detected. Another proposer may build on parent block instead";
+            this.logger.verbose(logMessage, {
               proposerHeadSlot,
               proposerHeadRoot,
               headSlot,
               headRoot,
+              isEpochTransition,
             });
             this.metrics?.weakHeadDetected.inc();
+            if (isEpochTransition) {
+              this.metrics?.precomputeNextEpochTransition.predictedReorg.inc();
+            }
             updatedHead = proposerHead;
           }
+        }
 
+        if (feeRecipient) {
           if (isForkPostGloas(fork)) {
             this.chain.builderCircuitBreaker.update(clockSlot, updatedHead);
           } else {
@@ -182,6 +197,7 @@ export class PrepareNextSlotScheduler {
         }
 
         // post-fulu we'll always reach here because preparedState is undefined
+        // we may run epoch transition not with headBlock if it's weak
         if (preparedState === undefined || updatedHead !== headBlock) {
           preparedState = await this.chain.regen.getBlockSlotState(
             updatedHead,
@@ -280,7 +296,7 @@ export class PrepareNextSlotScheduler {
       //  + if next slot is a skipped slot, it'd help getting target checkpoint state faster to validate attestations
       if (isEpochTransition) {
         this.metrics?.precomputeNextEpochTransition.count.inc({result: "success"}, 1);
-        const previousHits = this.chain.regen.updatePreComputedCheckpoint(headRoot, nextEpoch);
+        const previousHits = this.chain.regen.updatePreComputedCheckpoint(updatedHead.blockRoot, nextEpoch);
         if (previousHits === 0) {
           this.metrics?.precomputeNextEpochTransition.waste.inc();
         }
@@ -289,6 +305,8 @@ export class PrepareNextSlotScheduler {
         this.logger.verbose("Completed PrepareNextSlotScheduler epoch transition", {
           nextEpoch,
           headSlot,
+          headRoot,
+          updatedHeadRoot: updatedHead.blockRoot,
           prepareSlot,
           previousHits,
           durationMs: Date.now() - start,

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1776,6 +1776,10 @@ export function createLodestarMetrics(
         name: "lodestar_precompute_next_epoch_transition_waste_total",
         help: "Total number of precomputing next epoch transition wasted",
       }),
+      predictedReorg: register.counter({
+        name: "lodestar_precompute_next_epoch_transition_predicted_reorg_total",
+        help: "Predicted epoch-boundary reorgs where the strong parent was dialed instead of the weak head",
+      }),
       duration: register.histogram({
         name: "lodestar_precompute_next_epoch_transition_duration_seconds",
         help: "Duration of precomputeNextEpochTransition, including epoch transition and hashTreeRoot",


### PR DESCRIPTION
**Motivation**

- starting Jun, we see more epoch transition when processing epoch boundary block, which correlate to lighthouse's release of v8.2.0, where it enabled epoch-boundary reorg by default
- we also did that via #9769, Prysm enabled it but it was not in their release yet

**Description**

- prepare for epoch-boundary reorg if we find weak head at the last slot of an epoch

Closes #9843

**AI Assistance Disclosure**

- created with the help of Claude