### PR TITLE
fix: allow proposer boost reorg bid over epoch transition

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1327,9 +1327,10 @@ export class BeaconChain implements IBeaconChain {
     }
   }
 
-  predictProposerHead(slot: Slot): ProtoBlock {
+  predictProposerHead(): ProtoBlock {
     this.metrics?.forkChoice.requests.inc();
     const timer = this.metrics?.forkChoice.findHead.startTimer({caller: FindHeadFnName.predictProposerHead});
+    const slot = this.clock.currentSlot;
     const secFromSlot = this.clock.secFromSlot(slot);
 
     try {

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -274,8 +274,8 @@ export interface IBeaconChain {
 
   recomputeForkChoiceHead(caller: ForkchoiceCaller): ProtoBlock;
 
-  /** When proposerBoostReorg is enabled, this is called at slot n-1 to predict the head block to build on if we are proposing at slot n */
-  predictProposerHead(slot: Slot): ProtoBlock;
+  /** When proposerBoostReorg is enabled, predict (as of the current slot) the head block a proposer would build on next slot */
+  predictProposerHead(): ProtoBlock;
 
   /** When proposerBoostReorg is enabled and we are proposing a block, this is called to determine which head block to build on */
   getProposerHead(slot: Slot): ProtoBlock;

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -157,7 +157,7 @@ export class PrepareNextSlotScheduler {
         //    last-block-of-epoch and build slot 0 on the strong parent (epoch-boundary reorg),
         //    so we should dial the strong parent through the boundary instead of the weak head.
         if (feeRecipient || isEpochTransition) {
-          const proposerHead = this.chain.predictProposerHead(clockSlot);
+          const proposerHead = this.chain.predictProposerHead();
           const {slot: proposerHeadSlot, blockRoot: proposerHeadRoot} = proposerHead;
 
           // If we predict a reorg, we build the epoch transition on the proposer head (parent) instead

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -1,4 +1,4 @@
-import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
+import {ProtoBlock} from "@lodestar/fork-choice";
 import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
 import {
   computeEpochAtSlot,
@@ -46,11 +46,12 @@ function getMinBidValue(currentHighestBid: number): number {
 /**
  * Check whether a bid builds on one of the paths compatible with the local head branch.
  *
- * Building directly on the parent is allowed for proposer-boost reorgs outside epoch boundaries.
+ * Building directly on the parent is allowed for proposer-boost reorgs, including at epoch
+ * boundaries when the head is weak enough that a reorg onto the strong parent is predicted.
  * Otherwise the bid must build on the local head's full or empty payload variant, as selected for its slot.
  */
-function isBidCompatibleWithHead(
-  forkChoice: IForkChoice,
+export function isBidCompatibleWithHead(
+  chain: IBeaconChain,
   head: ProtoBlock,
   bidSlot: Slot,
   bidParentBlockRoot: RootHex,
@@ -60,9 +61,13 @@ function isBidCompatibleWithHead(
   const buildsOnParentPayload = bidParentBlockHash === head.parentBlockHash;
 
   if (buildsOnParentBlock && buildsOnParentPayload) {
-    // The spec allows this at epoch boundaries, but Lodestar does not propagate these bids because validating
-    // them requires an epoch transition for a parent state that cannot be used for proposer-boost reorgs.
-    return !isStartSlotOfEpoch(bidSlot);
+    if (!isStartSlotOfEpoch(bidSlot)) {
+      return true;
+    }
+    // Epoch-boundary reorgs are allowed, but only propagate the bid if its parent matches the block
+    // we predict a proposer would reorg onto — predictProposerHead returns the strong parent only
+    // when the head is weak.
+    return chain.predictProposerHead().blockRoot === bidParentBlockRoot;
   }
 
   if (bidParentBlockRoot !== head.blockRoot) {
@@ -71,7 +76,7 @@ function isBidCompatibleWithHead(
 
   const buildsOnHeadPayload = bidParentBlockHash === head.executionPayloadBlockHash;
 
-  if (forkChoice.shouldBuildOnFull(head, bidSlot)) {
+  if (chain.forkChoice.shouldBuildOnFull(head, bidSlot)) {
     return buildsOnHeadPayload;
   }
 
@@ -114,7 +119,7 @@ async function validateExecutionPayloadBid(
 
   // [IGNORE] The bid is compatible with the current head branch.
   const head = chain.forkChoice.getHead();
-  if (!isBidCompatibleWithHead(chain.forkChoice, head, bid.slot, bidParentBlockRoot, bidParentBlockHash)) {
+  if (!isBidCompatibleWithHead(chain, head, bid.slot, bidParentBlockRoot, bidParentBlockHash)) {
     throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
       code: ExecutionPayloadBidErrorCode.INCOMPATIBLE_WITH_HEAD,
       slot: bid.slot,

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -50,7 +50,7 @@ function getMinBidValue(currentHighestBid: number): number {
  * boundaries when the head is weak enough that a reorg onto the strong parent is predicted.
  * Otherwise the bid must build on the local head's full or empty payload variant, as selected for its slot.
  */
-export function isBidCompatibleWithHead(
+function isBidCompatibleWithHead(
   chain: IBeaconChain,
   head: ProtoBlock,
   bidSlot: Slot,


### PR DESCRIPTION
**Motivation**

- previously, we didn't allow reorg bid over epoch transition in #9756, with the assumption that we don't do epoch boundary reorg
- now we switch to allow proposer boost reorg over epoch boundary, we even prepare for it at epoch boundary in #9915
- see https://github.com/ChainSafe/lodestar/issues/9741#issuecomment-5429503310

**Description**

- change bid gossip validation logic of `isBidCompatibleWithHead()` to allow epoch boundary reorg if it's the same as what we predict
- with this, we still do 1 epoch transition per epoch if what we predict is correct

**AI Assistance Disclosure**

- created with the help of Claude