### PR TITLE
fix: keep event stream alive if an event can not be processed

### DIFF
--- a/packages/api/src/beacon/client/events.ts
+++ b/packages/api/src/beacon/client/events.ts
@@ -37,8 +37,13 @@ export function getClient(config: ChainForkConfig, baseUrl: string): ApiClient {
 
       for (const topic of topics) {
         eventSource.addEventListener(topic, (event: MessageEvent) => {
-          const message = eventSerdes.fromJson(topic, JSON.parse(event.data));
-          onEvent({type: topic, message} as BeaconEvent);
+          try {
+            const message = eventSerdes.fromJson(topic, JSON.parse(event.data));
+            onEvent({type: topic, message} as BeaconEvent);
+          } catch (e) {
+            // A throw here leaves the EventSource parser with a stale data buffer which breaks all later events
+            onError?.(e as Error);
+          }
         });
       }
 

--- a/packages/api/test/unit/beacon/genericServerTest/events.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/events.test.ts
@@ -119,4 +119,47 @@ describe("beacon / events", () => {
 
     expect(eventsReceived).toEqual([eventHead]);
   });
+
+  it("Keep the stream alive if the event consumer throws", async () => {
+    const eventHead1: BeaconEvent = {
+      type: EventType.head,
+      message: eventTestData[EventType.head],
+    };
+    const eventHead2: BeaconEvent = {
+      type: EventType.head,
+      message: {...eventTestData[EventType.head], slot: eventTestData[EventType.head].slot + 1},
+    };
+    const eventsReceived: BeaconEvent[] = [];
+    const errorsReceived: Error[] = [];
+
+    await new Promise<void>((resolve, reject) => {
+      mockApi.eventstream.mockImplementation(async ({onEvent}) => {
+        try {
+          onEvent(eventHead1);
+          await sleep(5);
+          onEvent(eventHead2);
+        } catch (e) {
+          reject(e);
+        }
+      });
+
+      const client = getClient(config, baseUrl);
+      void client.eventstream({
+        topics: [EventType.head],
+        signal: controller.signal,
+        onEvent: (event) => {
+          eventsReceived.push(event);
+          // Simulates a consumer failing on the first event, the next event must still be delivered
+          if (eventsReceived.length === 1) throw Error("consumer failed");
+          resolve();
+        },
+        onError: (e) => {
+          errorsReceived.push(e);
+        },
+      });
+    });
+
+    expect(eventsReceived).toEqual([eventHead1, eventHead2]);
+    expect(errorsReceived.map((e) => e.message)).toEqual(["consumer failed"]);
+  });
 });


### PR DESCRIPTION
Client-side counterpart of #9872. If an event can not be deserialized or the consumer throws, the error escapes the `eventsource` listener and leaves its internal data buffer stale. Every later event on any topic then fails to parse, and reconnecting does not recover it as the buffer is tied to the `EventSource` instance. The validator client keeps running but silently stops receiving head events until it is restarted.

Errors thrown while handling an event are now caught and surfaced via `onError`, only that single event is dropped.
