### PR TITLE
chore: add forkSeq to IBeaconStateView

### DIFF
--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -108,6 +108,10 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
     return this.config.getForkName(this.cachedState.slot);
   }
 
+  get forkSeq(): ForkSeq {
+    return this.config.getForkSeq(this.cachedState.slot);
+  }
+
   get slot(): number {
     return this.cachedState.slot;
   }

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -302,12 +302,10 @@ export type IBeaconStateViewLatestFork = Omit<
 /**
  * Contract a BeaconStateView backing implementation must satisfy.
  *
- * Differs from `IBeaconStateViewLatestFork` in three ways:
+ * Differs from `IBeaconStateViewLatestFork` in two ways:
  * - `executionPayloadAvailability` is a raw `{uint8Array, bitLen}` POJO — a
  *   native (`.node`) binding cannot construct a `BitArray` across FFI.
  *   `NativeBeaconStateView` lifts it back to `BitArray` for beacon-node.
- * - `forkSeq` is derived by `NativeBeaconStateView` from the binding's `forkName`
- *   (`ForkSeq[forkName]`), so the binding does not need to expose it.
  * - Methods that produce another view (`stateTransition`, `processSlots`,
  *   `loadOtherState`, `withParentPayloadApplied`) return `IBeaconStateViewNative`
  *   so callers can re-wrap without an `as unknown` cast. Param lists are reused
@@ -318,12 +316,7 @@ export type IBeaconStateViewLatestFork = Omit<
  */
 export type IBeaconStateViewNative = Omit<
   IBeaconStateViewLatestFork,
