### PR TITLE
fix: reject invalid characters in fromHex on nodejs build

### DIFF
--- a/packages/utils/src/bytes/nodejs.ts
+++ b/packages/utils/src/bytes/nodejs.ts
@@ -57,6 +57,15 @@ export function fromHex(hex: string): Uint8Array {
   }
 
   const b = Buffer.from(hex, "hex");
+
+  // Buffer.from stops at the first character it cannot decode and returns what it read so far,
+  // so an invalid string yields a short array instead of an error. The browser implementation
+  // throws on such input, and a silently truncated result is worse than a rejected one for a
+  // caller that only checks the value it got back. A length mismatch is exactly the invalid case.
+  if (b.length !== hex.length / 2) {
+    throw new Error(`hex string contains invalid characters: ${hex}`);
+  }
+
   return new Uint8Array(b.buffer, b.byteOffset, b.length);
 }
 

--- a/packages/utils/test/unit/bytes.test.ts
+++ b/packages/utils/test/unit/bytes.test.ts
@@ -145,6 +145,17 @@ describe("fromHex and fromHexInto", () => {
       expect(toHex(buffer)).toBe(toHex(output));
     });
   }
+
+  // Both builds must agree here. `Buffer.from(hex, "hex")` decodes up to the first character it
+  // cannot read and returns that prefix, so without an explicit check the nodejs build answered a
+  // short array where the browser build threw. This file runs under both projects.
+  const invalidCases: string[] = ["0xzzzz", "0x0011zz2233", "0xgg", "0x00-1", "zzzz"];
+
+  for (const input of invalidCases) {
+    it(`should reject hex string ${input} with invalid characters`, () => {
+      expect(() => fromHex(input)).toThrow();
+    });
+  }
 });
 
 describe("toHexString", () => {


### PR DESCRIPTION
**Motivation**

`fromHex` has two implementations, selected by the `#bytes` condition in `packages/utils/package.json`: `browser.js` in browsers, `nodejs.js` everywhere else. They disagree on invalid input.

The browser build decodes character by character and throws `Invalid hex character code`. The nodejs build calls `Buffer.from(hex, "hex")`, which decodes up to the first character it cannot read and returns that prefix, so an invalid string silently yields a short array:

| input | nodejs | browser |
| --- | --- | --- |
| `0xzzzz` | `len=0` | throws |
| `0x0011zz2233` | `len=2` | throws |
| `0xgg` | `len=0` | throws |
| `0x00-1` | `len=1` | throws |

Valid hex is byte for byte identical on both, so only the invalid case diverges.

`fromHex` has 126 call sites. One is `packages/api/src/builder/routes.ts`, which parses relay supplied `parent_hash`, `parent_root` and `pubkey`. A malformed value there becomes a truncated array rather than an error. The wrong length means SSZ rejects it downstream, so this is a correctness and consistency problem rather than a validation bypass, but a caller that only inspects the returned value gets no signal that its input was garbage.

**Description**

Compare the decoded length against the expected one and throw when they differ. `Buffer.from` truncating at the first bad character means a length mismatch is exactly the invalid case, so this is one comparison and the valid path is untouched.

Tests cover five invalid inputs. Worth knowing for review: `packages/utils/test/browser` is a symlink to `./unit`, so the single file runs under both the unit and browser projects and pins the two implementations to the same behaviour.

**Testing**

Reverting only `nodejs.ts` and keeping the tests fails exactly the 5 new cases, with the other 56 in the file unaffected.

- `packages/utils` unit suite: 231 passed
- `packages/api` unit suite: 669 passed, this is the heaviest `fromHex` consumer and includes the builder routes
- `check-types` and `biome check` clean on both changed files


**AI Assistance**

This PR was produced with Claude Code: the fix, the tests, this description and the replies to review comments were AI-generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
