### PR TITLE
docs: clarify gloas builder configuration

### DIFF
--- a/docs/pages/run/validator-management/proposer-config.md
+++ b/docs/pages/run/validator-management/proposer-config.md
@@ -42,7 +42,7 @@ default_config:
 
 `min_bid` is a floor in Gwei on the counted total payment, applied to p2p and builder API bids alike. `max_execution_payment` caps the execution layer payment in Gwei counted toward a builder API bid, values above `0` require `--allowDangerousTrustedPayments`. `max_execution_payment` has no effect without builder entries, p2p bids never carry an execution payment.
 
-`boost_factor` applies to the p2p bid, while each builder's own `builder_boost_factor` applies to that builder's API bid. An explicitly configured per-validator `boost_factor` takes precedence over `selection`.
+`boost_factor` applies to the p2p bid, while each builder's own `builder_boost_factor` applies to that builder's API bid. An explicitly configured per-validator `boost_factor` takes precedence over `selection`, a `boost_factor` in `default_config` only applies when `selection` is `maxprofit`.
 
 `builders` lists the builders to request bids from, with the same per-builder entries as the keymanager builder config API. Each entry has a required `url` and optional `auth_data`, `builder_pubkeys`, `max_execution_payment`, `min_bid` and `builder_boost_factor`, the last three defaulting to the values set on the builder section. Multiple entries may share a `url` only if they have distinct `auth_data`. Per-key entries replace the builders the validator client is configured with; setting both `--builder.urls` and `builders` in `default_config` is an error.
 

--- a/docs/pages/run/validator-management/proposer-config.md
+++ b/docs/pages/run/validator-management/proposer-config.md
@@ -40,7 +40,7 @@ default_config:
 
 ### Builder settings from Gloas
 
-`min_bid` is a floor in Gwei on the counted total payment, applied to p2p and builder API bids alike. `max_execution_payment` caps the execution layer payment in Gwei counted toward a builder API bid, values above `0` require `--allowDangerousTrustedPayments`. It has no effect without builder entries, p2p bids never carry an execution payment.
+`min_bid` is a floor in Gwei on the counted total payment, applied to p2p and builder API bids alike. `max_execution_payment` caps the execution layer payment in Gwei counted toward a builder API bid, values above `0` require `--allowDangerousTrustedPayments`. `max_execution_payment` has no effect without builder entries, p2p bids never carry an execution payment.
 
 `boost_factor` applies to the p2p bid, while each builder's own `builder_boost_factor` applies to that builder's API bid. An explicitly configured per-validator `boost_factor` takes precedence over `selection`.
 