-  | "executionPayloadAvailability"
-  | "forkSeq"
-  | "loadOtherState"
-  | "stateTransition"
-  | "processSlots"
-  | "withParentPayloadApplied"
+  "executionPayloadAvailability" | "loadOtherState" | "stateTransition" | "processSlots" | "withParentPayloadApplied"
 > & {
   executionPayloadAvailability: {uint8Array: Uint8Array; bitLen: number};
   loadOtherState(...args: Parameters<IBeaconStateViewLatestFork["loadOtherState"]>): IBeaconStateViewNative;

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -10,6 +10,7 @@ import {
   ForkPostFulu,
   ForkPostGloas,
   ForkPostHeze,
+  ForkSeq,
   isForkPostAltair,
   isForkPostBellatrix,
   isForkPostCapella,
@@ -62,6 +63,7 @@ export interface IBeaconStateView {
 
   // phase0
   forkName: ForkName;
+  forkSeq: ForkSeq;
   slot: Slot;
   fork: Fork;
   epoch: Epoch;
@@ -300,10 +302,12 @@ export type IBeaconStateViewLatestFork = Omit<
 /**
  * Contract a BeaconStateView backing implementation must satisfy.
  *
- * Differs from `IBeaconStateViewLatestFork` in two ways:
+ * Differs from `IBeaconStateViewLatestFork` in three ways:
  * - `executionPayloadAvailability` is a raw `{uint8Array, bitLen}` POJO — a
  *   native (`.node`) binding cannot construct a `BitArray` across FFI.
  *   `NativeBeaconStateView` lifts it back to `BitArray` for beacon-node.
+ * - `forkSeq` is derived by `NativeBeaconStateView` from the binding's `forkName`
+ *   (`ForkSeq[forkName]`), so the binding does not need to expose it.
  * - Methods that produce another view (`stateTransition`, `processSlots`,
  *   `loadOtherState`, `withParentPayloadApplied`) return `IBeaconStateViewNative`
  *   so callers can re-wrap without an `as unknown` cast. Param lists are reused
@@ -314,7 +318,12 @@ export type IBeaconStateViewLatestFork = Omit<
  */
 export type IBeaconStateViewNative = Omit<
   IBeaconStateViewLatestFork,
-  "executionPayloadAvailability" | "loadOtherState" | "stateTransition" | "processSlots" | "withParentPayloadApplied"
+  | "executionPayloadAvailability"
+  | "forkSeq"
+  | "loadOtherState"
+  | "stateTransition"
+  | "processSlots"
+  | "withParentPayloadApplied"
 > & {
   executionPayloadAvailability: {uint8Array: Uint8Array; bitLen: number};
   loadOtherState(...args: Parameters<IBeaconStateViewLatestFork["loadOtherState"]>): IBeaconStateViewNative;

--- a/packages/state-transition/src/stateView/nativeBeaconStateView.ts
+++ b/packages/state-transition/src/stateView/nativeBeaconStateView.ts
@@ -63,6 +63,7 @@ import {
 export class NativeBeaconStateView implements IBeaconStateViewLatestFork {
   // phase0
   private _forkName: ForkName | null = null;
+  private _forkSeq: ForkSeq | null = null;
   private _slot: Slot | null = null;
   private _fork: Fork | null = null;
   private _epoch: Epoch | null = null;
@@ -192,7 +193,10 @@ export class NativeBeaconStateView implements IBeaconStateViewLatestFork {
   }
 
   get forkSeq(): ForkSeq {
-    return ForkSeq[this.forkName];
+    if (this._forkSeq === null) {
+      this._forkSeq = this.binding.forkSeq;
+    }
+    return this._forkSeq;
   }
 
   get slot(): Slot {

--- a/packages/state-transition/src/stateView/nativeBeaconStateView.ts
+++ b/packages/state-transition/src/stateView/nativeBeaconStateView.ts
@@ -1,6 +1,6 @@
 import {CompactMultiProof} from "@chainsafe/persistent-merkle-tree";
 import {BitArray, ByteViews} from "@chainsafe/ssz";
-import {ForkName} from "@lodestar/params";
+import {ForkName, ForkSeq} from "@lodestar/params";
 import {
   BeaconBlock,
   BeaconState,
@@ -189,6 +189,10 @@ export class NativeBeaconStateView implements IBeaconStateViewLatestFork {
       this._forkName = this.binding.forkName;
     }
     return this._forkName;
+  }
+
+  get forkSeq(): ForkSeq {
+    return ForkSeq[this.forkName];
   }
 
   get slot(): Slot {

--- a/packages/state-transition/test/unit/stateView/nativeBeaconStateView.test.ts
+++ b/packages/state-transition/test/unit/stateView/nativeBeaconStateView.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from "vitest";
 import {BitArray} from "@chainsafe/ssz";
-import {ForkName, ForkSeq} from "@lodestar/params";
+import {ForkSeq} from "@lodestar/params";
 import {IBeaconStateViewNative} from "../../../src/stateView/interface.js";
 import {NativeBeaconStateView} from "../../../src/stateView/nativeBeaconStateView.js";
 
@@ -84,20 +84,20 @@ describe("NativeBeaconStateView", () => {
     expect(view.getBalance(2)).toBe(32_000_000_002);
   });
 
-  it("derives forkSeq from the binding's forkName", () => {
-    let forkNameAccessCount = 0;
+  it("reads forkSeq directly from the binding", () => {
+    let forkSeqAccessCount = 0;
     const binding = {
-      get forkName() {
-        forkNameAccessCount++;
-        return ForkName.electra;
+      get forkSeq() {
+        forkSeqAccessCount++;
+        return ForkSeq.electra;
       },
     } as unknown as IBeaconStateViewNative;
 
     const view = new NativeBeaconStateView(binding);
     expect(view.forkSeq).toBe(ForkSeq.electra);
 
-    // Derived from the cached forkName: a second access doesn't re-hit the binding
+    // Cached: a second access doesn't re-hit the binding
     expect(view.forkSeq).toBe(ForkSeq.electra);
-    expect(forkNameAccessCount).toBe(1);
+    expect(forkSeqAccessCount).toBe(1);
   });
 });

--- a/packages/state-transition/test/unit/stateView/nativeBeaconStateView.test.ts
+++ b/packages/state-transition/test/unit/stateView/nativeBeaconStateView.test.ts
@@ -38,6 +38,7 @@ describe("NativeBeaconStateView", () => {
   it("caches forwarded properties so the binding is hit once", () => {
     let forkAccessCount = 0;
     let latestBlockHeaderAccessCount = 0;
+    let forkSeqAccessCount = 0;
     const fakeFork = {previousVersion: new Uint8Array(4), currentVersion: new Uint8Array(4), epoch: 0};
     const fakeHeader = {
       slot: 0,
@@ -56,6 +57,10 @@ describe("NativeBeaconStateView", () => {
         latestBlockHeaderAccessCount++;
         return fakeHeader;
       },
+      get forkSeq() {
+        forkSeqAccessCount++;
+        return ForkSeq.electra;
+      },
     } as unknown as IBeaconStateViewNative;
 
     const view = new NativeBeaconStateView(binding);
@@ -63,8 +68,11 @@ describe("NativeBeaconStateView", () => {
     expect(view.fork).toBe(fakeFork);
     expect(view.latestBlockHeader).toBe(fakeHeader);
     expect(view.latestBlockHeader).toBe(fakeHeader);
+    expect(view.forkSeq).toBe(ForkSeq.electra);
+    expect(view.forkSeq).toBe(ForkSeq.electra);
     expect(forkAccessCount).toBe(1);
     expect(latestBlockHeaderAccessCount).toBe(1);
+    expect(forkSeqAccessCount).toBe(1);
   });
 
   it("delegates pass-through getters and methods to the binding", () => {
@@ -82,22 +90,5 @@ describe("NativeBeaconStateView", () => {
     expect(view.validatorCount).toBe(17);
     expect(view.getBlockRootAtSlot(7)).toEqual(new Uint8Array([7]));
     expect(view.getBalance(2)).toBe(32_000_000_002);
-  });
-
-  it("reads forkSeq directly from the binding", () => {
-    let forkSeqAccessCount = 0;
-    const binding = {
-      get forkSeq() {
-        forkSeqAccessCount++;
-        return ForkSeq.electra;
-      },
-    } as unknown as IBeaconStateViewNative;
-
-    const view = new NativeBeaconStateView(binding);
-    expect(view.forkSeq).toBe(ForkSeq.electra);
-
-    // Cached: a second access doesn't re-hit the binding
-    expect(view.forkSeq).toBe(ForkSeq.electra);
-    expect(forkSeqAccessCount).toBe(1);
   });
 });

--- a/packages/state-transition/test/unit/stateView/nativeBeaconStateView.test.ts
+++ b/packages/state-transition/test/unit/stateView/nativeBeaconStateView.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from "vitest";
 import {BitArray} from "@chainsafe/ssz";
+import {ForkName, ForkSeq} from "@lodestar/params";
 import {IBeaconStateViewNative} from "../../../src/stateView/interface.js";
 import {NativeBeaconStateView} from "../../../src/stateView/nativeBeaconStateView.js";
 
@@ -81,5 +82,22 @@ describe("NativeBeaconStateView", () => {
     expect(view.validatorCount).toBe(17);
     expect(view.getBlockRootAtSlot(7)).toEqual(new Uint8Array([7]));
     expect(view.getBalance(2)).toBe(32_000_000_002);
+  });
+
+  it("derives forkSeq from the binding's forkName", () => {
+    let forkNameAccessCount = 0;
+    const binding = {
+      get forkName() {
+        forkNameAccessCount++;
+        return ForkName.electra;
+      },
+    } as unknown as IBeaconStateViewNative;
+
+    const view = new NativeBeaconStateView(binding);
+    expect(view.forkSeq).toBe(ForkSeq.electra);
+
+    // Derived from the cached forkName: a second access doesn't re-hit the binding
+    expect(view.forkSeq).toBe(ForkSeq.electra);
+    expect(forkNameAccessCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Motivation

Requested by @wemeetagain in https://github.com/ChainSafe/lodestar/pull/9698#discussion_r3864577673 — expose `forkSeq: ForkSeq` on `IBeaconStateView` so consumers can compare fork ordering directly off the state view instead of re-deriving it from `forkName`/`slot`.

## Description

- Add `forkSeq: ForkSeq` to the `IBeaconStateView` interface.
- `BeaconStateView` returns `config.getForkSeq(slot)` (mirrors the existing `forkName` getter).
- `NativeBeaconStateView` derives it from the binding's cached `forkName` via `ForkSeq[forkName]`, so **no native-binding change** is needed. `forkSeq` is `Omit`ted from `IBeaconStateViewNative` (same treatment as `executionPayloadAvailability`), keeping the future Zig binding contract unchanged.
- Unit test covering the native derivation.

Build, type-check, lint, and `state-transition` unit tests pass.

🤖 Generated with AI assistance