### PR TITLE
feat: track queue time of gossipsub messages

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -104,7 +104,7 @@ export function createLodestarMetrics(
         help: "Age of the first item of each key in the indexed queues in seconds",
         buckets: [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 5],
       }),
-      queueTime: register.histogram<{topic: string}>({
+      queueTime: register.histogram<{topic: GossipType}>({
         name: "lodestar_gossip_validation_queue_time_seconds",
         help: "Total time an item stays in queue until it is processed in seconds",
         labelNames: ["topic"],

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -104,9 +104,10 @@ export function createLodestarMetrics(
         help: "Age of the first item of each key in the indexed queues in seconds",
         buckets: [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 5],
       }),
-      queueTime: register.histogram({
+      queueTime: register.histogram<{topic: string}>({
         name: "lodestar_gossip_validation_queue_time_seconds",
         help: "Total time an item stays in queue until it is processed in seconds",
+        labelNames: ["topic"],
         buckets: [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 5],
       }),
     },

--- a/packages/beacon-node/src/network/processor/gossipQueues/indexed.ts
+++ b/packages/beacon-node/src/network/processor/gossipQueues/indexed.ts
@@ -86,7 +86,6 @@ export class IndexedGossipQueueMinSize<T extends {indexed?: string; queueAddedMs
     const now = Date.now();
     // here we mutate item, which is used for gossip validation later
     item.indexed = key;
-    item.queueAddedMs = now;
     let queueItem = this.indexedItems.get(key);
     if (queueItem == null) {
       queueItem = {firstSeenMs: now, listItems: new LinkedList<T>()};

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -537,6 +537,7 @@ export class NetworkProcessor {
 
   private pushPendingGossipsubMessageToQueue(message: PendingGossipsubMessage): void {
     const topicType = message.topic.type;
+    message.queueAddedMs = Date.now();
     const droppedCount = this.gossipQueues[topicType].add(message);
     if (droppedCount) {
       // No need to report the dropped job to gossip. It will be eventually pruned from the mcache
@@ -723,12 +724,20 @@ export class NetworkProcessor {
       for (const msg of messageOrArray) {
         msg.startProcessUnixSec = nowSec;
         if (msg.queueAddedMs !== undefined) {
-          this.metrics?.gossipValidationQueue.queueTime.observe(nowSec - msg.queueAddedMs / 1000);
+          this.metrics?.gossipValidationQueue.queueTime.observe(
+            {topic: msg.topic.type},
+            nowSec - msg.queueAddedMs / 1000
+          );
         }
       }
     } else {
-      // indexed queue is not used here
       messageOrArray.startProcessUnixSec = nowSec;
+      if (messageOrArray.queueAddedMs !== undefined) {
+        this.metrics?.gossipValidationQueue.queueTime.observe(
+          {topic: messageOrArray.topic.type},
+          nowSec - messageOrArray.queueAddedMs / 1000
+        );
+      }
     }
 
     const acceptanceArr = Array.isArray(messageOrArray)

--- a/packages/beacon-node/test/unit/network/processor/gossipQueues/indexed.test.ts
+++ b/packages/beacon-node/test/unit/network/processor/gossipQueues/indexed.test.ts
@@ -12,7 +12,7 @@ function toItem(key: string): Item {
 }
 
 function toIndexedItem(key: string): Item {
-  return {key, indexed: key.substring(0, 1), queueAddedMs: 0};
+  return {key, indexed: key.substring(0, 1)};
 }
 
 describe("IndexedGossipQueueMinSize", () => {


### PR DESCRIPTION
**Motivation**

- `recvToValLatency` is high for some data columns as monitored on mainnet:
```
  debug: Received gossip dataColumn slot=15052195, blockRoot=0x0996…7d61, timeCreatedSec=1787450366.11, expectedColumns=128, receivedColumns=123, currentSlot=15052195, peerId=16Uiu2HAmJaDrPZjuPihnEjY44U4nibRKNU33GmNtBmQfw2YxK3KX, delaySec=3.303999900817871, secFromSlot=4.107000112533569, gossipSubnet=119, columnIndex=119, recvToValLatency=0.8030002117156982, recvToValidation=1.128000020980835, validationTime=0.3249998092651367
```
we want to know if the latency happens before or after the message was added to queue

**Description**

right now we only track queue time for `beacon_attestation`. This will also track it for remaining topic types

part of #9942

**AI Assistance Disclosure**

- created with the help of Claude