### PR TITLE
chore: stop registering validators with external builders post-gloas

### DIFF
--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -106,7 +106,7 @@ export class BlockProposingService {
 
       const strictFeeRecipientCheck = this.validatorStore.strictFeeRecipientCheck(pubkeyHex);
       const {selection: builderSelection, boostFactor: builderBoostFactor} =
-        this.validatorStore.getBuilderSelectionParams(pubkeyHex);
+        this.validatorStore.getBuilderSelectionParams(pubkeyHex, slot);
       const feeRecipient = this.validatorStore.getFeeRecipient(pubkeyHex);
       const blindedLocal = this.opts.blindedLocal;
 

--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -1,6 +1,6 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
-import {GENESIS_EPOCH, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkSeq, GENESIS_EPOCH, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {IClock} from "@lodestar/state-transition";
 import {Epoch, bellatrix} from "@lodestar/types";
 import {Metrics} from "../metrics.js";
@@ -80,6 +80,9 @@ export function pollBuilderValidatorRegistration(
     if (epoch < config.BELLATRIX_FORK_EPOCH - 1) return;
     const slot = epoch * SLOTS_PER_EPOCH;
 
+    // Validator registrations are pre-gloas only, replaced by builder preferences
+    if (config.getForkSeq(slot) >= ForkSeq.gloas) return;
+
     // registerValidator is not as time sensitive as attesting.
     // Poll indices first, then call api.validator.registerValidator once
     await validatorStore.pollValidatorIndices().catch((e: Error) => {
@@ -91,7 +94,7 @@ export function pollBuilderValidatorRegistration(
       .filter(
         (pubkeyHex): pubkeyHex is string =>
           pubkeyHex !== undefined &&
-          validatorStore.getBuilderSelectionParams(pubkeyHex).selection !==
+          validatorStore.getBuilderSelectionParams(pubkeyHex, slot).selection !==
             routes.validator.BuilderSelection.ExecutionOnly
       );
 

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -309,12 +309,12 @@ export class ValidatorStore {
 
   getBuilderSelectionParams(
     pubkeyHex: PubkeyHex,
-    slot?: Slot
+    slot: Slot
   ): {selection: routes.validator.BuilderSelection; boostFactor: bigint} {
     // Builder bids post-gloas are in-protocol, so the default strategy uses them regardless of
     // whether they are received over p2p or through a builder API. Pre-gloas there is no
     // in-protocol builder, so the default remains local-only (executiononly).
-    const isPostGloas = slot !== undefined && this.config.getForkSeq(slot) >= ForkSeq.gloas;
+    const isPostGloas = this.config.getForkSeq(slot) >= ForkSeq.gloas;
     return this.resolveBuilderSelectionParams(pubkeyHex, isPostGloas);
   }
 


### PR DESCRIPTION
`pollBuilderValidatorRegistration` has no upper fork bound, it keeps sending `registerValidator` every epoch past Gloas where there is no external builder to register with.

That is currently masked by `getBuilderSelectionParams` being called without a slot, which resolves the pre-Gloas `executiononly` default and filters every validator out of the registration. Requiring the slot surfaces it, the default becomes `default` post-gloas and registrations would start going out.

- require `slot` in `getBuilderSelectionParams`, an omitted slot silently resolved as pre-Gloas
- skip validator registrations post-gloas, they are replaced by builder preferences
- pass the slot on the pre-gloas block production path, that call site is only reached pre-gloas so behaviour is unchanged
