### PR TITLE
feat(builder): add Engine payload source

### DIFF
--- a/packages/builder/src/services/payloadSource.ts
+++ b/packages/builder/src/services/payloadSource.ts
@@ -19,13 +19,15 @@ export type ForkchoiceState = {
 
 export type PayloadAttributes<F extends ForkPostGloas = ForkPostGloas> = SSEPayloadAttributes<F>["payloadAttributes"];
 
-export type BuildRequest<F extends ForkPostGloas = ForkPostGloas> = {
-  fork: F;
-  forkchoiceState: ForkchoiceState;
-  payloadAttributes: PayloadAttributes<F>;
-  /** Logical custody set. The transport serializes it for Engine API; null means no custody service. */
-  custodyColumns: ColumnIndex[] | null;
-};
+export type BuildRequest<F extends ForkPostGloas = ForkPostGloas> = F extends ForkPostGloas
+  ? {
+      fork: F;
+      forkchoiceState: ForkchoiceState;
+      payloadAttributes: PayloadAttributes<F>;
+      /** Logical custody set. The transport serializes it for Engine API; null means no custody service. */
+      custodyColumns: ColumnIndex[] | null;
+    }
+  : never;
 
 export type BuildHandle<F extends ForkPostGloas = ForkPostGloas> = {
   sourceId: string;
@@ -65,7 +67,7 @@ export interface PayloadSourceEngine {
 /** Source that prepares and retrieves complete execution payloads without owning build scheduling policy. */
 export interface PayloadSource {
   readonly id: string;
-  prepare<F extends ForkPostGloas>(request: BuildRequest<F>): Promise<BuildHandle<F>>;
+  prepare<R extends BuildRequest>(request: R): Promise<BuildHandle<R["fork"]>>;
   getPayload<F extends ForkPostGloas>(handle: BuildHandle<F>): Promise<BuiltPayload<F>>;
 }
 
@@ -98,7 +100,7 @@ export class EnginePayloadSource implements PayloadSource {
     private readonly engine: PayloadSourceEngine
   ) {}
 
-  async prepare<F extends ForkPostGloas>(request: BuildRequest<F>): Promise<BuildHandle<F>> {
+  async prepare<R extends BuildRequest>(request: R): Promise<BuildHandle<R["fork"]>> {
     const {headBlockHash, safeBlockHash, finalizedBlockHash} = request.forkchoiceState;
     const payloadId = await this.engine.notifyForkchoiceUpdate(
       request.fork,

--- a/packages/builder/src/services/payloadSource.ts
+++ b/packages/builder/src/services/payloadSource.ts
@@ -59,16 +59,21 @@ export interface PayloadSourceEngine {
     safeBlockHash: RootHex,
     finalizedBlockHash: RootHex,
     payloadAttributes: PayloadAttributes<F>,
-    custodyColumns: ColumnIndex[] | null
+    custodyColumns: ColumnIndex[] | null,
+    signal: AbortSignal
   ): Promise<PayloadId | null>;
-  getPayload<F extends ForkPostGloas>(fork: F, payloadId: PayloadId): Promise<EnginePayloadResult<F>>;
+  getPayload<F extends ForkPostGloas>(
+    fork: F,
+    payloadId: PayloadId,
+    signal: AbortSignal
+  ): Promise<EnginePayloadResult<F>>;
 }
 
 /** Source that prepares and retrieves complete execution payloads without owning build scheduling policy. */
 export interface PayloadSource {
   readonly id: string;
-  prepare<R extends BuildRequest>(request: R): Promise<BuildHandle<R["fork"]>>;
-  getPayload<F extends ForkPostGloas>(handle: BuildHandle<F>): Promise<BuiltPayload<F>>;
+  prepare<R extends BuildRequest>(request: R, signal: AbortSignal): Promise<BuildHandle<R["fork"]>>;
+  getPayload<F extends ForkPostGloas>(handle: BuildHandle<F>, signal: AbortSignal): Promise<BuiltPayload<F>>;
 }
 
 export enum PayloadSourceErrorCode {
@@ -100,7 +105,7 @@ export class EnginePayloadSource implements PayloadSource {
     private readonly engine: PayloadSourceEngine
   ) {}
 
-  async prepare<R extends BuildRequest>(request: R): Promise<BuildHandle<R["fork"]>> {
+  async prepare<R extends BuildRequest>(request: R, signal: AbortSignal): Promise<BuildHandle<R["fork"]>> {
     const {headBlockHash, safeBlockHash, finalizedBlockHash} = request.forkchoiceState;
     const payloadId = await this.engine.notifyForkchoiceUpdate(
       request.fork,
@@ -108,7 +113,8 @@ export class EnginePayloadSource implements PayloadSource {
       safeBlockHash,
       finalizedBlockHash,
       request.payloadAttributes,
-      request.custodyColumns
+      request.custodyColumns,
+      signal
     );
 
     if (payloadId === null) {
@@ -121,7 +127,7 @@ export class EnginePayloadSource implements PayloadSource {
     return {sourceId: this.id, fork: request.fork, payloadId};
   }
 
-  async getPayload<F extends ForkPostGloas>(handle: BuildHandle<F>): Promise<BuiltPayload<F>> {
+  async getPayload<F extends ForkPostGloas>(handle: BuildHandle<F>, signal: AbortSignal): Promise<BuiltPayload<F>> {
     if (handle.sourceId !== this.id) {
       throw new PayloadSourceError(
         {
@@ -135,7 +141,8 @@ export class EnginePayloadSource implements PayloadSource {
 
     const {executionPayload, executionPayloadValue, blobsBundle, executionRequests} = await this.engine.getPayload(
       handle.fork,
-      handle.payloadId
+      handle.payloadId,
+      signal
     );
 
     if (blobsBundle === undefined) {

--- a/packages/builder/src/services/payloadSource.ts
+++ b/packages/builder/src/services/payloadSource.ts
@@ -51,7 +51,7 @@ export type EnginePayloadResult<F extends ForkPostGloas = ForkPostGloas> = {
   executionRequests?: ExecutionRequests<F>;
 };
 
-/** Narrow Engine boundary whose transport owns serialization, retries, timeouts, and Builder-lifetime cancellation. */
+/** Narrow Engine boundary whose transport owns serialization, retries, and request execution. */
 export interface PayloadSourceEngine {
   notifyForkchoiceUpdate<F extends ForkPostGloas>(
     fork: F,

--- a/packages/builder/src/services/payloadSource.ts
+++ b/packages/builder/src/services/payloadSource.ts
@@ -1,5 +1,12 @@
 import type {ForkPostGloas} from "@lodestar/params";
-import type {BlobsBundle, ExecutionPayload, ExecutionRequests, RootHex, SSEPayloadAttributes} from "@lodestar/types";
+import type {
+  BlobsBundle,
+  ColumnIndex,
+  ExecutionPayload,
+  ExecutionRequests,
+  RootHex,
+  SSEPayloadAttributes,
+} from "@lodestar/types";
 import {LodestarError} from "@lodestar/utils";
 
 export type PayloadId = string;
@@ -16,6 +23,7 @@ export type BuildRequest<F extends ForkPostGloas = ForkPostGloas> = {
   fork: F;
   forkchoiceState: ForkchoiceState;
   payloadAttributes: PayloadAttributes<F>;
+  custodyColumns: ColumnIndex[];
 };
 
 export type BuildHandle<F extends ForkPostGloas = ForkPostGloas> = {
@@ -47,7 +55,8 @@ export interface PayloadSourceEngine {
     headBlockHash: RootHex,
     safeBlockHash: RootHex,
     finalizedBlockHash: RootHex,
-    payloadAttributes: PayloadAttributes
+    payloadAttributes: PayloadAttributes,
+    custodyColumns: ColumnIndex[]
   ): Promise<PayloadId | null>;
   getPayload(fork: ForkPostGloas, payloadId: PayloadId): Promise<EnginePayloadResult>;
 }
@@ -95,7 +104,8 @@ export class EnginePayloadSource implements PayloadSource {
       headBlockHash,
       safeBlockHash,
       finalizedBlockHash,
-      request.payloadAttributes
+      request.payloadAttributes,
+      request.custodyColumns
     );
 
     if (payloadId === null) {

--- a/packages/builder/src/services/payloadSource.ts
+++ b/packages/builder/src/services/payloadSource.ts
@@ -23,7 +23,8 @@ export type BuildRequest<F extends ForkPostGloas = ForkPostGloas> = {
   fork: F;
   forkchoiceState: ForkchoiceState;
   payloadAttributes: PayloadAttributes<F>;
-  custodyColumns: ColumnIndex[];
+  /** Logical custody set. The transport serializes it for Engine API; null means no custody service. */
+  custodyColumns: ColumnIndex[] | null;
 };
 
 export type BuildHandle<F extends ForkPostGloas = ForkPostGloas> = {
@@ -48,7 +49,7 @@ export type EnginePayloadResult<F extends ForkPostGloas = ForkPostGloas> = {
   executionRequests?: ExecutionRequests<F>;
 };
 
-/** Narrow Engine API boundary whose transport owns request retries, timeouts, and Builder-lifetime cancellation. */
+/** Narrow Engine boundary whose transport owns serialization, retries, timeouts, and Builder-lifetime cancellation. */
 export interface PayloadSourceEngine {
   notifyForkchoiceUpdate<F extends ForkPostGloas>(
     fork: F,
@@ -56,7 +57,7 @@ export interface PayloadSourceEngine {
     safeBlockHash: RootHex,
     finalizedBlockHash: RootHex,
     payloadAttributes: PayloadAttributes<F>,
-    custodyColumns: ColumnIndex[]
+    custodyColumns: ColumnIndex[] | null
   ): Promise<PayloadId | null>;
   getPayload<F extends ForkPostGloas>(fork: F, payloadId: PayloadId): Promise<EnginePayloadResult<F>>;
 }
@@ -90,7 +91,7 @@ export type PayloadSourceErrorType =
 
 export class PayloadSourceError extends LodestarError<PayloadSourceErrorType> {}
 
-/** Payload source backed by an execution client's Engine API. */
+/** Payload source backed by an injected Engine boundary. Engine ownership and lifecycle remain caller policy. */
 export class EnginePayloadSource implements PayloadSource {
   constructor(
     readonly id: string,

--- a/packages/builder/src/services/payloadSource.ts
+++ b/packages/builder/src/services/payloadSource.ts
@@ -1,0 +1,157 @@
+import type {ForkPostGloas} from "@lodestar/params";
+import type {BlobsBundle, ExecutionPayload, ExecutionRequests, RootHex, gloas} from "@lodestar/types";
+import {LodestarError} from "@lodestar/utils";
+
+export type PayloadId = string;
+
+export type ForkchoiceState = {
+  headBlockHash: RootHex;
+  safeBlockHash: RootHex;
+  finalizedBlockHash: RootHex;
+};
+
+export type BuildRequest = {
+  fork: ForkPostGloas;
+  forkchoiceState: ForkchoiceState;
+  payloadAttributes: gloas.PayloadAttributes;
+};
+
+export type BuildHandle = {
+  sourceId: string;
+  fork: ForkPostGloas;
+  payloadId: PayloadId;
+};
+
+export type BuiltPayload = {
+  sourceId: string;
+  fork: ForkPostGloas;
+  executionPayload: ExecutionPayload<ForkPostGloas>;
+  executionRequests: ExecutionRequests<ForkPostGloas>;
+  blobsBundle: BlobsBundle<ForkPostGloas>;
+  executionPayloadValue: bigint;
+};
+
+export type EnginePayloadResult = {
+  executionPayload: ExecutionPayload;
+  executionPayloadValue: bigint;
+  blobsBundle?: BlobsBundle;
+  executionRequests?: ExecutionRequests;
+};
+
+/** Narrow Engine API boundary required by an Engine-backed payload source. */
+export interface PayloadSourceEngine {
+  notifyForkchoiceUpdate(
+    fork: ForkPostGloas,
+    headBlockHash: RootHex,
+    safeBlockHash: RootHex,
+    finalizedBlockHash: RootHex,
+    payloadAttributes: gloas.PayloadAttributes
+  ): Promise<PayloadId | null>;
+  getPayload(fork: ForkPostGloas, payloadId: PayloadId): Promise<EnginePayloadResult>;
+}
+
+/** Source that prepares and retrieves complete execution payloads. */
+export interface PayloadSource {
+  readonly id: string;
+  prepare(request: BuildRequest): Promise<BuildHandle>;
+  getPayload(handle: BuildHandle): Promise<BuiltPayload>;
+}
+
+export enum PayloadSourceErrorCode {
+  NO_PAYLOAD_ID = "PAYLOAD_SOURCE_ERROR_NO_PAYLOAD_ID",
+  SOURCE_MISMATCH = "PAYLOAD_SOURCE_ERROR_SOURCE_MISMATCH",
+  MISSING_BLOBS_BUNDLE = "PAYLOAD_SOURCE_ERROR_MISSING_BLOBS_BUNDLE",
+  MISSING_EXECUTION_REQUESTS = "PAYLOAD_SOURCE_ERROR_MISSING_EXECUTION_REQUESTS",
+}
+
+export type PayloadSourceErrorType =
+  | {code: PayloadSourceErrorCode.NO_PAYLOAD_ID; sourceId: string}
+  | {
+      code: PayloadSourceErrorCode.SOURCE_MISMATCH;
+      sourceId: string;
+      handleSourceId: string;
+    }
+  | {
+      code: PayloadSourceErrorCode.MISSING_BLOBS_BUNDLE | PayloadSourceErrorCode.MISSING_EXECUTION_REQUESTS;
+      sourceId: string;
+      payloadId: PayloadId;
+    };
+
+export class PayloadSourceError extends LodestarError<PayloadSourceErrorType> {}
+
+/** Payload source backed by an execution client's Engine API. */
+export class EnginePayloadSource implements PayloadSource {
+  constructor(
+    readonly id: string,
+    private readonly engine: PayloadSourceEngine
+  ) {}
+
+  async prepare(request: BuildRequest): Promise<BuildHandle> {
+    const {headBlockHash, safeBlockHash, finalizedBlockHash} = request.forkchoiceState;
+    const payloadId = await this.engine.notifyForkchoiceUpdate(
+      request.fork,
+      headBlockHash,
+      safeBlockHash,
+      finalizedBlockHash,
+      request.payloadAttributes
+    );
+
+    if (payloadId === null) {
+      throw new PayloadSourceError(
+        {code: PayloadSourceErrorCode.NO_PAYLOAD_ID, sourceId: this.id},
+        `Execution client did not return a payload ID sourceId=${this.id}`
+      );
+    }
+
+    return {sourceId: this.id, fork: request.fork, payloadId};
+  }
+
+  async getPayload(handle: BuildHandle): Promise<BuiltPayload> {
+    if (handle.sourceId !== this.id) {
+      throw new PayloadSourceError(
+        {
+          code: PayloadSourceErrorCode.SOURCE_MISMATCH,
+          sourceId: this.id,
+          handleSourceId: handle.sourceId,
+        },
+        `Payload handle belongs to another source sourceId=${this.id} handleSourceId=${handle.sourceId}`
+      );
+    }
+
+    const {executionPayload, executionPayloadValue, blobsBundle, executionRequests} = await this.engine.getPayload(
+      handle.fork,
+      handle.payloadId
+    );
+
+    if (blobsBundle === undefined) {
+      throw new PayloadSourceError(
+        {
+          code: PayloadSourceErrorCode.MISSING_BLOBS_BUNDLE,
+          sourceId: this.id,
+          payloadId: handle.payloadId,
+        },
+        `Execution client did not return a blobs bundle sourceId=${this.id} payloadId=${handle.payloadId}`
+      );
+    }
+
+    if (executionRequests === undefined) {
+      throw new PayloadSourceError(
+        {
+          code: PayloadSourceErrorCode.MISSING_EXECUTION_REQUESTS,
+          sourceId: this.id,
+          payloadId: handle.payloadId,
+        },
+        `Execution client did not return execution requests sourceId=${this.id} payloadId=${handle.payloadId}`
+      );
+    }
+
+    return {
+      sourceId: this.id,
+      fork: handle.fork,
+      executionPayload: executionPayload as ExecutionPayload<ForkPostGloas>,
+      executionRequests: executionRequests as ExecutionRequests<ForkPostGloas>,
+      blobsBundle: blobsBundle as BlobsBundle<ForkPostGloas>,
+      executionPayloadValue,
+    };
+  }
+}

--- a/packages/builder/src/services/payloadSource.ts
+++ b/packages/builder/src/services/payloadSource.ts
@@ -41,24 +41,24 @@ export type BuiltPayload<F extends ForkPostGloas = ForkPostGloas> = {
   executionPayloadValue: bigint;
 };
 
-export type EnginePayloadResult = {
-  executionPayload: ExecutionPayload<ForkPostGloas>;
+export type EnginePayloadResult<F extends ForkPostGloas = ForkPostGloas> = {
+  executionPayload: ExecutionPayload<F>;
   executionPayloadValue: bigint;
-  blobsBundle?: BlobsBundle<ForkPostGloas>;
-  executionRequests?: ExecutionRequests<ForkPostGloas>;
+  blobsBundle?: BlobsBundle<F>;
+  executionRequests?: ExecutionRequests<F>;
 };
 
 /** Narrow Engine API boundary whose transport owns request retries, timeouts, and Builder-lifetime cancellation. */
 export interface PayloadSourceEngine {
-  notifyForkchoiceUpdate(
-    fork: ForkPostGloas,
+  notifyForkchoiceUpdate<F extends ForkPostGloas>(
+    fork: F,
     headBlockHash: RootHex,
     safeBlockHash: RootHex,
     finalizedBlockHash: RootHex,
-    payloadAttributes: PayloadAttributes,
+    payloadAttributes: PayloadAttributes<F>,
     custodyColumns: ColumnIndex[]
   ): Promise<PayloadId | null>;
-  getPayload(fork: ForkPostGloas, payloadId: PayloadId): Promise<EnginePayloadResult>;
+  getPayload<F extends ForkPostGloas>(fork: F, payloadId: PayloadId): Promise<EnginePayloadResult<F>>;
 }
 
 /** Source that prepares and retrieves complete execution payloads without owning build scheduling policy. */
@@ -160,9 +160,9 @@ export class EnginePayloadSource implements PayloadSource {
     return {
       sourceId: this.id,
       fork: handle.fork,
-      executionPayload: executionPayload as ExecutionPayload<F>,
-      executionRequests: executionRequests as ExecutionRequests<F>,
-      blobsBundle: blobsBundle as BlobsBundle<F>,
+      executionPayload,
+      executionRequests,
+      blobsBundle,
       executionPayloadValue,
     };
   }

--- a/packages/builder/src/services/payloadSource.ts
+++ b/packages/builder/src/services/payloadSource.ts
@@ -1,5 +1,5 @@
 import type {ForkPostGloas} from "@lodestar/params";
-import type {BlobsBundle, ExecutionPayload, ExecutionRequests, RootHex, gloas} from "@lodestar/types";
+import type {BlobsBundle, ExecutionPayload, ExecutionRequests, RootHex, SSEPayloadAttributes} from "@lodestar/types";
 import {LodestarError} from "@lodestar/utils";
 
 export type PayloadId = string;
@@ -10,51 +10,53 @@ export type ForkchoiceState = {
   finalizedBlockHash: RootHex;
 };
 
-export type BuildRequest = {
-  fork: ForkPostGloas;
+export type PayloadAttributes<F extends ForkPostGloas = ForkPostGloas> = SSEPayloadAttributes<F>["payloadAttributes"];
+
+export type BuildRequest<F extends ForkPostGloas = ForkPostGloas> = {
+  fork: F;
   forkchoiceState: ForkchoiceState;
-  payloadAttributes: gloas.PayloadAttributes;
+  payloadAttributes: PayloadAttributes<F>;
 };
 
-export type BuildHandle = {
+export type BuildHandle<F extends ForkPostGloas = ForkPostGloas> = {
   sourceId: string;
-  fork: ForkPostGloas;
+  fork: F;
   payloadId: PayloadId;
 };
 
-export type BuiltPayload = {
+export type BuiltPayload<F extends ForkPostGloas = ForkPostGloas> = {
   sourceId: string;
-  fork: ForkPostGloas;
-  executionPayload: ExecutionPayload<ForkPostGloas>;
-  executionRequests: ExecutionRequests<ForkPostGloas>;
-  blobsBundle: BlobsBundle<ForkPostGloas>;
+  fork: F;
+  executionPayload: ExecutionPayload<F>;
+  executionRequests: ExecutionRequests<F>;
+  blobsBundle: BlobsBundle<F>;
   executionPayloadValue: bigint;
 };
 
 export type EnginePayloadResult = {
-  executionPayload: ExecutionPayload;
+  executionPayload: ExecutionPayload<ForkPostGloas>;
   executionPayloadValue: bigint;
-  blobsBundle?: BlobsBundle;
-  executionRequests?: ExecutionRequests;
+  blobsBundle?: BlobsBundle<ForkPostGloas>;
+  executionRequests?: ExecutionRequests<ForkPostGloas>;
 };
 
-/** Narrow Engine API boundary required by an Engine-backed payload source. */
+/** Narrow Engine API boundary whose transport owns request retries, timeouts, and Builder-lifetime cancellation. */
 export interface PayloadSourceEngine {
   notifyForkchoiceUpdate(
     fork: ForkPostGloas,
     headBlockHash: RootHex,
     safeBlockHash: RootHex,
     finalizedBlockHash: RootHex,
-    payloadAttributes: gloas.PayloadAttributes
+    payloadAttributes: PayloadAttributes
   ): Promise<PayloadId | null>;
   getPayload(fork: ForkPostGloas, payloadId: PayloadId): Promise<EnginePayloadResult>;
 }
 
-/** Source that prepares and retrieves complete execution payloads. */
+/** Source that prepares and retrieves complete execution payloads without owning build scheduling policy. */
 export interface PayloadSource {
   readonly id: string;
-  prepare(request: BuildRequest): Promise<BuildHandle>;
-  getPayload(handle: BuildHandle): Promise<BuiltPayload>;
+  prepare<F extends ForkPostGloas>(request: BuildRequest<F>): Promise<BuildHandle<F>>;
+  getPayload<F extends ForkPostGloas>(handle: BuildHandle<F>): Promise<BuiltPayload<F>>;
 }
 
 export enum PayloadSourceErrorCode {
@@ -86,7 +88,7 @@ export class EnginePayloadSource implements PayloadSource {
     private readonly engine: PayloadSourceEngine
   ) {}
 
-  async prepare(request: BuildRequest): Promise<BuildHandle> {
+  async prepare<F extends ForkPostGloas>(request: BuildRequest<F>): Promise<BuildHandle<F>> {
     const {headBlockHash, safeBlockHash, finalizedBlockHash} = request.forkchoiceState;
     const payloadId = await this.engine.notifyForkchoiceUpdate(
       request.fork,
@@ -106,7 +108,7 @@ export class EnginePayloadSource implements PayloadSource {
     return {sourceId: this.id, fork: request.fork, payloadId};
   }
 
-  async getPayload(handle: BuildHandle): Promise<BuiltPayload> {
+  async getPayload<F extends ForkPostGloas>(handle: BuildHandle<F>): Promise<BuiltPayload<F>> {
     if (handle.sourceId !== this.id) {
       throw new PayloadSourceError(
         {
@@ -148,9 +150,9 @@ export class EnginePayloadSource implements PayloadSource {
     return {
       sourceId: this.id,
       fork: handle.fork,
-      executionPayload: executionPayload as ExecutionPayload<ForkPostGloas>,
-      executionRequests: executionRequests as ExecutionRequests<ForkPostGloas>,
-      blobsBundle: blobsBundle as BlobsBundle<ForkPostGloas>,
+      executionPayload: executionPayload as ExecutionPayload<F>,
+      executionRequests: executionRequests as ExecutionRequests<F>,
+      blobsBundle: blobsBundle as BlobsBundle<F>,
       executionPayloadValue,
     };
   }

--- a/packages/builder/src/services/payloadSource.ts
+++ b/packages/builder/src/services/payloadSource.ts
@@ -24,7 +24,7 @@ export type BuildRequest<F extends ForkPostGloas = ForkPostGloas> = F extends Fo
       fork: F;
       forkchoiceState: ForkchoiceState;
       payloadAttributes: PayloadAttributes<F>;
-      /** Logical custody set. The transport serializes it for Engine API; null means no custody service. */
+      /** CL data-column custody set for EL blobpool sampling; null if the CL provides no custody services. */
       custodyColumns: ColumnIndex[] | null;
     }
   : never;

--- a/packages/builder/test/unit/services/payloadSource.test.ts
+++ b/packages/builder/test/unit/services/payloadSource.test.ts
@@ -36,6 +36,7 @@ describe("EnginePayloadSource", () => {
   void mismatchedRequest;
 
   const handle: BuildHandle<ForkName.gloas> = {sourceId, fork: ForkName.gloas, payloadId};
+  const signal = new AbortController().signal;
 
   let notifyForkchoiceUpdate: Mock<NotifyForkchoiceUpdate>;
   let getPayload: Mock<GetPayload>;
@@ -51,7 +52,7 @@ describe("EnginePayloadSource", () => {
   it("prepares a payload and returns a source-bound handle", async () => {
     notifyForkchoiceUpdate.mockResolvedValue(payloadId);
 
-    const result = await source.prepare(request);
+    const result = await source.prepare(request, signal);
 
     expect(notifyForkchoiceUpdate).toHaveBeenCalledWith(
       ForkName.gloas,
@@ -59,7 +60,8 @@ describe("EnginePayloadSource", () => {
       forkchoiceState.safeBlockHash,
       forkchoiceState.finalizedBlockHash,
       payloadAttributes,
-      custodyColumns
+      custodyColumns,
+      signal
     );
     expect(result).toEqual(handle);
   });
@@ -67,7 +69,7 @@ describe("EnginePayloadSource", () => {
   it("preserves a null custody set", async () => {
     notifyForkchoiceUpdate.mockResolvedValue(payloadId);
 
-    await source.prepare({...request, custodyColumns: null});
+    await source.prepare({...request, custodyColumns: null}, signal);
 
     expect(notifyForkchoiceUpdate).toHaveBeenCalledWith(
       ForkName.gloas,
@@ -75,7 +77,8 @@ describe("EnginePayloadSource", () => {
       forkchoiceState.safeBlockHash,
       forkchoiceState.finalizedBlockHash,
       payloadAttributes,
-      null
+      null,
+      signal
     );
   });
 
@@ -90,13 +93,16 @@ describe("EnginePayloadSource", () => {
       executionPayloadValue: 12_345_678_901_234_567_890n,
     });
 
-    const result = await source.prepare({
-      fork: ForkName.heze,
-      forkchoiceState,
-      payloadAttributes: hezePayloadAttributes,
-      custodyColumns,
-    });
-    const builtPayload = await source.getPayload(result);
+    const result = await source.prepare(
+      {
+        fork: ForkName.heze,
+        forkchoiceState,
+        payloadAttributes: hezePayloadAttributes,
+        custodyColumns,
+      },
+      signal
+    );
+    const builtPayload = await source.getPayload(result, signal);
 
     expect(result.fork).toBe(ForkName.heze);
     expect(notifyForkchoiceUpdate).toHaveBeenCalledWith(
@@ -105,9 +111,10 @@ describe("EnginePayloadSource", () => {
       forkchoiceState.safeBlockHash,
       forkchoiceState.finalizedBlockHash,
       hezePayloadAttributes,
-      custodyColumns
+      custodyColumns,
+      signal
     );
-    expect(getPayload).toHaveBeenCalledWith(ForkName.heze, payloadId);
+    expect(getPayload).toHaveBeenCalledWith(ForkName.heze, payloadId, signal);
     expect(builtPayload.fork).toBe(ForkName.heze);
     expect(hezePayloadAttributes.inclusionListTransactions).toHaveLength(1);
   });
@@ -115,7 +122,7 @@ describe("EnginePayloadSource", () => {
   it("rejects a missing payload ID with a structured error", async () => {
     notifyForkchoiceUpdate.mockResolvedValue(null);
 
-    const error = await getPayloadSourceError(source.prepare(request));
+    const error = await getPayloadSourceError(source.prepare(request, signal));
 
     expect(error.type).toEqual({code: PayloadSourceErrorCode.NO_PAYLOAD_ID, sourceId});
   });
@@ -128,16 +135,16 @@ describe("EnginePayloadSource", () => {
   ])("propagates %s errors from payload preparation", async (_name, error) => {
     notifyForkchoiceUpdate.mockRejectedValue(error);
 
-    await expect(source.prepare(request)).rejects.toBe(error);
+    await expect(source.prepare(request, signal)).rejects.toBe(error);
   });
 
   it("retrieves a complete payload without rebuilding exact-width values", async () => {
     const result = getEnginePayloadResult();
     getPayload.mockResolvedValue(result);
 
-    const builtPayload = await source.getPayload(handle);
+    const builtPayload = await source.getPayload(handle, signal);
 
-    expect(getPayload).toHaveBeenCalledWith(ForkName.gloas, payloadId);
+    expect(getPayload).toHaveBeenCalledWith(ForkName.gloas, payloadId, signal);
     expect(builtPayload.sourceId).toBe(sourceId);
     expect(builtPayload.fork).toBe(ForkName.gloas);
     expect(builtPayload.executionPayload).toBe(result.executionPayload);
@@ -147,7 +154,7 @@ describe("EnginePayloadSource", () => {
   });
 
   it("rejects a handle belonging to another source before calling the Engine API", async () => {
-    const error = await getPayloadSourceError(source.getPayload({...handle, sourceId: "engine-1"}));
+    const error = await getPayloadSourceError(source.getPayload({...handle, sourceId: "engine-1"}, signal));
 
     expect(error.type).toEqual({
       code: PayloadSourceErrorCode.SOURCE_MISMATCH,
@@ -160,7 +167,7 @@ describe("EnginePayloadSource", () => {
   it("rejects a response without a blobs bundle", async () => {
     getPayload.mockResolvedValue({...getEnginePayloadResult(), blobsBundle: undefined});
 
-    const error = await getPayloadSourceError(source.getPayload(handle));
+    const error = await getPayloadSourceError(source.getPayload(handle, signal));
 
     expect(error.type).toEqual({code: PayloadSourceErrorCode.MISSING_BLOBS_BUNDLE, sourceId, payloadId});
   });
@@ -168,7 +175,7 @@ describe("EnginePayloadSource", () => {
   it("rejects a response without execution requests", async () => {
     getPayload.mockResolvedValue({...getEnginePayloadResult(), executionRequests: undefined});
 
-    const error = await getPayloadSourceError(source.getPayload(handle));
+    const error = await getPayloadSourceError(source.getPayload(handle, signal));
 
     expect(error.type).toEqual({code: PayloadSourceErrorCode.MISSING_EXECUTION_REQUESTS, sourceId, payloadId});
   });
@@ -177,7 +184,7 @@ describe("EnginePayloadSource", () => {
     const error = new TimeoutError("engine_getPayloadV6");
     getPayload.mockRejectedValue(error);
 
-    await expect(source.getPayload(handle)).rejects.toBe(error);
+    await expect(source.getPayload(handle, signal)).rejects.toBe(error);
   });
 });
 
@@ -196,10 +203,11 @@ type NotifyForkchoiceUpdate = (
   safeBlockHash: RootHex,
   finalizedBlockHash: RootHex,
   payloadAttributes: PayloadAttributes,
-  custodyColumns: ColumnIndex[] | null
+  custodyColumns: ColumnIndex[] | null,
+  signal: AbortSignal
 ) => Promise<PayloadId | null>;
 
-type GetPayload = (fork: ForkPostGloas, payloadId: PayloadId) => Promise<EnginePayloadResult>;
+type GetPayload = (fork: ForkPostGloas, payloadId: PayloadId, signal: AbortSignal) => Promise<EnginePayloadResult>;
 
 async function getPayloadSourceError(promise: Promise<unknown>): Promise<PayloadSourceError> {
   try {

--- a/packages/builder/test/unit/services/payloadSource.test.ts
+++ b/packages/builder/test/unit/services/payloadSource.test.ts
@@ -30,6 +30,11 @@ describe("EnginePayloadSource", () => {
     payloadAttributes,
     custodyColumns,
   };
+
+  // @ts-expect-error Heze requests cannot use Gloas payload attributes.
+  const mismatchedRequest: BuildRequest = {...request, fork: ForkName.heze};
+  void mismatchedRequest;
+
   const handle: BuildHandle<ForkName.gloas> = {sourceId, fork: ForkName.gloas, payloadId};
 
   let notifyForkchoiceUpdate: Mock<NotifyForkchoiceUpdate>;

--- a/packages/builder/test/unit/services/payloadSource.test.ts
+++ b/packages/builder/test/unit/services/payloadSource.test.ts
@@ -1,12 +1,14 @@
-import {Mocked, beforeEach, describe, expect, it, vi} from "vitest";
-import {ForkName} from "@lodestar/params";
-import {ssz} from "@lodestar/types";
+import {type Mock, beforeEach, describe, expect, it, vi} from "vitest";
+import {ForkName, type ForkPostGloas} from "@lodestar/params";
+import {type ColumnIndex, type RootHex, ssz} from "@lodestar/types";
 import {ErrorAborted, TimeoutError, toRootHex} from "@lodestar/utils";
 import {
   BuildHandle,
   BuildRequest,
   EnginePayloadResult,
   EnginePayloadSource,
+  PayloadAttributes,
+  PayloadId,
   PayloadSourceEngine,
   PayloadSourceError,
   PayloadSourceErrorCode,
@@ -30,23 +32,23 @@ describe("EnginePayloadSource", () => {
   };
   const handle: BuildHandle<ForkName.gloas> = {sourceId, fork: ForkName.gloas, payloadId};
 
-  let engine: Mocked<PayloadSourceEngine>;
+  let notifyForkchoiceUpdate: Mock<NotifyForkchoiceUpdate>;
+  let getPayload: Mock<GetPayload>;
   let source: EnginePayloadSource;
 
   beforeEach(() => {
-    engine = {
-      notifyForkchoiceUpdate: vi.fn(),
-      getPayload: vi.fn(),
-    };
+    notifyForkchoiceUpdate = vi.fn();
+    getPayload = vi.fn();
+    const engine = {notifyForkchoiceUpdate, getPayload} as unknown as PayloadSourceEngine;
     source = new EnginePayloadSource(sourceId, engine);
   });
 
   it("prepares a payload and returns a source-bound handle", async () => {
-    engine.notifyForkchoiceUpdate.mockResolvedValue(payloadId);
+    notifyForkchoiceUpdate.mockResolvedValue(payloadId);
 
     const result = await source.prepare(request);
 
-    expect(engine.notifyForkchoiceUpdate).toHaveBeenCalledWith(
+    expect(notifyForkchoiceUpdate).toHaveBeenCalledWith(
       ForkName.gloas,
       forkchoiceState.headBlockHash,
       forkchoiceState.safeBlockHash,
@@ -60,8 +62,8 @@ describe("EnginePayloadSource", () => {
   it("supports post-Gloas forks without narrowing the fork", async () => {
     const hezePayloadAttributes = ssz.heze.PayloadAttributes.defaultValue();
     hezePayloadAttributes.inclusionListTransactions = [Uint8Array.from([1, 2, 3])];
-    engine.notifyForkchoiceUpdate.mockResolvedValue(payloadId);
-    engine.getPayload.mockResolvedValue({
+    notifyForkchoiceUpdate.mockResolvedValue(payloadId);
+    getPayload.mockResolvedValue({
       executionPayload: ssz.heze.ExecutionPayload.defaultValue(),
       blobsBundle: ssz.heze.BlobsBundle.defaultValue(),
       executionRequests: ssz.heze.ExecutionRequests.defaultValue(),
@@ -77,7 +79,7 @@ describe("EnginePayloadSource", () => {
     const builtPayload = await source.getPayload(result);
 
     expect(result.fork).toBe(ForkName.heze);
-    expect(engine.notifyForkchoiceUpdate).toHaveBeenCalledWith(
+    expect(notifyForkchoiceUpdate).toHaveBeenCalledWith(
       ForkName.heze,
       forkchoiceState.headBlockHash,
       forkchoiceState.safeBlockHash,
@@ -85,13 +87,13 @@ describe("EnginePayloadSource", () => {
       hezePayloadAttributes,
       custodyColumns
     );
-    expect(engine.getPayload).toHaveBeenCalledWith(ForkName.heze, payloadId);
+    expect(getPayload).toHaveBeenCalledWith(ForkName.heze, payloadId);
     expect(builtPayload.fork).toBe(ForkName.heze);
     expect(hezePayloadAttributes.inclusionListTransactions).toHaveLength(1);
   });
 
   it("rejects a missing payload ID with a structured error", async () => {
-    engine.notifyForkchoiceUpdate.mockResolvedValue(null);
+    notifyForkchoiceUpdate.mockResolvedValue(null);
 
     const error = await getPayloadSourceError(source.prepare(request));
 
@@ -104,18 +106,18 @@ describe("EnginePayloadSource", () => {
     ["timeout", new TimeoutError("engine_forkchoiceUpdatedV4")],
     ["cancellation", new ErrorAborted("engine_forkchoiceUpdatedV4")],
   ])("propagates %s errors from payload preparation", async (_name, error) => {
-    engine.notifyForkchoiceUpdate.mockRejectedValue(error);
+    notifyForkchoiceUpdate.mockRejectedValue(error);
 
     await expect(source.prepare(request)).rejects.toBe(error);
   });
 
   it("retrieves a complete payload without rebuilding exact-width values", async () => {
     const result = getEnginePayloadResult();
-    engine.getPayload.mockResolvedValue(result);
+    getPayload.mockResolvedValue(result);
 
     const builtPayload = await source.getPayload(handle);
 
-    expect(engine.getPayload).toHaveBeenCalledWith(ForkName.gloas, payloadId);
+    expect(getPayload).toHaveBeenCalledWith(ForkName.gloas, payloadId);
     expect(builtPayload.sourceId).toBe(sourceId);
     expect(builtPayload.fork).toBe(ForkName.gloas);
     expect(builtPayload.executionPayload).toBe(result.executionPayload);
@@ -132,11 +134,11 @@ describe("EnginePayloadSource", () => {
       sourceId,
       handleSourceId: "engine-1",
     });
-    expect(engine.getPayload).not.toHaveBeenCalled();
+    expect(getPayload).not.toHaveBeenCalled();
   });
 
   it("rejects a response without a blobs bundle", async () => {
-    engine.getPayload.mockResolvedValue({...getEnginePayloadResult(), blobsBundle: undefined});
+    getPayload.mockResolvedValue({...getEnginePayloadResult(), blobsBundle: undefined});
 
     const error = await getPayloadSourceError(source.getPayload(handle));
 
@@ -144,7 +146,7 @@ describe("EnginePayloadSource", () => {
   });
 
   it("rejects a response without execution requests", async () => {
-    engine.getPayload.mockResolvedValue({...getEnginePayloadResult(), executionRequests: undefined});
+    getPayload.mockResolvedValue({...getEnginePayloadResult(), executionRequests: undefined});
 
     const error = await getPayloadSourceError(source.getPayload(handle));
 
@@ -153,7 +155,7 @@ describe("EnginePayloadSource", () => {
 
   it("propagates retrieval errors without replacing their type", async () => {
     const error = new TimeoutError("engine_getPayloadV6");
-    engine.getPayload.mockRejectedValue(error);
+    getPayload.mockRejectedValue(error);
 
     await expect(source.getPayload(handle)).rejects.toBe(error);
   });
@@ -167,6 +169,17 @@ function getEnginePayloadResult(): EnginePayloadResult {
     executionPayloadValue: 12_345_678_901_234_567_890n,
   };
 }
+
+type NotifyForkchoiceUpdate = (
+  fork: ForkPostGloas,
+  headBlockHash: RootHex,
+  safeBlockHash: RootHex,
+  finalizedBlockHash: RootHex,
+  payloadAttributes: PayloadAttributes,
+  custodyColumns: ColumnIndex[]
+) => Promise<PayloadId | null>;
+
+type GetPayload = (fork: ForkPostGloas, payloadId: PayloadId) => Promise<EnginePayloadResult>;
 
 async function getPayloadSourceError(promise: Promise<unknown>): Promise<PayloadSourceError> {
   try {

--- a/packages/builder/test/unit/services/payloadSource.test.ts
+++ b/packages/builder/test/unit/services/payloadSource.test.ts
@@ -21,7 +21,13 @@ describe("EnginePayloadSource", () => {
     finalizedBlockHash: toRootHex(Uint8Array.from({length: 32}, () => 3)),
   };
   const payloadAttributes = ssz.gloas.PayloadAttributes.defaultValue();
-  const request: BuildRequest<ForkName.gloas> = {fork: ForkName.gloas, forkchoiceState, payloadAttributes};
+  const custodyColumns = [0, 3, 127];
+  const request: BuildRequest<ForkName.gloas> = {
+    fork: ForkName.gloas,
+    forkchoiceState,
+    payloadAttributes,
+    custodyColumns,
+  };
   const handle: BuildHandle<ForkName.gloas> = {sourceId, fork: ForkName.gloas, payloadId};
 
   let engine: Mocked<PayloadSourceEngine>;
@@ -45,7 +51,8 @@ describe("EnginePayloadSource", () => {
       forkchoiceState.headBlockHash,
       forkchoiceState.safeBlockHash,
       forkchoiceState.finalizedBlockHash,
-      payloadAttributes
+      payloadAttributes,
+      custodyColumns
     );
     expect(result).toEqual(handle);
   });
@@ -65,6 +72,7 @@ describe("EnginePayloadSource", () => {
       fork: ForkName.heze,
       forkchoiceState,
       payloadAttributes: hezePayloadAttributes,
+      custodyColumns,
     });
     const builtPayload = await source.getPayload(result);
 
@@ -74,7 +82,8 @@ describe("EnginePayloadSource", () => {
       forkchoiceState.headBlockHash,
       forkchoiceState.safeBlockHash,
       forkchoiceState.finalizedBlockHash,
-      hezePayloadAttributes
+      hezePayloadAttributes,
+      custodyColumns
     );
     expect(engine.getPayload).toHaveBeenCalledWith(ForkName.heze, payloadId);
     expect(builtPayload.fork).toBe(ForkName.heze);

--- a/packages/builder/test/unit/services/payloadSource.test.ts
+++ b/packages/builder/test/unit/services/payloadSource.test.ts
@@ -59,6 +59,21 @@ describe("EnginePayloadSource", () => {
     expect(result).toEqual(handle);
   });
 
+  it("preserves a null custody set", async () => {
+    notifyForkchoiceUpdate.mockResolvedValue(payloadId);
+
+    await source.prepare({...request, custodyColumns: null});
+
+    expect(notifyForkchoiceUpdate).toHaveBeenCalledWith(
+      ForkName.gloas,
+      forkchoiceState.headBlockHash,
+      forkchoiceState.safeBlockHash,
+      forkchoiceState.finalizedBlockHash,
+      payloadAttributes,
+      null
+    );
+  });
+
   it("supports post-Gloas forks without narrowing the fork", async () => {
     const hezePayloadAttributes = ssz.heze.PayloadAttributes.defaultValue();
     hezePayloadAttributes.inclusionListTransactions = [Uint8Array.from([1, 2, 3])];
@@ -176,7 +191,7 @@ type NotifyForkchoiceUpdate = (
   safeBlockHash: RootHex,
   finalizedBlockHash: RootHex,
   payloadAttributes: PayloadAttributes,
-  custodyColumns: ColumnIndex[]
+  custodyColumns: ColumnIndex[] | null
 ) => Promise<PayloadId | null>;
 
 type GetPayload = (fork: ForkPostGloas, payloadId: PayloadId) => Promise<EnginePayloadResult>;

--- a/packages/builder/test/unit/services/payloadSource.test.ts
+++ b/packages/builder/test/unit/services/payloadSource.test.ts
@@ -21,8 +21,8 @@ describe("EnginePayloadSource", () => {
     finalizedBlockHash: toRootHex(Uint8Array.from({length: 32}, () => 3)),
   };
   const payloadAttributes = ssz.gloas.PayloadAttributes.defaultValue();
-  const request: BuildRequest = {fork: ForkName.gloas, forkchoiceState, payloadAttributes};
-  const handle: BuildHandle = {sourceId, fork: ForkName.gloas, payloadId};
+  const request: BuildRequest<ForkName.gloas> = {fork: ForkName.gloas, forkchoiceState, payloadAttributes};
+  const handle: BuildHandle<ForkName.gloas> = {sourceId, fork: ForkName.gloas, payloadId};
 
   let engine: Mocked<PayloadSourceEngine>;
   let source: EnginePayloadSource;
@@ -51,10 +51,21 @@ describe("EnginePayloadSource", () => {
   });
 
   it("supports post-Gloas forks without narrowing the fork", async () => {
+    const hezePayloadAttributes = ssz.heze.PayloadAttributes.defaultValue();
+    hezePayloadAttributes.inclusionListTransactions = [Uint8Array.from([1, 2, 3])];
     engine.notifyForkchoiceUpdate.mockResolvedValue(payloadId);
-    engine.getPayload.mockResolvedValue(getEnginePayloadResult());
+    engine.getPayload.mockResolvedValue({
+      executionPayload: ssz.heze.ExecutionPayload.defaultValue(),
+      blobsBundle: ssz.heze.BlobsBundle.defaultValue(),
+      executionRequests: ssz.heze.ExecutionRequests.defaultValue(),
+      executionPayloadValue: 12_345_678_901_234_567_890n,
+    });
 
-    const result = await source.prepare({...request, fork: ForkName.heze});
+    const result = await source.prepare({
+      fork: ForkName.heze,
+      forkchoiceState,
+      payloadAttributes: hezePayloadAttributes,
+    });
     const builtPayload = await source.getPayload(result);
 
     expect(result.fork).toBe(ForkName.heze);
@@ -63,10 +74,11 @@ describe("EnginePayloadSource", () => {
       forkchoiceState.headBlockHash,
       forkchoiceState.safeBlockHash,
       forkchoiceState.finalizedBlockHash,
-      payloadAttributes
+      hezePayloadAttributes
     );
     expect(engine.getPayload).toHaveBeenCalledWith(ForkName.heze, payloadId);
     expect(builtPayload.fork).toBe(ForkName.heze);
+    expect(hezePayloadAttributes.inclusionListTransactions).toHaveLength(1);
   });
 
   it("rejects a missing payload ID with a structured error", async () => {

--- a/packages/builder/test/unit/services/payloadSource.test.ts
+++ b/packages/builder/test/unit/services/payloadSource.test.ts
@@ -79,6 +79,7 @@ describe("EnginePayloadSource", () => {
 
   it.each([
     ["transport", new Error("connection reset")],
+    ["unsupported Engine response", new Error("Method not found")],
     ["timeout", new TimeoutError("engine_forkchoiceUpdatedV4")],
     ["cancellation", new ErrorAborted("engine_forkchoiceUpdatedV4")],
   ])("propagates %s errors from payload preparation", async (_name, error) => {

--- a/packages/builder/test/unit/services/payloadSource.test.ts
+++ b/packages/builder/test/unit/services/payloadSource.test.ts
@@ -1,0 +1,159 @@
+import {Mocked, beforeEach, describe, expect, it, vi} from "vitest";
+import {ForkName} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
+import {ErrorAborted, TimeoutError, toRootHex} from "@lodestar/utils";
+import {
+  BuildHandle,
+  BuildRequest,
+  EnginePayloadResult,
+  EnginePayloadSource,
+  PayloadSourceEngine,
+  PayloadSourceError,
+  PayloadSourceErrorCode,
+} from "../../../src/services/payloadSource.js";
+
+describe("EnginePayloadSource", () => {
+  const sourceId = "engine-0";
+  const payloadId = "0x0102030405060708";
+  const forkchoiceState = {
+    headBlockHash: toRootHex(Uint8Array.from({length: 32}, () => 1)),
+    safeBlockHash: toRootHex(Uint8Array.from({length: 32}, () => 2)),
+    finalizedBlockHash: toRootHex(Uint8Array.from({length: 32}, () => 3)),
+  };
+  const payloadAttributes = ssz.gloas.PayloadAttributes.defaultValue();
+  const request: BuildRequest = {fork: ForkName.gloas, forkchoiceState, payloadAttributes};
+  const handle: BuildHandle = {sourceId, fork: ForkName.gloas, payloadId};
+
+  let engine: Mocked<PayloadSourceEngine>;
+  let source: EnginePayloadSource;
+
+  beforeEach(() => {
+    engine = {
+      notifyForkchoiceUpdate: vi.fn(),
+      getPayload: vi.fn(),
+    };
+    source = new EnginePayloadSource(sourceId, engine);
+  });
+
+  it("prepares a payload and returns a source-bound handle", async () => {
+    engine.notifyForkchoiceUpdate.mockResolvedValue(payloadId);
+
+    const result = await source.prepare(request);
+
+    expect(engine.notifyForkchoiceUpdate).toHaveBeenCalledWith(
+      ForkName.gloas,
+      forkchoiceState.headBlockHash,
+      forkchoiceState.safeBlockHash,
+      forkchoiceState.finalizedBlockHash,
+      payloadAttributes
+    );
+    expect(result).toEqual(handle);
+  });
+
+  it("supports post-Gloas forks without narrowing the fork", async () => {
+    engine.notifyForkchoiceUpdate.mockResolvedValue(payloadId);
+    engine.getPayload.mockResolvedValue(getEnginePayloadResult());
+
+    const result = await source.prepare({...request, fork: ForkName.heze});
+    const builtPayload = await source.getPayload(result);
+
+    expect(result.fork).toBe(ForkName.heze);
+    expect(engine.notifyForkchoiceUpdate).toHaveBeenCalledWith(
+      ForkName.heze,
+      forkchoiceState.headBlockHash,
+      forkchoiceState.safeBlockHash,
+      forkchoiceState.finalizedBlockHash,
+      payloadAttributes
+    );
+    expect(engine.getPayload).toHaveBeenCalledWith(ForkName.heze, payloadId);
+    expect(builtPayload.fork).toBe(ForkName.heze);
+  });
+
+  it("rejects a missing payload ID with a structured error", async () => {
+    engine.notifyForkchoiceUpdate.mockResolvedValue(null);
+
+    const error = await getPayloadSourceError(source.prepare(request));
+
+    expect(error.type).toEqual({code: PayloadSourceErrorCode.NO_PAYLOAD_ID, sourceId});
+  });
+
+  it.each([
+    ["transport", new Error("connection reset")],
+    ["timeout", new TimeoutError("engine_forkchoiceUpdatedV4")],
+    ["cancellation", new ErrorAborted("engine_forkchoiceUpdatedV4")],
+  ])("propagates %s errors from payload preparation", async (_name, error) => {
+    engine.notifyForkchoiceUpdate.mockRejectedValue(error);
+
+    await expect(source.prepare(request)).rejects.toBe(error);
+  });
+
+  it("retrieves a complete payload without rebuilding exact-width values", async () => {
+    const result = getEnginePayloadResult();
+    engine.getPayload.mockResolvedValue(result);
+
+    const builtPayload = await source.getPayload(handle);
+
+    expect(engine.getPayload).toHaveBeenCalledWith(ForkName.gloas, payloadId);
+    expect(builtPayload.sourceId).toBe(sourceId);
+    expect(builtPayload.fork).toBe(ForkName.gloas);
+    expect(builtPayload.executionPayload).toBe(result.executionPayload);
+    expect(builtPayload.blobsBundle).toBe(result.blobsBundle);
+    expect(builtPayload.executionRequests).toBe(result.executionRequests);
+    expect(builtPayload.executionPayloadValue).toBe(result.executionPayloadValue);
+  });
+
+  it("rejects a handle belonging to another source before calling the Engine API", async () => {
+    const error = await getPayloadSourceError(source.getPayload({...handle, sourceId: "engine-1"}));
+
+    expect(error.type).toEqual({
+      code: PayloadSourceErrorCode.SOURCE_MISMATCH,
+      sourceId,
+      handleSourceId: "engine-1",
+    });
+    expect(engine.getPayload).not.toHaveBeenCalled();
+  });
+
+  it("rejects a response without a blobs bundle", async () => {
+    engine.getPayload.mockResolvedValue({...getEnginePayloadResult(), blobsBundle: undefined});
+
+    const error = await getPayloadSourceError(source.getPayload(handle));
+
+    expect(error.type).toEqual({code: PayloadSourceErrorCode.MISSING_BLOBS_BUNDLE, sourceId, payloadId});
+  });
+
+  it("rejects a response without execution requests", async () => {
+    engine.getPayload.mockResolvedValue({...getEnginePayloadResult(), executionRequests: undefined});
+
+    const error = await getPayloadSourceError(source.getPayload(handle));
+
+    expect(error.type).toEqual({code: PayloadSourceErrorCode.MISSING_EXECUTION_REQUESTS, sourceId, payloadId});
+  });
+
+  it("propagates retrieval errors without replacing their type", async () => {
+    const error = new TimeoutError("engine_getPayloadV6");
+    engine.getPayload.mockRejectedValue(error);
+
+    await expect(source.getPayload(handle)).rejects.toBe(error);
+  });
+});
+
+function getEnginePayloadResult(): EnginePayloadResult {
+  return {
+    executionPayload: ssz.gloas.ExecutionPayload.defaultValue(),
+    blobsBundle: ssz.gloas.BlobsBundle.defaultValue(),
+    executionRequests: ssz.gloas.ExecutionRequests.defaultValue(),
+    executionPayloadValue: 12_345_678_901_234_567_890n,
+  };
+}
+
+async function getPayloadSourceError(promise: Promise<unknown>): Promise<PayloadSourceError> {
+  try {
+    await promise;
+    throw Error("Expected PayloadSourceError");
+  } catch (error) {
+    if (!(error instanceof PayloadSourceError)) {
+      throw error;
+    }
+    return error;
+  }
+}


### PR DESCRIPTION
## Motivation

The Builder needs a small payload-source boundary before runtime wiring and slot orchestration are added. The existing Builder package has no abstraction for preparing a payload through the Engine API and retrieving the exact payload material later.

## Current behavior

The Builder cannot request or retrieve execution payloads from an injected Engine client.

## Proposed behavior

Add a package-internal `PayloadSource` contract and an `EnginePayloadSource` implementation that:

- carries the post-Gloas fork in the request and the returned handle, so retrieval asks the Engine for the right fork;
- prepares a payload with forkchoice state and payload attributes;
- passes a null custody set to [Engine API `forkchoiceUpdatedV4`](https://github.com/ethereum/execution-apis/blob/main/src/engine/amsterdam.md#engine_forkchoiceupdatedv4), since the Builder does not custody or sample data columns and a null set leaves the execution client's sampling set untouched;
- binds the source, fork, and payload ID in the returned handle;
- retrieves the execution payload, blobs bundle, execution requests, and payload value without rebuilding or narrowing exact-width values;
- accepts a per-request abort signal and forwards it through the injected Engine boundary;
- rejects incomplete Engine responses with structured error codes; and
- preserves transport, timeout, and cancellation errors from the injected Engine boundary.

The injected boundary contains only the two Engine method shapes this service needs. This avoids adding a dependency from `@lodestar/builder` to the full `@lodestar/beacon-node` package. Its transport owns serialization, retries, and request execution. Later orchestration owns request cancellation, build scheduling, deadlines, stale-result suppression, and job concurrency.

This is an unwired direct-Engine payload-source boundary extracted from Nico's proof of concept for independent review. Direct Engine access is the current implementation baseline. This PR does not choose shared versus dedicated EL use or ownership of `forkchoiceUpdated`. It does not change Builder initialization, CLI options, concrete Engine ownership, payload-attribute production, payload scheduling, bid construction, storage, publication, selection, or reveal behavior.

## Evidence

- 11 focused payload-source tests, type-check and Biome on the changed files, and `git diff --check` passed on 16 September 2026 at `98aa5bf`, after review: the custody set is hardcoded to `null`, the types are fixed to `ForkPostGloas` like the rest of the package, and the source-mismatch check is removed.
- Historical validation base: `f22c5ce63e`
- Current head: `98aa5bf`
- Architecture reference: [`nflaig/builder` at `99fd8fa9ad`](https://github.com/ChainSafe/lodestar/tree/99fd8fa9ad3a867fced3a5907a68edf3a519c1cd/packages/builder)
- Tracking issue: [krisoshea-eth/lodestar#59](https://github.com/krisoshea-eth/lodestar/issues/59)
- The Heze test uses Heze payload attributes with `inclusionListTransactions`, rather than relabeling a Gloas value.
- Consensus-specs #5549 and execution-apis #774 add the custody-column parameter to post-Gloas `engine_forkchoiceUpdatedV4`. The Builder always passes `null`, matching `prepare_execution_payload` in the validator spec; a null set leaves the execution client's sampling set unchanged.

## Downstream validation

The unwired boundary has three isolated downstream artifacts:

- upstream draft [#9973](https://github.com/ChainSafe/lodestar/pull/9973) applies duplicate sharing, job limits, phase deadlines, request cancellation, and deterministic cleanup, and has been merged forward onto this head and adapted to the simplified types; its clean two-file comparison remains in [fork PR #61](https://github.com/krisoshea-eth/lodestar/pull/61);
- [payload store PR #63](https://github.com/krisoshea-eth/lodestar/pull/63) remains a broader comparison proposal for [#9970](https://github.com/ChainSafe/lodestar/pull/9970). The narrowed, test-only [markolazic01/lodestar#9](https://github.com/markolazic01/lodestar/pull/9) has merged into Marko's branch and is incorporated in #9970. That does not adopt #63's broader capacity, copying or first-write guarantees;
- the temporary [combined integration branch](https://github.com/krisoshea-eth/lodestar/tree/krisoshea/builder-direct-engine-integration) proves one source result crosses orchestration and storage unchanged, while the later bid, selection, and reveal services compose on the same branch. At historical snapshot `6c1aff6c66`, it composed the source, orchestration, store, bid-policy, bid-ledger, and proposer-preferences components. That snapshot passed 152 Builder tests, type-check, Biome, build/import, and diff checks with Node 24.13.0. It predates subsequent component fixes.

These artifacts validate the contract without adding unresolved Builder or CLI wiring to this PR.

## Testing

At `98aa5bf`:

- 11 focused payload-source tests
- type-check and Biome on the two changed files
- `git diff --check`

Previously recorded at `2d2ff420f3` with Node 24.13.0 and the repository's installed dependencies: all Builder unit tests, Builder package type-check, lint, and build and import check.

## AI assistance

AI assistance was used during codebase research, implementation, drafting, testing, and review. The submitted code and PR text were reviewed and revised by the author, including manual edits and technical decisions.