### PR TITLE
fix: log local block value in gloas block selection

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -985,7 +985,11 @@ export function getValidatorApi(
           source: ProducedBlockSource.engine,
           reason: EngineBlockSelectionReason.BuilderCensorship,
         });
-        logger.warn("Selected local block: censorship suspected in builder bid", logCtx);
+        logger.warn("Selected local block: censorship suspected in builder bid", {
+          ...logCtx,
+          durationMs: engineResult.durationMs,
+          ...getBlockValueLogInfo(engineResult.value),
+        });
       } else if (engineResult.status === "fulfilled" && bidResult.status === "fulfilled") {
         const result = selectBlockProductionSourceByBoostFactor({
           builderBoostFactor,
@@ -995,7 +999,14 @@ export function getValidatorApi(
         });
         source = result.source;
         metrics?.blockProductionSelectionResults.inc(result);
-        logger.info(`Selected ${source} block`, {reason: result.reason, ...logCtx});
+        logger.info(`Selected ${source} block`, {
+          reason: result.reason,
+          ...logCtx,
+          engineDurationMs: engineResult.durationMs,
+          ...getBlockValueLogInfo(engineResult.value, ProducedBlockSource.engine),
+          builderDurationMs: bidResult.durationMs,
+          ...getBlockValueLogInfo(bidResult.value, ProducedBlockSource.builder),
+        });
         bestResult = source === ProducedBlockSource.builder ? bidResult : engineResult;
       } else if (bidResult.status === "fulfilled") {
         source = ProducedBlockSource.builder;
@@ -1008,6 +1019,8 @@ export function getValidatorApi(
         logger.info("Selected builder bid block: no local block produced", {
           reason,
           ...logCtx,
+          durationMs: bidResult.durationMs,
+          ...getBlockValueLogInfo(bidResult.value),
           error: engineResult.status === "rejected" ? (engineResult.reason as Error).message : undefined,
         });
       } else if (engineResult.status === "fulfilled") {
@@ -1023,6 +1036,8 @@ export function getValidatorApi(
         logger.info("Selected local block: no builder bid block produced", {
           reason,
           ...logCtx,
+          durationMs: engineResult.durationMs,
+          ...getBlockValueLogInfo(engineResult.value),
           error: bidResult.status === "rejected" ? (bidResult.reason as Error).message : undefined,
         });
       }


### PR DESCRIPTION
**Motivation**

`produceBlockV4` logs only the builder side of the block selection, so a `Selected builder block reason=block_value` line cannot be explained from the logs. `engineExecutionPayloadValue` is the left-hand side of the comparison in `selectBlockProductionSourceByBoostFactor` and is never printed, at any log level.

Real example from glamsterdam-devnet-8, slot 93507 (`lodestar-reth-2` proposing):

```
Selected builder block reason=block_value, slot=93507, parentSlot=93506, parentBlockRoot=0x60f4…d611,
parentBlockHash=0x0711…3180, fork=gloas, builderBoostFactor=90, strictFeeRecipientCheck=false,
circuitBreakerActive=false, bidValue=189026982, builderIndex=10044, bidBlockHash=0xdbc8…2608
```

There is no way to tell from this whether the local block lost by a hair or by a mile. Answering "why did this node take the bid instead of self-building?" required pulling the `engine_getPayloadV6` response out of an rpc-snooper capture to recover `"blockValue": "0x1437deaedd051f2"` — 0.09105 ETH local against a 0.18903 ETH bid, with a threshold of 0.17012 ETH at `builderBoostFactor=90`. That capture only exists because ethpandaops nodes run a snooper in front of the engine API; on any normal node the information is simply gone.

This is a regression against the pre-gloas path: `produceEngineOrBuilderBlock` already spreads `getBlockValueLogInfo` for both sources. Nothing else covers the gap either — `logger.verbose("Produced block", …)` carries only the winning block's value, and `blockProductionExecutionPayloadValue` is observed only for the winning `source`.

**Description**

Spread `getBlockValueLogInfo` and the race durations into all four `produceBlockV4` selection log sites, matching what `produceEngineOrBuilderBlock` does:

- value comparison (`reason=block_value`) — tagged `engine*` / `builder*` keys plus `engineDurationMs` / `builderDurationMs`, so both sides of the inequality are on the line in the same unit
- suspected censorship, no-local-block, no-bid-block — untagged keys plus `durationMs` for whichever block was produced

Log-only change, no behaviour change. `bidValue` stays as-is, it is the raw bid in Gwei while `builderExecutionPayloadValue` is the pretty ETH value used in the comparison.

The line above becomes:

```
Selected builder block reason=block_value, …, bidValue=189026982, builderIndex=10044, bidBlockHash=0xdbc8…2608,
engineDurationMs=…, engineExecutionPayloadValue=0.09105 ETH, engineConsensusBlockValue=…, engineBlockTotalValue=…,
builderDurationMs=…, builderExecutionPayloadValue=0.18902 ETH, builderConsensusBlockValue=…, builderBlockTotalValue=…
```

#9832 rewrites this block and carries the same gap (its `logCtx` gains `bidSource` / `bidTotal` / `bidBoostFactor` but still no engine value), so it will want the equivalent change on rebase.

**AI Assistance Disclosure**

Claude Code was used to investigate the devnet incident that surfaced this, and to write the patch and this description.
