### PR TITLE
fix(heze): key inclusion lists by dependent_root per consensus-specs v1.7.0-alpha.14

### DIFF
--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -273,8 +273,8 @@ export const InclusionListDutyType = new ContainerType(
     validatorIndex: ssz.ValidatorIndex,
     /** The slot at which the validator must produce the inclusion list */
     slot: ssz.Slot,
-    /** Root of the inclusion list committee the duty was derived from */
-    inclusionListCommitteeRoot: ssz.Root,
+    /** Shuffling dependent root of the duty's epoch, to set as `dependent_root` on the inclusion list */
+    dependentRoot: ssz.Root,
   },
   {jsonCase: "eth2"}
 );

--- a/packages/api/test/unit/beacon/testData/events.ts
+++ b/packages/api/test/unit/beacon/testData/events.ts
@@ -361,7 +361,7 @@ export const eventTestData: EventData = {
       message: {
         slot: "10",
         validator_index: "123",
-        inclusion_list_committee_root: "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf",
+        dependent_root: "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf",
         transactions: ["0x02f8", "0x03a1"],
       },
       signature:

--- a/packages/api/test/unit/beacon/testData/validator.ts
+++ b/packages/api/test/unit/beacon/testData/validator.ts
@@ -171,7 +171,7 @@ export const testData: GenericServerTestCases<Endpoints> = {
           pubkey: new Uint8Array(48).fill(1),
           validatorIndex: 2,
           slot: 7,
-          inclusionListCommitteeRoot: new Uint8Array(32).fill(3),
+          dependentRoot: new Uint8Array(32).fill(3),
         },
       ],
       meta: {executionOptimistic: true, dependentRoot: ZERO_HASH_HEX},

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -30,7 +30,6 @@ import {
   getInclusionListCommittee,
   isStatePostAltair,
   isStatePostGloas,
-  isStatePostHeze,
   proposerShufflingDecisionRoot,
 } from "@lodestar/state-transition";
 import {
@@ -88,6 +87,7 @@ import {ZERO_HASH} from "../../../constants/index.js";
 import {BuilderStatus, NoBidReceived} from "../../../execution/builder/http.js";
 import {validateGossipFnRetryUnknownRoot} from "../../../network/processor/gossipHandlers.js";
 import {CommitteeSubscription} from "../../../network/subnets/index.js";
+import {getInclusionListDependentRoot} from "../../../util/dependentRoot.js";
 import {callInNextEventLoop} from "../../../util/eventLoop.js";
 import {isOptimisticBlock} from "../../../util/forkChoice.js";
 import {getBlockGraffiti, toGraffitiBytes} from "../../../util/graffiti.js";
@@ -911,16 +911,26 @@ export function getValidatorApi(
       // view including untimely lists (only_timely=False), so a bid accepted here also satisfies
       // the timely-only view every other validator enforces.
       if (builderBid !== null && isForkPostHeze(fork)) {
-        const headState = chain.getHeadState();
-        if (isStatePostHeze(headState)) {
-          const {inclusionListBits} = builderBid.message as heze.ExecutionPayloadBid;
-          if (!chain.inclusionListStore.isInclusionListBitsInclusive(headState, slot - 1, inclusionListBits, false)) {
-            logger.verbose("Discarding builder bid with non-inclusive inclusion list bits", {
-              slot,
-              builderIndex: builderBid.message.builderIndex,
-            });
-            builderBid = null;
-          }
+        const {inclusionListBits} = builderBid.message as heze.ExecutionPayloadBid;
+        const inclusionListSlot = slot - 1;
+        const inclusionListDependentRoot = getInclusionListDependentRoot(
+          chain.forkChoice,
+          parentBlock,
+          inclusionListSlot
+        );
+        if (
+          !chain.inclusionListStore.isInclusionListBitsInclusive(
+            inclusionListSlot,
+            inclusionListDependentRoot,
+            inclusionListBits,
+            false
+          )
+        ) {
+          logger.verbose("Discarding builder bid with non-inclusive inclusion list bits", {
+            slot,
+            builderIndex: builderBid.message.builderIndex,
+          });
+          builderBid = null;
         }
       }
 
@@ -1945,17 +1955,19 @@ export function getValidatorApi(
       const epochStartSlot = computeStartSlotAtEpoch(epoch);
       const shuffling = state.getShufflingAtEpoch(epoch);
 
+      // The shuffling dependent root of `epoch`, which the validator sets as `dependent_root` on its
+      // inclusion lists (spec `get_signed_inclusion_list`) and the `dependent_root` the duties are
+      // reported against.
+      const dependentRoot = fromHex(state.getShufflingDecisionRoot(epoch)) || (await getGenesisBlockRoot(state));
+
       // A validator can sit on several slots' committees within an epoch; the duty for the
       // earliest such slot is the one reported, matching how attester duties are served.
-      const dutyByValidator = new Map<ValidatorIndex, {slot: Slot; committeeRoot: Uint8Array}>();
+      const dutySlotByValidator = new Map<ValidatorIndex, Slot>();
       for (let i = 0; i < SLOTS_PER_EPOCH; i++) {
         const slot = epochStartSlot + i;
-        const committee = getInclusionListCommittee(shuffling, slot);
-        let committeeRoot: Uint8Array | null = null;
-        for (const validatorIndex of committee) {
-          if (requestedIndices.has(validatorIndex) && !dutyByValidator.has(validatorIndex)) {
-            committeeRoot ??= ssz.heze.InclusionListCommittee.hashTreeRoot(Array.from(committee));
-            dutyByValidator.set(validatorIndex, {slot, committeeRoot});
+        for (const validatorIndex of getInclusionListCommittee(shuffling, slot)) {
+          if (requestedIndices.has(validatorIndex) && !dutySlotByValidator.has(validatorIndex)) {
+            dutySlotByValidator.set(validatorIndex, slot);
           }
         }
       }
@@ -1963,18 +1975,11 @@ export function getValidatorApi(
       const duties: routes.validator.InclusionListDuty[] = [];
       for (let i = 0; i < indices.length; i++) {
         const validatorIndex = indices[i];
-        const duty = dutyByValidator.get(validatorIndex);
-        if (duty) {
-          duties.push({
-            pubkey: pubkeys[i],
-            validatorIndex,
-            slot: duty.slot,
-            inclusionListCommitteeRoot: duty.committeeRoot,
-          });
+        const slot = dutySlotByValidator.get(validatorIndex);
+        if (slot !== undefined) {
+          duties.push({pubkey: pubkeys[i], validatorIndex, slot, dependentRoot});
         }
       }
-
-      const dependentRoot = fromHex(state.getShufflingDecisionRoot(epoch)) || (await getGenesisBlockRoot(state));
 
       return {
         data: duties,
@@ -1994,15 +1999,16 @@ export function getValidatorApi(
       }
 
       const timer = metrics?.inclusionListsValidationTime.startTimer();
+      let committeeIndex: number;
       try {
-        await validateApiInclusionList(chain, signedInclusionList);
+        ({committeeIndex} = await validateApiInclusionList(chain, signedInclusionList));
       } finally {
         timer?.({source: InclusionListSource.api});
       }
 
       const secFromSlot = chain.clock.secFromSlot(slot, Date.now() / 1000);
       const isTimely = secFromSlot * 1000 < chain.config.getInclusionListDueMs();
-      chain.inclusionListStore.process(signedInclusionList, isTimely);
+      chain.inclusionListStore.process(signedInclusionList, committeeIndex, isTimely);
 
       chain.emitter.emit(routes.events.EventType.inclusionList, {
         version: chain.config.getForkName(slot),

--- a/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
+++ b/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
@@ -8,6 +8,7 @@ import {
 import {DataAvailabilityStatus, isStatePostGloas, isStatePostHeze} from "@lodestar/state-transition";
 import {isErrorAborted} from "@lodestar/utils";
 import {ExecutionPayloadStatus} from "../../execution/index.js";
+import {getInclusionListDependentRoot} from "../../util/dependentRoot.js";
 import {isQueueErrorAborted} from "../../util/queue/index.js";
 import {BeaconChain} from "../chain.js";
 import {RegenCaller} from "../regen/interface.js";
@@ -170,10 +171,16 @@ export async function importExecutionPayload(
   }
 
   // [New in Heze:EIP7805] The payload is checked against the inclusion lists observed for the
-  // slot preceding the block, restricted to those that arrived before the inclusion list
-  // deadline. The engine reports the outcome on the newPayload response.
+  // slot preceding the block, keyed by that slot's shuffling dependent root on the block's branch
+  // and restricted to those that arrived before the inclusion list deadline. The engine reports
+  // the outcome on the newPayload response.
+  const inclusionListSlot = protoBlock.slot - 1;
   const inclusionListTransactions = isStatePostHeze(blockState)
-    ? this.inclusionListStore.getInclusionListTransactions(blockState, blockState.slot - 1, true)
+    ? this.inclusionListStore.getInclusionListTransactions(
+        inclusionListSlot,
+        getInclusionListDependentRoot(this.forkChoice, protoBlock, inclusionListSlot),
+        true
+      )
     : undefined;
 
   // 4a. Run EL and signature verification in parallel

--- a/packages/beacon-node/src/chain/errors/inclusionList.ts
+++ b/packages/beacon-node/src/chain/errors/inclusionList.ts
@@ -1,4 +1,4 @@
-import {Root, Slot, ValidatorIndex} from "@lodestar/types";
+import {Epoch, RootHex, Slot, ValidatorIndex} from "@lodestar/types";
 import {GossipActionError} from "./gossipValidation.js";
 
 export enum InclusionListErrorCode {
@@ -6,7 +6,10 @@ export enum InclusionListErrorCode {
   INVALID_SLOT = "INCLUSION_LIST_ERROR_INVALID_SLOT",
   MORE_THAN_TWO = "INCLUSION_LIST_ERROR_MORE_THAN_TWO",
   VALIDATOR_NOT_IN_COMMITTEE = "INCLUSION_LIST_ERROR_VALIDATOR_NOT_IN_COMMITTEE",
-  INVALID_COMMITTEE_ROOT = "INCLUSION_LIST_ERROR_INVALID_COMMITTEE_ROOT",
+  UNKNOWN_DEPENDENT_ROOT = "INCLUSION_LIST_ERROR_UNKNOWN_DEPENDENT_ROOT",
+  INVALID_DEPENDENT_ROOT_SLOT = "INCLUSION_LIST_ERROR_INVALID_DEPENDENT_ROOT_SLOT",
+  INVALID_DEPENDENT_ROOT = "INCLUSION_LIST_ERROR_INVALID_DEPENDENT_ROOT",
+  MISSING_SHUFFLING = "INCLUSION_LIST_ERROR_MISSING_SHUFFLING",
   INVALID_SIGNATURE = "INCLUSION_LIST_ERROR_INVALID_SIGNATURE",
   PRE_HEZE_SLOT = "INCLUSION_LIST_ERROR_PRE_HEZE_SLOT",
 }
@@ -16,7 +19,15 @@ export type InclusionListErrorType =
   | {code: InclusionListErrorCode.INVALID_SLOT; inclusionListSlot: Slot; currentSlot: Slot}
   | {code: InclusionListErrorCode.MORE_THAN_TWO; validatorIndex: ValidatorIndex}
   | {code: InclusionListErrorCode.VALIDATOR_NOT_IN_COMMITTEE; validatorIndex: ValidatorIndex}
-  | {code: InclusionListErrorCode.INVALID_COMMITTEE_ROOT; received: Root; expected: Root}
+  | {code: InclusionListErrorCode.UNKNOWN_DEPENDENT_ROOT; dependentRoot: RootHex}
+  | {
+      code: InclusionListErrorCode.INVALID_DEPENDENT_ROOT_SLOT;
+      dependentRoot: RootHex;
+      dependentSlot: Slot;
+      maxSlot: Slot;
+    }
+  | {code: InclusionListErrorCode.INVALID_DEPENDENT_ROOT; dependentRoot: RootHex; epoch: Epoch}
+  | {code: InclusionListErrorCode.MISSING_SHUFFLING; dependentRoot: RootHex; epoch: Epoch}
   | {code: InclusionListErrorCode.INVALID_SIGNATURE}
   | {code: InclusionListErrorCode.PRE_HEZE_SLOT; inclusionListSlot: Slot};
 

--- a/packages/beacon-node/src/chain/opPools/inclusionListStore.ts
+++ b/packages/beacon-node/src/chain/opPools/inclusionListStore.ts
@@ -1,60 +1,55 @@
 import {BitArray} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
 import {INCLUSION_LIST_COMMITTEE_SIZE} from "@lodestar/params";
-import type {IBeaconStateViewHeze} from "@lodestar/state-transition";
 import {RootHex, Slot, ValidatorIndex, bellatrix, heze, ssz} from "@lodestar/types";
 import {MapDef, toHex, toRootHex} from "@lodestar/utils";
-
-/**
- * Maximum number of distinct inclusion lists retained per committee root.
- *
- * process() stores at most one inclusion list per validator, so the natural bound is
- * INCLUSION_LIST_COMMITTEE_SIZE. Gossip validation already rejects inclusion lists from
- * validators outside the committee, but on_inclusion_list has no such check yet, so keep a
- * headroom bound here as a DoS guard rather than trusting the caller.
- */
-const MAX_INCLUSION_LISTS_PER_COMMITTEE = INCLUSION_LIST_COMMITTEE_SIZE * 2;
 
 export enum InclusionListInsertOutcome {
   /** Stored as a new entry. */
   New = "New",
   /** Slot is older than the prune horizon. */
   Old = "Old",
-  /** Committee root is at capacity. */
+  /** `(slot, dependent_root)` is at capacity. */
   ReachLimit = "ReachLimit",
   /** Identical inclusion list already stored. */
   Seen = "Seen",
   /** New equivocation evidence: this validator already has a different inclusion list stored. */
   Equivocating = "Equivocating",
-  /** Validator was already marked as an equivocator for this committee root. */
+  /** Validator was already marked as an equivocator for this `(slot, dependent_root)`. */
   SubsequentEquivocation = "SubsequentEquivocation",
 }
 
+type InclusionListEntry = {
+  signedInclusionList: heze.SignedInclusionList;
+  /** Position of the validator in `get_inclusion_list_committee(state, slot)` for this `(slot, dependent_root)`. */
+  committeeIndex: number;
+  /** Received before the inclusion list deadline of its slot. */
+  timely: boolean;
+};
+
 /**
- * Pool of inclusion lists, keyed by `inclusion_list_committee_root`.
+ * Pool of inclusion lists, keyed by `(slot, dependent_root)` with one entry per validator index
+ * (spec `InclusionListStore`).
  *
- * The committee root is the spec key and already pins down the slot, so slot is not part of it.
- * `committeeRootsBySlot` exists only so prune() can find the roots belonging to a passed slot.
+ * The committee of a `(slot, dependent_root)` is fixed, so the validator's committee position is
+ * recorded at insert time (gossip validation already resolves the committee) and the bit-oriented
+ * read paths need no shuffling lookup.
  *
  * Signed inclusion lists are retained rather than unwrapped messages so InclusionListsByIndices
  * can serve them back to peers.
  *
- * Equivocators are tracked per committee root instead of being removed from `inclusionLists`,
- * because the read paths filter by validator index: once a validator equivocates, every
- * inclusion list it sent for that committee root stops counting, including the one already
- * stored.
+ * The first inclusion list of a validator stays stored; an equivocation marks the validator so the
+ * read paths skip it, as in spec `process_inclusion_list`.
  */
 export class InclusionListStore {
-  /** committee_root -> inclusion_list_root -> SignedInclusionList */
-  private readonly inclusionLists = new MapDef<RootHex, Map<RootHex, heze.SignedInclusionList>>(
-    () => new Map<RootHex, heze.SignedInclusionList>()
+  /** slot -> dependent_root -> validator index -> entry */
+  private readonly inclusionLists = new MapDef<Slot, MapDef<RootHex, Map<ValidatorIndex, InclusionListEntry>>>(
+    () => new MapDef<RootHex, Map<ValidatorIndex, InclusionListEntry>>(() => new Map())
   );
-  /** inclusion_list_root -> was received before the gossip deadline */
-  private readonly inclusionListTimeliness = new Map<RootHex, boolean>();
-  /** committee_root -> equivocating validator indices */
-  private readonly equivocators = new MapDef<RootHex, Set<ValidatorIndex>>(() => new Set<ValidatorIndex>());
-  /** slot -> committee roots seen at that slot, for pruning */
-  private readonly committeeRootsBySlot = new MapDef<Slot, Set<RootHex>>(() => new Set<RootHex>());
+  /** slot -> dependent_root -> equivocating validator indices */
+  private readonly equivocators = new MapDef<Slot, MapDef<RootHex, Set<ValidatorIndex>>>(
+    () => new MapDef<RootHex, Set<ValidatorIndex>>(() => new Set())
+  );
   /** slot -> validator index -> count, for the p2p "first or second message" rule */
   private readonly validatorIlCountBySlot = new MapDef<Slot, Map<ValidatorIndex, number>>(
     () => new Map<ValidatorIndex, number>()
@@ -66,8 +61,10 @@ export class InclusionListStore {
 
   get size(): number {
     let count = 0;
-    for (const inclusionLists of this.inclusionLists.values()) {
-      count += inclusionLists.size;
+    for (const byDependentRoot of this.inclusionLists.values()) {
+      for (const entries of byDependentRoot.values()) {
+        count += entries.size;
+      }
     }
     return count;
   }
@@ -75,12 +72,16 @@ export class InclusionListStore {
   /**
    * Store a signed inclusion list along with the locally observed timeliness.
    *
-   * Late inclusion lists are stored with `isTimely=false` rather than dropped: they still count
+   * Late inclusion lists are stored with `timely=false` rather than dropped: they still count
    * toward the non-timely view used when validating another node's `inclusion_list_bits`.
    */
-  process(signedInclusionList: heze.SignedInclusionList, isTimely: boolean): InclusionListInsertOutcome {
+  process(
+    signedInclusionList: heze.SignedInclusionList,
+    committeeIndex: number,
+    timely: boolean
+  ): InclusionListInsertOutcome {
     const inclusionList = signedInclusionList.message;
-    const {slot, validatorIndex, inclusionListCommitteeRoot} = inclusionList;
+    const {slot, validatorIndex} = inclusionList;
 
     if (slot < this.lowestPermissibleSlot) {
       return InclusionListInsertOutcome.Old;
@@ -89,35 +90,27 @@ export class InclusionListStore {
     const counts = this.validatorIlCountBySlot.getOrDefault(slot);
     counts.set(validatorIndex, (counts.get(validatorIndex) ?? 0) + 1);
 
-    const committeeRoot = toRootHex(inclusionListCommitteeRoot);
+    const dependentRoot = toRootHex(inclusionList.dependentRoot);
+    const stored = this.inclusionLists.getOrDefault(slot).getOrDefault(dependentRoot);
 
-    const equivocators = this.equivocators.getOrDefault(committeeRoot);
-    if (equivocators.has(validatorIndex)) {
-      return InclusionListInsertOutcome.SubsequentEquivocation;
-    }
-
-    const stored = this.inclusionLists.getOrDefault(committeeRoot);
-    const inclusionListRoot = toRootHex(ssz.heze.InclusionList.hashTreeRoot(inclusionList));
-
-    for (const [storedRoot, storedInclusionList] of stored) {
-      if (storedInclusionList.message.validatorIndex !== validatorIndex) {
-        continue;
-      }
-      if (storedRoot === inclusionListRoot) {
+    const entry = stored.get(validatorIndex);
+    if (entry !== undefined) {
+      if (ssz.heze.InclusionList.equals(entry.signedInclusionList.message, inclusionList)) {
         return InclusionListInsertOutcome.Seen;
+      }
+      const equivocators = this.equivocators.getOrDefault(slot).getOrDefault(dependentRoot);
+      if (equivocators.has(validatorIndex)) {
+        return InclusionListInsertOutcome.SubsequentEquivocation;
       }
       equivocators.add(validatorIndex);
       return InclusionListInsertOutcome.Equivocating;
     }
 
-    if (stored.size >= MAX_INCLUSION_LISTS_PER_COMMITTEE) {
+    if (stored.size >= INCLUSION_LIST_COMMITTEE_SIZE) {
       return InclusionListInsertOutcome.ReachLimit;
     }
 
-    stored.set(inclusionListRoot, signedInclusionList);
-    this.inclusionListTimeliness.set(inclusionListRoot, isTimely);
-    this.committeeRootsBySlot.getOrDefault(slot).add(committeeRoot);
-
+    stored.set(validatorIndex, {signedInclusionList, committeeIndex, timely});
     return InclusionListInsertOutcome.New;
   }
 
@@ -129,12 +122,12 @@ export class InclusionListStore {
     return (this.validatorIlCountBySlot.get(slot)?.get(validatorIndex) ?? 0) >= 2;
   }
 
-  /** Deduplicated transactions from valid, non-equivocating inclusion lists at `slot`. */
-  getInclusionListTransactions(state: IBeaconStateViewHeze, slot: Slot, onlyTimely = true): bellatrix.Transactions {
+  /** Deduplicated transactions from valid, non-equivocating inclusion lists at `(slot, dependentRoot)`. */
+  getInclusionListTransactions(slot: Slot, dependentRoot: RootHex, onlyTimely = true): bellatrix.Transactions {
     const transactions: bellatrix.Transactions = [];
     const seen = new Set<string>();
 
-    for (const signedInclusionList of this.getEligible(state, slot, onlyTimely)) {
+    for (const {signedInclusionList} of this.getEligible(slot, dependentRoot, onlyTimely)) {
       for (const transaction of signedInclusionList.message.transactions) {
         const key = toHex(transaction);
         if (!seen.has(key)) {
@@ -148,61 +141,31 @@ export class InclusionListStore {
   }
 
   /** Bit `i` is set iff committee member `i` submitted a valid, non-equivocating inclusion list. */
-  getInclusionListBits(state: IBeaconStateViewHeze, slot: Slot, onlyTimely = true): BitArray {
-    const submitted = new Set<ValidatorIndex>();
-    for (const signedInclusionList of this.getEligible(state, slot, onlyTimely)) {
-      submitted.add(signedInclusionList.message.validatorIndex);
-    }
-
-    const committee = state.getInclusionListCommittee(slot);
+  getInclusionListBits(slot: Slot, dependentRoot: RootHex, onlyTimely = true): BitArray {
     const bits = BitArray.fromBitLen(INCLUSION_LIST_COMMITTEE_SIZE);
-    for (let i = 0; i < committee.length; i++) {
-      if (submitted.has(committee[i])) {
-        bits.set(i, true);
-      }
+    for (const {committeeIndex} of this.getEligible(slot, dependentRoot, onlyTimely)) {
+      bits.set(committeeIndex, true);
     }
     return bits;
   }
 
   /** True iff `bits` has a bit set for every bit set in the local inclusion list bits. */
-  isInclusionListBitsInclusive(state: IBeaconStateViewHeze, slot: Slot, bits: BitArray, onlyTimely = true): boolean {
-    const local = this.getInclusionListBits(state, slot, onlyTimely);
-    for (let i = 0; i < INCLUSION_LIST_COMMITTEE_SIZE; i++) {
-      if (local.get(i) && !bits.get(i)) {
+  isInclusionListBitsInclusive(slot: Slot, dependentRoot: RootHex, bits: BitArray, onlyTimely = true): boolean {
+    for (const {committeeIndex} of this.getEligible(slot, dependentRoot, onlyTimely)) {
+      if (!bits.get(committeeIndex)) {
         return false;
       }
     }
     return true;
   }
 
-  /** Inclusion lists for the given committee indices, to serve InclusionListsByIndices. */
-  getByIndices(
-    state: IBeaconStateViewHeze,
-    slot: Slot,
-    committeeRoot: RootHex,
-    indices: BitArray
-  ): heze.SignedInclusionList[] {
-    const stored = this.inclusionLists.get(committeeRoot);
-    if (!stored || stored.size === 0) {
-      return [];
-    }
-
-    const committee = state.getInclusionListCommittee(slot);
-    const requested = new Set<ValidatorIndex>();
-    for (const i of indices.getTrueBitIndexes()) {
-      if (i < committee.length) {
-        requested.add(committee[i]);
-      }
-    }
-
-    const equivocators = this.equivocators.get(committeeRoot);
+  /** Inclusion lists for the given committee positions, to serve InclusionListsByIndices. */
+  getByIndices(slot: Slot, dependentRoot: RootHex, indices: BitArray): heze.SignedInclusionList[] {
     const out: heze.SignedInclusionList[] = [];
-    for (const signedInclusionList of stored.values()) {
-      const {validatorIndex} = signedInclusionList.message;
-      if (equivocators?.has(validatorIndex) || !requested.has(validatorIndex)) {
-        continue;
+    for (const {signedInclusionList, committeeIndex} of this.getEligible(slot, dependentRoot, false)) {
+      if (indices.get(committeeIndex)) {
+        out.push(signedInclusionList);
       }
-      out.push(signedInclusionList);
     }
     return out;
   }
@@ -214,53 +177,41 @@ export class InclusionListStore {
   prune(clockSlot: Slot): void {
     const horizon = clockSlot - this.config.MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS;
 
-    for (const [slot, committeeRoots] of this.committeeRootsBySlot) {
-      if (slot >= horizon) {
-        continue;
+    for (const slot of this.inclusionLists.keys()) {
+      if (slot < horizon) {
+        this.inclusionLists.delete(slot);
       }
-      for (const committeeRoot of committeeRoots) {
-        const stored = this.inclusionLists.get(committeeRoot);
-        if (stored) {
-          for (const inclusionListRoot of stored.keys()) {
-            this.inclusionListTimeliness.delete(inclusionListRoot);
-          }
-          this.inclusionLists.delete(committeeRoot);
-        }
-        this.equivocators.delete(committeeRoot);
+    }
+    for (const slot of this.equivocators.keys()) {
+      if (slot < horizon) {
+        this.equivocators.delete(slot);
       }
-      this.committeeRootsBySlot.delete(slot);
-      this.validatorIlCountBySlot.delete(slot);
+    }
+    for (const slot of this.validatorIlCountBySlot.keys()) {
+      if (slot < horizon) {
+        this.validatorIlCountBySlot.delete(slot);
+      }
     }
 
     this.lowestPermissibleSlot = Math.max(horizon, 0);
   }
 
-  /**
-   * Inclusion lists at `slot` that count toward the local view: stored under the committee root
-   * implied by the local state, from a non-equivocating validator, and timely when required.
-   */
-  private *getEligible(
-    state: IBeaconStateViewHeze,
-    slot: Slot,
-    onlyTimely: boolean
-  ): Generator<heze.SignedInclusionList> {
-    const committee = state.getInclusionListCommittee(slot);
-    const committeeRoot = toRootHex(ssz.heze.InclusionListCommittee.hashTreeRoot(Array.from(committee)));
-
-    const stored = this.inclusionLists.get(committeeRoot);
+  /** Entries at `(slot, dependentRoot)` from non-equivocating validators, timely when required. */
+  private *getEligible(slot: Slot, dependentRoot: RootHex, onlyTimely: boolean): Generator<InclusionListEntry> {
+    const stored = this.inclusionLists.get(slot)?.get(dependentRoot);
     if (!stored || stored.size === 0) {
       return;
     }
-    const equivocators = this.equivocators.get(committeeRoot);
+    const equivocators = this.equivocators.get(slot)?.get(dependentRoot);
 
-    for (const [inclusionListRoot, signedInclusionList] of stored) {
-      if (equivocators?.has(signedInclusionList.message.validatorIndex)) {
+    for (const [validatorIndex, entry] of stored) {
+      if (equivocators?.has(validatorIndex)) {
         continue;
       }
-      if (onlyTimely && !this.inclusionListTimeliness.get(inclusionListRoot)) {
+      if (onlyTimely && !entry.timely) {
         continue;
       }
-      yield signedInclusionList;
+      yield entry;
     }
   }
 }

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -31,7 +31,6 @@ import {
   isStatePostBellatrix,
   isStatePostCapella,
   isStatePostGloas,
-  isStatePostHeze,
 } from "@lodestar/state-transition";
 import {
   BLSPubkey,
@@ -64,7 +63,7 @@ import {GWEI_TO_WEI, Logger, byteArrayEquals, fromHex, sleep, toHex, toPubkeyHex
 import {ZERO_HASH_HEX} from "../../constants/index.js";
 import {numToQuantity} from "../../execution/engine/utils.js";
 import {IExecutionBuilder, IExecutionEngine, PayloadAttributes, PayloadId} from "../../execution/index.js";
-import {getShufflingDependentRoot} from "../../util/dependentRoot.js";
+import {getInclusionListDependentRoot, getShufflingDependentRoot} from "../../util/dependentRoot.js";
 import {fromGraffitiBytes} from "../../util/graffiti.js";
 import {kzg} from "../../util/kzg.js";
 import type {BeaconChain} from "../chain.js";
@@ -957,15 +956,25 @@ function preparePayloadAttributes(
   }
 
   if (ForkSeq[fork] >= ForkSeq.heze) {
-    if (!isStatePostHeze(prepareState)) {
-      throw new Error("Expected Heze state for Heze payload attributes");
-    }
     // The payload built for prepareSlot must satisfy the inclusion lists observed for the
-    // preceding slot. Unlike validation, the proposer builds against its full view including
-    // untimely lists (only_timely=False in prepare_execution_payload), so the payload also
-    // satisfies the timely-only subset every validator enforces.
+    // preceding slot, keyed by the shuffling dependent root of that slot on the parent's branch.
+    // Unlike validation, the proposer builds against its full view including untimely lists
+    // (only_timely=False in prepare_execution_payload), so the payload also satisfies the
+    // timely-only subset every validator enforces.
+    const parentBlockRootHex = toRootHex(parentBlockRoot);
+    const parentBlock = chain.forkChoice.getBlockHexDefaultStatus(parentBlockRootHex);
+    if (parentBlock === null) {
+      throw new Error(
+        `Parent block not in fork choice for Heze payload attributes parentBlockRoot=${parentBlockRootHex}`
+      );
+    }
+    const inclusionListSlot = prepareSlot - 1;
     (payloadAttributes as heze.SSEPayloadAttributes["payloadAttributes"]).inclusionListTransactions =
-      chain.inclusionListStore.getInclusionListTransactions(prepareState, prepareSlot - 1, false);
+      chain.inclusionListStore.getInclusionListTransactions(
+        inclusionListSlot,
+        getInclusionListDependentRoot(chain.forkChoice, parentBlock, inclusionListSlot),
+        false
+      );
   }
 
   return payloadAttributes;

--- a/packages/beacon-node/src/chain/regen/interface.ts
+++ b/packages/beacon-node/src/chain/regen/interface.ts
@@ -22,6 +22,7 @@ export enum RegenCaller {
   validateGossipAttestation = "validateGossipAttestation",
   validateGossipVoluntaryExit = "validateGossipVoluntaryExit",
   validateGossipExecutionPayloadBid = "validateGossipExecutionPayloadBid",
+  validateGossipInclusionList = "validateGossipInclusionList",
   validateGossipPayloadAttestationMessage = "validateGossipPayloadAttestationMessage",
   validateGossipProposerPreferences = "validateGossipProposerPreferences",
   onForkChoiceFinalized = "onForkChoiceFinalized",

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -1,6 +1,6 @@
 import {PublicKey} from "@chainsafe/blst";
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
-import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
+import {PAYLOAD_BUILDER_VERSION, isForkPostHeze} from "@lodestar/params";
 import {
   computeEpochAtSlot,
   createSingleSignatureSetFromComponents,
@@ -9,11 +9,10 @@ import {
   isGasLimitTargetCompatible,
   isStartSlotOfEpoch,
   isStatePostGloas,
-  isStatePostHeze,
 } from "@lodestar/state-transition";
 import {RootHex, Slot, ValidatorIndex, gloas, heze} from "@lodestar/types";
 import {byteArrayEquals, toHex, toRootHex} from "@lodestar/utils";
-import {getShufflingDependentRoot} from "../../util/dependentRoot.js";
+import {getInclusionListDependentRoot, getShufflingDependentRoot} from "../../util/dependentRoot.js";
 import {ExecutionPayloadBidError, ExecutionPayloadBidErrorCode, GossipAction} from "../errors/index.js";
 import {IBeaconChain} from "../index.js";
 import {RegenCaller} from "../regen/index.js";
@@ -373,11 +372,20 @@ async function validateExecutionPayloadBid(
 
   // [IGNORE] [New in Heze:EIP7805] bid.inclusionListBits covers our view of the inclusion lists
   // for the slot preceding the bid, restricted to the ones that arrived before the deadline. A
-  // builder that saw fewer lists than we did cannot have built a payload satisfying ours.
-  const headState = chain.getHeadState();
-  if (isStatePostHeze(headState)) {
+  // builder that saw fewer lists than we did cannot have built a payload satisfying ours. Our view
+  // is keyed by `(bid.slot - 1, get_shuffling_dependent_root(store, bid.parent_block_root, epoch))`.
+  if (isForkPostHeze(chain.config.getForkName(bid.slot))) {
     const {inclusionListBits} = bid as heze.ExecutionPayloadBid;
-    if (!chain.inclusionListStore.isInclusionListBitsInclusive(headState, bid.slot - 1, inclusionListBits, true)) {
+    const inclusionListSlot = bid.slot - 1;
+    const inclusionListDependentRoot = getInclusionListDependentRoot(chain.forkChoice, parentBlock, inclusionListSlot);
+    if (
+      !chain.inclusionListStore.isInclusionListBitsInclusive(
+        inclusionListSlot,
+        inclusionListDependentRoot,
+        inclusionListBits,
+        true
+      )
+    ) {
       throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
         code: ExecutionPayloadBidErrorCode.INCLUSION_LIST_BITS_NOT_INCLUSIVE,
         builderIndex: bid.builderIndex,

--- a/packages/beacon-node/src/chain/validation/inclusionList.ts
+++ b/packages/beacon-node/src/chain/validation/inclusionList.ts
@@ -1,33 +1,50 @@
-import {isForkPostHeze} from "@lodestar/params";
-import {getInclusionListSignatureSet, isStatePostHeze} from "@lodestar/state-transition";
-import {heze, ssz} from "@lodestar/types";
-import {byteArrayEquals} from "@lodestar/utils";
+import {ProtoBlock} from "@lodestar/fork-choice";
+import {GENESIS_SLOT, MIN_SEED_LOOKAHEAD, isForkPostHeze} from "@lodestar/params";
+import {
+  EpochShuffling,
+  computeEpochAtSlot,
+  computeStartSlotAtEpoch,
+  getInclusionListCommittee,
+  getInclusionListSignatureSet,
+} from "@lodestar/state-transition";
+import {Epoch, RootHex, heze} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
 import {InclusionListSource} from "../blocks/types.js";
 import {InclusionListError, InclusionListErrorCode, InclusionListErrorType} from "../errors/inclusionList.js";
 import {GossipAction} from "../errors/index.js";
 import {IBeaconChain} from "../interface.js";
+import {RegenCaller} from "../regen/index.js";
+import {isValidDependentRoot} from "./proposerPreferences.js";
 
 export enum InvalidInclusionListReason {
   maxSizeExceeded = "max_size_exceeded",
   slotOutOfRange = "slot_out_of_range",
   seenTwice = "seen_twice",
+  unknownDependentRoot = "unknown_dependent_root",
+  invalidDependentRootSlot = "invalid_dependent_root_slot",
+  invalidDependentRoot = "invalid_dependent_root",
+  missingShuffling = "missing_shuffling",
   validatorNotInCommittee = "validator_not_in_committee",
-  committeeRootMismatch = "committee_root_mismatch",
   invalidSignature = "invalid_signature",
   preHezeSlot = "pre_heze_slot",
 }
 
+export type InclusionListValidationResult = {
+  /** Position of `validator_index` in `get_inclusion_list_committee(state, slot)` */
+  committeeIndex: number;
+};
+
 export async function validateApiInclusionList(
   chain: IBeaconChain,
   signedInclusionList: heze.SignedInclusionList
-): Promise<void> {
+): Promise<InclusionListValidationResult> {
   return validateInclusionList(chain, signedInclusionList, InclusionListSource.api);
 }
 
 export async function validateGossipInclusionList(
   chain: IBeaconChain,
   signedInclusionList: heze.SignedInclusionList
-): Promise<void> {
+): Promise<InclusionListValidationResult> {
   return validateInclusionList(chain, signedInclusionList, InclusionListSource.gossip);
 }
 
@@ -38,8 +55,8 @@ async function validateInclusionList(
   chain: IBeaconChain,
   signedInclusionList: heze.SignedInclusionList,
   source: InclusionListSource
-): Promise<void> {
-  const {slot, validatorIndex, transactions, inclusionListCommitteeRoot} = signedInclusionList.message;
+): Promise<InclusionListValidationResult> {
+  const {slot, validatorIndex, transactions, dependentRoot} = signedInclusionList.message;
 
   const inclusionListSize = transactions.reduce((total, transaction) => total + transaction.byteLength, 0);
   const reject = (reason: InvalidInclusionListReason, type: InclusionListErrorType): never => {
@@ -78,7 +95,7 @@ async function validateInclusionList(
   }
 
   // [IGNORE] The message is either the first or second valid message received from validatorIndex.
-  // Checked before the committee lookups below, which are the expensive part.
+  // Checked before the dependent root and committee lookups below, which are the expensive part.
   if (chain.inclusionListStore.seenTwice(slot, validatorIndex)) {
     ignore(InvalidInclusionListReason.seenTwice, {
       code: InclusionListErrorCode.MORE_THAN_TWO,
@@ -86,43 +103,98 @@ async function validateInclusionList(
     });
   }
 
-  // Thrown inline rather than via ignore() so the type guard narrows headState below;
+  // [IGNORE] The block with root message.dependent_root has been seen
+  const dependentRootHex = toRootHex(dependentRoot);
+  // Thrown inline rather than via ignore() so the type guard narrows dependentBlock below;
   // control-flow analysis does not follow never-returning arrow functions.
-  const headState = chain.getHeadState();
-  if (!isStatePostHeze(headState)) {
-    chain.metrics?.inclusionListsInvalid.inc({source, reason: InvalidInclusionListReason.preHezeSlot});
+  const dependentBlock = chain.forkChoice.getBlockHexDefaultStatus(dependentRootHex);
+  if (dependentBlock === null) {
+    chain.metrics?.inclusionListsInvalid.inc({source, reason: InvalidInclusionListReason.unknownDependentRoot});
     throw new InclusionListError(GossipAction.IGNORE, {
-      code: InclusionListErrorCode.PRE_HEZE_SLOT,
-      inclusionListSlot: slot,
+      code: InclusionListErrorCode.UNKNOWN_DEPENDENT_ROOT,
+      dependentRoot: dependentRootHex,
     });
   }
 
-  const committee = headState.getInclusionListCommittee(slot);
+  // [REJECT] The slot of the block with root message.dependent_root is strictly less than
+  // compute_start_slot_at_epoch(compute_epoch_at_slot(message.slot) - MIN_SEED_LOOKAHEAD).
+  // Clamped to genesis like compute_shuffling_dependent_slot, which returns GENESIS_SLOT for the
+  // first MIN_SEED_LOOKAHEAD epochs.
+  const epoch = computeEpochAtSlot(slot);
+  const dependentEpoch = epoch - MIN_SEED_LOOKAHEAD;
+  const maxDependentSlot = Math.max(GENESIS_SLOT, computeStartSlotAtEpoch(dependentEpoch) - 1);
+  if (dependentBlock.slot > maxDependentSlot) {
+    reject(InvalidInclusionListReason.invalidDependentRootSlot, {
+      code: InclusionListErrorCode.INVALID_DEPENDENT_ROOT_SLOT,
+      dependentRoot: dependentRootHex,
+      dependentSlot: dependentBlock.slot,
+      maxSlot: maxDependentSlot,
+    });
+  }
 
-  // [REJECT] validatorIndex is in get_inclusion_list_committee(state, message.slot)
-  if (!committee.includes(validatorIndex)) {
+  // [IGNORE] is_valid_dependent_root(store, message.dependent_root, epoch - MIN_SEED_LOOKAHEAD)
+  if (!isValidDependentRoot(chain.forkChoice, dependentBlock, dependentEpoch)) {
+    ignore(InvalidInclusionListReason.invalidDependentRoot, {
+      code: InclusionListErrorCode.INVALID_DEPENDENT_ROOT,
+      dependentRoot: dependentRootHex,
+      epoch: dependentEpoch,
+    });
+  }
+
+  // [REJECT] validatorIndex is in get_inclusion_list_committee(state, message.slot), where state is the
+  // state of the block with root message.dependent_root processed up to message.slot. That committee is
+  // the shuffling of `epoch` keyed by `dependent_root`.
+  const shuffling = await getShuffling(chain, epoch, dependentRootHex, dependentBlock);
+  if (shuffling === null) {
+    chain.metrics?.inclusionListsInvalid.inc({source, reason: InvalidInclusionListReason.missingShuffling});
+    throw new InclusionListError(GossipAction.IGNORE, {
+      code: InclusionListErrorCode.MISSING_SHUFFLING,
+      dependentRoot: dependentRootHex,
+      epoch,
+    });
+  }
+  const committeeIndex = getInclusionListCommittee(shuffling, slot).indexOf(validatorIndex);
+  if (committeeIndex === -1) {
     reject(InvalidInclusionListReason.validatorNotInCommittee, {
       code: InclusionListErrorCode.VALIDATOR_NOT_IN_COMMITTEE,
       validatorIndex,
     });
   }
 
-  // [REJECT] message.inclusionListCommitteeRoot equals hash_tree_root of the local committee
-  const expectedCommitteeRoot = ssz.heze.InclusionListCommittee.hashTreeRoot(Array.from(committee));
-  if (!byteArrayEquals(inclusionListCommitteeRoot, expectedCommitteeRoot)) {
-    reject(InvalidInclusionListReason.committeeRootMismatch, {
-      code: InclusionListErrorCode.INVALID_COMMITTEE_ROOT,
-      received: inclusionListCommitteeRoot,
-      expected: expectedCommitteeRoot,
-    });
-  }
-
   // [REJECT] The signature is valid with respect to the validator's public key
-  const signatureSet = getInclusionListSignatureSet(chain.config, headState.slot, signedInclusionList);
+  const signatureSet = getInclusionListSignatureSet(chain.config, chain.clock.currentSlot, signedInclusionList);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
     reject(InvalidInclusionListReason.invalidSignature, {code: InclusionListErrorCode.INVALID_SIGNATURE});
   }
 
   chain.metrics?.inclusionListsValid.inc({source});
   chain.metrics?.inclusionListsValidSize.inc(inclusionListSize);
+
+  return {committeeIndex};
+}
+
+/**
+ * The shuffling of `epoch` on the branch of `dependentBlock`. Head states populate the cache with
+ * their current and next shufflings, so this only regenerates on a branch the head has not seen.
+ */
+async function getShuffling(
+  chain: IBeaconChain,
+  epoch: Epoch,
+  dependentRootHex: RootHex,
+  dependentBlock: ProtoBlock
+): Promise<EpochShuffling | null> {
+  const cached = await chain.shufflingCache.get(epoch, dependentRootHex);
+  if (cached !== null) {
+    return cached;
+  }
+  try {
+    return await chain.regenStateForAttestationVerification(
+      epoch,
+      dependentRootHex,
+      dependentBlock,
+      RegenCaller.validateGossipInclusionList
+    );
+  } catch {
+    return null;
+  }
 }

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1346,8 +1346,9 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       );
 
       const timer = metrics?.inclusionListsValidationTime.startTimer();
+      let committeeIndex: number;
       try {
-        await validateGossipInclusionList(chain, signedInclusionList);
+        ({committeeIndex} = await validateGossipInclusionList(chain, signedInclusionList));
       } finally {
         timer?.({source: InclusionListSource.gossip});
       }
@@ -1358,7 +1359,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       metrics?.inclusionListArrivalTime.observe(secFromSlot);
       const isTimely = secFromSlot * 1000 < config.getInclusionListDueMs();
 
-      const insertOutcome = chain.inclusionListStore.process(signedInclusionList, isTimely);
+      const insertOutcome = chain.inclusionListStore.process(signedInclusionList, committeeIndex, isTimely);
       metrics?.opPool.inclusionListStore.insertOutcome.inc({insertOutcome});
       metrics?.opPool.inclusionListStore.size.set(chain.inclusionListStore.size);
 

--- a/packages/beacon-node/src/network/reqresp/handlers/inclusionListsByIndices.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/inclusionListsByIndices.ts
@@ -1,6 +1,6 @@
 import {PeerId} from "@libp2p/interface";
 import {ResponseOutgoing} from "@lodestar/reqresp";
-import {computeEpochAtSlot, computeStartSlotAtEpoch, isStatePostHeze} from "@lodestar/state-transition";
+import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {heze, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
@@ -20,7 +20,7 @@ export async function* onInclusionListsByIndices(
   peerId: PeerId,
   peerClient: string
 ): AsyncIterable<ResponseOutgoing> {
-  const {slot, inclusionListCommitteeRoot, indices} = requestBody;
+  const {slot, dependentRoot, indices} = requestBody;
 
   const minimumRequestSlot = Math.max(
     chain.clock.currentSlot - chain.config.MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS,
@@ -36,17 +36,7 @@ export async function* onInclusionListsByIndices(
     return;
   }
 
-  const headState = chain.getHeadState();
-  if (!isStatePostHeze(headState)) {
-    return;
-  }
-
-  const signedInclusionLists = chain.inclusionListStore.getByIndices(
-    headState,
-    slot,
-    toRootHex(inclusionListCommitteeRoot),
-    indices
-  );
+  const signedInclusionLists = chain.inclusionListStore.getByIndices(slot, toRootHex(dependentRoot), indices);
 
   const boundary = chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(slot));
   for (const signedInclusionList of signedInclusionLists.slice(0, chain.config.MAX_REQUEST_INCLUSION_LIST)) {

--- a/packages/beacon-node/src/util/dependentRoot.ts
+++ b/packages/beacon-node/src/util/dependentRoot.ts
@@ -1,5 +1,7 @@
 import {EpochDifference, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
-import {Epoch, RootHex} from "@lodestar/types";
+import {MIN_SEED_LOOKAHEAD} from "@lodestar/params";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {Epoch, RootHex, Slot} from "@lodestar/types";
 
 /**
  * Get dependent root of a shuffling given a message epoch and a proto block.
@@ -48,4 +50,23 @@ export function getShufflingDependentRoot(
   }
 
   return shufflingDependentRoot;
+}
+
+/**
+ * Spec `get_shuffling_dependent_root(store, block.root, compute_epoch_at_slot(inclusionListSlot))`:
+ * the ancestor of `block` at `compute_shuffling_dependent_slot(epoch)`, the last block before the
+ * start of `epoch - MIN_SEED_LOOKAHEAD`. Unlike `getShufflingDependentRoot`, `block` may sit at or
+ * after `epoch`: a payload is checked against the inclusion lists of the slot preceding its block.
+ */
+export function getInclusionListDependentRoot(
+  forkChoice: IForkChoice,
+  block: ProtoBlock,
+  inclusionListSlot: Slot
+): RootHex {
+  const epoch = computeEpochAtSlot(inclusionListSlot);
+  const blockEpoch = computeEpochAtSlot(block.slot);
+  if (blockEpoch < epoch - MIN_SEED_LOOKAHEAD) {
+    return block.blockRoot;
+  }
+  return forkChoice.getDependentRoot(block, blockEpoch - epoch + MIN_SEED_LOOKAHEAD);
 }

--- a/packages/beacon-node/test/unit/chain/opPools/inclusionListStore.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/inclusionListStore.test.ts
@@ -2,31 +2,29 @@ import {beforeEach, describe, expect, it} from "vitest";
 import {BitArray} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
 import {INCLUSION_LIST_COMMITTEE_SIZE} from "@lodestar/params";
-import type {IBeaconStateViewHeze} from "@lodestar/state-transition";
-import {ValidatorIndex, heze, ssz} from "@lodestar/types";
+import {ValidatorIndex, heze} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
 import {InclusionListInsertOutcome, InclusionListStore} from "../../../../src/chain/opPools/inclusionListStore.js";
 
 describe("chain / opPools / InclusionListStore", () => {
   const slot = 100;
-  // Distinct validator indices, one per committee position
+  const dependentRoot = Buffer.alloc(32, 0xaa);
+  const dependentRootHex = toRootHex(dependentRoot);
+  // Distinct validator indices, one per committee position: validator i + 1 sits at position i
   const committee = Uint32Array.from(Array.from({length: INCLUSION_LIST_COMMITTEE_SIZE}, (_, i) => i + 1));
-  const committeeRoot = ssz.heze.InclusionListCommittee.hashTreeRoot(Array.from(committee));
-
-  const state = {
-    getInclusionListCommittee: () => committee,
-  } as unknown as IBeaconStateViewHeze;
+  const committeeIndexOf = (validatorIndex: ValidatorIndex): number => committee.indexOf(validatorIndex);
 
   const config = {MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS: 1} as BeaconConfig;
 
   const makeInclusionList = (
     validatorIndex: ValidatorIndex,
     transactions: Uint8Array[],
-    opts?: {slot?: number; committeeRoot?: Uint8Array}
+    opts?: {slot?: number; dependentRoot?: Uint8Array}
   ): heze.SignedInclusionList => ({
     message: {
       slot: opts?.slot ?? slot,
       validatorIndex,
-      inclusionListCommitteeRoot: opts?.committeeRoot ?? committeeRoot,
+      dependentRoot: opts?.dependentRoot ?? dependentRoot,
       transactions,
     },
     signature: Buffer.alloc(96, 0),
@@ -36,77 +34,102 @@ describe("chain / opPools / InclusionListStore", () => {
   const txB = Uint8Array.from([4, 5]);
 
   let store: InclusionListStore;
+  const process = (signedInclusionList: heze.SignedInclusionList, timely: boolean): InclusionListInsertOutcome =>
+    store.process(signedInclusionList, committeeIndexOf(signedInclusionList.message.validatorIndex), timely);
+
   beforeEach(() => {
     store = new InclusionListStore(config);
   });
 
   it("stores a new inclusion list", () => {
-    expect(store.process(makeInclusionList(1, [txA]), true)).toBe(InclusionListInsertOutcome.New);
+    expect(process(makeInclusionList(1, [txA]), true)).toBe(InclusionListInsertOutcome.New);
     expect(store.size).toBe(1);
   });
 
   it("returns Seen for an identical re-submission without marking an equivocation", () => {
-    store.process(makeInclusionList(1, [txA]), true);
+    process(makeInclusionList(1, [txA]), true);
 
-    expect(store.process(makeInclusionList(1, [txA]), true)).toBe(InclusionListInsertOutcome.Seen);
+    expect(process(makeInclusionList(1, [txA]), true)).toBe(InclusionListInsertOutcome.Seen);
     expect(store.size).toBe(1);
-    expect(store.getInclusionListTransactions(state, slot)).toHaveLength(1);
+    expect(store.getInclusionListTransactions(slot, dependentRootHex)).toHaveLength(1);
   });
 
   it("marks an equivocation on a conflicting inclusion list and stops counting the validator", () => {
-    store.process(makeInclusionList(1, [txA]), true);
-    store.process(makeInclusionList(2, [txB]), true);
+    process(makeInclusionList(1, [txA]), true);
+    process(makeInclusionList(2, [txB]), true);
 
-    expect(store.process(makeInclusionList(1, [txB]), true)).toBe(InclusionListInsertOutcome.Equivocating);
-    // The conflicting list is not stored, and the already-stored one stops counting
-    expect(store.getInclusionListTransactions(state, slot)).toEqual([txB]);
-    expect(store.getInclusionListBits(state, slot).getTrueBitIndexes()).toEqual([1]);
+    expect(process(makeInclusionList(1, [txB]), true)).toBe(InclusionListInsertOutcome.Equivocating);
+    // The first list stays stored but no longer counts
+    expect(store.size).toBe(2);
+    expect(store.getInclusionListTransactions(slot, dependentRootHex)).toEqual([txB]);
+    expect(store.getInclusionListBits(slot, dependentRootHex).getTrueBitIndexes()).toEqual([1]);
 
-    expect(store.process(makeInclusionList(1, [txA]), true)).toBe(InclusionListInsertOutcome.SubsequentEquivocation);
+    expect(process(makeInclusionList(1, [txB]), true)).toBe(InclusionListInsertOutcome.SubsequentEquivocation);
+    // The stored list is already processed, resubmitting it is not new evidence
+    expect(process(makeInclusionList(1, [txA]), true)).toBe(InclusionListInsertOutcome.Seen);
+    expect(store.getInclusionListTransactions(slot, dependentRootHex)).toEqual([txB]);
   });
 
   it("deduplicates transactions across inclusion lists", () => {
-    store.process(makeInclusionList(1, [txA, txB]), true);
-    store.process(makeInclusionList(2, [txA]), true);
+    process(makeInclusionList(1, [txA, txB]), true);
+    process(makeInclusionList(2, [txA]), true);
 
-    expect(store.getInclusionListTransactions(state, slot)).toEqual([txA, txB]);
+    expect(store.getInclusionListTransactions(slot, dependentRootHex)).toEqual([txA, txB]);
   });
 
   it("excludes untimely inclusion lists unless onlyTimely is false", () => {
-    store.process(makeInclusionList(1, [txA]), true);
-    store.process(makeInclusionList(2, [txB]), false);
+    process(makeInclusionList(1, [txA]), true);
+    process(makeInclusionList(2, [txB]), false);
 
-    expect(store.getInclusionListTransactions(state, slot)).toEqual([txA]);
-    expect(store.getInclusionListBits(state, slot).getTrueBitIndexes()).toEqual([0]);
+    expect(store.getInclusionListTransactions(slot, dependentRootHex)).toEqual([txA]);
+    expect(store.getInclusionListBits(slot, dependentRootHex).getTrueBitIndexes()).toEqual([0]);
 
-    expect(store.getInclusionListTransactions(state, slot, false)).toEqual([txA, txB]);
-    expect(store.getInclusionListBits(state, slot, false).getTrueBitIndexes()).toEqual([0, 1]);
+    expect(store.getInclusionListTransactions(slot, dependentRootHex, false)).toEqual([txA, txB]);
+    expect(store.getInclusionListBits(slot, dependentRootHex, false).getTrueBitIndexes()).toEqual([0, 1]);
   });
 
-  it("ignores inclusion lists stored under a different committee root", () => {
+  it("keys inclusion lists by slot and dependent root", () => {
     const otherRoot = Buffer.alloc(32, 0xff);
-    store.process(makeInclusionList(1, [txA], {committeeRoot: otherRoot}), true);
+    process(makeInclusionList(1, [txA], {dependentRoot: otherRoot}), true);
+    process(makeInclusionList(2, [txB], {slot: slot + 1}), true);
 
-    expect(store.size).toBe(1);
-    expect(store.getInclusionListTransactions(state, slot)).toEqual([]);
+    expect(store.size).toBe(2);
+    expect(store.getInclusionListTransactions(slot, dependentRootHex)).toEqual([]);
+    expect(store.getInclusionListTransactions(slot, toRootHex(otherRoot))).toEqual([txA]);
+    expect(store.getInclusionListTransactions(slot + 1, dependentRootHex)).toEqual([txB]);
+  });
+
+  it("tracks equivocations per slot and dependent root", () => {
+    const otherRoot = Buffer.alloc(32, 0xff);
+    process(makeInclusionList(1, [txA]), true);
+    process(makeInclusionList(1, [txB]), true);
+
+    expect(process(makeInclusionList(1, [txA], {dependentRoot: otherRoot}), true)).toBe(InclusionListInsertOutcome.New);
+    expect(store.getInclusionListTransactions(slot, dependentRootHex)).toEqual([]);
+    expect(store.getInclusionListTransactions(slot, toRootHex(otherRoot))).toEqual([txA]);
   });
 
   describe("isInclusionListBitsInclusive", () => {
     beforeEach(() => {
-      store.process(makeInclusionList(1, [txA]), true);
-      store.process(makeInclusionList(3, [txB]), true);
+      process(makeInclusionList(1, [txA]), true);
+      process(makeInclusionList(3, [txB]), true);
     });
 
     it("accepts bits that cover the local view", () => {
       const bits = BitArray.fromBoolArray(
         Array.from({length: INCLUSION_LIST_COMMITTEE_SIZE}, (_, i) => i === 0 || i === 2 || i === 5)
       );
-      expect(store.isInclusionListBitsInclusive(state, slot, bits)).toBe(true);
+      expect(store.isInclusionListBitsInclusive(slot, dependentRootHex, bits)).toBe(true);
     });
 
     it("rejects bits missing a locally observed inclusion list", () => {
       const bits = BitArray.fromBoolArray(Array.from({length: INCLUSION_LIST_COMMITTEE_SIZE}, (_, i) => i === 0));
-      expect(store.isInclusionListBitsInclusive(state, slot, bits)).toBe(false);
+      expect(store.isInclusionListBitsInclusive(slot, dependentRootHex, bits)).toBe(false);
+    });
+
+    it("accepts any bits for an unknown dependent root", () => {
+      const bits = BitArray.fromBitLen(INCLUSION_LIST_COMMITTEE_SIZE);
+      expect(store.isInclusionListBitsInclusive(slot, toRootHex(Buffer.alloc(32, 0xff)), bits)).toBe(true);
     });
   });
 
@@ -114,29 +137,29 @@ describe("chain / opPools / InclusionListStore", () => {
     it("returns only the requested committee positions", () => {
       const first = makeInclusionList(1, [txA]);
       const third = makeInclusionList(3, [txB]);
-      store.process(first, true);
-      store.process(third, true);
+      process(first, true);
+      process(third, true);
 
       const indices = BitArray.fromBoolArray(Array.from({length: INCLUSION_LIST_COMMITTEE_SIZE}, (_, i) => i === 2));
-      expect(store.getByIndices(state, slot, committeeRootHex(), indices)).toEqual([third]);
+      expect(store.getByIndices(slot, dependentRootHex, indices)).toEqual([third]);
     });
 
     it("serves untimely inclusion lists but never equivocators", () => {
       const untimely = makeInclusionList(1, [txA]);
-      store.process(untimely, false);
-      store.process(makeInclusionList(3, [txA]), true);
-      store.process(makeInclusionList(3, [txB]), true);
+      process(untimely, false);
+      process(makeInclusionList(3, [txA]), true);
+      process(makeInclusionList(3, [txB]), true);
 
       const indices = BitArray.fromBoolArray(
         Array.from({length: INCLUSION_LIST_COMMITTEE_SIZE}, (_, i) => i === 0 || i === 2)
       );
-      expect(store.getByIndices(state, slot, committeeRootHex(), indices)).toEqual([untimely]);
+      expect(store.getByIndices(slot, dependentRootHex, indices)).toEqual([untimely]);
     });
   });
 
   describe("prune", () => {
     it("retains MIN_SLOTS_FOR_INCLUSION_LISTS_REQUESTS slots beyond the inclusion list slot", () => {
-      store.process(makeInclusionList(1, [txA]), true);
+      process(makeInclusionList(1, [txA]), true);
 
       store.prune(slot + 1);
       expect(store.size).toBe(1);
@@ -148,24 +171,17 @@ describe("chain / opPools / InclusionListStore", () => {
     it("rejects inclusion lists below the prune horizon", () => {
       store.prune(slot + 2);
 
-      expect(store.process(makeInclusionList(1, [txA]), true)).toBe(InclusionListInsertOutcome.Old);
+      expect(process(makeInclusionList(1, [txA]), true)).toBe(InclusionListInsertOutcome.Old);
+      expect(store.size).toBe(0);
     });
-  });
 
-  describe("seenTwice", () => {
-    it("tracks the p2p first-or-second message rule per validator and slot", () => {
-      expect(store.seenTwice(slot, 1)).toBe(false);
-
-      store.process(makeInclusionList(1, [txA]), true);
-      expect(store.seenTwice(slot, 1)).toBe(false);
-
-      store.process(makeInclusionList(1, [txB]), true);
+    it("forgets the first-or-second rule counters of pruned slots", () => {
+      process(makeInclusionList(1, [txA]), true);
+      process(makeInclusionList(1, [txB]), true);
       expect(store.seenTwice(slot, 1)).toBe(true);
-      expect(store.seenTwice(slot, 2)).toBe(false);
+
+      store.prune(slot + 2);
+      expect(store.seenTwice(slot, 1)).toBe(false);
     });
   });
-
-  function committeeRootHex(): string {
-    return `0x${Buffer.from(committeeRoot).toString("hex")}`;
-  }
 });

--- a/packages/types/src/heze/sszTypes.ts
+++ b/packages/types/src/heze/sszTypes.ts
@@ -25,7 +25,7 @@ export const InclusionList = new ContainerType(
   {
     slot: Slot,
     validatorIndex: ValidatorIndex,
-    inclusionListCommitteeRoot: Root,
+    dependentRoot: Root,
     transactions: InclusionListTransactions,
   },
   {typeName: "InclusionList", jsonCase: "eth2"}
@@ -42,7 +42,7 @@ export const SignedInclusionList = new ContainerType(
 export const InclusionListsByIndicesRequest = new ContainerType(
   {
     slot: Slot,
-    inclusionListCommitteeRoot: Root,
+    dependentRoot: Root,
     indices: new BitVectorType(INCLUSION_LIST_COMMITTEE_SIZE),
   },
   {typeName: "InclusionListsByIndicesRequest", jsonCase: "eth2"}

--- a/packages/validator/src/services/inclusionList.ts
+++ b/packages/validator/src/services/inclusionList.ts
@@ -112,7 +112,7 @@ export class InclusionListService {
         const inclusionList: heze.InclusionList = {
           slot: duty.slot,
           validatorIndex: duty.validatorIndex,
-          inclusionListCommitteeRoot: duty.inclusionListCommitteeRoot,
+          dependentRoot: duty.dependentRoot,
           transactions: inclusionListTransactions,
         };
         try {


### PR DESCRIPTION
**Motivation**

On `focil-devnet-0` (ethrex/besu × lodestar/teku, ethereum-package) Lodestar and Teku disagree on the `InclusionList` container. consensus-specs [#5513](https://github.com/ethereum/consensus-specs/pull/5513) (in `v1.7.0-alpha.14`) renamed `inclusion_list_committee_root` to `dependent_root` and changed its meaning to the shuffling dependent root of the inclusion list's epoch; [#5544](https://github.com/ethereum/consensus-specs/pull/5544) re-keyed the `InclusionListStore` by `(slot, dependent_root)`. Teku (`a5315f7a`) implements the new semantics; this branch still implements the alpha.13 `hash_tree_root(committee)` form.

Observable effects on the devnet:
- Dora: `beacon block stream failed to decode inclusion_list event: dependent root missing client=1-ethrex-lodestar` — the `inclusion_list` SSE event serializes the old field name.
- Inclusion lists from Teku would fail Lodestar's committee-root equality check (`INCLUSION_LIST_ERROR_INVALID_COMMITTEE_ROOT`) and vice versa, since the root is a block root under the new spec.

**Description**

Port of #5513 / #5544:

- `types`: rename the field on `InclusionList` and `InclusionListsByIndicesRequest` (SSZ layout unchanged, JSON name is now `dependent_root`).
- Gossip validation (`chain/validation/inclusionList.ts`): replace the committee-root equality check with the new rules — `[IGNORE]` dependent block seen, `[REJECT]` dependent block slot bound, `[IGNORE] is_valid_dependent_root(store, dependent_root, epoch - MIN_SEED_LOOKAHEAD)` (reusing the helper from proposer preferences validation) — and resolve the committee from the shuffling keyed by `(epoch, dependent_root)`, regenerating on a cache miss the same way attestation validation does. Validation now returns the validator's committee position.
- `InclusionListStore`: keyed by `(slot, dependent_root)` with one entry per validator index. The committee position is recorded at insert time so `getInclusionListBits` / `isInclusionListBitsInclusive` / `getByIndices` need no shuffling lookup. Per spec `process_inclusion_list`, the first list of an equivocating validator stays stored but is excluded from reads.
- Payload import (`record_payload_inclusion_list_satisfaction`), payload attributes (`prepare_execution_payload`), bid gossip validation and builder-bid selection derive the key via a new `getInclusionListDependentRoot(forkChoice, block, inclusionListSlot)` = `get_shuffling_dependent_root(store, block.root, compute_epoch_at_slot(slot))`, which unlike `getShufflingDependentRoot` accepts a block at or after the epoch (a payload is checked against the lists of the slot preceding its block).
- `InclusionListsByIndices` handler takes `dependent_root` from the request.
- Validator API: `InclusionListDuty` carries `dependent_root` (the same value as the response's `dependent_root` meta, i.e. `get_shuffling_dependent_root(store, head_root, epoch)`) instead of `inclusion_list_committee_root`, and the VC sets it on the inclusion lists it signs (spec `get_signed_inclusion_list`).

Not in scope, but worth knowing for this devnet: spec `MAX_SIGNED_INCLUSION_LIST_SIZE = 8348` leaves no room for the 4-byte SSZ offset per transaction, so a full 8192-byte list (~65 txs, as Teku and ethrex produce) serializes to ~8580 bytes and is refused by `outboundTransform` (`ssz_snappy encoded data length 8586 > 8348`, 209 of 211 local publishes on the devnet). That needs a spec-side change.

**Testing**

- `pnpm build`, `check-types` on `types`/`api`/`validator`/`beacon-node`, biome clean.
- `InclusionListStore` unit tests rewritten for the new keying/equivocation semantics; `api` and `validator` unit suites pass.
- Not yet run against the devnet — a `focil-devnet-0` image rebuild will follow.

https://claude.ai/code/session_01YHCg1Q6QaZn8rPjB7za3UB