### PR TITLE
fix: ignore bids from builders exiting in the parent payload

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1007,6 +1007,7 @@ export function getValidatorApi(
       // builder directly.
       const bestBidPromise: Promise<BidCandidate | null> = (async () => {
         const [builderApiBids, p2pBid] = await Promise.all([builderApiBidsPromise, p2pBidPromise]);
+        let parentExecutionRequestsPromise: Promise<gloas.ExecutionRequests> | null = null;
 
         const candidates = (
           await Promise.all(
@@ -1018,6 +1019,10 @@ export function getValidatorApi(
                   parentBlockHash: bidParentBlockHash,
                   parentBlockRoot: parentBlockRootHex,
                   entry,
+                  getParentExecutionRequests: () => {
+                    parentExecutionRequestsPromise ??= chain.getParentExecutionRequests(parentSlot, parentBlockRootHex);
+                    return parentExecutionRequestsPromise;
+                  },
                 });
                 return {
                   signedBid,

--- a/packages/beacon-node/src/chain/errors/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/errors/executionPayloadBid.ts
@@ -9,6 +9,7 @@ export enum ExecutionPayloadBidErrorCode {
   BID_ALREADY_KNOWN = "EXECUTION_PAYLOAD_BID_ERROR_BID_ALREADY_KNOWN",
   BID_TOO_LOW = "EXECUTION_PAYLOAD_BID_ERROR_BID_TOO_LOW",
   BID_TOO_HIGH = "EXECUTION_PAYLOAD_BID_ERROR_BID_TOO_HIGH",
+  BUILDER_MAY_EXIT = "EXECUTION_PAYLOAD_BID_ERROR_BUILDER_MAY_EXIT",
   TOO_MANY_KZG_COMMITMENTS = "EXECUTION_PAYLOAD_BID_ERROR_TOO_MANY_KZG_COMMITMENTS",
   UNKNOWN_BLOCK_ROOT = "EXECUTION_PAYLOAD_BID_ERROR_UNKNOWN_BLOCK_ROOT",
   UNKNOWN_PARENT_BLOCK_HASH = "EXECUTION_PAYLOAD_BID_ERROR_UNKNOWN_PARENT_BLOCK_HASH",
@@ -50,6 +51,11 @@ export type ExecutionPayloadBidErrorType =
     }
   | {code: ExecutionPayloadBidErrorCode.BID_TOO_LOW; bidValue: number; currentHighestBid: number}
   | {code: ExecutionPayloadBidErrorCode.BID_TOO_HIGH; bidValue: number; builderBalance: number}
+  | {
+      code: ExecutionPayloadBidErrorCode.BUILDER_MAY_EXIT;
+      builderIndex: BuilderIndex;
+      parentBlockRoot: RootHex;
+    }
   | {
       code: ExecutionPayloadBidErrorCode.TOO_MANY_KZG_COMMITMENTS;
       blobKzgCommitmentsLen: number;

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -91,6 +91,8 @@ function isBidCompatibleWithHead(
  * Transient gossip rules (head compatibility, first bid per tuple, value increment, proposer
  * preferences) are not applied, since those only limit forwarding of peers' messages and the
  * builder may legitimately bid on a branch this node does not consider head.
+ * The parent-payload builder-exit rule is omitted because this endpoint only accepts bids from
+ * the operator's own builder.
  *
  * Throws on any failed check. Also throws if the bid's parent block is unknown or its state is
  * unavailable, since the checks cannot be evaluated against the parent branch.

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -497,6 +497,29 @@ async function validateExecutionPayloadBid(
     });
   }
 
+  // [IGNORE] The parent's payload does not try to exit the builder
+  if (byteArrayEquals(bid.parentBlockHash, state.latestExecutionPayloadBid.blockHash)) {
+    const requests = await chain.getParentExecutionRequests(parentBlock.slot, parentBlock.blockRoot).catch(() => {
+      throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
+        code: ExecutionPayloadBidErrorCode.UNKNOWN_PARENT_BLOCK_HASH,
+        parentBlockHash: bidParentBlockHash,
+      });
+    });
+    if (
+      requests.builderExits.some(
+        (request) =>
+          byteArrayEquals(request.pubkey, builder.pubkey) &&
+          byteArrayEquals(request.sourceAddress, builder.executionAddress)
+      )
+    ) {
+      throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
+        code: ExecutionPayloadBidErrorCode.BUILDER_MAY_EXIT,
+        builderIndex: bid.builderIndex,
+        parentBlockRoot: bidParentBlockRoot,
+      });
+    }
+  }
+
   // [REJECT] `signed_execution_payload_bid.signature` is valid with respect to the `bid.builder_index`.
   const signatureSet = createSingleSignatureSetFromComponents(
     builder.pubkey,

--- a/packages/beacon-node/src/execution/builder/validateBid.ts
+++ b/packages/beacon-node/src/execution/builder/validateBid.ts
@@ -37,10 +37,11 @@ export async function validateBuilderApiExecutionPayloadBid(
     parentBlockHash: RootHex;
     parentBlockRoot: RootHex;
     entry: routes.validator.BuilderEntry;
+    getParentExecutionRequests: () => Promise<gloas.ExecutionRequests>;
   }
 ): Promise<void> {
   const bid = signedExecutionPayloadBid.message;
-  const {slot, parentBlock, parentBlockHash, parentBlockRoot, entry} = request;
+  const {slot, parentBlock, parentBlockHash, parentBlockRoot, entry, getParentExecutionRequests} = request;
 
   if (bid.slot !== slot) {
     throw Error(`Bid slot=${bid.slot} does not match requested slot=${slot}`);
@@ -120,7 +121,7 @@ export async function validateBuilderApiExecutionPayloadBid(
 
   // The parent's payload does not try to exit the builder
   if (byteArrayEquals(bid.parentBlockHash, state.latestExecutionPayloadBid.blockHash)) {
-    const requests = await chain.getParentExecutionRequests(parentBlock.slot, parentBlock.blockRoot);
+    const requests = await getParentExecutionRequests();
     if (
       requests.builderExits.some(
         (request) =>

--- a/packages/beacon-node/src/execution/builder/validateBid.ts
+++ b/packages/beacon-node/src/execution/builder/validateBid.ts
@@ -118,6 +118,20 @@ export async function validateBuilderApiExecutionPayloadBid(
     throw Error(`Invalid bid prevRandao=${toHex(bid.prevRandao)} expected=${toHex(randaoMix)}`);
   }
 
+  // The parent's payload does not try to exit the builder
+  if (byteArrayEquals(bid.parentBlockHash, state.latestExecutionPayloadBid.blockHash)) {
+    const requests = await chain.getParentExecutionRequests(parentBlock.slot, parentBlock.blockRoot);
+    if (
+      requests.builderExits.some(
+        (request) =>
+          byteArrayEquals(request.pubkey, builder.pubkey) &&
+          byteArrayEquals(request.sourceAddress, builder.executionAddress)
+      )
+    ) {
+      throw Error(`Bid builderIndex=${bid.builderIndex} may exit in the parent payload`);
+    }
+  }
+
   // The builder must honor the proposer preferences it learned over gossip
   const bidEpoch = computeEpochAtSlot(bid.slot);
   const dependentRootHex = (() => {


### PR DESCRIPTION
see https://github.com/ethereum/consensus-specs/pull/5580