### PR TITLE
refactor(bindings): split computeNewStateRoot computation

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
+++ b/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
@@ -1,11 +1,5 @@
-import {
-  DataAvailabilityStatus,
-  ExecutionPayloadStatus,
-  IBeaconStateView,
-  StateHashTreeRootSource,
-} from "@lodestar/state-transition";
+import {EMPTY_SIGNATURE, IBeaconStateView} from "@lodestar/state-transition";
 import {BeaconBlock, BlindedBeaconBlock, Gwei, Root} from "@lodestar/types";
-import {ZERO_HASH} from "../../constants/index.js";
 import {Metrics} from "../../metrics/index.js";
 
 /**
@@ -19,35 +13,6 @@ export function computeNewStateRoot(
   block: BeaconBlock | BlindedBeaconBlock
 ): {newStateRoot: Root; proposerReward: Gwei; postState: IBeaconStateView} {
   // Set signature to zero to re-use stateTransition() function which requires the SignedBeaconBlock type
-  const blockEmptySig = {message: block, signature: ZERO_HASH};
-
-  const postState = state.stateTransition(
-    blockEmptySig,
-    {
-      // ExecutionPayloadStatus.valid: Assume payload valid, it has been produced by a trusted EL
-      executionPayloadStatus: ExecutionPayloadStatus.valid,
-      // DataAvailabilityStatus.available: Assume the blobs to be available, have just been produced by trusted EL
-      dataAvailabilityStatus: DataAvailabilityStatus.Available,
-      // verifyStateRoot: false  | the root in the block is zero-ed, it's being computed here
-      verifyStateRoot: false,
-      // verifyProposer: false   | as the block signature is zero-ed
-      verifyProposer: false,
-      // verifySignatures: false | since the data to assemble the block is trusted
-      verifySignatures: false,
-      // Preserve cache in source state, since the resulting state is not added to the state cache
-      dontTransferCache: true,
-    },
-    {metrics}
-  );
-
-  const {attestations, syncAggregate, slashing} = postState.proposerRewards;
-  const proposerReward = BigInt(attestations + syncAggregate + slashing);
-
-  const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
-    source: StateHashTreeRootSource.computeNewStateRoot,
-  });
-  const newStateRoot = postState.hashTreeRoot();
-  hashTreeRootTimer?.();
-
-  return {newStateRoot, proposerReward, postState};
+  const signedBlock = {message: block, signature: EMPTY_SIGNATURE};
+  return state.computeNewStateRoot({block: signedBlock}, {metrics});
 }

--- a/packages/beacon-node/test/unit/chain/produceBlock/computeNewStateRoot.test.ts
+++ b/packages/beacon-node/test/unit/chain/produceBlock/computeNewStateRoot.test.ts
@@ -1,0 +1,25 @@
+import {describe, expect, it, vi} from "vitest";
+import {EMPTY_SIGNATURE, IBeaconStateView} from "@lodestar/state-transition";
+import {ssz} from "@lodestar/types";
+import {computeNewStateRoot} from "../../../../src/chain/produceBlock/computeNewStateRoot.js";
+
+describe("computeNewStateRoot", () => {
+  it("delegates to the state view with a signed block", () => {
+    const block = ssz.phase0.BeaconBlock.defaultValue();
+    const expectedResult = {
+      newStateRoot: new Uint8Array(32),
+      proposerReward: 1n,
+      postState: {} as IBeaconStateView,
+    };
+    const computeNewStateRootMock = vi.fn(() => expectedResult);
+    const state = {computeNewStateRoot: computeNewStateRootMock} as unknown as IBeaconStateView;
+
+    const result = computeNewStateRoot(null, state, block);
+
+    expect(result).toBe(expectedResult);
+    expect(computeNewStateRootMock).toHaveBeenCalledWith(
+      {block: {message: block, signature: EMPTY_SIGNATURE}},
+      {metrics: null}
+    );
+  });
+});

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -43,6 +43,8 @@ export * from "./signatureSets/index.js";
 export * from "./stateTransition.js";
 export {BeaconStateView} from "./stateView/beaconStateView.js";
 export {
+  type ComputeNewStateRootInput,
+  type ComputeNewStateRootResult,
   type IBeaconStateView,
   type IBeaconStateViewAltair,
   type IBeaconStateViewBellatrix,

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -70,7 +70,15 @@ import {loadState} from "../util/loadState/loadState.js";
 import {PreVerifyBuilderDepositsResult, preVerifyBuilderDepositsPreGloas} from "../util/preVerifyBuilderDeposits.js";
 import {getRandaoMix} from "../util/seed.js";
 import {getLatestWeakSubjectivityCheckpointEpoch} from "../util/weakSubjectivity.js";
-import {IBeaconStateView, IBeaconStateViewGloas, IBeaconStateViewLatestFork, isStatePostGloas} from "./interface.js";
+import {computeNewStateRootStateTransitionOpts, getComputeNewStateRootResult} from "./computeNewStateRoot.js";
+import {
+  ComputeNewStateRootInput,
+  ComputeNewStateRootResult,
+  IBeaconStateView,
+  IBeaconStateViewGloas,
+  IBeaconStateViewLatestFork,
+  isStatePostGloas,
+} from "./interface.js";
 
 export class BeaconStateView implements IBeaconStateViewLatestFork {
   private readonly config: BeaconConfig;
@@ -822,6 +830,13 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
   }
 
   // State transition
+
+  computeNewStateRoot({block}: ComputeNewStateRootInput, modules: StateTransitionModules): ComputeNewStateRootResult {
+    const postState = new BeaconStateView(
+      stateTransition(this.cachedState, block, computeNewStateRootStateTransitionOpts, modules)
+    );
+    return getComputeNewStateRootResult(postState, modules);
+  }
 
   stateTransition(
     signedBlock: SignedBeaconBlock | SignedBlindedBeaconBlock,

--- a/packages/state-transition/src/stateView/computeNewStateRoot.ts
+++ b/packages/state-transition/src/stateView/computeNewStateRoot.ts
@@ -1,0 +1,35 @@
+import {DataAvailabilityStatus, ExecutionPayloadStatus} from "../block/externalData.js";
+import {StateHashTreeRootSource, StateTransitionModules, StateTransitionOpts} from "../stateTransition.js";
+import {ComputeNewStateRootResult, IBeaconStateView} from "./interface.js";
+
+/** State transition options for computing the state root of a locally produced block. */
+export const computeNewStateRootStateTransitionOpts: StateTransitionOpts = {
+  // ExecutionPayloadStatus.valid: Assume payload valid, it has been produced by a trusted EL
+  executionPayloadStatus: ExecutionPayloadStatus.valid,
+  // DataAvailabilityStatus.available: Assume the blobs to be available, have just been produced by trusted EL
+  dataAvailabilityStatus: DataAvailabilityStatus.Available,
+  // verifyStateRoot: false  | the root in the block is zero-ed, it's being computed here
+  verifyStateRoot: false,
+  // verifyProposer: false   | as the block signature is zero-ed
+  verifyProposer: false,
+  // verifySignatures: false | since the data to assemble the block is trusted
+  verifySignatures: false,
+  // Preserve cache in source state, since the resulting state is not added to the state cache
+  dontTransferCache: true,
+};
+
+export function getComputeNewStateRootResult(
+  postState: IBeaconStateView,
+  {metrics}: StateTransitionModules
+): ComputeNewStateRootResult {
+  const {attestations, syncAggregate, slashing} = postState.proposerRewards;
+  const proposerReward = BigInt(attestations + syncAggregate + slashing);
+
+  const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
+    source: StateHashTreeRootSource.computeNewStateRoot,
+  });
+  const newStateRoot = postState.hashTreeRoot();
+  hashTreeRootTimer?.();
+
+  return {newStateRoot, proposerReward, postState};
+}

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -29,6 +29,7 @@ import {
   Epoch,
   ExecutionPayloadBid,
   ExecutionPayloadHeader,
+  Gwei,
   Root,
   RootHex,
   SignedBeaconBlock,
@@ -53,6 +54,20 @@ import {SyncCommitteeWitness} from "../lightClient/types.js";
 import {StateTransitionModules, StateTransitionOpts} from "../stateTransition.js";
 import {EpochShuffling} from "../util/epochShuffling.js";
 import {PreVerifyBuilderDepositsResult} from "../util/preVerifyBuilderDeposits.js";
+
+/** Inputs for computing the state root of a locally produced block. */
+export type ComputeNewStateRootInput = {
+  block: SignedBeaconBlock | SignedBlindedBeaconBlock;
+  /** Pre-serialized block bytes for native implementations. */
+  ssz?: Uint8Array;
+};
+
+/** State root computation result. Includes data derived from the post-state. */
+export type ComputeNewStateRootResult = {
+  newStateRoot: Root;
+  proposerReward: Gwei;
+  postState: IBeaconStateView;
+};
 
 /**
  * A read-only view of the BeaconState.
@@ -161,6 +176,7 @@ export interface IBeaconStateView {
   hashTreeRoot(): Uint8Array;
 
   // State transition
+  computeNewStateRoot(input: ComputeNewStateRootInput, modules: StateTransitionModules): ComputeNewStateRootResult;
   stateTransition(
     signedBlock: SignedBeaconBlock | SignedBlindedBeaconBlock,
     options: StateTransitionOpts,
@@ -308,13 +324,20 @@ export type IBeaconStateViewLatestFork = Omit<
  *   `loadOtherState`, `withParentPayloadApplied`) return `IBeaconStateViewNative`
  *   so callers can re-wrap without an `as unknown` cast. Param lists are reused
  *   via `Parameters<...>` to avoid duplicating signatures.
+ * - `computeNewStateRoot` is implemented by the wrapper because its inputs differ
+ *   between the TypeScript and Zig implementations.
  *
  * The TS-side `BeaconStateView` also structurally satisfies this contract since
  * `BitArray` exposes `uint8Array` and `bitLen`.
  */
 export type IBeaconStateViewNative = Omit<
   IBeaconStateViewLatestFork,
-  "executionPayloadAvailability" | "loadOtherState" | "stateTransition" | "processSlots" | "withParentPayloadApplied"
+  | "computeNewStateRoot"
+  | "executionPayloadAvailability"
+  | "loadOtherState"
+  | "stateTransition"
+  | "processSlots"
+  | "withParentPayloadApplied"
 > & {
   executionPayloadAvailability: {uint8Array: Uint8Array; bitLen: number};
   loadOtherState(...args: Parameters<IBeaconStateViewLatestFork["loadOtherState"]>): IBeaconStateViewNative;

--- a/packages/state-transition/src/stateView/nativeBeaconStateView.ts
+++ b/packages/state-transition/src/stateView/nativeBeaconStateView.ts
@@ -36,7 +36,10 @@ import {SyncCommitteeWitness} from "../lightClient/types.js";
 import {StateTransitionModules, StateTransitionOpts} from "../stateTransition.js";
 import {EpochShuffling} from "../util/epochShuffling.js";
 import {PreVerifyBuilderDepositsResult} from "../util/preVerifyBuilderDeposits.js";
+import {computeNewStateRootStateTransitionOpts, getComputeNewStateRootResult} from "./computeNewStateRoot.js";
 import {
+  ComputeNewStateRootInput,
+  ComputeNewStateRootResult,
   IBeaconStateView,
   IBeaconStateViewGloas,
   IBeaconStateViewLatestFork,
@@ -636,6 +639,13 @@ export class NativeBeaconStateView implements IBeaconStateViewLatestFork {
   }
 
   // State transition
+
+  computeNewStateRoot(input: ComputeNewStateRootInput, modules: StateTransitionModules): ComputeNewStateRootResult {
+    const postState = new NativeBeaconStateView(
+      this.binding.stateTransition(input.block, computeNewStateRootStateTransitionOpts, modules)
+    );
+    return getComputeNewStateRootResult(postState, modules);
+  }
 
   stateTransition(
     signedBlock: SignedBeaconBlock | SignedBlindedBeaconBlock,


### PR DESCRIPTION
**Motivation**

Zig STF uses raw block bytes, so during block production we had to do a round-trip ser/deser just to compute the new state root. We need to change the interface to add `computeNewStateRoot` to accept both a block and optionally the ssz bytes if using native stf.

See:

relevant code: https://github.com/ChainSafe/lodestar/blob/56b36936de2c91fd5eb0919950cc89c31ef1c4bc/packages/beacon-node/src/chain/chain.ts#L1151-L1164
PR: https://github.com/ChainSafe/lodestar/pull/9632

**Description**

Add `computeNewStateRoot` with signed block and optional SSZ bytes to avoid unnecessary serialization of blocks when using native stf.

The TS implementation is unchanged. Only the interface changes so that we can serialize when needed and let zig stf use bytes.

**AI Assistance Disclosure**

codex was used to write most of this
