### PR TITLE
fix: pre-establish builder connections before requesting bids

### DIFF
--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -400,10 +400,8 @@ export class PrepareNextSlotScheduler {
   };
 
   /**
-   * Pre-establish the builder connections so the handshake lands outside the bid deadline, the
-   * post-Gloas counterpart to the legacy builder `checkStatus` below. Scheduled later in the slot
-   * rather than now: this runs at PREPARE_NEXT_SLOT_BPS and idle connections are dropped within
-   * seconds, so connecting here would go cold again before bids are requested.
+   * Pre-establish the builder connections so the handshake lands outside the bid deadline. Scheduled
+   * later in the slot, connecting at PREPARE_NEXT_SLOT_BPS would go cold before bids are requested.
    */
   private checkBuilderStatusBeforeSlot(prepareSlot: Slot): void {
     const msBeforeSlot = this.config.getSlotComponentDurationMs(BUILDER_STATUS_CHECK_BEFORE_SLOT_BPS);

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -45,10 +45,13 @@ const PREPARE_EPOCH_LIMIT = 1;
  * Expressed in bps so it scales with slot duration (mainnet vs minimal/devnet). */
 const BUILDER_PREVERIFY_LIMIT_BPS = 2000;
 
-/* How far before the next slot builder connections are pre-established, see
- * `checkBuilderStatusBeforeSlot`. 1667 = 16.67% of slot (2s on mainnet). Must stay under the few
- * seconds an idle connection survives, while leaving room for a round trip to a distant builder. */
-const BUILDER_STATUS_CHECK_LEAD_BPS = 1667;
+/**
+ * How far before the next slot builder connections are pre-established, see `checkBuilderStatusBeforeSlot`.
+ *
+ * 1667 = 16.67% of slot (2s on mainnet). Must stay under the few seconds an idle connection survives,
+ * while leaving room for a round trip to a distant builder to complete before the slot begins.
+ */
+const BUILDER_STATUS_CHECK_BEFORE_SLOT_BPS = 1667;
 
 /**
  * At Bellatrix, if we are responsible for proposing in next slot, we want to prepare payload
@@ -403,8 +406,8 @@ export class PrepareNextSlotScheduler {
    * seconds, so connecting here would go cold again before bids are requested.
    */
   private checkBuilderStatusBeforeSlot(prepareSlot: Slot): void {
-    const leadMs = this.config.getSlotComponentDurationMs(BUILDER_STATUS_CHECK_LEAD_BPS);
-    const msUntilCheck = -this.chain.clock.msFromSlot(prepareSlot) - leadMs;
+    const msBeforeSlot = this.config.getSlotComponentDurationMs(BUILDER_STATUS_CHECK_BEFORE_SLOT_BPS);
+    const msUntilCheck = -this.chain.clock.msFromSlot(prepareSlot) - msBeforeSlot;
     sleep(Math.max(0, msUntilCheck), this.signal)
       .then(() => this.chain.builderApiClient.checkStatus())
       .catch((e) => {

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -45,6 +45,11 @@ const PREPARE_EPOCH_LIMIT = 1;
  * Expressed in bps so it scales with slot duration (mainnet vs minimal/devnet). */
 const BUILDER_PREVERIFY_LIMIT_BPS = 2000;
 
+/* How far before the next slot builder connections are pre-established, see
+ * `checkBuilderStatusBeforeSlot`. 1667 = 16.67% of slot (2s on mainnet). Must stay under the few
+ * seconds an idle connection survives, while leaving room for a round trip to a distant builder. */
+const BUILDER_STATUS_CHECK_LEAD_BPS = 1667;
+
 /**
  * At Bellatrix, if we are responsible for proposing in next slot, we want to prepare payload
  * 4s before the start of next slot at PREPARE_NEXT_SLOT_BPS of the current slot.
@@ -185,6 +190,7 @@ export class PrepareNextSlotScheduler {
         if (feeRecipient) {
           if (isForkPostGloas(fork)) {
             this.chain.builderCircuitBreaker.update(clockSlot, updatedHead);
+            this.checkBuilderStatusBeforeSlot(prepareSlot);
           } else {
             // Update the builder status, if enabled shoot an api call to check status
             this.chain.updateBuilderStatus(clockSlot);
@@ -389,6 +395,24 @@ export class PrepareNextSlotScheduler {
       }
     }
   };
+
+  /**
+   * Pre-establish the builder connections so the handshake lands outside the bid deadline, the
+   * post-Gloas counterpart to the legacy builder `checkStatus` below. Scheduled later in the slot
+   * rather than now: this runs at PREPARE_NEXT_SLOT_BPS and idle connections are dropped within
+   * seconds, so connecting here would go cold again before bids are requested.
+   */
+  private checkBuilderStatusBeforeSlot(prepareSlot: Slot): void {
+    const leadMs = this.config.getSlotComponentDurationMs(BUILDER_STATUS_CHECK_LEAD_BPS);
+    const msUntilCheck = -this.chain.clock.msFromSlot(prepareSlot) - leadMs;
+    sleep(Math.max(0, msUntilCheck), this.signal)
+      .then(() => this.chain.builderApiClient.checkStatus())
+      .catch((e) => {
+        if (!isErrorAborted(e)) {
+          this.logger.debug("Failed to check builder status", {prepareSlot}, e as Error);
+        }
+      });
+  }
 
   computeStateHashTreeRoot(state: IBeaconStateView, isEpochTransition: boolean): void {
     // cache HashObjects for faster hashTreeRoot() later, especially for computeNewStateRoot() if we need to produce a block at slot 0 of epoch

--- a/packages/beacon-node/src/execution/builder/apiClient.ts
+++ b/packages/beacon-node/src/execution/builder/apiClient.ts
@@ -202,10 +202,8 @@ export class BuilderApiClient {
   }
 
   /**
-   * Establish the connection to every known builder outside the bid deadline: a cold TCP/TLS
-   * handshake to a distant builder can exhaust `BUILDER_BID_DEADLINE_MS` on its own, and a long
-   * idle connection may be half-open, failing only once written to. Doubles as a liveness check,
-   * failures never propagate.
+   * Establish the connection to every known builder outside the bid deadline, a cold TCP/TLS handshake
+   * to a distant builder can exhaust `BUILDER_BID_DEADLINE_MS` on its own. Failures never propagate.
    */
   async checkStatus(): Promise<void> {
     await Promise.all(

--- a/packages/beacon-node/src/execution/builder/apiClient.ts
+++ b/packages/beacon-node/src/execution/builder/apiClient.ts
@@ -203,7 +203,7 @@ export class BuilderApiClient {
 
   /**
    * Establish the connection to every known builder outside the bid deadline, a cold TCP/TLS handshake
-   * to a distant builder can exhaust `BUILDER_BID_DEADLINE_MS` on its own. Failures never propagate.
+   * to a distant builder can exhaust `BUILDER_BID_DEADLINE_MS` on its own.
    */
   async checkStatus(): Promise<void> {
     await Promise.all(

--- a/packages/beacon-node/src/execution/builder/apiClient.ts
+++ b/packages/beacon-node/src/execution/builder/apiClient.ts
@@ -203,7 +203,8 @@ export class BuilderApiClient {
 
   /**
    * Establish the connection to every known builder outside the bid deadline, a cold TCP/TLS handshake
-   * to a distant builder can exhaust `BUILDER_BID_DEADLINE_MS` on its own.
+   * to a distant builder can exhaust `BUILDER_BID_DEADLINE_MS` on its own, and a long idle connection
+   * may be half-open and only fail once written to.
    */
   async checkStatus(): Promise<void> {
     await Promise.all(

--- a/packages/beacon-node/src/execution/builder/apiClient.ts
+++ b/packages/beacon-node/src/execution/builder/apiClient.ts
@@ -201,6 +201,27 @@ export class BuilderApiClient {
     }
   }
 
+  /**
+   * Establish the connection to every known builder outside the bid deadline: a cold TCP/TLS
+   * handshake to a distant builder can exhaust `BUILDER_BID_DEADLINE_MS` on its own, and a long
+   * idle connection may be half-open, failing only once written to. Doubles as a liveness check,
+   * failures never propagate.
+   */
+  async checkStatus(): Promise<void> {
+    await Promise.all(
+      Array.from(this.clients.entries()).map(async ([url, client]) => {
+        try {
+          (await client.status()).assertOk();
+          this.metrics?.builderApi.statusChecks.inc({status: "success"});
+          this.logger?.debug("Builder is ready", {builder: toPrintableUrl(url)});
+        } catch (e) {
+          this.metrics?.builderApi.statusChecks.inc({status: "error"});
+          this.logger?.warn("Builder status check failed", {builder: toPrintableUrl(url)}, e as Error);
+        }
+      })
+    );
+  }
+
   private async getOrCreateClient(
     url: BuilderUrl,
     proposerPubkey: BLSPubkey,

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -2036,6 +2036,11 @@ export function createLodestarMetrics(
     },
 
     builderApi: {
+      statusChecks: register.counter<{status: "success" | "error"}>({
+        name: "lodestar_builder_api_status_checks_total",
+        help: "Total count of status checks sent to external builders ahead of a proposal",
+        labelNames: ["status"],
+      }),
       bidRequests: register.counter({
         name: "lodestar_builder_api_bid_requests_total",
         help: "Total count of execution payload bid requests sent to external builders",

--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -165,6 +165,7 @@ vi.mock("../../src/chain/chain.js", async (importActual) => {
         getExecutionPayloadBids: vi.fn().mockResolvedValue([]),
         submitBuilderPreferences: vi.fn(),
         submitSignedBeaconBlock: vi.fn(),
+        checkStatus: vi.fn().mockResolvedValue(undefined),
       },
       opPool: new OpPool(config as BeaconConfig),
       aggregatedAttestationPool: new AggregatedAttestationPool(config as BeaconConfig),

--- a/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
+++ b/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
@@ -178,7 +178,7 @@ describe("PrepareNextSlot scheduler", () => {
     );
   });
 
-  it("gloas - should update builder circuit breaker instead of builder status", async () => {
+  it("gloas - should update builder circuit breaker and check builder api status ahead of the slot", async () => {
     getForkStub.mockReturnValue(ForkName.gloas);
     const headBlock = {...zeroProtoBlock, blockRoot: "0xhead", slot: SLOTS_PER_EPOCH - 3} as ProtoBlock;
     const proposerHead = {...zeroProtoBlock, blockRoot: "0xparent", slot: SLOTS_PER_EPOCH - 4} as ProtoBlock;
@@ -199,6 +199,12 @@ describe("PrepareNextSlot scheduler", () => {
     ]);
 
     expect(chainStub.builderCircuitBreaker.update).toHaveBeenCalledWith(SLOTS_PER_EPOCH - 2, proposerHead);
+    // The legacy pre-gloas builder status path stays untouched
     expect(updateBuilderStatus).not.toHaveBeenCalled();
+    // Scheduled close to the slot boundary, not now, so the connection is still warm at bid time
+    expect(chainStub.builderApiClient.checkStatus).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(config.SLOT_DURATION_MS / 3);
+    expect(chainStub.builderApiClient.checkStatus).toHaveBeenCalled();
   });
 });

--- a/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
+++ b/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
@@ -179,6 +179,9 @@ describe("PrepareNextSlot scheduler", () => {
   });
 
   it("gloas - should update builder circuit breaker and check builder api status ahead of the slot", async () => {
+    // Anchor the fake clock to the start of clockSlot, else msFromSlot resolves against wall time
+    // and the scheduled check collapses to a zero delay
+    vi.setSystemTime((SLOTS_PER_EPOCH - 2) * config.SLOT_DURATION_MS);
     getForkStub.mockReturnValue(ForkName.gloas);
     const headBlock = {...zeroProtoBlock, blockRoot: "0xhead", slot: SLOTS_PER_EPOCH - 3} as ProtoBlock;
     const proposerHead = {...zeroProtoBlock, blockRoot: "0xparent", slot: SLOTS_PER_EPOCH - 4} as ProtoBlock;
@@ -201,10 +204,13 @@ describe("PrepareNextSlot scheduler", () => {
     expect(chainStub.builderCircuitBreaker.update).toHaveBeenCalledWith(SLOTS_PER_EPOCH - 2, proposerHead);
     // The legacy pre-gloas builder status path stays untouched
     expect(updateBuilderStatus).not.toHaveBeenCalled();
-    // Scheduled close to the slot boundary, not now, so the connection is still warm at bid time
+
+    // Past PREPARE_NEXT_SLOT_BPS but before the check is due, an undelayed check would have run
+    await vi.advanceTimersByTimeAsync(config.SLOT_DURATION_MS / 12);
     expect(chainStub.builderApiClient.checkStatus).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(config.SLOT_DURATION_MS / 3);
+    // Past BUILDER_STATUS_CHECK_BEFORE_SLOT_BPS, connections are warmed before bids are requested
+    await vi.advanceTimersByTimeAsync(config.SLOT_DURATION_MS / 4);
     expect(chainStub.builderApiClient.checkStatus).toHaveBeenCalled();
   });
 });

--- a/packages/beacon-node/test/unit/execution/builder/apiClient.test.ts
+++ b/packages/beacon-node/test/unit/execution/builder/apiClient.test.ts
@@ -7,17 +7,17 @@ import {BuilderApiClient} from "../../../../src/execution/builder/apiClient.js";
 import {IClock} from "../../../../src/util/clock.js";
 import {getMockedLogger} from "../../../mocks/loggerMock.js";
 
-const {getExecutionPayloadBid, submitBuilderPreferences, submitSignedBeaconBlock, verifySignatureSets} = vi.hoisted(
-  () => ({
+const {getExecutionPayloadBid, submitBuilderPreferences, submitSignedBeaconBlock, status, verifySignatureSets} =
+  vi.hoisted(() => ({
     getExecutionPayloadBid: vi.fn(),
     submitBuilderPreferences: vi.fn(),
     submitSignedBeaconBlock: vi.fn(),
+    status: vi.fn(),
     verifySignatureSets: vi.fn().mockResolvedValue(true),
-  })
-);
+  }));
 
 vi.mock("@lodestar/api/builder", () => ({
-  getClient: () => ({getExecutionPayloadBid, submitBuilderPreferences, submitSignedBeaconBlock}),
+  getClient: () => ({getExecutionPayloadBid, submitBuilderPreferences, submitSignedBeaconBlock, status}),
 }));
 
 const bls = {
@@ -182,7 +182,47 @@ describe("execution/builder/apiClient", () => {
 
     expect(bids.map((bid) => bid.signedBid.message.builderIndex)).toEqual([1, 0]);
   });
+
+  it("logs a debug line for each builder that is ready", async () => {
+    const url = "https://builder.example.com";
+    const {client, logger} = await getClientWithBuilder(url);
+    status.mockResolvedValue({assertOk: () => {}});
+
+    await client.checkStatus();
+
+    expect(status).toHaveBeenCalledOnce();
+    expect(logger.debug).toHaveBeenCalledWith("Builder is ready", {builder: url});
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("warns when a builder fails its status check without throwing", async () => {
+    const url = "https://builder.example.com";
+    const {client, logger} = await getClientWithBuilder(url);
+    status.mockRejectedValue(new Error("builder is down"));
+
+    await expect(client.checkStatus()).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith("Builder status check failed", {builder: url}, expect.any(Error));
+    expect(logger.debug).not.toHaveBeenCalledWith("Builder is ready", {builder: url});
+  });
 });
+
+/** A client with one builder already dialed, so there is something to check the status of */
+async function getClientWithBuilder(url: string) {
+  const logger = getMockedLogger();
+  const client = new BuilderApiClient({}, config, clock, bls, null, logger);
+
+  getExecutionPayloadBid.mockResolvedValue({value: () => undefined});
+  await client.getExecutionPayloadBids(
+    [getBuilderEntry(url, 1)],
+    1,
+    new Uint8Array(32),
+    new Uint8Array(32),
+    new Uint8Array(48)
+  );
+  vi.clearAllMocks();
+  return {client, logger};
+}
 
 function getBuilderEntry(url: string, slot: number): routes.validator.BuilderEntry {
   const auth = ssz.gloas.SignedBuilderRequestAuth.defaultValue();


### PR DESCRIPTION
Post-Gloas `prepareNextSlot` replaced the builder status check with the circuit breaker update, so the builders a proposal is about to request bids from are never contacted beforehand. Every bid request then pays a full TCP/TLS handshake inside `BUILDER_BID_DEADLINE_MS`, which a distant builder can exhaust on the handshake alone.

On glamsterdam-devnet-8 with 8 builders configured, 21 of 41 bid requests failed with `Timeout getExecutionPayloadBid request`. Node drops idle keep-alive sockets after ~4s, measured against a builder at 262ms RTT:

| idle before request | request |
|---|---|
| 3s | 292ms |
| 6s | 881ms |
| 12s | 920ms |

`prepareNextSlot` runs at `PREPARE_NEXT_SLOT_BPS`, a slot before the proposal, so a check there is cold again by the time bids are requested. Scheduling it close to the slot boundary instead, same builder:

| | bid request |
|---|---|
| no preceding check | 918ms |
| check 2s earlier | 294ms |

Running this on the same node took bid request errors from 51% (21/41) to 5.7% (8/140), and bids received from 49% to 83%.

- add `checkStatus()` to `BuilderApiClient`, pinging every known builder concurrently, failures are logged and never propagate
- call it from `prepareNextSlot` post-gloas, scheduled `BUILDER_STATUS_CHECK_BEFORE_SLOT_BPS` before the slot we propose
- add `lodestar_builder_api_status_checks_total`

Raising the client keep-alive is not a substitute, a connection idle for minutes through NAT is frequently half-open and fails only once written to, inside the deadline where there is no recovery.

Only builders already in the `clients` map are pinged, which the preference submissions populate ~96s ahead of a proposal. That map is never evicted, so a builder dropped from the config keeps being pinged until restart, see #9951.
