### PR TITLE
feat: log builder configuration at startup

### DIFF
--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -171,6 +171,11 @@ export const defaultOptions = {
   blindedLocal: false,
 };
 
+/** Pre-Gloas there is no in-protocol builder so the default is local-only, post-Gloas bids are used */
+export function getDefaultBuilderSelection(isPostGloas: boolean): routes.validator.BuilderSelection {
+  return isPostGloas ? defaultOptions.builderAliasSelection : defaultOptions.builderSelection;
+}
+
 export const MAX_BUILDER_BOOST_FACTOR = 2n ** 64n - 1n;
 
 /**
@@ -323,7 +328,7 @@ export class ValidatorStore {
     isPostGloas: boolean
   ): {selection: routes.validator.BuilderSelection; boostFactor: bigint} {
     const validatorBuilder = this.validators.get(pubkeyHex)?.builder;
-    const defaultSelection = isPostGloas ? defaultOptions.builderAliasSelection : defaultOptions.builderSelection;
+    const defaultSelection = getDefaultBuilderSelection(isPostGloas);
     let selection = validatorBuilder?.selection ?? this.defaultProposerConfig.builder.selection ?? defaultSelection;
 
     // The standard per-key builder config directly controls the post-Gloas boost. It takes

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -171,12 +171,33 @@ export const defaultOptions = {
   blindedLocal: false,
 };
 
+export const MAX_BUILDER_BOOST_FACTOR = 2n ** 64n - 1n;
+
 /** Pre-Gloas there is no in-protocol builder so the default is local-only, post-Gloas bids are used */
 export function getDefaultBuilderSelection(isPostGloas: boolean): routes.validator.BuilderSelection {
   return isPostGloas ? defaultOptions.builderAliasSelection : defaultOptions.builderSelection;
 }
 
