### PR TITLE
fix(beacon-node): skip empty Gloas payloads during range sync

### DIFF
--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -154,7 +154,6 @@ export async function processBlocks(
           // we validated DA before reaching this
           throw new Error(`Payload envelope for slot ${slot} not complete after DA verification`);
         }
-        // we already awaited DA in verifyBlocksInEpoch for this segment
         await importExecutionPayload.call(this, payloadInput, payloadDA, {validSignature: false});
       }
 

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -143,17 +143,18 @@ export async function processBlocks(
         await importBlock.call(this, fullyVerifiedBlock, opts);
       }
 
-      const payloadInput = payloadEnvelopes?.get(slot);
-      if (payloadInput?.hasPayloadEnvelope()) {
+      // PayloadEnvelopeInput is shared and may receive an envelope after the DA snapshot was taken.
+      const payloadDA = payloadDAStatuses.get(slot);
+      if (payloadDA !== undefined) {
+        const payloadInput = payloadEnvelopes?.get(slot);
+        if (payloadInput === undefined) {
+          throw new Error(`Missing payload input for slot ${slot} after DA verification`);
+        }
         if (!payloadInput.isComplete()) {
           // we validated DA before reaching this
           throw new Error(`Payload envelope for slot ${slot} not complete after DA verification`);
         }
         // we already awaited DA in verifyBlocksInEpoch for this segment
-        const payloadDA = payloadDAStatuses.get(slot);
-        if (payloadDA === undefined) {
-          throw new Error(`Missing payload DA status for slot ${slot}`);
-        }
         await importExecutionPayload.call(this, payloadInput, payloadDA, {validSignature: false});
       }
 

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -132,12 +132,15 @@ export async function verifyBlocksInEpoch(
     }> =
       fork >= ForkSeq.gloas
         ? (async () => {
-            // Validate DA for ALL payloads in the Map, not just those paired with blockInputs.
+            // Range sync creates a PayloadEnvelopeInput for every Gloas block, but an entry without
+            // an envelope represents a valid EMPTY slot and has no payload DA to verify.
             // A checkpoint-sync batch may include a payload for a slot whose block was filtered
             // out of relevantBlocks (e.g., the anchor at the finalized slot); that payload still
             // needs DA validation so it can be imported in processBlocks.
             const payloadInputsForDa: PayloadEnvelopeInput[] =
-              payloadEnvelopes !== null ? Array.from(payloadEnvelopes.values()) : [];
+              payloadEnvelopes !== null
+                ? Array.from(payloadEnvelopes.values()).filter((payloadInput) => payloadInput.hasPayloadEnvelope())
+                : [];
             const {dataAvailabilityStatuses, availableTime} = await verifyPayloadsDataAvailability(
               payloadInputsForDa,
               abortController.signal

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -652,7 +652,9 @@ export class SyncChain {
 
         const blockSlots = downloadSuccessOutput.blocks.map((b) => b.slot);
         const envelopeSlots = downloadSuccessOutput.payloadEnvelopes
-          ? Array.from(downloadSuccessOutput.payloadEnvelopes.keys())
+          ? Array.from(downloadSuccessOutput.payloadEnvelopes.entries())
+              .filter(([, payloadInput]) => payloadInput.hasPayloadEnvelope())
+              .map(([slot]) => slot)
           : null;
 
         this.logger.debug(logMessage, {
@@ -684,13 +686,18 @@ export class SyncChain {
    */
   private async processBatch(batch: Batch): Promise<void> {
     const {blocks, payloadEnvelopes, peers} = batch.startProcessing();
+    const envelopeSlots = payloadEnvelopes
+      ? Array.from(payloadEnvelopes.entries())
+          .filter(([, payloadInput]) => payloadInput.hasPayloadEnvelope())
+          .map(([slot]) => slot)
+      : null;
 
     const logCtx = {
       id: this.logId,
       ...batch.getMetadata(),
       blockCount: blocks.length,
       blockSlots: prettyPrintIndices(blocks.map((b) => b.slot)),
-      ...(payloadEnvelopes ? {envelopeSlots: prettyPrintIndices(Array.from(payloadEnvelopes.keys()))} : {}),
+      ...(envelopeSlots ? {envelopeSlots: prettyPrintIndices(envelopeSlots)} : {}),
       peers: peers.map(prettyPrintPeerIdStr).join(","),
     };
     this.logger.verbose("Processing batch", logCtx);

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -212,7 +212,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       for (const block of blocks) {
         await this.chain.processBlock(block, flags);
         const payloadEnvelope = payloadEnvelopes?.get(block.slot);
-        if (payloadEnvelope) {
+        if (payloadEnvelope?.hasPayloadEnvelope()) {
           await this.chain.processExecutionPayload(payloadEnvelope);
         }
       }

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -7,7 +7,11 @@ import {DataAvailabilityStatus, IBeaconStateView} from "@lodestar/state-transiti
 import {ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {importBlock} from "../../../../src/chain/blocks/importBlock.js";
-import {PayloadError, PayloadErrorCode} from "../../../../src/chain/blocks/importExecutionPayload.js";
+import {
+  PayloadError,
+  PayloadErrorCode,
+  importExecutionPayload,
+} from "../../../../src/chain/blocks/importExecutionPayload.js";
 import {processBlocks} from "../../../../src/chain/blocks/index.js";
 import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {assertLinearChainSegment} from "../../../../src/chain/blocks/utils/chainSegment.js";
@@ -21,6 +25,10 @@ import {MockBlockInput} from "../../../utils/blockInput.js";
 import {generateProtoBlock} from "../../../utils/typeGenerator.js";
 
 vi.mock("../../../../src/chain/blocks/importBlock.js");
+vi.mock("../../../../src/chain/blocks/importExecutionPayload.js", async (importActual) => {
+  const mod = await importActual<typeof import("../../../../src/chain/blocks/importExecutionPayload.js")>();
+  return {...mod, importExecutionPayload: vi.fn()};
+});
 vi.mock("../../../../src/chain/blocks/utils/chainSegment.js");
 vi.mock("../../../../src/chain/blocks/verifyBlock.js");
 vi.mock("../../../../src/chain/blocks/verifyBlocksSanityChecks.js");
@@ -119,6 +127,37 @@ describe("chain / blocks / processBlocks", () => {
 
     expect(seenBlockProposers.isKnown(slot, proposerIndex)).toBe(true);
     expect(importBlock).toHaveBeenCalledOnce();
+  });
+
+  it("does not import an envelope received after the DA verification snapshot", async () => {
+    let hasPayloadEnvelope = false;
+    const payloadInput = {
+      slot,
+      hasPayloadEnvelope: () => hasPayloadEnvelope,
+      isComplete: () => true,
+    } as unknown as PayloadEnvelopeInput;
+
+    vi.mocked(verifyBlocksInEpoch).mockImplementation(async () => {
+      hasPayloadEnvelope = true;
+      return {
+        postStates: [{forkName: ForkName.deneb} as IBeaconStateView],
+        proposerBalanceDeltas: [0],
+        segmentExecStatus: {
+          execAborted: null,
+          executionStatuses: [ExecutionStatus.Valid],
+          executionTime: 0,
+        },
+        blockDAStatuses: [DataAvailabilityStatus.Available],
+        payloadDAStatuses: new Map(),
+        indexedAttestationsByBlock: [[]],
+      };
+    });
+
+    await processBlocks.call(chain, [blockInput], new Map([[slot, payloadInput]]), {});
+
+    expect(hasPayloadEnvelope).toBe(true);
+    expect(importBlock).toHaveBeenCalledOnce();
+    expect(importExecutionPayload).not.toHaveBeenCalled();
   });
 
   // The gloas payload import throws a PayloadError. Range sync relies on it arriving intact so it can

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -132,7 +132,10 @@ describe("chain / blocks / processBlocks", () => {
     expect(importBlock).toHaveBeenCalledOnce();
   });
 
-  it("imports a DA-verified payload inline after its block", async () => {
+  it.each([
+    {name: "imports a DA-verified payload inline after its block", envelopeBeforeDa: true},
+    {name: "does not import an envelope received after the DA verification snapshot", envelopeBeforeDa: false},
+  ])("$name", async ({envelopeBeforeDa}) => {
     const gloasConfig = createChainForkConfig({...config, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
     chain = getMockedBeaconChain({config: gloasConfig});
     Object.defineProperty(chain, "seenBlockProposers", {value: seenBlockProposers});
@@ -160,7 +163,9 @@ describe("chain / blocks / processBlocks", () => {
     });
     const envelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
     envelope.message.beaconBlockRoot = blockRoot;
-    payloadInput.addPayloadEnvelope({envelope, source: PayloadEnvelopeInputSource.byRange, seenTimestampSec: 1});
+    if (envelopeBeforeDa) {
+      payloadInput.addPayloadEnvelope({envelope, source: PayloadEnvelopeInputSource.byRange, seenTimestampSec: 1});
+    }
 
     vi.mocked(verifyBlocksSanityChecks).mockReturnValue({
       relevantBlocks: [gloasBlockInput],
@@ -176,51 +181,31 @@ describe("chain / blocks / processBlocks", () => {
         executionTime: 0,
       },
       blockDAStatuses: [DataAvailabilityStatus.NotRequired],
-      payloadDAStatuses: new Map([[slot, DataAvailabilityStatus.NotRequired]]),
+      payloadDAStatuses: new Map(envelopeBeforeDa ? [[slot, DataAvailabilityStatus.NotRequired]] : []),
       indexedAttestationsByBlock: [[]],
+    });
+    vi.mocked(importBlock).mockImplementationOnce(async () => {
+      expect(payloadInput.hasPayloadEnvelope()).toBe(envelopeBeforeDa);
+      if (!envelopeBeforeDa) {
+        payloadInput.addPayloadEnvelope({envelope, source: PayloadEnvelopeInputSource.byRange, seenTimestampSec: 2});
+      }
     });
     vi.mocked(importExecutionPayload).mockResolvedValue(undefined);
 
     await processBlocks.call(chain, [gloasBlockInput], new Map([[slot, payloadInput]]), {});
 
+    expect(payloadInput.isComplete()).toBe(true);
     expect(importBlock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({blockInput: gloasBlockInput}), {});
-    expect(importExecutionPayload).toHaveBeenCalledExactlyOnceWith(payloadInput, DataAvailabilityStatus.NotRequired, {
-      validSignature: false,
-    });
-    expect(vi.mocked(importBlock).mock.invocationCallOrder[0]).toBeLessThan(
-      vi.mocked(importExecutionPayload).mock.invocationCallOrder[0]
-    );
-  });
-
-  it("does not import an envelope received after the DA verification snapshot", async () => {
-    let hasPayloadEnvelope = false;
-    const payloadInput = {
-      slot,
-      hasPayloadEnvelope: () => hasPayloadEnvelope,
-      isComplete: () => true,
-    } as unknown as PayloadEnvelopeInput;
-
-    vi.mocked(verifyBlocksInEpoch).mockImplementation(async () => {
-      hasPayloadEnvelope = true;
-      return {
-        postStates: [{forkName: ForkName.deneb} as IBeaconStateView],
-        proposerBalanceDeltas: [0],
-        segmentExecStatus: {
-          execAborted: null,
-          executionStatuses: [ExecutionStatus.Valid],
-          executionTime: 0,
-        },
-        blockDAStatuses: [DataAvailabilityStatus.Available],
-        payloadDAStatuses: new Map(),
-        indexedAttestationsByBlock: [[]],
-      };
-    });
-
-    await processBlocks.call(chain, [blockInput], new Map([[slot, payloadInput]]), {});
-
-    expect(hasPayloadEnvelope).toBe(true);
-    expect(importBlock).toHaveBeenCalledOnce();
-    expect(importExecutionPayload).not.toHaveBeenCalled();
+    if (envelopeBeforeDa) {
+      expect(importExecutionPayload).toHaveBeenCalledExactlyOnceWith(payloadInput, DataAvailabilityStatus.NotRequired, {
+        validSignature: false,
+      });
+      expect(vi.mocked(importBlock).mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(importExecutionPayload).mock.invocationCallOrder[0]
+      );
+    } else {
+      expect(importExecutionPayload).not.toHaveBeenCalled();
+    }
   });
 
   // The gloas payload import throws a PayloadError. Range sync relies on it arriving intact so it can

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -6,6 +6,8 @@ import {ForkName} from "@lodestar/params";
 import {DataAvailabilityStatus, IBeaconStateView} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
+import {BlockInputNoData} from "../../../../src/chain/blocks/blockInput/blockInput.js";
+import {BlockInputSource} from "../../../../src/chain/blocks/blockInput/types.js";
 import {importBlock} from "../../../../src/chain/blocks/importBlock.js";
 import {
   PayloadError,
@@ -14,6 +16,7 @@ import {
 } from "../../../../src/chain/blocks/importExecutionPayload.js";
 import {processBlocks} from "../../../../src/chain/blocks/index.js";
 import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
+import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
 import {assertLinearChainSegment} from "../../../../src/chain/blocks/utils/chainSegment.js";
 import {verifyBlocksInEpoch} from "../../../../src/chain/blocks/verifyBlock.js";
 import {verifyBlocksSanityChecks} from "../../../../src/chain/blocks/verifyBlocksSanityChecks.js";
@@ -127,6 +130,66 @@ describe("chain / blocks / processBlocks", () => {
 
     expect(seenBlockProposers.isKnown(slot, proposerIndex)).toBe(true);
     expect(importBlock).toHaveBeenCalledOnce();
+  });
+
+  it("imports a DA-verified payload inline after its block", async () => {
+    const gloasConfig = createChainForkConfig({...config, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
+    chain = getMockedBeaconChain({config: gloasConfig});
+    Object.defineProperty(chain, "seenBlockProposers", {value: seenBlockProposers});
+    const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+    block.message.slot = slot;
+    const blockRoot = ssz.gloas.BeaconBlock.hashTreeRoot(block.message);
+    const blockRootHex = toRootHex(blockRoot);
+    const gloasBlockInput = BlockInputNoData.createFromBlock({
+      block,
+      blockRootHex,
+      forkName: ForkName.gloas,
+      daOutOfRange: false,
+      source: BlockInputSource.byRange,
+      seenTimestampSec: 0,
+    });
+    const payloadInput = PayloadEnvelopeInput.createFromBlock({
+      block,
+      blockRootHex,
+      forkName: ForkName.gloas,
+      sampledColumns: [0],
+      custodyColumns: [0],
+      daOutOfRange: false,
+      source: PayloadEnvelopeInputSource.byRange,
+      seenTimestampSec: 0,
+    });
+    const envelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    envelope.message.beaconBlockRoot = blockRoot;
+    payloadInput.addPayloadEnvelope({envelope, source: PayloadEnvelopeInputSource.byRange, seenTimestampSec: 1});
+
+    vi.mocked(verifyBlocksSanityChecks).mockReturnValue({
+      relevantBlocks: [gloasBlockInput],
+      parentSlots: [slot - 1],
+      parentBlock: generateProtoBlock({slot: slot - 1}),
+    });
+    vi.mocked(verifyBlocksInEpoch).mockResolvedValue({
+      postStates: [{forkName: ForkName.gloas} as IBeaconStateView],
+      proposerBalanceDeltas: [0],
+      segmentExecStatus: {
+        execAborted: null,
+        executionStatuses: [ExecutionStatus.Valid],
+        executionTime: 0,
+      },
+      blockDAStatuses: [DataAvailabilityStatus.NotRequired],
+      payloadDAStatuses: new Map([[slot, DataAvailabilityStatus.NotRequired]]),
+      indexedAttestationsByBlock: [[]],
+    });
+    vi.mocked(importExecutionPayload).mockResolvedValue(undefined);
+
+    await processBlocks.call(chain, [gloasBlockInput], new Map([[slot, payloadInput]]), {});
+
+    expect(importBlock).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({blockInput: gloasBlockInput}), {});
+    expect(importExecutionPayload).toHaveBeenCalledExactlyOnceWith(payloadInput, DataAvailabilityStatus.NotRequired, {
+      validSignature: false,
+    });
+    expect(vi.mocked(importBlock).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(importExecutionPayload).mock.invocationCallOrder[0]
+    );
   });
 
   it("does not import an envelope received after the DA verification snapshot", async () => {

--- a/packages/beacon-node/test/unit/chain/blocks/verifyBlock.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyBlock.test.ts
@@ -4,8 +4,10 @@ import {config as configDef} from "@lodestar/config/default";
 import {ExecutionStatus} from "@lodestar/fork-choice";
 import {ForkName} from "@lodestar/params";
 import {DataAvailabilityStatus, IBeaconStateView} from "@lodestar/state-transition";
-import {SignedBeaconBlock, ssz} from "@lodestar/types";
+import {ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
+import {BlockInputNoData} from "../../../../src/chain/blocks/blockInput/blockInput.js";
+import {BlockInputSource} from "../../../../src/chain/blocks/blockInput/types.js";
 import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
 import {verifyBlocksInEpoch} from "../../../../src/chain/blocks/verifyBlock.js";
@@ -14,7 +16,6 @@ import {verifyBlocksSignatures} from "../../../../src/chain/blocks/verifyBlocksS
 import {verifyBlocksStateTransitionOnly} from "../../../../src/chain/blocks/verifyBlocksStateTransitionOnly.js";
 import {SeenBlockProposers} from "../../../../src/chain/seenCache/seenBlockProposers.js";
 import {getMockedBeaconChain} from "../../../mocks/mockedBeaconChain.js";
-import {MockBlockInput} from "../../../utils/blockInput.js";
 import {generateProtoBlock} from "../../../utils/typeGenerator.js";
 
 vi.mock("../../../../src/chain/blocks/verifyBlocksExecutionPayloads.js");
@@ -55,16 +56,18 @@ describe("chain / blocks / verifyBlocksInEpoch", () => {
     );
     const blockRoot = ssz.gloas.BeaconBlock.hashTreeRoot(block.message);
     const blockRootHex = toRootHex(blockRoot);
-    const blockInput = new MockBlockInput({
-      forkName: ForkName.gloas,
-      slot: block.message.slot,
+    const blockInput = BlockInputNoData.createFromBlock({
+      block,
       blockRootHex,
+      forkName: ForkName.gloas,
+      daOutOfRange: false,
+      source: BlockInputSource.byRange,
+      seenTimestampSec: 0,
     });
-    blockInput._block = block;
 
     const payloadInput = PayloadEnvelopeInput.createFromBlock({
       blockRootHex,
-      block: block as SignedBeaconBlock<typeof ForkName.gloas>,
+      block,
       forkName: ForkName.gloas,
       sampledColumns: [0],
       custodyColumns: [0],

--- a/packages/beacon-node/test/unit/chain/blocks/verifyBlock.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyBlock.test.ts
@@ -3,7 +3,7 @@ import {createChainForkConfig} from "@lodestar/config";
 import {config as configDef} from "@lodestar/config/default";
 import {ExecutionStatus} from "@lodestar/fork-choice";
 import {ForkName} from "@lodestar/params";
-import {IBeaconStateView} from "@lodestar/state-transition";
+import {DataAvailabilityStatus, IBeaconStateView} from "@lodestar/state-transition";
 import {SignedBeaconBlock, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
@@ -26,12 +26,35 @@ describe("chain / blocks / verifyBlocksInEpoch", () => {
     vi.clearAllMocks();
   });
 
-  it("does not verify DA for an empty Gloas payload slot", async () => {
+  it.each([
+    {
+      name: "does not verify DA for an empty Gloas payload slot",
+      hasEnvelope: false,
+      blobCount: 0,
+      expectedPayloadDA: undefined,
+    },
+    {
+      name: "verifies DA for a received Gloas payload envelope without blobs",
+      hasEnvelope: true,
+      blobCount: 0,
+      expectedPayloadDA: DataAvailabilityStatus.NotRequired,
+    },
+    {
+      name: "verifies DA for a received Gloas payload envelope with sampled columns",
+      hasEnvelope: true,
+      blobCount: 1,
+      expectedPayloadDA: DataAvailabilityStatus.Available,
+    },
+  ])("$name", async ({hasEnvelope, blobCount, expectedPayloadDA}) => {
     const config = createChainForkConfig({...configDef, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
     const chain = getMockedBeaconChain({config});
     const block = ssz.gloas.SignedBeaconBlock.defaultValue();
     block.message.slot = 1;
-    const blockRootHex = toRootHex(ssz.gloas.BeaconBlock.hashTreeRoot(block.message));
+    block.message.body.signedExecutionPayloadBid.message.blobKzgCommitments = Array.from({length: blobCount}, () =>
+      Buffer.alloc(48, 0x77)
+    );
+    const blockRoot = ssz.gloas.BeaconBlock.hashTreeRoot(block.message);
+    const blockRootHex = toRootHex(blockRoot);
     const blockInput = new MockBlockInput({
       forkName: ForkName.gloas,
       slot: block.message.slot,
@@ -49,7 +72,23 @@ describe("chain / blocks / verifyBlocksInEpoch", () => {
       source: PayloadEnvelopeInputSource.byRange,
       daOutOfRange: false,
     });
-    expect(payloadInput.hasPayloadEnvelope()).toBe(false);
+    if (hasEnvelope) {
+      const envelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+      envelope.message.beaconBlockRoot = blockRoot;
+      payloadInput.addPayloadEnvelope({
+        envelope,
+        source: PayloadEnvelopeInputSource.byRange,
+        seenTimestampSec: 1,
+      });
+    }
+    if (blobCount > 0) {
+      payloadInput.addColumn({
+        columnSidecar: ssz.gloas.DataColumnSidecar.defaultValue(),
+        source: PayloadEnvelopeInputSource.byRange,
+        seenTimestampSec: 2,
+      });
+    }
+    expect(payloadInput.hasPayloadEnvelope()).toBe(hasEnvelope);
     expect(payloadInput.hasAllData()).toBe(true);
 
     const preState = {
@@ -78,6 +117,9 @@ describe("chain / blocks / verifyBlocksInEpoch", () => {
       {verifyOnly: true}
     );
 
-    expect(result.payloadDAStatuses.size).toBe(0);
+    expect(result.blockDAStatuses).toEqual([DataAvailabilityStatus.NotRequired]);
+    expect(result.payloadDAStatuses).toEqual(
+      new Map(expectedPayloadDA === undefined ? [] : [[block.message.slot, expectedPayloadDA]])
+    );
   });
 });

--- a/packages/beacon-node/test/unit/chain/blocks/verifyBlock.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyBlock.test.ts
@@ -1,0 +1,83 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {createChainForkConfig} from "@lodestar/config";
+import {config as configDef} from "@lodestar/config/default";
+import {ExecutionStatus} from "@lodestar/fork-choice";
+import {ForkName} from "@lodestar/params";
+import {IBeaconStateView} from "@lodestar/state-transition";
+import {SignedBeaconBlock, ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
+import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
+import {verifyBlocksInEpoch} from "../../../../src/chain/blocks/verifyBlock.js";
+import {verifyBlocksExecutionPayload} from "../../../../src/chain/blocks/verifyBlocksExecutionPayloads.js";
+import {verifyBlocksSignatures} from "../../../../src/chain/blocks/verifyBlocksSignatures.js";
+import {verifyBlocksStateTransitionOnly} from "../../../../src/chain/blocks/verifyBlocksStateTransitionOnly.js";
+import {SeenBlockProposers} from "../../../../src/chain/seenCache/seenBlockProposers.js";
+import {getMockedBeaconChain} from "../../../mocks/mockedBeaconChain.js";
+import {MockBlockInput} from "../../../utils/blockInput.js";
+import {generateProtoBlock} from "../../../utils/typeGenerator.js";
+
+vi.mock("../../../../src/chain/blocks/verifyBlocksExecutionPayloads.js");
+vi.mock("../../../../src/chain/blocks/verifyBlocksSignatures.js");
+vi.mock("../../../../src/chain/blocks/verifyBlocksStateTransitionOnly.js");
+
+describe("chain / blocks / verifyBlocksInEpoch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not verify DA for an empty Gloas payload slot", async () => {
+    const config = createChainForkConfig({...configDef, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
+    const chain = getMockedBeaconChain({config});
+    const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+    block.message.slot = 1;
+    const blockRootHex = toRootHex(ssz.gloas.BeaconBlock.hashTreeRoot(block.message));
+    const blockInput = new MockBlockInput({
+      forkName: ForkName.gloas,
+      slot: block.message.slot,
+      blockRootHex,
+    });
+    blockInput._block = block;
+
+    const payloadInput = PayloadEnvelopeInput.createFromBlock({
+      blockRootHex,
+      block: block as SignedBeaconBlock<typeof ForkName.gloas>,
+      forkName: ForkName.gloas,
+      sampledColumns: [0],
+      custodyColumns: [0],
+      seenTimestampSec: 0,
+      source: PayloadEnvelopeInputSource.byRange,
+      daOutOfRange: false,
+    });
+    expect(payloadInput.hasPayloadEnvelope()).toBe(false);
+    expect(payloadInput.hasAllData()).toBe(true);
+
+    const preState = {
+      slot: 0,
+      isStateValidatorsNodesPopulated: () => true,
+    } as unknown as IBeaconStateView;
+    chain.regen.getPreState.mockResolvedValue(preState);
+    Object.defineProperty(chain, "seenBlockProposers", {value: new SeenBlockProposers()});
+    vi.mocked(verifyBlocksExecutionPayload).mockResolvedValue({
+      execAborted: null,
+      executionStatuses: [ExecutionStatus.Syncing],
+      executionTime: 0,
+    });
+    vi.mocked(verifyBlocksStateTransitionOnly).mockResolvedValue({
+      postStates: [preState],
+      proposerBalanceDeltas: [0],
+      verifyStateTime: 0,
+    });
+    vi.mocked(verifyBlocksSignatures).mockResolvedValue({verifySignaturesTime: 0});
+
+    const result = await verifyBlocksInEpoch.call(
+      chain,
+      generateProtoBlock({slot: 0}),
+      [blockInput],
+      new Map([[block.message.slot, payloadInput]]),
+      {verifyOnly: true}
+    );
+
+    expect(result.payloadDAStatuses.size).toBe(0);
+  });
+});

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -1,13 +1,16 @@
 import {afterEach, describe, expect, it, vi} from "vitest";
+import {createChainForkConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
 import {testLogger} from "@lodestar/logger/test-utils";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, Slot, phase0, ssz} from "@lodestar/types";
-import {Logger, fromHex} from "@lodestar/utils";
-import {BlockInputPreData} from "../../../../src/chain/blocks/blockInput/blockInput.js";
+import {Logger, fromHex, toRootHex} from "@lodestar/utils";
+import {BlockInputNoData, BlockInputPreData} from "../../../../src/chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource, IBlockInput} from "../../../../src/chain/blocks/blockInput/types.js";
+import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
+import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
 import {BlockError, BlockErrorCode} from "../../../../src/chain/errors/index.js";
 import {ZERO_HASH} from "../../../../src/constants/index.js";
 import {ExecutionPayloadStatus} from "../../../../src/execution/index.js";
@@ -18,6 +21,7 @@ import {RangeSyncType} from "../../../../src/sync/utils/remoteSyncType.js";
 import {Clock} from "../../../../src/util/clock.js";
 import {CustodyConfig} from "../../../../src/util/dataColumns.js";
 import {linspace} from "../../../../src/util/numpy.js";
+import {getMockedLogger} from "../../../mocks/loggerMock.js";
 import {getRandPeerIdStr, validPeerIdStr} from "../../../utils/peer.js";
 
 describe("sync / range / chain", () => {
@@ -154,6 +158,89 @@ describe("sync / range / chain", () => {
       });
     });
   }
+
+  it.each([
+    {receivedSlots: [1, 3], expectedEnvelopeSlots: "[1, 3]"},
+    {receivedSlots: [], expectedEnvelopeSlots: "[]"},
+  ])("logs only received envelope slots: $expectedEnvelopeSlots", async ({receivedSlots, expectedEnvelopeSlots}) => {
+    const gloasConfig = createChainForkConfig({...config, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
+    const gloasCustodyConfig = new CustodyConfig({nodeId, config: gloasConfig});
+    const log = getMockedLogger();
+    const blocks: IBlockInput[] = [];
+    const payloadEnvelopes = new Map<Slot, PayloadEnvelopeInput>();
+
+    for (const slot of [3, 1, 2]) {
+      const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+      block.message.slot = slot;
+      const blockRoot = ssz.gloas.BeaconBlock.hashTreeRoot(block.message);
+      const blockRootHex = toRootHex(blockRoot);
+      blocks.push(
+        BlockInputNoData.createFromBlock({
+          block,
+          blockRootHex,
+          forkName: ForkName.gloas,
+          daOutOfRange: false,
+          source: BlockInputSource.byRange,
+          seenTimestampSec: 0,
+        })
+      );
+      const payloadInput = PayloadEnvelopeInput.createFromBlock({
+        block,
+        blockRootHex,
+        forkName: ForkName.gloas,
+        sampledColumns: gloasCustodyConfig.sampledColumns,
+        custodyColumns: gloasCustodyConfig.custodyColumns,
+        daOutOfRange: false,
+        source: PayloadEnvelopeInputSource.byRange,
+        seenTimestampSec: 0,
+      });
+      if (receivedSlots.includes(slot)) {
+        const envelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+        envelope.message.beaconBlockRoot = blockRoot;
+        envelope.message.payload.slotNumber = slot;
+        payloadInput.addPayloadEnvelope({envelope, source: PayloadEnvelopeInputSource.byRange, seenTimestampSec: 0});
+      }
+      payloadEnvelopes.set(slot, payloadInput);
+    }
+
+    const target: ChainTarget = {slot: 3, root: ZERO_HASH};
+    const processChainSegment = vi.fn<SyncChainFns["processChainSegment"]>().mockResolvedValue(undefined);
+    await new Promise<void>((resolve, reject) => {
+      const chain = new SyncChain(
+        0,
+        target,
+        RangeSyncType.Finalized,
+        {
+          processChainSegment,
+          downloadByRange: async () => ({result: {blocks, payloadEnvelopes}, warnings: null}),
+          getConnectedPeerSyncMeta: (peerId) => ({
+            ...getConnectedPeerSyncMeta(peerId),
+            custodyColumns: gloasCustodyConfig.sampledColumns,
+            earliestAvailableSlot: 0,
+          }),
+          reportPeer,
+          pruneBlockInputs,
+          onEnd: (err) => (err ? reject(err) : resolve()),
+        },
+        {
+          config: gloasConfig,
+          clock: new Clock({config: gloasConfig, genesisTime: 0, signal: new AbortController().signal}),
+          custodyConfig: gloasCustodyConfig,
+          logger: log,
+          metrics: null,
+        },
+        undefined
+      );
+      chain.addPeer(peer, target);
+      chain.startSyncing(0);
+    });
+
+    expect(processChainSegment).toHaveBeenCalledExactlyOnceWith(blocks, payloadEnvelopes, RangeSyncType.Finalized);
+    const expectedLog = expect.objectContaining({envelopeSlots: expectedEnvelopeSlots, blockSlots: "[1-3]"});
+    expect(log.debug).toHaveBeenCalledWith("Finished downloading batch by range", expectedLog);
+    expect(log.verbose).toHaveBeenCalledWith("Processing batch", expectedLog);
+    expect(log.verbose).toHaveBeenCalledWith("Processed batch", expectedLog);
+  });
 
   it("does not self-register a metrics collect fn per SyncChain (leak regression)", () => {
     const headSyncPeers = {addCollect: vi.fn(), set: vi.fn(), reset: vi.fn()};

--- a/packages/beacon-node/test/unit/sync/range/range.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/range.test.ts
@@ -1,0 +1,105 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {createChainForkConfig} from "@lodestar/config";
+import {config} from "@lodestar/config/default";
+import {ForkName} from "@lodestar/params";
+import {IBeaconStateViewGloas} from "@lodestar/state-transition";
+import {ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {BlockInputNoData} from "../../../../src/chain/blocks/blockInput/blockInput.js";
+import {BlockInputSource} from "../../../../src/chain/blocks/blockInput/types.js";
+import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
+import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
+import {SyncChain} from "../../../../src/sync/range/chain.js";
+import {RangeSync} from "../../../../src/sync/range/range.js";
+import {RangeSyncType} from "../../../../src/sync/utils/remoteSyncType.js";
+import {getMockedBeaconChain} from "../../../mocks/mockedBeaconChain.js";
+import {getMockedNetwork} from "../../../mocks/mockedNetwork.js";
+import {validPeerIdStr} from "../../../utils/peer.js";
+
+vi.mock("../../../../src/sync/range/chain.js", () => ({
+  SyncChain: vi.fn().mockImplementation(function MockedSyncChain(...args: ConstructorParameters<typeof SyncChain>) {
+    return {
+      firstBatchEpoch: args[0],
+      target: args[1],
+      syncType: args[2],
+      peers: 1,
+      addPeer: vi.fn(),
+      startSyncing: vi.fn(),
+    };
+  }),
+}));
+
+describe("sync / range / per-block processing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {hasEnvelope: false, blobCount: 0},
+    {hasEnvelope: false, blobCount: 1},
+    {hasEnvelope: true, blobCount: 0},
+    {hasEnvelope: true, blobCount: 1},
+  ])("hasEnvelope=$hasEnvelope, blobCount=$blobCount", async ({hasEnvelope, blobCount}) => {
+    const gloasConfig = createChainForkConfig({...config, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
+    const chain = getMockedBeaconChain({config: gloasConfig});
+    chain.processExecutionPayload = vi.fn().mockResolvedValue(undefined);
+    chain.getHeadState.mockReturnValue({
+      forkName: ForkName.gloas,
+      latestExecutionPayloadBid: ssz.gloas.ExecutionPayloadBid.defaultValue(),
+    } as IBeaconStateViewGloas);
+    const rangeSync = new RangeSync(
+      {chain, network: getMockedNetwork(), config: chain.config, logger: chain.logger, metrics: null},
+      {disableProcessAsChainSegment: true}
+    );
+    const localStatus = ssz.fulu.Status.defaultValue();
+    rangeSync.addPeer(validPeerIdStr, localStatus, {...localStatus, finalizedEpoch: 1});
+    expect(SyncChain).toHaveBeenCalledOnce();
+    const {processChainSegment} = vi.mocked(SyncChain).mock.calls[0][3];
+
+    const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+    block.message.slot = 1;
+    block.message.body.signedExecutionPayloadBid.message.blobKzgCommitments = Array.from({length: blobCount}, () =>
+      Buffer.alloc(48, 0x77)
+    );
+    const blockRoot = ssz.gloas.BeaconBlock.hashTreeRoot(block.message);
+    const blockRootHex = toRootHex(blockRoot);
+    const blockInput = BlockInputNoData.createFromBlock({
+      block,
+      blockRootHex,
+      forkName: ForkName.gloas,
+      daOutOfRange: false,
+      source: BlockInputSource.byRange,
+      seenTimestampSec: 0,
+    });
+    const payloadInput = PayloadEnvelopeInput.createFromBlock({
+      block,
+      blockRootHex,
+      forkName: ForkName.gloas,
+      sampledColumns: [0],
+      custodyColumns: [0],
+      daOutOfRange: false,
+      source: PayloadEnvelopeInputSource.byRange,
+      seenTimestampSec: 0,
+    });
+    if (hasEnvelope) {
+      const envelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+      envelope.message.beaconBlockRoot = blockRoot;
+      payloadInput.addPayloadEnvelope({envelope, source: PayloadEnvelopeInputSource.byRange, seenTimestampSec: 1});
+    }
+
+    await processChainSegment([blockInput], new Map([[block.message.slot, payloadInput]]), RangeSyncType.Finalized);
+
+    expect(chain.processBlock).toHaveBeenCalledExactlyOnceWith(
+      blockInput,
+      expect.objectContaining({fromRangeSync: true})
+    );
+    if (hasEnvelope) {
+      expect(chain.processExecutionPayload).toHaveBeenCalledExactlyOnceWith(payloadInput);
+      expect(chain.processBlock.mock.invocationCallOrder[0]).toBeLessThan(
+        chain.processExecutionPayload.mock.invocationCallOrder[0]
+      );
+    } else {
+      expect(chain.processExecutionPayload).not.toHaveBeenCalled();
+    }
+  });
+});


### PR DESCRIPTION
**Motivation**

Sync was not progressing when attempting to sync a Platabergnet node.

**Summary**

Fix range sync stalling on Gloas batches that contain EMPTY payload slots.

Range sync creates a `PayloadEnvelopeInput` for every Gloas block, including slots where no payload envelope was received.

`verifyBlocksInEpoch` passed all of these inputs to DA verification. For an EMPTY slot, `getTimeComplete()` threw `Not yet complete`, causing Lodestar to repeatedly download and retry the same valid batch without advancing.

The input is also shared with gossip and API processing, so an envelope can arrive after the DA verification set is selected. Inline payload import must therefore use the same verification snapshot rather than re-reading mutable input state.

**Solution**

- Exclude inputs without a payload envelope from payload DA verification.
- Use `payloadDAStatuses` as the authoritative snapshot for inline payload import.
- Leave envelopes received after that snapshot to their existing gossip or API processing path.
- Add regression coverage for EMPTY Gloas slots and concurrent envelope arrival.

**Testing**

- Targeted block processing and payload DA tests
- Ran Biome checks on the changed files.
- Manually verified checkpoint sync on Platåberget. The previously stalled node synced in approximately one minute.

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

<!-- Insert any AI assistance disclosure here -->
Assisted by GPT-5.6 Sol