### PR TITLE
fix: minor improvement on ptc message gossip validation

### DIFF
--- a/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
+++ b/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
@@ -7,7 +7,6 @@ import {RootHex, gloas, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {GossipAction, PayloadAttestationError, PayloadAttestationErrorCode} from "../errors/index.js";
 import {IBeaconChain} from "../index.js";
-import {RegenCaller} from "../regen/index.js";
 
 export type PayloadAttestationValidationResult = {
   attDataRootHex: RootHex;
@@ -82,15 +81,18 @@ async function validatePayloadAttestationMessage(
   // TODO GLOAS: implement this. Technically if we cannot get proto block from fork choice,
   // it is possible that the block didn't pass the validation
 
-  // Use the referenced block's branch state for the PTC committee check
-  const state = await chain.regen
-    .getBlockSlotState(block, data.slot, {dontTransferCache: true}, RegenCaller.validateGossipPayloadAttestationMessage)
-    .catch(() => {
-      throw new PayloadAttestationError(GossipAction.IGNORE, {
-        code: PayloadAttestationErrorCode.UNKNOWN_BLOCK_ROOT,
-        blockRoot: toRootHex(data.beaconBlockRoot),
-      });
+  // Use the referenced block's branch state for the PTC committee check.
+  // block.slot === data.slot is enforced above, so the block's post-state (cached by state root
+  // at import) is exactly the block state
+  const state = chain.regen.getStateSync(block.stateRoot);
+  if (state == null) {
+    // Block state not in cache — same "cannot validate now" case the regen path handled by
+    // rejecting. Skip the expensive replay-regen a fallback would trigger and just ignore.
+    throw new PayloadAttestationError(GossipAction.IGNORE, {
+      code: PayloadAttestationErrorCode.UNKNOWN_BLOCK_ROOT,
+      blockRoot: toRootHex(data.beaconBlockRoot),
     });
+  }
 
   if (!isStatePostGloas(state)) {
     throw new Error(`Expected gloas+ state for payload attestation validation, got fork=${state.forkName}`);

--- a/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
+++ b/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
@@ -81,13 +81,10 @@ async function validatePayloadAttestationMessage(
   // TODO GLOAS: implement this. Technically if we cannot get proto block from fork choice,
   // it is possible that the block didn't pass the validation
 
-  // Use the referenced block's branch state for the PTC committee check.
-  // block.slot === data.slot is enforced above, so the block's post-state (cached by state root
-  // at import) is exactly the block state
+  // block.slot === data.slot is enforced above, so use the block's post-state directly to avoid
+  // getting through regen queue
   const state = chain.regen.getStateSync(block.stateRoot);
   if (state == null) {
-    // Block state not in cache — same "cannot validate now" case the regen path handled by
-    // rejecting. Skip the expensive replay-regen a fallback would trigger and just ignore.
     throw new PayloadAttestationError(GossipAction.IGNORE, {
       code: PayloadAttestationErrorCode.UNKNOWN_BLOCK_ROOT,
       blockRoot: toRootHex(data.beaconBlockRoot),

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1268,13 +1268,8 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       const delaySec = chain.clock.secFromSlot(payloadAttestationMessage.data.slot, seenTimestampSec);
       metrics?.gossipPayloadAttestationMessage.elapsedTimeTillReceived.observe({source: OpSource.gossip}, delaySec);
 
-      let isNextSlotProposer = true;
-      try {
-        const nextSlotProposer = chain.getHeadState().getBeaconProposer(payloadAttestationMessage.data.slot + 1);
-        isNextSlotProposer = chain.beaconProposerCache.get(nextSlotProposer) !== undefined;
-      } catch (_e) {
-        // getBeaconProposer out of lookahead etc. — keep the permissive default
-      }
+      const nextSlotProposer = chain.getHeadState().getBeaconProposer(payloadAttestationMessage.data.slot + 1);
+      const isNextSlotProposer = chain.beaconProposerCache.get(nextSlotProposer) !== undefined;
 
       if (isNextSlotProposer) {
         try {
@@ -1285,7 +1280,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
           );
           metrics?.opPool.payloadAttestationPool.gossipInsertOutcome.inc({insertOutcome});
         } catch (e) {
-          logger.error("Error adding to payloadAttestation pool", {}, e as Error);
+          logger.debug("Error adding to payloadAttestation pool", {}, e as Error);
         }
       }
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1268,16 +1268,27 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       const delaySec = chain.clock.secFromSlot(payloadAttestationMessage.data.slot, seenTimestampSec);
       metrics?.gossipPayloadAttestationMessage.elapsedTimeTillReceived.observe({source: OpSource.gossip}, delaySec);
 
+      let isNextSlotProposer = true;
       try {
-        const insertOutcome = chain.payloadAttestationPool.add(
-          payloadAttestationMessage,
-          validationResult.attDataRootHex,
-          validationResult.validatorCommitteeIndices
-        );
-        metrics?.opPool.payloadAttestationPool.gossipInsertOutcome.inc({insertOutcome});
-      } catch (e) {
-        logger.error("Error adding to payloadAttestation pool", {}, e as Error);
+        const nextSlotProposer = chain.getHeadState().getBeaconProposer(payloadAttestationMessage.data.slot + 1);
+        isNextSlotProposer = chain.beaconProposerCache.get(nextSlotProposer) !== undefined;
+      } catch (_e) {
+        // getBeaconProposer out of lookahead etc. — keep the permissive default
       }
+
+      if (isNextSlotProposer) {
+        try {
+          const insertOutcome = chain.payloadAttestationPool.add(
+            payloadAttestationMessage,
+            validationResult.attDataRootHex,
+            validationResult.validatorCommitteeIndices
+          );
+          metrics?.opPool.payloadAttestationPool.gossipInsertOutcome.inc({insertOutcome});
+        } catch (e) {
+          logger.error("Error adding to payloadAttestation pool", {}, e as Error);
+        }
+      }
+
       chain.forkChoice.notifyPtcMessages(
         toRootHex(payloadAttestationMessage.data.beaconBlockRoot),
         payloadAttestationMessage.data.slot,


### PR DESCRIPTION
**Motivation**

- minor improvement on ptc gossip validation job time

**Description**

- use `getStateSync()` to avoid having to going through regen queue
- only add ptc message to pool if we're next slot proposer, it could take up to ~5ms, see https://github.com/ChainSafe/lodestar/issues/9960#issuecomment-5494208232

Closes #9960

**AI Assistance Disclosure**

- created with the help of Claude