--- a/docs/pages/run/validator-management/proposer-config.md
+++ b/docs/pages/run/validator-management/proposer-config.md
@@ -42,6 +42,8 @@ Starting with Gloas, the builder section additionally supports `min_bid` (floor 
 
 Post-Gloas, an explicitly configured per-validator `boost_factor` takes precedence over `selection`.
 
+Post-Gloas the boost is applied on both sides of the bid comparison: the per-validator `boost_factor` boosts the p2p bid, while each builder's own `builder_boost_factor` boosts that builder's API bid. Setting only `boost_factor` leaves every entry inheriting it, so both sides are boosted equally and the ranking is unchanged. To favour builder API bids over p2p bids, raise `builder_boost_factor` on the entries above the validator's `boost_factor`.
+
 The builder section also supports a `builders` list with the same per-builder entries as the keymanager builder config API. Each entry has a required `url` and optional `auth_data`, `builder_pubkeys`, `max_execution_payment`, `min_bid` and `builder_boost_factor`. Multiple entries may share a `url` only if they have distinct `auth_data`. Per-key entries replace the builders the validator client is configured with; setting both `--builder.urls` and `builders` in `default_config` is an error.
 
 ```yaml

--- a/docs/pages/run/validator-management/proposer-config.md
+++ b/docs/pages/run/validator-management/proposer-config.md
@@ -38,13 +38,13 @@ default_config:
     boost_factor: "90"
 ```
 
-Starting with Gloas, the builder section additionally supports `min_bid` (floor in Gwei on the counted total payment from a builder bid) and `max_execution_payment` (ceiling in Gwei on the execution layer payment counted toward a builder bid, values above `0` require `--allowDangerousTrustedPayments`).
+### Builder settings from Gloas
 
-Post-Gloas, an explicitly configured per-validator `boost_factor` takes precedence over `selection`.
+`min_bid` is a floor in Gwei on the counted total payment, applied to p2p and builder API bids alike. `max_execution_payment` caps the execution layer payment in Gwei counted toward a builder API bid, values above `0` require `--allowDangerousTrustedPayments`. It has no effect without builder entries, p2p bids never carry an execution payment.
 
-Post-Gloas the boost is applied on both sides of the bid comparison: the per-validator `boost_factor` boosts the p2p bid, while each builder's own `builder_boost_factor` boosts that builder's API bid. Setting only `boost_factor` leaves every entry inheriting it, so both sides are boosted equally and the ranking is unchanged. To favour builder API bids over p2p bids, raise `builder_boost_factor` on the entries above the validator's `boost_factor`.
+`boost_factor` applies to the p2p bid, while each builder's own `builder_boost_factor` applies to that builder's API bid. An explicitly configured per-validator `boost_factor` takes precedence over `selection`.
 
-The builder section also supports a `builders` list with the same per-builder entries as the keymanager builder config API. Each entry has a required `url` and optional `auth_data`, `builder_pubkeys`, `max_execution_payment`, `min_bid` and `builder_boost_factor`. Multiple entries may share a `url` only if they have distinct `auth_data`. Per-key entries replace the builders the validator client is configured with; setting both `--builder.urls` and `builders` in `default_config` is an error.
+`builders` lists the builders to request bids from, with the same per-builder entries as the keymanager builder config API. Each entry has a required `url` and optional `auth_data`, `builder_pubkeys`, `max_execution_payment`, `min_bid` and `builder_boost_factor`, the last three defaulting to the values set on the builder section. Multiple entries may share a `url` only if they have distinct `auth_data`. Per-key entries replace the builders the validator client is configured with; setting both `--builder.urls` and `builders` in `default_config` is an error.
 
 ```yaml
 builder:

--- a/packages/cli/src/options/beaconNodeOptions/builder.ts
+++ b/packages/cli/src/options/beaconNodeOptions/builder.ts
@@ -31,7 +31,8 @@ export function parseArgs(args: ExecutionBuilderArgs): IBeaconNodeOptions["execu
 
 export const options: CliCommandOptions<ExecutionBuilderArgs> = {
   builder: {
-    description: "Enable external builder",
+    description:
+      "Enable external builder. Pre-Gloas only, deprecated post-Gloas where builders are configured on the validator client",
     type: "boolean",
     default: defaultExecutionBuilderHttpOpts.enabled,
     group: "builder",
@@ -39,7 +40,8 @@ export const options: CliCommandOptions<ExecutionBuilderArgs> = {
 
   "builder.url": {
     alias: ["builder.urls"],
-    description: "Url hosting the builder API",
+    description:
+      "Url hosting the builder API. Pre-Gloas only, deprecated post-Gloas where builders are configured on the validator client with its own `--builder.urls`, which takes a list rather than this single url",
     defaultDescription: defaultExecutionBuilderHttpOpts.url,
     type: "string",
     group: "builder",

--- a/packages/cli/src/options/beaconNodeOptions/builder.ts
+++ b/packages/cli/src/options/beaconNodeOptions/builder.ts
@@ -41,7 +41,7 @@ export const options: CliCommandOptions<ExecutionBuilderArgs> = {
   "builder.url": {
     alias: ["builder.urls"],
     description:
-      "Url hosting the builder API. Pre-Gloas only, deprecated post-Gloas where builders are configured on the validator client with its own `--builder.urls`, which takes a list rather than this single url",
+      "Url hosting the builder API. Pre-Gloas only, deprecated post-Gloas where builders are configured on the validator client",
     defaultDescription: defaultExecutionBuilderHttpOpts.url,
     type: "string",
     group: "builder",


### PR DESCRIPTION
- group the Gloas builder settings into their own section
- `min_bid` also applies to the p2p bid, it was documented as a floor on builder bids only
- `max_execution_payment` only takes effect through a builder entry, it has no effect without one since p2p bids never carry an execution payment
- `boost_factor` applies to the p2p bid, each entry's `builder_boost_factor` applies to that builder's API bid
- a `boost_factor` in `default_config` is only used with `selection: maxprofit`, otherwise the boost is derived from `selection`
- the beacon node `--builder` and `--builder.url` are pre-Gloas only, deprecated post-Gloas where builders are configured on the validator client
