### PR TITLE
fix: avoid epoch transition when validating gossip block

### DIFF
--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -267,7 +267,7 @@ export async function validateGossipBlock(
         chain.metrics?.gossipBlock.preStateSource.inc({source: "parentState"});
         return parentState;
       } catch {
-        // parent state not in memory → fall back to disk reload / dial-forward
+        // if parent state is not in memory, we fall back to disk reload / dial-forward
         chain.metrics?.gossipBlock.preStateSource.inc({source: "fallbackPreState"});
         chain.logger.debug("Parent state not in memory, falling back to getPreState for gossip block validation", {
           slot: blockSlot,

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -12,6 +12,7 @@ import {
   MAX_PROPOSER_SLASHINGS,
   MAX_VOLUNTARY_EXITS,
   MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD,
+  MIN_SEED_LOOKAHEAD,
   isForkPostBellatrix,
   isForkPostDeneb,
   isForkPostGloas,
@@ -249,26 +250,58 @@ export async function validateGossipBlock(
     // This requires execution engine integration to verify the parent block hash
   }
 
-  // use getPreState to reload state if needed. It also checks for whether the current finalized checkpoint is an ancestor of the block.
-  // As a result, we throw an IGNORE (whereas the spec says we should REJECT for this scenario).
+  // For gossip forwarding we only need the state to check the block's proposer index.
+  // If the state cannot be regenerated we throw an IGNORE (whereas the spec says we should REJECT for the
+  // finalized-ancestor scenario, which is already guarded by the parentBlock lookup above).
   // this is something we should change this in the future to make the code airtight to the spec.
   // [IGNORE] The block's parent (defined by block.parent_root) has been seen (via both gossip and non-gossip sources) (a client MAY queue blocks for processing once the parent block is retrieved).
   // [REJECT] The block's parent (defined by block.parent_root) passes validation.
-  const blockState = await chain.regen
-    .getPreState(block, {dontTransferCache: true}, RegenCaller.validateGossipBlock)
-    .catch(() => {
-      throw new BlockGossipError(GossipAction.IGNORE, {code: BlockErrorCode.PARENT_BLOCK_UNKNOWN, parentRoot});
+  const canUseParentState = blockEpoch - computeEpochAtSlot(parentBlock.slot) <= MIN_SEED_LOOKAHEAD;
+
+  const getValidationState = async () => {
+    const getPreState = () =>
+      chain.regen.getPreState(block, {dontTransferCache: true}, RegenCaller.validateGossipBlock);
+    if (canUseParentState) {
+      try {
+        const parentState = await chain.regen.getState(parentBlock.stateRoot, RegenCaller.validateGossipBlock);
+        chain.metrics?.gossipBlock.preStateSource.inc({source: "parentState"});
+        return parentState;
+      } catch {
+        // parent state not in memory → fall back to disk reload / dial-forward
+        chain.metrics?.gossipBlock.preStateSource.inc({source: "fallbackPreState"});
+        chain.logger.debug("Parent state not in memory, falling back to getPreState for gossip block validation", {
+          slot: blockSlot,
+          root: blockRoot,
+          parentSlot: parentBlock.slot,
+          parentRoot,
+        });
+        return getPreState();
+      }
+    }
+    // parent is >1 epoch behind (deep skip) → beyond proposer-lookahead range, must dial forward
+    chain.metrics?.gossipBlock.preStateSource.inc({source: "preState"});
+    chain.logger.debug("Cannot use parent state for gossip block validation, dialing forward via getPreState", {
+      slot: blockSlot,
+      root: blockRoot,
+      parentSlot: parentBlock.slot,
+      parentRoot,
     });
+    return getPreState();
+  };
+
+  const state = await getValidationState().catch(() => {
+    throw new BlockGossipError(GossipAction.IGNORE, {code: BlockErrorCode.PARENT_BLOCK_UNKNOWN, parentRoot});
+  });
 
   // in forky condition, make sure to populate ShufflingCache with regened state
-  chain.shufflingCache.processState(blockState);
+  chain.shufflingCache.processState(state);
 
   // [REJECT] The block's execution payload timestamp is correct with respect to the slot
   // -- i.e. execution_payload.timestamp == compute_timestamp_at_slot(state, block.slot).
   if (isForkPostBellatrix(fork) && !isForkPostGloas(fork)) {
     if (!isExecutionBlockBodyType(block.body)) throw Error("Not execution block body type");
     const executionPayload = block.body.executionPayload;
-    if (isStatePostBellatrix(blockState) && blockState.isExecutionStateType && blockState.isExecutionEnabled(block)) {
+    if (isStatePostBellatrix(state) && state.isExecutionStateType && state.isExecutionEnabled(block)) {
       const expectedTimestamp = computeTimeAtSlot(config, blockSlot, chain.genesisTime);
       if (executionPayload.timestamp !== computeTimeAtSlot(config, blockSlot, chain.genesisTime)) {
         throw new BlockGossipError(GossipAction.REJECT, {
@@ -281,7 +314,7 @@ export async function validateGossipBlock(
   }
 
   // [REJECT] The proposer index is a valid validator index
-  if (proposerIndex >= blockState.validatorCount) {
+  if (proposerIndex >= state.validatorCount) {
     throw new BlockGossipError(GossipAction.REJECT, {code: BlockErrorCode.UNKNOWN_PROPOSER, proposerIndex});
   }
 
@@ -293,7 +326,7 @@ export async function validateGossipBlock(
   // shuffling (defined by parent_root/slot). If the proposer_index cannot immediately be verified against the expected
   // shuffling, the block MAY be queued for later processing while proposers for the block's branch are calculated --
   // in such a case do not REJECT, instead IGNORE this message.
-  if (blockState.getBeaconProposer(blockSlot) !== proposerIndex) {
+  if (state.getBeaconProposer(blockSlot) !== proposerIndex) {
     throw new BlockGossipError(GossipAction.REJECT, {code: BlockErrorCode.INCORRECT_PROPOSER, proposerIndex});
   }
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -921,6 +921,12 @@ export function createLodestarMetrics(
         help: "Count of errors, by error type, while processing blocks",
         labelNames: ["error"],
       }),
+
+      preStateSource: register.counter<{source: "parentState" | "fallbackPreState" | "preState"}>({
+        name: "lodestar_gossip_block_validation_pre_state_source_total",
+        help: "Source of the pre-state used for gossip block validation",
+        labelNames: ["source"],
+      }),
     },
     gossipBlob: {
       recvToValidation: register.histogram({

--- a/packages/beacon-node/test/unit/chain/validation/block.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/block.test.ts
@@ -2,7 +2,7 @@ import {Mock, Mocked, beforeEach, describe, expect, it, vi} from "vitest";
 import {createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {config as configDef} from "@lodestar/config/default";
 import {ProtoBlock} from "@lodestar/fork-choice";
-import {ForkName, ForkPostDeneb, ForkPreFulu} from "@lodestar/params";
+import {ForkName, ForkPostDeneb, ForkPreFulu, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {BeaconStateView, signedBlockToSignedHeader} from "@lodestar/state-transition";
 import {SignedBeaconBlock, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
@@ -246,7 +246,7 @@ describe("gossip block validation", () => {
         forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
         forkChoice.getBlockHexAndBlockHash.mockReturnValue({slot: clockSlot - 1} as ProtoBlock);
         const state = new BeaconStateView(generateCachedState());
-        regen.getPreState.mockResolvedValue(state);
+        regen.getState.mockResolvedValue(state);
         vi.spyOn(state.cachedState.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
 
         const validation = expectRejectedWithLodestarError(
@@ -295,7 +295,8 @@ describe("gossip block validation", () => {
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce(null);
     // Returned parent block is latter than proposed block
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
-    // Regen not able to get the parent block state
+    // Regen not able to get the parent block state (fast path getState, then getPreState fallback)
+    regen.getState.mockRejectedValue(undefined);
     regen.getPreState.mockRejectedValue(undefined);
 
     await expectRejectedWithLodestarError(
@@ -310,7 +311,7 @@ describe("gossip block validation", () => {
     // Returned parent block is latter than proposed block
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
     // Regen returns some state
-    regen.getPreState.mockResolvedValue(new BeaconStateView(generateCachedState()));
+    regen.getState.mockResolvedValue(new BeaconStateView(generateCachedState()));
     // BLS signature verifier returns invalid
     verifySignature.mockResolvedValue(false);
 
@@ -327,7 +328,7 @@ describe("gossip block validation", () => {
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
     // Regen returns some state
     const state = new BeaconStateView(generateCachedState());
-    regen.getPreState.mockResolvedValue(state);
+    regen.getState.mockResolvedValue(state);
     // BLS signature verifier returns valid
     verifySignature.mockResolvedValue(true);
     // Force proposer shuffling cache to return wrong value
@@ -339,20 +340,61 @@ describe("gossip block validation", () => {
     );
   });
 
-  it("valid", async () => {
+  it("valid - uses parent state (fast path), no epoch transition", async () => {
     // Return not known for proposed block
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce(null);
-    // Returned parent block is latter than proposed block
+    // Returned parent block is one epoch behind the proposed block (within proposer-lookahead range)
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
-    // Regen returns some state
+    // Regen returns the parent state directly, no dial-forward
     const state = new BeaconStateView(generateCachedState());
-    regen.getPreState.mockResolvedValue(state);
+    regen.getState.mockResolvedValue(state);
     // BLS signature verifier returns valid
     verifySignature.mockResolvedValue(true);
     // Force proposer shuffling cache to return correct value
     vi.spyOn(state.cachedState.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
 
     await validateGossipBlock(config, chain, job, ForkName.phase0);
+
+    expect(regen.getState).toHaveBeenCalledOnce();
+    expect(regen.getPreState).not.toHaveBeenCalled();
+  });
+
+  it("valid - falls back to getPreState when parent state not in memory", async () => {
+    forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce(null);
+    forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
+    const state = new BeaconStateView(generateCachedState());
+    // Fast path miss: parent state not in memory, then getPreState resolves (disk reload / dial-forward)
+    regen.getState.mockRejectedValue(undefined);
+    regen.getPreState.mockResolvedValue(state);
+    verifySignature.mockResolvedValue(true);
+    vi.spyOn(state.cachedState.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
+
+    await validateGossipBlock(config, chain, job, ForkName.phase0);
+
+    expect(regen.getState).toHaveBeenCalledOnce();
+    expect(regen.getPreState).toHaveBeenCalledOnce();
+  });
+
+  it("valid - deep skip uses getPreState (parent more than 1 epoch behind)", async () => {
+    // Block is in epoch 2, parent in epoch 0 -> beyond proposer-lookahead range
+    const deepClockSlot = 2 * SLOTS_PER_EPOCH;
+    vi.spyOn(chain.clock, "currentSlotWithGossipDisparity", "get").mockReturnValue(deepClockSlot);
+    const deepBlock = ssz.deneb.BeaconBlock.defaultValue();
+    deepBlock.slot = deepClockSlot;
+    deepBlock.proposerIndex = proposerIndex;
+    const deepJob: SignedBeaconBlock = {signature, message: deepBlock};
+
+    forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce(null);
+    forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: SLOTS_PER_EPOCH - 1} as ProtoBlock);
+    const state = new BeaconStateView(generateCachedState());
+    regen.getPreState.mockResolvedValue(state);
+    verifySignature.mockResolvedValue(true);
+    vi.spyOn(state.cachedState.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
+
+    await validateGossipBlock(config, chain, deepJob, ForkName.phase0);
+
+    expect(regen.getPreState).toHaveBeenCalledOnce();
+    expect(regen.getState).not.toHaveBeenCalled();
   });
 
   it("deneb - TOO_MANY_KZG_COMMITMENTS", async () => {
@@ -367,7 +409,7 @@ describe("gossip block validation", () => {
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
     // Regen returns some state
     const state = new BeaconStateView(generateCachedState());
-    regen.getPreState.mockResolvedValue(state);
+    regen.getState.mockResolvedValue(state);
     // BLS signature verifier returns valid
     verifySignature.mockResolvedValue(true);
     // Force proposer shuffling cache to return correct value
@@ -393,7 +435,7 @@ describe("gossip block validation", () => {
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
     // Regen returns some state
     const state = new BeaconStateView(generateCachedState());
-    regen.getPreState.mockResolvedValue(state);
+    regen.getState.mockResolvedValue(state);
     // BLS signature verifier returns valid
     verifySignature.mockResolvedValue(true);
     // Force proposer shuffling cache to return correct value


### PR DESCRIPTION
**Motivation**

- post fulu, we know proposer index 1-epoch ahead so we don't need to get through epoch transition in that case, that will spread that block super slowly as we saw it in #9873

**Description**

- if parent block is <= 1 epoch to gossip block, use parent block. If there is error, use the old `getPreState()` which support the reload mechanism
- otherwise, use the old `getPreState()` api
- add log and metric

Closes #9873

**AI Assistance Disclosure**

- created with the help of Claude
