### PR TITLE
chore: builder log levels and value formatting

### DIFF
--- a/packages/beacon-node/src/execution/builder/apiClient.ts
+++ b/packages/beacon-node/src/execution/builder/apiClient.ts
@@ -237,7 +237,7 @@ export class BuilderApiClient {
         {config: this.config, metrics: this.metrics?.builderHttpClient, logger: this.logger}
       );
       this.clients.set(url, client);
-      this.logger?.info("External builder registered", {url: toPrintableUrl(url)});
+      this.logger?.debug("External builder registered", {url: toPrintableUrl(url)});
     }
     return client;
   }

--- a/packages/builder/src/services/builderStatusTracker.ts
+++ b/packages/builder/src/services/builderStatusTracker.ts
@@ -1,6 +1,6 @@
 import {ApiClient} from "@lodestar/api";
 import {BuilderIndex, BuilderStatus, Epoch} from "@lodestar/types";
-import {Logger} from "@lodestar/utils";
+import {Logger, prettyGweiToEth} from "@lodestar/utils";
 import {getBuilderStatus} from "../identity.js";
 import {Metrics, builderStatusValue} from "../metrics.js";
 
@@ -34,7 +34,7 @@ export class BuilderStatusTracker {
       this.balanceGwei = builderStatus.balance;
       this.logger.info("Builder status", {
         status: builderStatus.status,
-        balance: builderStatus.balance,
+        balance: prettyGweiToEth(builderStatus.balance),
         epoch: currentEpoch,
       });
       this.metrics?.builderStatus.set(builderStatusValue[builderStatus.status]);

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -14,7 +14,7 @@ import {
   Slot,
   isBlindedSignedBeaconBlock,
 } from "@lodestar/types";
-import {extendError, prettyBytes, prettyWeiToEth, toPubkeyHex, toRootHex} from "@lodestar/utils";
+import {extendError, prettyBytes, prettyGweiToEth, prettyWeiToEth, toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";
 import {PubkeyHex} from "../types.js";
 import {LoggerVc} from "../util/index.js";
@@ -204,7 +204,7 @@ export class BlockProposingService {
       payloadLocal,
       builderSelection,
       builderBoostFactor,
-      builderMinBid,
+      builderMinBid: prettyGweiToEth(builderMinBid),
       builderUrls: builderEntries.map((entry) => entry.url).join(","),
     });
     this.metrics?.proposerStepCallProduceBlock.observe(this.clock.secFromSlot(slot));

--- a/packages/validator/src/services/builderPreferences.ts
+++ b/packages/validator/src/services/builderPreferences.ts
@@ -136,7 +136,8 @@ export class BuilderPreferencesService {
       }
       this.logger.debug("Submitted builder preferences", {count: entries.length});
     } catch (e) {
-      this.logger.error("Error submitting builder preferences", {count: entries.length}, e as Error);
+      // Best-effort, a builder that rejects preferences does not fail the proposal
+      this.logger.warn("Error submitting builder preferences", {count: entries.length}, e as Error);
     }
   };
 }

--- a/packages/validator/src/services/builderPreferences.ts
+++ b/packages/validator/src/services/builderPreferences.ts
@@ -136,7 +136,6 @@ export class BuilderPreferencesService {
       }
       this.logger.debug("Submitted builder preferences", {count: entries.length});
     } catch (e) {
-      // Best-effort, a builder that rejects preferences does not fail the proposal
       this.logger.warn("Error submitting builder preferences", {count: entries.length}, e as Error);
     }
   };


### PR DESCRIPTION
- log the builder min bid and builder balance as ETH, `builderMinBid=1000000000000` is hard to read for operators
- lower a failed builder preferences submission to `warn`, it can not fail a proposal
- lower `External builder registered` to `debug`
