### PR TITLE
feat: track late canonical blocks

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
+++ b/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
@@ -1,5 +1,6 @@
 import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {LoggerNode} from "@lodestar/logger/node";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Checkpoint} from "@lodestar/types/phase0";
 import {callFnWhenAwait} from "@lodestar/utils";
 import {IBeaconDb} from "../../db/index.js";
@@ -208,6 +209,9 @@ export class ArchiveStore {
       const finalizedEpoch = finalized.epoch;
       this.logger.verbose("Start processing finalized checkpoint", {epoch: finalizedEpoch, rootHex: finalized.rootHex});
 
+      // we want to track late imported canonical blocks, but it's not nice to do it at syncig time
+      const isNodeSynced = this.chain.clock.currentSlot - this.chain.forkChoice.getHead().slot <= SLOTS_PER_EPOCH;
+
       let timer = this.metrics?.processFinalizedCheckpoint.durationByTask.startTimer();
       await archiveBlocks(
         this.chain.config,
@@ -217,6 +221,8 @@ export class ArchiveStore {
         this.logger,
         finalized,
         this.chain.clock.currentEpoch,
+        this.metrics,
+        isNodeSynced,
         this.archiveDataEpochs,
         this.chain.opts.persistOrphanedBlocks,
         this.chain.opts.persistOrphanedBlocksDir

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -8,6 +8,7 @@ import {Epoch, Slot} from "@lodestar/types";
 import {Logger, fromAsync, fromHex, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {IBeaconDb} from "../../../db/index.js";
 import {BlockArchiveBatchPutBinaryItem} from "../../../db/repositories/index.js";
+import {Metrics} from "../../../metrics/metrics.js";
 import {ensureDir, writeIfNotExist} from "../../../util/file.js";
 import {BlockRootHex} from "../../../util/sszBytes.js";
 import {LightClientServer} from "../../lightClient/index.js";
@@ -54,6 +55,8 @@ export async function archiveBlocks(
   logger: Logger,
   finalizedCheckpoint: CheckpointWithHex,
   currentEpoch: Epoch,
+  metrics: Metrics | null,
+  isNodeSynced: boolean,
   archiveDataEpochs?: number,
   persistOrphanedBlocks?: boolean,
   persistOrphanedBlocksDir?: string
@@ -75,6 +78,21 @@ export async function archiveBlocks(
   }));
 
   const logCtx = {currentEpoch, finalizedEpoch: finalizedCheckpoint.epoch, finalizedRoot: finalizedCheckpoint.rootHex};
+
+  // `finalizedCanonicalBlocks` is newest -> oldest; its LAST element is the previous-finalized
+  // boundary block, already audited on the prior run, so exclude it to avoid double counting.
+  if (isNodeSynced && finalizedCanonicalBlocks.length > 1) {
+    const lateBlocks = finalizedCanonicalBlocks.slice(0, -1).filter((block) => !block.importedTimely);
+    if (lateBlocks.length > 0) {
+      metrics?.importBlock.lateCanonicalBlock.inc(lateBlocks.length);
+      const lateSlots = lateBlocks.map((block) => block.slot).sort((a, b) => a - b);
+      logger.verbose("Late imported canonical blocks", {
+        ...logCtx,
+        count: lateBlocks.length,
+        slotRange: prettyPrintIndices(lateSlots),
+      });
+    }
+  }
 
   if (finalizedCanonicalBlockRoots.length > 0) {
     const migratedSlots = await migrateBlocksFromHotToColdDb(db, logger, finalizedCanonicalBlockRoots);

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -22,6 +22,16 @@ const BLOB_SIDECAR_BATCH_SIZE = 32;
 type BlockRootSlot = {slot: Slot; root: Uint8Array};
 
 /**
+ * Why a finalized-canonical block was imported after the attestation cutoff.
+ */
+export enum LateCanonicalBlockReason {
+  // received on time, but finished importing after the attestation cutoff → this node's processing lagged
+  SlowImport = "slow_import",
+  // block reached this node late on the network thread
+  LateReceive = "late_receive",
+}
+
+/**
  * Persist orphaned block to disk
  */
 async function persistOrphanedBlock(
@@ -84,11 +94,19 @@ export async function archiveBlocks(
   if (isNodeSynced && finalizedCanonicalBlocks.length > 1) {
     const lateBlocks = finalizedCanonicalBlocks.slice(0, -1).filter((block) => !block.importedTimely);
     if (lateBlocks.length > 0) {
-      metrics?.importBlock.lateCanonicalBlock.inc(lateBlocks.length);
+      let slowImport = 0;
+      for (const block of lateBlocks) {
+        // received late => late_receive; otherwise we had it on time but were slow to import => slow_import
+        const reason = block.timeliness ? LateCanonicalBlockReason.SlowImport : LateCanonicalBlockReason.LateReceive;
+        if (block.timeliness) slowImport++;
+        metrics?.importBlock.lateCanonicalBlock.inc({reason});
+      }
       const lateSlots = lateBlocks.map((block) => block.slot).sort((a, b) => a - b);
       logger.verbose("Late imported canonical blocks", {
         ...logCtx,
         count: lateBlocks.length,
+        slowImport,
+        lateReceive: lateBlocks.length - slowImport,
         slotRange: prettyPrintIndices(lateSlots),
       });
     }

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -25,7 +25,7 @@ type BlockRootSlot = {slot: Slot; root: Uint8Array};
  * Why a finalized-canonical block was imported after the attestation cutoff.
  */
 export enum LateCanonicalBlockReason {
-  // received on time, but finished importing after the attestation cutoff → this node's processing lagged
+  // received on time, but finished importing after the attestation cutoff
   SlowImport = "slow_import",
   // block reached this node late on the network thread
   LateReceive = "late_receive",
@@ -334,7 +334,7 @@ async function migrateBlocksFromHotToColdDb(db: IBeaconDb, logger: Logger, block
     ]);
     for (const entry of canonicalBlockEntries) migratedSlots.push(entry.slot);
   }
-  // Ancestor walk is newest → oldest; sort ascending so `prettyPrintIndices` renders cleanly.
+  // Ancestor walk is newest to oldest; sort ascending so `prettyPrintIndices` renders cleanly.
   return migratedSlots.sort((a, b) => a - b);
 }
 
@@ -473,7 +473,7 @@ async function migrateDataColumnSidecarsFromHotToColdDb(
     await Promise.all(promises);
   }
 
-  // Ancestor walk is newest → oldest; sort ascending so `prettyPrintIndices` renders cleanly.
+  // Ancestor walk is newest to oldest; sort ascending so `prettyPrintIndices` renders cleanly.
   return migratedSlots.sort((a, b) => a - b);
 }
 
@@ -521,7 +521,7 @@ async function migrateExecutionPayloadEnvelopesFromHotToColdDb(
   ]);
 
   // Slots are ascending in hot-db key order — sort to guarantee `prettyPrintIndices` output is clean
-  // regardless of ancestor-walk order (newest → oldest).
+  // regardless of ancestor-walk order (newest to oldest).
   return envelopeEntries.map((entry) => entry.key).sort((a, b) => a - b);
 }
 

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -85,7 +85,7 @@ export async function importBlock(
   const currentEpoch = computeEpochAtSlot(currentSlot);
   const blockEpoch = computeEpochAtSlot(blockSlot);
   const prevFinalizedEpoch = this.forkChoice.getFinalizedCheckpoint().epoch;
-  const blockDelaySec =
+  const receiveDelaySec =
     fullyVerifiedBlock.seenTimestampSec - computeTimeAtSlot(this.config, blockSlot, postState.genesisTime);
   const recvToValLatency = Date.now() / 1000 - (opts.seenTimestampSec ?? Date.now() / 1000);
   const fork = this.config.getForkSeq(blockSlot);
@@ -122,10 +122,12 @@ export async function importBlock(
     executionStatus = parentBlock.executionStatus;
   }
 
+  const importDelaySec = this.clock.secFromSlot(blockSlot);
   const blockSummary = this.forkChoice.onBlock(
     block.message,
     postState,
-    blockDelaySec,
+    receiveDelaySec,
+    importDelaySec,
     currentSlot,
     executionStatus,
     dataAvailabilityStatus

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -135,6 +135,7 @@ export function initializeForkChoiceFromFinalizedState(
         blockRoot: toRootHex(checkpoint.root),
         timeliness: true, // Optimistically assume is timely
         ptcTimeliness: true, // Spec: block_timeliness for anchor = [True, True]
+        importedTimely: true, // Optimistically assume is timely
         proposerIndex: blockHeader.proposerIndex,
 
         justifiedEpoch: justifiedCheckpoint.epoch,
@@ -233,6 +234,7 @@ export function initializeForkChoiceFromUnfinalizedState(
     targetRoot: headRoot,
     timeliness: true, // Optimistically assume is timely
     ptcTimeliness: true, // Spec: block_timeliness for anchor = [True, True]
+    importedTimely: true, // Optimistically assume is timely
     proposerIndex: blockHeader.proposerIndex,
 
     justifiedEpoch: justifiedCheckpoint.epoch,

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -2,6 +2,7 @@
 import {NotReorgedReason} from "@lodestar/fork-choice";
 import {ArchiveStoreTask} from "../../chain/archiveStore/archiveStore.js";
 import {FrequencyStateArchiveStep} from "../../chain/archiveStore/strategies/frequencyStateArchiveStrategy.js";
+import type {LateCanonicalBlockReason} from "../../chain/archiveStore/utils/archiveBlocks.js";
 import {BlockInputSource} from "../../chain/blocks/blockInput/index.js";
 import {PayloadErrorCode} from "../../chain/blocks/importExecutionPayload.js";
 import {
@@ -1047,9 +1048,10 @@ export function createLodestarMetrics(
         name: "lodestar_import_block_set_head_after_cutoff_total",
         help: "Total times an imported block is set as head after ATTESTATION_DUE_BPS of the slot",
       }),
-      lateCanonicalBlock: register.counter({
+      lateCanonicalBlock: register.counter<{reason: LateCanonicalBlockReason}>({
         name: "lodestar_import_block_late_canonical_total",
-        help: "Total finalized-canonical blocks this node imported after the attestation cutoff",
+        help: "Total finalized-canonical blocks this node imported after the attestation cutoff; reason distinguishes this node's processing lag (slow_import) from late reception (late_receive)",
+        labelNames: ["reason"],
       }),
       bySource: register.gauge<{source: BlockInputSource}>({
         name: "lodestar_import_block_by_source_total",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1047,6 +1047,10 @@ export function createLodestarMetrics(
         name: "lodestar_import_block_set_head_after_cutoff_total",
         help: "Total times an imported block is set as head after ATTESTATION_DUE_BPS of the slot",
       }),
+      lateCanonicalBlock: register.counter({
+        name: "lodestar_import_block_late_canonical_total",
+        help: "Total finalized-canonical blocks this node imported after the attestation cutoff",
+      }),
       bySource: register.gauge<{source: BlockInputSource}>({
         name: "lodestar_import_block_by_source_total",
         help: "Total number of imported blocks by source",

--- a/packages/beacon-node/test/mocks/fork-choice/timeliness.ts
+++ b/packages/beacon-node/test/mocks/fork-choice/timeliness.ts
@@ -14,11 +14,11 @@ export class TimelinessForkChoice extends ForkChoice {
   /**
    * This is to mark the `lateSlot` as not timely.
    */
-  protected isBlockTimely(block: BeaconBlock, blockDelaySec: number): boolean {
+  protected isBlockReceivedTimely(block: BeaconBlock, receiveDelaySec: number): boolean {
     if (block.slot === this.lateSlot) {
       return false;
     }
 
-    return super.isBlockTimely(block, blockDelaySec);
+    return super.isBlockReceivedTimely(block, receiveDelaySec);
   }
 }

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -67,6 +67,7 @@ describe.skip(`getAttestationsForBlock vc=${vc}`, () => {
           executionStatus: ExecutionStatus.PreMerge,
 
           timeliness: false,
+          importedTimely: false,
           ptcTimeliness: false,
           proposerIndex: 0,
           dataAvailabilityStatus: DataAvailabilityStatus.PreData,
@@ -97,6 +98,7 @@ describe.skip(`getAttestationsForBlock vc=${vc}`, () => {
             executionPayloadBlockHash: null,
             executionStatus: ExecutionStatus.PreMerge,
             timeliness: false,
+            importedTimely: false,
             ptcTimeliness: false,
             proposerIndex: 0,
             dataAvailabilityStatus: DataAvailabilityStatus.PreData,

--- a/packages/beacon-node/test/spec/utils/gossipValidation.ts
+++ b/packages/beacon-node/test/spec/utils/gossipValidation.ts
@@ -481,6 +481,7 @@ export async function runGossipValidationTest(
             signedBlock.message,
             postState,
             0,
+            0,
             slot,
             ExecutionStatus.Valid,
             getDataAvailabilityStatusForFork(fork)
@@ -495,6 +496,7 @@ export async function runGossipValidationTest(
           chain.forkChoice.onBlock(
             signedBlock.message,
             postState,
+            0,
             0,
             slot,
             ExecutionStatus.Syncing,

--- a/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
+++ b/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
@@ -8,6 +8,7 @@ import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {archiveBlocks} from "../../../../src/chain/archiveStore/utils/archiveBlocks.js";
 import {ZERO_HASH_HEX} from "../../../../src/constants/index.js";
+import type {Metrics} from "../../../../src/metrics/metrics.js";
 import {MockedBeaconChain, getMockedBeaconChain} from "../../../mocks/mockedBeaconChain.js";
 import {MockedBeaconDb, getMockedBeaconDb} from "../../../mocks/mockedBeaconDb.js";
 import {generateProtoBlock} from "../../../utils/typeGenerator.js";
@@ -70,7 +71,9 @@ describe("block archiver task", () => {
       lightclientServer,
       logger,
       {epoch: 5, root: fromHexString(ZERO_HASH_HEX), rootHex: ZERO_HASH_HEX},
-      currentEpoch
+      currentEpoch,
+      null,
+      false
     );
 
     const expectedData = canonicalBlocks
@@ -148,7 +151,9 @@ describe("block archiver task", () => {
         root: fromHexString(ZERO_HASH_HEX),
         rootHex: ZERO_HASH_HEX,
       },
-      currentEpoch
+      currentEpoch,
+      null,
+      false
     );
 
     // Verify data column sidecars are archived
@@ -224,7 +229,9 @@ describe("block archiver task", () => {
       lightclientServer,
       logger,
       {epoch: 1, root: fromHexString(ZERO_HASH_HEX), rootHex: ZERO_HASH_HEX},
-      1
+      1,
+      null,
+      false
     );
 
     // Block migration writes only the new ancestor (boundary skipped because its hot-db entry is null)
@@ -263,10 +270,74 @@ describe("block archiver task", () => {
       lightclientServer,
       logger,
       {epoch: 1, root: fromHexString(ZERO_HASH_HEX), rootHex: ZERO_HASH_HEX},
-      1
+      1,
+      null,
+      false
     );
 
     expect(dbStub.blockArchive.batchPutBinary).not.toHaveBeenCalled();
     expect(dbStub.dataColumnSidecarArchive.putManyBinary).not.toHaveBeenCalled();
+  });
+
+  describe("audit late-imported-but-canonical blocks", () => {
+    function getCanonicalBlocksWithLateImports() {
+      return [
+        generateProtoBlock({slot: 10, blockRoot: toHexString(Buffer.alloc(32, 10)), importedTimely: false}),
+        generateProtoBlock({slot: 9, blockRoot: toHexString(Buffer.alloc(32, 9)), importedTimely: true}),
+        generateProtoBlock({slot: 8, blockRoot: toHexString(Buffer.alloc(32, 8)), importedTimely: false}),
+        generateProtoBlock({slot: 7, blockRoot: toHexString(Buffer.alloc(32, 7)), importedTimely: false}),
+      ];
+    }
+
+    function getMetricsWithIncSpy() {
+      const inc = vi.fn();
+      const metrics = {importBlock: {lateCanonicalBlock: {inc}}} as unknown as Metrics;
+      return {metrics, inc};
+    }
+
+    it("counts non-boundary late-imported canonical blocks when synced", async () => {
+      vi.spyOn(forkChoiceStub, "getAllAncestorAndNonAncestorBlocksDefaultStatus").mockReturnValue({
+        ancestors: getCanonicalBlocksWithLateImports(),
+        nonAncestors: [],
+      });
+      const {metrics, inc} = getMetricsWithIncSpy();
+
+      await archiveBlocks(
+        defaultConfig,
+        dbStub,
+        forkChoiceStub,
+        lightclientServer,
+        logger,
+        {epoch: 5, root: fromHexString(ZERO_HASH_HEX), rootHex: ZERO_HASH_HEX},
+        8,
+        metrics,
+        true // isNodeSynced
+      );
+
+      expect(inc).toHaveBeenCalledTimes(1);
+      expect(inc).toHaveBeenCalledWith(2);
+    });
+
+    it("does not count late-imported blocks when not synced", async () => {
+      vi.spyOn(forkChoiceStub, "getAllAncestorAndNonAncestorBlocksDefaultStatus").mockReturnValue({
+        ancestors: getCanonicalBlocksWithLateImports(),
+        nonAncestors: [],
+      });
+      const {metrics, inc} = getMetricsWithIncSpy();
+
+      await archiveBlocks(
+        defaultConfig,
+        dbStub,
+        forkChoiceStub,
+        lightclientServer,
+        logger,
+        {epoch: 5, root: fromHexString(ZERO_HASH_HEX), rootHex: ZERO_HASH_HEX},
+        8,
+        metrics,
+        false // isNodeSynced
+      );
+
+      expect(inc).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
+++ b/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
@@ -281,7 +281,7 @@ describe("block archiver task", () => {
 
   describe("audit late-imported-but-canonical blocks", () => {
     // newest -> oldest; last element is the previous-finalized boundary (excluded). Late =
-    // importedTimely === false. Invariant: timeliness === false ⟹ importedTimely === false.
+    // importedTimely === false. Invariant: timeliness === false implies importedTimely === false.
     //   slot 10: late import, received late     => late_receive
     //   slot  9: imported on time               => not late
     //   slot  8: late import, received on time   => slow_import

--- a/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
+++ b/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
@@ -6,7 +6,7 @@ import {PayloadStatus} from "@lodestar/fork-choice";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
-import {archiveBlocks} from "../../../../src/chain/archiveStore/utils/archiveBlocks.js";
+import {LateCanonicalBlockReason, archiveBlocks} from "../../../../src/chain/archiveStore/utils/archiveBlocks.js";
 import {ZERO_HASH_HEX} from "../../../../src/constants/index.js";
 import type {Metrics} from "../../../../src/metrics/metrics.js";
 import {MockedBeaconChain, getMockedBeaconChain} from "../../../mocks/mockedBeaconChain.js";
@@ -280,12 +280,38 @@ describe("block archiver task", () => {
   });
 
   describe("audit late-imported-but-canonical blocks", () => {
+    // newest -> oldest; last element is the previous-finalized boundary (excluded). Late =
+    // importedTimely === false. Invariant: timeliness === false ⟹ importedTimely === false.
+    //   slot 10: late import, received late     => late_receive
+    //   slot  9: imported on time               => not late
+    //   slot  8: late import, received on time   => slow_import
+    //   slot  7: boundary, excluded
     function getCanonicalBlocksWithLateImports() {
       return [
-        generateProtoBlock({slot: 10, blockRoot: toHexString(Buffer.alloc(32, 10)), importedTimely: false}),
-        generateProtoBlock({slot: 9, blockRoot: toHexString(Buffer.alloc(32, 9)), importedTimely: true}),
-        generateProtoBlock({slot: 8, blockRoot: toHexString(Buffer.alloc(32, 8)), importedTimely: false}),
-        generateProtoBlock({slot: 7, blockRoot: toHexString(Buffer.alloc(32, 7)), importedTimely: false}),
+        generateProtoBlock({
+          slot: 10,
+          blockRoot: toHexString(Buffer.alloc(32, 10)),
+          importedTimely: false,
+          timeliness: false,
+        }),
+        generateProtoBlock({
+          slot: 9,
+          blockRoot: toHexString(Buffer.alloc(32, 9)),
+          importedTimely: true,
+          timeliness: true,
+        }),
+        generateProtoBlock({
+          slot: 8,
+          blockRoot: toHexString(Buffer.alloc(32, 8)),
+          importedTimely: false,
+          timeliness: true,
+        }),
+        generateProtoBlock({
+          slot: 7,
+          blockRoot: toHexString(Buffer.alloc(32, 7)),
+          importedTimely: false,
+          timeliness: false,
+        }),
       ];
     }
 
@@ -295,7 +321,7 @@ describe("block archiver task", () => {
       return {metrics, inc};
     }
 
-    it("counts non-boundary late-imported canonical blocks when synced", async () => {
+    it("counts non-boundary late-imported canonical blocks by reason when synced", async () => {
       vi.spyOn(forkChoiceStub, "getAllAncestorAndNonAncestorBlocksDefaultStatus").mockReturnValue({
         ancestors: getCanonicalBlocksWithLateImports(),
         nonAncestors: [],
@@ -314,8 +340,10 @@ describe("block archiver task", () => {
         true // isNodeSynced
       );
 
-      expect(inc).toHaveBeenCalledTimes(1);
-      expect(inc).toHaveBeenCalledWith(2);
+      // one inc per late non-boundary block: slot 10 (late_receive), slot 8 (slow_import)
+      expect(inc).toHaveBeenCalledTimes(2);
+      expect(inc).toHaveBeenCalledWith({reason: LateCanonicalBlockReason.LateReceive});
+      expect(inc).toHaveBeenCalledWith({reason: LateCanonicalBlockReason.SlowImport});
     });
 
     it("does not count late-imported blocks when not synced", async () => {

--- a/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -105,6 +105,7 @@ describe("LodestarForkChoice", () => {
         targetBlock.message,
         targetState,
         blockDelaySec,
+        blockDelaySec,
         currentSlot,
         executionStatus,
         dataAvailabilityStatus
@@ -112,6 +113,7 @@ describe("LodestarForkChoice", () => {
       forkChoice.onBlock(
         orphanedBlock.message,
         orphanedState,
+        blockDelaySec,
         blockDelaySec,
         currentSlot,
         executionStatus,
@@ -123,6 +125,7 @@ describe("LodestarForkChoice", () => {
         parentBlock.message,
         parentState,
         blockDelaySec,
+        blockDelaySec,
         currentSlot,
         executionStatus,
         dataAvailabilityStatus
@@ -133,6 +136,7 @@ describe("LodestarForkChoice", () => {
       forkChoice.onBlock(
         childBlock.message,
         childState,
+        blockDelaySec,
         blockDelaySec,
         currentSlot,
         executionStatus,
@@ -196,19 +200,75 @@ describe("LodestarForkChoice", () => {
       const currentSlot = 128;
       forkChoice.updateTime(currentSlot);
 
-      forkChoice.onBlock(block08.message, state08, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
-      forkChoice.onBlock(block12.message, state12, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
-      forkChoice.onBlock(block16.message, state16, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
-      forkChoice.onBlock(block20.message, state20, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
-      forkChoice.onBlock(block24.message, state24, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
-      forkChoice.onBlock(block28.message, state28, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
+      forkChoice.onBlock(
+        block08.message,
+        state08,
+        blockDelaySec,
+        blockDelaySec,
+        currentSlot,
+        executionStatus,
+        dataAvailabilityStatus
+      );
+      forkChoice.onBlock(
+        block12.message,
+        state12,
+        blockDelaySec,
+        blockDelaySec,
+        currentSlot,
+        executionStatus,
+        dataAvailabilityStatus
+      );
+      forkChoice.onBlock(
+        block16.message,
+        state16,
+        blockDelaySec,
+        blockDelaySec,
+        currentSlot,
+        executionStatus,
+        dataAvailabilityStatus
+      );
+      forkChoice.onBlock(
+        block20.message,
+        state20,
+        blockDelaySec,
+        blockDelaySec,
+        currentSlot,
+        executionStatus,
+        dataAvailabilityStatus
+      );
+      forkChoice.onBlock(
+        block24.message,
+        state24,
+        blockDelaySec,
+        blockDelaySec,
+        currentSlot,
+        executionStatus,
+        dataAvailabilityStatus
+      );
+      forkChoice.onBlock(
+        block28.message,
+        state28,
+        blockDelaySec,
+        blockDelaySec,
+        currentSlot,
+        executionStatus,
+        dataAvailabilityStatus
+      );
       expect(forkChoice.getAllAncestorBlocks(hashBlock(block16.message), PayloadStatus.FULL)).toHaveLength(4);
       expect(forkChoice.getAllAncestorBlocks(hashBlock(block24.message), PayloadStatus.FULL)).toHaveLength(6);
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block08.message))).not.toBeNull();
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block12.message))).not.toBeNull();
       expect(forkChoice.hasBlockHex(hashBlock(block08.message))).toBe(true);
       expect(forkChoice.hasBlockHex(hashBlock(block12.message))).toBe(true);
-      forkChoice.onBlock(block32.message, state32, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
+      forkChoice.onBlock(
+        block32.message,
+        state32,
+        blockDelaySec,
+        blockDelaySec,
+        currentSlot,
+        executionStatus,
+        dataAvailabilityStatus
+      );
       forkChoice.prune(hashBlock(block16.message));
       expect(forkChoice.getAllAncestorBlocks(hashBlock(block16.message), PayloadStatus.FULL).length).toBeWithMessage(
         1,
@@ -242,6 +302,7 @@ describe("LodestarForkChoice", () => {
         targetBlock.message,
         targetState,
         blockDelaySec,
+        blockDelaySec,
         currentSlot,
         executionStatus,
         dataAvailabilityStatus
@@ -249,6 +310,7 @@ describe("LodestarForkChoice", () => {
       forkChoice.onBlock(
         orphanedBlock.message,
         orphanedState,
+        blockDelaySec,
         blockDelaySec,
         currentSlot,
         executionStatus,
@@ -258,6 +320,7 @@ describe("LodestarForkChoice", () => {
         parentBlock.message,
         parentState,
         blockDelaySec,
+        blockDelaySec,
         currentSlot,
         executionStatus,
         dataAvailabilityStatus
@@ -265,6 +328,7 @@ describe("LodestarForkChoice", () => {
       forkChoice.onBlock(
         childBlock.message,
         childState,
+        blockDelaySec,
         blockDelaySec,
         currentSlot,
         executionStatus,
@@ -313,6 +377,7 @@ describe("LodestarForkChoice", () => {
         blockW.message,
         stateW,
         blockDelaySec,
+        blockDelaySec,
         blockW.message.slot,
         executionStatus,
         dataAvailabilityStatus
@@ -325,6 +390,7 @@ describe("LodestarForkChoice", () => {
         blockX.message,
         stateX,
         blockDelaySec,
+        blockDelaySec,
         blockX.message.slot,
         executionStatus,
         dataAvailabilityStatus
@@ -336,6 +402,7 @@ describe("LodestarForkChoice", () => {
       forkChoice.onBlock(
         blockY.message,
         stateY,
+        blockDelaySec,
         blockDelaySec,
         blockY.message.slot,
         executionStatus,
@@ -377,6 +444,7 @@ describe("LodestarForkChoice", () => {
       forkChoice.onBlock(
         blockZ.message,
         stateZ,
+        blockDelaySec,
         blockDelaySec,
         blockZ.message.slot,
         executionStatus,

--- a/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenPayloadEnvelopeInput.test.ts
@@ -106,6 +106,7 @@ describe("SeenPayloadEnvelopeInput", () => {
       unrealizedFinalizedEpoch: 0,
       unrealizedFinalizedRoot: blockRoot,
       timeliness: false,
+      importedTimely: false,
       ptcTimeliness: false,
       proposerIndex: 0,
       executionPayloadBlockHash: null,

--- a/packages/beacon-node/test/utils/state.ts
+++ b/packages/beacon-node/test/utils/state.ts
@@ -169,6 +169,7 @@ export const zeroProtoBlock: ProtoBlock = {
   unrealizedFinalizedRoot: ZERO_HASH_HEX,
 
   timeliness: false,
+  importedTimely: false,
   ptcTimeliness: false,
   proposerIndex: 0,
 

--- a/packages/beacon-node/test/utils/typeGenerator.ts
+++ b/packages/beacon-node/test/utils/typeGenerator.ts
@@ -40,6 +40,7 @@ export function generateProtoBlock(overrides: Partial<ProtoBlock> = {}): ProtoBl
     unrealizedFinalizedRoot: ZERO_HASH_HEX,
 
     timeliness: false,
+    importedTimely: false,
     ptcTimeliness: false,
     proposerIndex: 0,
     payloadStatus: PayloadStatus.FULL,

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -76,6 +76,7 @@ export function getAttestationValidData(opts: AttestationValidDataOpts): {
     unrealizedFinalizedRoot: ZERO_HASH_HEX,
 
     timeliness: false,
+    importedTimely: false,
     ptcTimeliness: false,
     proposerIndex: 0,
 

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1757,6 +1757,7 @@ export class ForkChoice implements IForkChoice {
   /**
    * Return true if THIS node finished importing the block before the attestation cutoff, ie. the
    * block was imported in a timely manner for its own slot.
+   * This is not part of the spec, we use this to determine late canonical blocks.
    */
   protected isBlockImportedTimely(block: BeaconBlock, importDelaySec: number): boolean {
     const fork = this.config.getForkName(block.slot);

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -732,7 +732,8 @@ export class ForkChoice implements IForkChoice {
   onBlock(
     block: BeaconBlock,
     state: IBeaconStateView,
-    blockDelaySec: number,
+    receiveDelaySec: number,
+    importDelaySec: number,
     currentSlot: Slot,
     executionStatus: BlockExecutionStatus,
     dataAvailabilityStatus: DataAvailabilityStatus
@@ -804,7 +805,7 @@ export class ForkChoice implements IForkChoice {
     // Decide whether this block should receive proposer boost, and whether the block is timely.
     // The store field `this.proposerBoostRoot` and `updateCheckpoints()` are mutated only after
     // `protoArray.onBlock()` succeeds
-    const isTimely = this.isBlockTimely(block, blockDelaySec);
+    const isTimely = this.isBlockReceivedTimely(block, receiveDelaySec);
     const isProposerBoostBlock =
       this.opts?.proposerBoost === true &&
       isTimely &&
@@ -875,7 +876,8 @@ export class ForkChoice implements IForkChoice {
       targetRoot: toRootHex(targetRoot),
       stateRoot: toRootHex(block.stateRoot),
       timeliness: isTimely,
-      ptcTimeliness: this.isBlockPtcTimely(block, blockDelaySec),
+      ptcTimeliness: this.isBlockPtcTimely(block, receiveDelaySec),
+      importedTimely: this.isBlockImportedTimely(block, importDelaySec),
       proposerIndex: block.proposerIndex,
 
       justifiedEpoch: stateJustifiedEpoch,
@@ -1731,7 +1733,7 @@ export class ForkChoice implements IForkChoice {
    * Return true if the block is timely for the current slot.
    * Child class can overwrite this for testing purpose.
    */
-  protected isBlockTimely(block: BeaconBlock, blockDelaySec: number): boolean {
+  protected isBlockReceivedTimely(block: BeaconBlock, blockDelaySec: number): boolean {
     const fork = this.config.getForkName(block.slot);
     const isBeforeLateBlockCutoff = blockDelaySec * 1000 < this.config.getAttestationDueMs(fork);
     return this.fcStore.currentSlot === block.slot && isBeforeLateBlockCutoff;
@@ -1750,6 +1752,16 @@ export class ForkChoice implements IForkChoice {
   protected isBlockPtcTimely(block: BeaconBlock, blockDelaySec: number): boolean {
     const ptcThresholdMs = this.config.getSlotComponentDurationMs(this.config.PAYLOAD_ATTESTATION_DUE_BPS);
     return this.fcStore.currentSlot === block.slot && blockDelaySec * 1000 < ptcThresholdMs;
+  }
+
+  /**
+   * Return true if THIS node finished importing the block before the attestation cutoff, ie. the
+   * block was imported in a timely manner for its own slot.
+   */
+  protected isBlockImportedTimely(block: BeaconBlock, importDelaySec: number): boolean {
+    const fork = this.config.getForkName(block.slot);
+    const isBeforeLateBlockCutoff = importDelaySec * 1000 < this.config.getAttestationDueMs(fork);
+    return this.fcStore.currentSlot === block.slot && isBeforeLateBlockCutoff;
   }
 
   /**

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -155,7 +155,8 @@ export interface IForkChoice {
   onBlock(
     block: BeaconBlock,
     state: IBeaconStateView,
-    blockDelaySec: number,
+    receiveDelaySec: number,
+    importDelaySec: number,
     currentSlot: Slot,
     executionStatus: BlockExecutionStatus,
     dataAvailabilityStatus: DataAvailabilityStatus

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -148,6 +148,9 @@ export type ProtoBlock = BlockExtraMeta & {
   // Spec: gloas/fork-choice.md#modified-record_block_timeliness (block_timeliness[PTC_TIMELINESS_INDEX])
   ptcTimeliness: boolean;
 
+  // Indicate whether THIS node finished importing the block before the attestation cutoff
+  importedTimely: boolean;
+
   // The index of the block proposer. Used by should_apply_proposer_boost to detect proposer equivocations
   proposerIndex: ValidatorIndex;
 

--- a/packages/fork-choice/test/perf/forkChoice/util.ts
+++ b/packages/fork-choice/test/perf/forkChoice/util.ts
@@ -162,6 +162,7 @@ export function initializeForkChoice(opts: Opts): ForkChoice {
       executionStatus: gloasBoosted ? ExecutionStatus.Valid : ExecutionStatus.PreMerge,
 
       timeliness: false,
+      importedTimely: false,
       ptcTimeliness: false,
       proposerIndex: 0,
       dataAvailabilityStatus: gloasBoosted ? DataAvailabilityStatus.Available : DataAvailabilityStatus.PreData,

--- a/packages/fork-choice/test/unit/forkChoice/fastConfirmationPause.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/fastConfirmationPause.test.ts
@@ -46,6 +46,7 @@ describe("fast confirmation pause/resume", () => {
         parentBlockHash: null,
         payloadStatus: PayloadStatus.FULL,
         timeliness: false,
+        importedTimely: false,
       } as Omit<ProtoBlock, "targetRoot">,
       genesisSlot
     );

--- a/packages/fork-choice/test/unit/forkChoice/fastConfirmationTestUtils.ts
+++ b/packages/fork-choice/test/unit/forkChoice/fastConfirmationTestUtils.ts
@@ -53,6 +53,7 @@ export function makeBlock(
     parentBlockHash: null,
     payloadStatus: PayloadStatus.FULL,
     timeliness: false,
+    importedTimely: false,
     ptcTimeliness: false,
     proposerIndex: 0,
   };

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -48,6 +48,7 @@ describe("Forkchoice", () => {
         parentBlockHash: null,
         payloadStatus: PayloadStatus.FULL,
         timeliness: false,
+        importedTimely: false,
         ptcTimeliness: false,
         proposerIndex: 0,
       } as Omit<ProtoBlock, "targetRoot">,
@@ -150,6 +151,7 @@ describe("Forkchoice", () => {
       executionStatus: ExecutionStatus.PreMerge,
 
       timeliness: false,
+      importedTimely: false,
       ptcTimeliness: false,
       proposerIndex: 0,
       dataAvailabilityStatus: DataAvailabilityStatus.PreData,

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -57,6 +57,7 @@ describe("Forkchoice / GetProposerHead", () => {
     executionStatus: ExecutionStatus.PreMerge,
 
     timeliness: false,
+    importedTimely: false,
     ptcTimeliness: false,
     proposerIndex: 0,
     dataAvailabilityStatus: DataAvailabilityStatus.PreData,
@@ -85,6 +86,7 @@ describe("Forkchoice / GetProposerHead", () => {
     executionStatus: ExecutionStatus.PreMerge,
 
     timeliness: false,
+    importedTimely: false,
     ptcTimeliness: false,
     proposerIndex: 0,
 
@@ -115,6 +117,7 @@ describe("Forkchoice / GetProposerHead", () => {
     executionStatus: ExecutionStatus.PreMerge,
 
     timeliness: false,
+    importedTimely: false,
     ptcTimeliness: false,
     proposerIndex: 0,
     weight: 212, // 240 - 29 + 1

--- a/packages/fork-choice/test/unit/forkChoice/proposerHeadTestUtils.ts
+++ b/packages/fork-choice/test/unit/forkChoice/proposerHeadTestUtils.ts
@@ -62,6 +62,7 @@ export function toProtoBlock(
     unrealizedFinalizedRoot: getBlockRoot(genesisSlot),
 
     timeliness: false,
+    importedTimely: false,
     ptcTimeliness: false,
     proposerIndex: 0,
 

--- a/packages/fork-choice/test/unit/forkChoice/safeBlocks.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/safeBlocks.test.ts
@@ -28,6 +28,7 @@ function buildBlock(opts: {
     unrealizedFinalizedEpoch: 0,
     unrealizedFinalizedRoot: "0x00",
     timeliness: true,
+    importedTimely: true,
     ptcTimeliness: false,
     proposerIndex: 0,
     payloadStatus: PayloadStatus.FULL,

--- a/packages/fork-choice/test/unit/forkChoice/shouldOverrideForkChoiceUpdate.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/shouldOverrideForkChoiceUpdate.test.ts
@@ -57,6 +57,7 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
     executionStatus: ExecutionStatus.PreMerge,
 
     timeliness: false,
+    importedTimely: false,
     ptcTimeliness: false,
     proposerIndex: 0,
     dataAvailabilityStatus: DataAvailabilityStatus.PreData,
@@ -85,6 +86,7 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
     executionStatus: ExecutionStatus.PreMerge,
 
     timeliness: false,
+    importedTimely: false,
     ptcTimeliness: false,
     proposerIndex: 0,
 
@@ -115,6 +117,7 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
     executionStatus: ExecutionStatus.PreMerge,
 
     timeliness: false,
+    importedTimely: false,
     ptcTimeliness: false,
     proposerIndex: 0,
     weight: 212, // 240 - 29 + 1

--- a/packages/fork-choice/test/unit/protoArray/attestationScore.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/attestationScore.test.ts
@@ -39,6 +39,7 @@ function toProtoBlock(slot: number, blockRoot: RootHex, parentRoot: RootHex): Pr
     unrealizedFinalizedRoot: "-",
 
     timeliness: false,
+    importedTimely: false,
     ptcTimeliness: false,
     proposerIndex: 0,
 

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -120,6 +120,7 @@ function setupForkChoice(): ProtoArray {
         unrealizedFinalizedRoot: "-",
 
         timeliness: false,
+        importedTimely: false,
         ptcTimeliness: false,
         proposerIndex: 0,
 

--- a/packages/fork-choice/test/unit/protoArray/getCommonAncestor.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/getCommonAncestor.test.ts
@@ -42,6 +42,7 @@ describe("getCommonAncestor", () => {
       unrealizedFinalizedRoot: "-",
 
       timeliness: false,
+      importedTimely: false,
       ptcTimeliness: false,
       proposerIndex: 0,
 
@@ -73,6 +74,7 @@ describe("getCommonAncestor", () => {
         unrealizedFinalizedRoot: "-",
 
         timeliness: false,
+        importedTimely: false,
         ptcTimeliness: false,
         proposerIndex: 0,
 

--- a/packages/fork-choice/test/unit/protoArray/getViableHeads.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/getViableHeads.test.ts
@@ -26,6 +26,7 @@ function blockFields(overrides: {
     unrealizedFinalizedRoot: "0",
 
     timeliness: false,
+    importedTimely: false,
     ptcTimeliness: false,
     proposerIndex: 0,
 

--- a/packages/fork-choice/test/unit/protoArray/gloas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/gloas.test.ts
@@ -49,6 +49,7 @@ describe("Gloas Fork Choice", () => {
       unrealizedFinalizedEpoch: genesisEpoch,
       unrealizedFinalizedRoot: genesisRoot,
       timeliness: true,
+      importedTimely: true,
       ptcTimeliness: true,
       proposerIndex: 0,
       executionPayloadBlockHash: blockRoot, // Use blockRoot as execution hash

--- a/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
@@ -31,6 +31,7 @@ describe("ProtoArray", () => {
         unrealizedFinalizedRoot: stateRoot,
 
         timeliness: false,
+        importedTimely: false,
         ptcTimeliness: false,
         proposerIndex: 0,
 
@@ -62,6 +63,7 @@ describe("ProtoArray", () => {
         unrealizedFinalizedRoot: stateRoot,
 
         timeliness: false,
+        importedTimely: false,
         ptcTimeliness: false,
         proposerIndex: 0,
 
@@ -94,6 +96,7 @@ describe("ProtoArray", () => {
         unrealizedFinalizedRoot: stateRoot,
 
         timeliness: false,
+        importedTimely: false,
         ptcTimeliness: false,
         proposerIndex: 0,
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -12145,7 +12145,7 @@
 - name: record_block_timeliness#gloas
   sources:
     - file: packages/fork-choice/src/forkChoice/forkChoice.ts
-      search: '^\s+protected isBlockTimely\('
+      search: '^\s+protected isBlockReceivedTimely\('
       regex: true
     - file: packages/fork-choice/src/forkChoice/forkChoice.ts
       search: '^\s+protected isBlockPtcTimely\('


### PR DESCRIPTION
**Motivation**

- we tracked late head blocks but that could be the network situation
- we want to track late imported canonical blocks, ie others voted for those but not this node. This metric is so important that I want to track on lodestar dashboard later
- log late imported canonical blocks to investigate case by case

**Description**

- when import block, track the time and pass to forkchoice
- new `importedTimely` flag in ProtoBlock
- track false `importedTimely` canonical flag when archiving blocks

part of #9942

**AI Assistance Disclosure**

- created with the help of Claude