### PR TITLE
feat(builder): payload store

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -9,6 +9,7 @@ import {Metrics} from "./metrics.js";
 import {logNodeVersion, waitForNodeReady} from "./readiness.js";
 import {BuilderSigner, Keypair} from "./services/builderSigner.js";
 import {BuilderStatusTracker} from "./services/builderStatusTracker.js";
+import {PayloadStore} from "./services/payloadStore.js";
 
 export type BuilderModules = {
   opts: BuilderOptions;
@@ -16,6 +17,7 @@ export type BuilderModules = {
   builderStatusTracker: BuilderStatusTracker;
   clock: IClock;
   index: BuilderIndex;
+  store: PayloadStore;
 };
 
 export type BuilderOptions = {
@@ -40,17 +42,20 @@ export class Builder {
   private readonly index: BuilderIndex;
   private readonly logger: Logger;
   private readonly executionFeeRecipient: ExecutionAddress;
+  private readonly store: PayloadStore;
 
-  constructor({opts, builderSigner, builderStatusTracker, clock, index}: BuilderModules) {
+  constructor({opts, builderSigner, builderStatusTracker, clock, index, store}: BuilderModules) {
     this.builderSigner = builderSigner;
     this.builderStatusTracker = builderStatusTracker;
     this.clock = clock;
     this.controller = opts.abortController;
     this.logger = opts.logger;
     this.index = index;
+    this.store = store;
 
     this.executionFeeRecipient = opts.executionFeeRecipient;
 
+    this.clock.runEverySlot(async (slot) => this.onSlot(slot));
     this.clock.runEveryEpoch((epoch) => this.builderStatusTracker.poll(epoch));
     this.clock.start(this.controller.signal);
 
@@ -90,7 +95,13 @@ export class Builder {
 
     const builderStatusTracker = new BuilderStatusTracker(api, logger, index, opts.metrics);
 
-    return new Builder({opts, builderSigner, builderStatusTracker, clock, index});
+    const store = new PayloadStore();
+
+    return new Builder({opts, builderSigner, builderStatusTracker, clock, index, store});
+  }
+
+  private async onSlot(slot: number): Promise<void> {
+    this.store.prune(slot);
   }
 
   async close(): Promise<void> {

--- a/packages/builder/src/services/payloadStore.ts
+++ b/packages/builder/src/services/payloadStore.ts
@@ -1,0 +1,51 @@
+import {ForkPostGloas} from "@lodestar/params";
+import {BlobsBundle, ExecutionPayload, Root, RootHex, Slot, gloas} from "@lodestar/types";
+
+// NOTE: BuiltPayload will migrate to payloadSource.ts when the payload source lands; the store
+// holds it here for now.
+export type BuiltPayload = {
+  sourceId: string;
+  executionPayload: ExecutionPayload<ForkPostGloas>;
+  executionRequests: gloas.ExecutionRequests;
+  blobsBundle: BlobsBundle<ForkPostGloas>;
+  /** Value of the payload to the fee recipient in wei, as reported by the execution client */
+  executionPayloadValue: bigint;
+};
+
+export type StoredPayload = {
+  slot: Slot;
+  parentBlockRoot: Root;
+  blockHash: RootHex;
+  payload: BuiltPayload;
+};
+
+/** Keep payloads for this many slots after their target slot, late blocks may still commit to them */
+const KEEP_SLOTS = 2;
+
+export class PayloadStore {
+  private readonly byBlockHash = new Map<RootHex, StoredPayload>();
+
+  add(payload: StoredPayload): void {
+    this.byBlockHash.set(payload.blockHash, payload);
+  }
+
+  get(blockHash: RootHex): StoredPayload | null {
+    return this.byBlockHash.get(blockHash) ?? null;
+  }
+
+  has(blockHash: RootHex): boolean {
+    return this.byBlockHash.has(blockHash);
+  }
+
+  prune(currentSlot: Slot): void {
+    for (const [blockHash, {slot}] of this.byBlockHash) {
+      if (slot + KEEP_SLOTS < currentSlot) {
+        this.byBlockHash.delete(blockHash);
+      }
+    }
+  }
+
+  get size(): number {
+    return this.byBlockHash.size;
+  }
+}

--- a/packages/builder/test/unit/services/payloadStore.test.ts
+++ b/packages/builder/test/unit/services/payloadStore.test.ts
@@ -1,0 +1,19 @@
+import {describe, expect, it} from "vitest";
+import {PayloadStore} from "../../../src/services/payloadStore.js";
+import {mockBuiltPayload} from "../utils/payload.js";
+
+describe("PayloadStore", () => {
+  const blockHash = "0x" + "cc".repeat(32);
+
+  it("stores and prunes payloads by slot", () => {
+    const store = new PayloadStore();
+    store.add({slot: 5, parentBlockRoot: Buffer.alloc(32), blockHash, payload: mockBuiltPayload()});
+    expect(store.has(blockHash)).toBe(true);
+    expect(store.get(blockHash)?.slot).toEqual(5);
+    store.prune(7);
+    expect(store.has(blockHash)).toBe(true);
+    store.prune(8);
+    expect(store.has(blockHash)).toBe(false);
+    expect(store.get(blockHash)).toBeNull();
+  });
+});

--- a/packages/builder/test/unit/services/payloadStore.test.ts
+++ b/packages/builder/test/unit/services/payloadStore.test.ts
@@ -5,6 +5,15 @@ import {mockBuiltPayload} from "../utils/payload.js";
 describe("PayloadStore", () => {
   const blockHash = "0x" + "cc".repeat(32);
 
+  it("returns no payload for an unknown hash and can prune an empty store", () => {
+    const store = new PayloadStore();
+
+    expect(store.get(blockHash)).toBeNull();
+    expect(store.has(blockHash)).toBe(false);
+    store.prune(8);
+    expect(store.size).toBe(0);
+  });
+
   it("stores and prunes payloads by slot", () => {
     const store = new PayloadStore();
     store.add({slot: 5, parentBlockRoot: Buffer.alloc(32), blockHash, payload: mockBuiltPayload()});
@@ -15,5 +24,53 @@ describe("PayloadStore", () => {
     store.prune(8);
     expect(store.has(blockHash)).toBe(false);
     expect(store.get(blockHash)).toBeNull();
+  });
+
+  it("does not increase the size when the same payload is added twice", () => {
+    const store = new PayloadStore();
+    const stored = {slot: 5, parentBlockRoot: Buffer.alloc(32), blockHash, payload: mockBuiltPayload({slot: 5})};
+
+    store.add(stored);
+    store.add(stored);
+
+    expect(store.size).toBe(1);
+    expect(store.get(blockHash)).toEqual(stored);
+  });
+
+  it("prunes expired payloads regardless of insertion order and keeps all retained hashes", () => {
+    const store = new PayloadStore();
+    const records = [8, 5, 6, 8].map((slot, index) => {
+      const hash = Buffer.alloc(32, index + 1);
+      return {
+        slot,
+        parentBlockRoot: Buffer.alloc(32, index + 5),
+        blockHash: "0x" + hash.toString("hex"),
+        payload: mockBuiltPayload({slot, blockHash: hash}),
+      };
+    });
+    for (const record of records) store.add(record);
+    expect(store.size).toBe(4);
+
+    store.prune(8);
+    store.prune(8);
+    expect(store.size).toBe(3);
+    for (const record of records) {
+      const retained = record.slot >= 6;
+      expect(store.has(record.blockHash), `membership for slot ${record.slot}`).toBe(retained);
+      expect(store.get(record.blockHash), `payload for hash ${record.blockHash}`).toEqual(retained ? record : null);
+    }
+
+    store.prune(9);
+    expect(store.size).toBe(2);
+    expect(store.has(records[2].blockHash)).toBe(false);
+    for (const record of [records[0], records[3]]) {
+      expect(store.get(record.blockHash), `retained slot-8 hash ${record.blockHash}`).toEqual(record);
+    }
+
+    store.prune(11);
+    expect(store.size).toBe(0);
+    for (const record of records) {
+      expect(store.get(record.blockHash), `expired hash ${record.blockHash}`).toBeNull();
+    }
   });
 });

--- a/packages/builder/test/unit/utils/payload.ts
+++ b/packages/builder/test/unit/utils/payload.ts
@@ -1,0 +1,36 @@
+import {Slot, ssz} from "@lodestar/types";
+import {BuiltPayload} from "../../../src/services/payloadStore.js";
+
+export const GWEI_TO_WEI = 1_000_000_000n;
+
+export function mockBuiltPayload({
+  sourceId = "el",
+  slot = 1,
+  parentHash = Buffer.alloc(32, 1),
+  blockHash = Buffer.alloc(32, 2),
+  prevRandao = Buffer.alloc(32, 3),
+  valueGwei = 1_000_000_000,
+  gasLimit = 30_000_000,
+}: {
+  sourceId?: string;
+  slot?: Slot;
+  parentHash?: Uint8Array;
+  blockHash?: Uint8Array;
+  prevRandao?: Uint8Array;
+  valueGwei?: number;
+  gasLimit?: number;
+} = {}): BuiltPayload {
+  const executionPayload = ssz.gloas.ExecutionPayload.defaultValue();
+  executionPayload.parentHash = parentHash;
+  executionPayload.blockHash = blockHash;
+  executionPayload.prevRandao = prevRandao;
+  executionPayload.gasLimit = gasLimit;
+  executionPayload.slotNumber = slot;
+  return {
+    sourceId,
+    executionPayload,
+    executionRequests: ssz.gloas.ExecutionRequests.defaultValue(),
+    blobsBundle: ssz.fulu.BlobsBundle.defaultValue(),
+    executionPayloadValue: BigInt(valueGwei) * GWEI_TO_WEI,
+  };
+}


### PR DESCRIPTION
**Motivation**

Add a simple payload store class and wire it into the builder.

**Description**

Contains:
- Basic payload store (`add`, `get`, `has`, `prune`, `size`)
- Builder wiring
- Test with mock payload util

Payload store is pruned on a per-slot basis.
This is a pre-requisite for retrieving payloads.