-export const MAX_BUILDER_BOOST_FACTOR = 2n ** 64n - 1n;
+/** Boost factor implied by a builder selection, `configuredBoostFactor` only applies to `maxprofit` */
+export function getBuilderBoostFactor(
+  selection: routes.validator.BuilderSelection,
+  configuredBoostFactor: bigint
+): bigint {
+  switch (selection) {
+    case routes.validator.BuilderSelection.Default:
+      // Default value slightly favors local block to improve censorship resistance of Ethereum
+      // The people have spoken and so it shall be https://x.com/lodestar_eth/status/1772679499928191044
+      return BigInt(90);
+    case routes.validator.BuilderSelection.MaxProfit:
+      return configuredBoostFactor;
+    case routes.validator.BuilderSelection.BuilderAlways:
+    case routes.validator.BuilderSelection.BuilderOnly:
+      return MAX_BUILDER_BOOST_FACTOR;
+    case routes.validator.BuilderSelection.ExecutionAlways:
+    case routes.validator.BuilderSelection.ExecutionOnly:
+      return BigInt(0);
+  }
+}
 
 /**
  * Service that sets up and handles validator attester duties.
@@ -348,27 +369,10 @@ export class ValidatorStore {
       }
     }
 
-    let boostFactor: bigint;
-    switch (selection) {
-      case routes.validator.BuilderSelection.Default:
-        // Default value slightly favors local block to improve censorship resistance of Ethereum
-        // The people have spoken and so it shall be https://x.com/lodestar_eth/status/1772679499928191044
-        boostFactor = BigInt(90);
-        break;
-
-      case routes.validator.BuilderSelection.MaxProfit:
-        boostFactor = validatorBuilder?.boostFactor ?? this.defaultProposerConfig.builder.boostFactor;
-        break;
-
-      case routes.validator.BuilderSelection.BuilderAlways:
-      case routes.validator.BuilderSelection.BuilderOnly:
-        boostFactor = MAX_BUILDER_BOOST_FACTOR;
-        break;
-
-      case routes.validator.BuilderSelection.ExecutionAlways:
-      case routes.validator.BuilderSelection.ExecutionOnly:
-        boostFactor = BigInt(0);
-    }
+    const boostFactor = getBuilderBoostFactor(
+      selection,
+      validatorBuilder?.boostFactor ?? this.defaultProposerConfig.builder.boostFactor
+    );
 
     return {selection, boostFactor};
   }

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -395,7 +395,7 @@ export class Validator {
       const defaultBuilderConfig = valProposerConfig?.defaultConfig.builder;
       const defaultBuilders = defaultBuilderConfig?.builders ?? [];
 
-      logger.info("Default builder config", {
+      logger.info("Builder config", {
         builders: defaultBuilders.map((entry) => toPrintableUrl(entry.url)).join(",") || "p2p only",
         boostFactor: getBuilderBoostFactor(
           defaultBuilderSelection,

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -6,10 +6,11 @@ import {
   assertEqualParams,
   createBeaconConfig,
 } from "@lodestar/config";
+import {ForkSeq} from "@lodestar/params";
 import {Clock, ClockOptions, IClock, computeEpochAtSlot, getCurrentSlot} from "@lodestar/state-transition";
 import {BLSPubkey, phase0, ssz} from "@lodestar/types";
 import {Genesis} from "@lodestar/types/phase0";
-import {Logger, toPrintableUrl, toRootHex} from "@lodestar/utils";
+import {Logger, prettyGweiToEth, toPrintableUrl, toRootHex} from "@lodestar/utils";
 import {waitForGenesis} from "./genesis.js";
 import {Metrics} from "./metrics.js";
 import {MetaDataRepository} from "./repositories/metaDataRepository.js";
@@ -27,7 +28,13 @@ import {ProposerPreferencesService} from "./services/proposerPreferences.js";
 import {PtcService} from "./services/ptc.js";
 import {SyncCommitteeService} from "./services/syncCommittee.js";
 import {SyncingStatusTracker} from "./services/syncingStatusTracker.js";
-import {Signer, ValidatorProposerConfig, ValidatorStore, defaultOptions} from "./services/validatorStore.js";
+import {
+  Signer,
+  ValidatorProposerConfig,
+  ValidatorStore,
+  defaultOptions,
+  getDefaultBuilderSelection,
+} from "./services/validatorStore.js";
 import {ISlashingProtection, Interchange, InterchangeFormatVersion} from "./slashingProtection/index.js";
 import {LodestarValidatorDatabaseController, ProcessShutdownCallback, PubkeyHex} from "./types.js";
 import {getLoggerVc} from "./util/index.js";
@@ -369,8 +376,10 @@ export class Validator {
     logger.info("Verified connected beacon node and validator have the same genesisValidatorRoot");
 
     const {broadcastValidation = defaultOptions.broadcastValidation, valProposerConfig} = opts;
+    // Resolve against the current fork, else this always reports the pre-Gloas default
+    const isPostGloas = config.getForkSeq(getCurrentSlot(config, Number(genesis.genesisTime))) >= ForkSeq.gloas;
     const defaultBuilderSelection =
-      valProposerConfig?.defaultConfig.builder?.selection ?? defaultOptions.builderSelection;
+      valProposerConfig?.defaultConfig.builder?.selection ?? getDefaultBuilderSelection(isPostGloas);
     const strictFeeRecipientCheck = valProposerConfig?.defaultConfig.strictFeeRecipientCheck ?? false;
     const suggestedFeeRecipient = valProposerConfig?.defaultConfig.feeRecipient ?? defaultOptions.suggestedFeeRecipient;
 
@@ -382,6 +391,25 @@ export class Validator {
     });
 
     metrics?.defaultConfiguration.set({builderSelection: defaultBuilderSelection, broadcastValidation}, 1);
+
+    // A misconfigured builder would otherwise only surface at the first proposal, hours away
+    const defaultBuilder = valProposerConfig?.defaultConfig.builder;
+    const defaultBuilders = defaultBuilder?.builders ?? [];
+    const validatorsWithBuilderOverrides = Object.values(valProposerConfig?.proposerConfig ?? {}).filter(
+      (proposerConfig) => proposerConfig.builder?.builders !== undefined
+    ).length;
+
+    if (defaultBuilders.length > 0 || validatorsWithBuilderOverrides > 0) {
+      logger.info("Builder API configured", {
+        builders: defaultBuilders.map((entry) => toPrintableUrl(entry.url)).join(",") || "none by default",
+        validatorsWithBuilderOverrides,
+        minBid: prettyGweiToEth(defaultBuilder?.minBid ?? defaultOptions.builderMinBid),
+        maxExecutionPayment: prettyGweiToEth(
+          defaultBuilder?.maxExecutionPayment ?? defaultOptions.builderMaxExecutionPayment
+        ),
+        active: isPostGloas,
+      });
+    }
 
     // Instantiates block and attestation services and runs them once the chain has been started.
     return Validator.init(opts, genesis, metrics);

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -6,7 +6,6 @@ import {
   assertEqualParams,
   createBeaconConfig,
 } from "@lodestar/config";
-import {ForkSeq} from "@lodestar/params";
 import {Clock, ClockOptions, IClock, computeEpochAtSlot, getCurrentSlot} from "@lodestar/state-transition";
 import {BLSPubkey, phase0, ssz} from "@lodestar/types";
 import {Genesis} from "@lodestar/types/phase0";
@@ -376,10 +375,9 @@ export class Validator {
     logger.info("Verified connected beacon node and validator have the same genesisValidatorRoot");
 
     const {broadcastValidation = defaultOptions.broadcastValidation, valProposerConfig} = opts;
-    // Resolve against the current fork, else this always reports the pre-Gloas default
-    const isPostGloas = config.getForkSeq(getCurrentSlot(config, Number(genesis.genesisTime))) >= ForkSeq.gloas;
+    const gloasScheduled = config.GLOAS_FORK_EPOCH !== Infinity;
     const defaultBuilderSelection =
-      valProposerConfig?.defaultConfig.builder?.selection ?? getDefaultBuilderSelection(isPostGloas);
+      valProposerConfig?.defaultConfig.builder?.selection ?? getDefaultBuilderSelection(gloasScheduled);
     const strictFeeRecipientCheck = valProposerConfig?.defaultConfig.strictFeeRecipientCheck ?? false;
     const suggestedFeeRecipient = valProposerConfig?.defaultConfig.feeRecipient ?? defaultOptions.suggestedFeeRecipient;
 
@@ -392,23 +390,23 @@ export class Validator {
 
     metrics?.defaultConfiguration.set({builderSelection: defaultBuilderSelection, broadcastValidation}, 1);
 
-    // A misconfigured builder would otherwise only surface at the first proposal, hours away
-    const defaultBuilder = valProposerConfig?.defaultConfig.builder;
-    const defaultBuilders = defaultBuilder?.builders ?? [];
-    const validatorsWithBuilderOverrides = Object.values(valProposerConfig?.proposerConfig ?? {}).filter(
-      (proposerConfig) => proposerConfig.builder?.builders !== undefined
-    ).length;
+    if (gloasScheduled) {
+      const defaultBuilderConfig = valProposerConfig?.defaultConfig.builder;
+      const defaultBuilders = defaultBuilderConfig?.builders ?? [];
+      const validatorsWithCustomBuilders = Object.values(valProposerConfig?.proposerConfig ?? {}).filter(
+        (proposerConfig) => proposerConfig.builder?.builders !== undefined
+      ).length;
 
-    if (defaultBuilders.length > 0 || validatorsWithBuilderOverrides > 0) {
-      logger.info("Builder API configured", {
-        builders: defaultBuilders.map((entry) => toPrintableUrl(entry.url)).join(",") || "none by default",
-        validatorsWithBuilderOverrides,
-        minBid: prettyGweiToEth(defaultBuilder?.minBid ?? defaultOptions.builderMinBid),
-        maxExecutionPayment: prettyGweiToEth(
-          defaultBuilder?.maxExecutionPayment ?? defaultOptions.builderMaxExecutionPayment
-        ),
-        active: isPostGloas,
-      });
+      if (defaultBuilders.length > 0 || validatorsWithCustomBuilders > 0) {
+        logger.info("Builder API configured", {
+          builders: defaultBuilders.map((entry) => toPrintableUrl(entry.url)).join(",") || "none by default",
+          validatorsWithCustomBuilders,
+          minBid: prettyGweiToEth(defaultBuilderConfig?.minBid ?? defaultOptions.builderMinBid),
+          maxExecutionPayment: prettyGweiToEth(
+            defaultBuilderConfig?.maxExecutionPayment ?? defaultOptions.builderMaxExecutionPayment
+          ),
+        });
+      }
     }
 
     // Instantiates block and attestation services and runs them once the chain has been started.

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -394,13 +394,9 @@ export class Validator {
     if (gloasScheduled) {
       const defaultBuilderConfig = valProposerConfig?.defaultConfig.builder;
       const defaultBuilders = defaultBuilderConfig?.builders ?? [];
-      const validatorsWithCustomBuilders = Object.values(valProposerConfig?.proposerConfig ?? {}).filter(
-        (proposerConfig) => proposerConfig.builder?.builders !== undefined
-      ).length;
 
-      logger.info("Builder configuration", {
+      logger.info("Default builder config", {
         builders: defaultBuilders.map((entry) => toPrintableUrl(entry.url)).join(",") || "p2p only",
-        validatorsWithCustomBuilders,
         boostFactor: getBuilderBoostFactor(
           defaultBuilderSelection,
           defaultBuilderConfig?.boostFactor ?? defaultOptions.builderBoostFactor

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -398,20 +398,18 @@ export class Validator {
         (proposerConfig) => proposerConfig.builder?.builders !== undefined
       ).length;
 
-      if (defaultBuilders.length > 0 || validatorsWithCustomBuilders > 0) {
-        logger.info("Builder API configured", {
-          builders: defaultBuilders.map((entry) => toPrintableUrl(entry.url)).join(",") || "none by default",
-          validatorsWithCustomBuilders,
-          boostFactor: getBuilderBoostFactor(
-            defaultBuilderSelection,
-            defaultBuilderConfig?.boostFactor ?? defaultOptions.builderBoostFactor
-          ),
-          minBid: prettyGweiToEth(defaultBuilderConfig?.minBid ?? defaultOptions.builderMinBid),
-          maxExecutionPayment: prettyGweiToEth(
-            defaultBuilderConfig?.maxExecutionPayment ?? defaultOptions.builderMaxExecutionPayment
-          ),
-        });
-      }
+      logger.info("Builder configuration", {
+        builders: defaultBuilders.map((entry) => toPrintableUrl(entry.url)).join(",") || "none",
+        validatorsWithCustomBuilders,
+        boostFactor: getBuilderBoostFactor(
+          defaultBuilderSelection,
+          defaultBuilderConfig?.boostFactor ?? defaultOptions.builderBoostFactor
+        ),
+        minBid: prettyGweiToEth(defaultBuilderConfig?.minBid ?? defaultOptions.builderMinBid),
+        maxExecutionPayment: prettyGweiToEth(
+          defaultBuilderConfig?.maxExecutionPayment ?? defaultOptions.builderMaxExecutionPayment
+        ),
+      });
     }
 
     // Instantiates block and attestation services and runs them once the chain has been started.

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -399,7 +399,7 @@ export class Validator {
       ).length;
 
       logger.info("Builder configuration", {
-        builders: defaultBuilders.map((entry) => toPrintableUrl(entry.url)).join(",") || "none",
+        builders: defaultBuilders.map((entry) => toPrintableUrl(entry.url)).join(",") || "p2p only",
         validatorsWithCustomBuilders,
         boostFactor: getBuilderBoostFactor(
           defaultBuilderSelection,

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -32,6 +32,7 @@ import {
   ValidatorProposerConfig,
   ValidatorStore,
   defaultOptions,
+  getBuilderBoostFactor,
   getDefaultBuilderSelection,
 } from "./services/validatorStore.js";
 import {ISlashingProtection, Interchange, InterchangeFormatVersion} from "./slashingProtection/index.js";
@@ -401,6 +402,10 @@ export class Validator {
         logger.info("Builder API configured", {
           builders: defaultBuilders.map((entry) => toPrintableUrl(entry.url)).join(",") || "none by default",
           validatorsWithCustomBuilders,
+          boostFactor: getBuilderBoostFactor(
+            defaultBuilderSelection,
+            defaultBuilderConfig?.boostFactor ?? defaultOptions.builderBoostFactor
+          ),
           minBid: prettyGweiToEth(defaultBuilderConfig?.minBid ?? defaultOptions.builderMinBid),
           maxExecutionPayment: prettyGweiToEth(
             defaultBuilderConfig?.maxExecutionPayment ?? defaultOptions.builderMaxExecutionPayment


### PR DESCRIPTION
Adds startup log to validator client that prints out the default builder configuration