### PR TITLE
feat(builder): bid policy

### DIFF
--- a/packages/builder/src/services/bidPolicy.ts
+++ b/packages/builder/src/services/bidPolicy.ts
@@ -1,0 +1,57 @@
+export type BidContext = {
+  /** Value of the payload to the builder's fee recipient, as reported by the execution client */
+  payloadValueGwei: number;
+  /** Builder balance that can back a bid, excess over the minimum and unsettled payments */
+  coverableGwei: number;
+};
+
+/** Decides how much to pay the proposer for a payload, null means do not bid */
+export interface BidPolicy {
+  computeValue(ctx: BidContext): number | null;
+}
+
+export type ProportionalBidPolicyOpts = {
+  /** Share of the payload value offered to the proposer, in basis points */
+  shareBps: number;
+  /** Fixed amount deducted from the share, e.g. to cover operating cost */
+  fixedCostGwei: number;
+  /** Never bid below this value */
+  minValueGwei: number;
+  /** Never bid above this value */
+  maxValueGwei?: number;
+};
+
+/**
+ * Offers a fixed share of the payload value, bounded by the configured limits and the
+ * builder's coverable balance. Independent of competing bids.
+ */
+export class ProportionalBidPolicy implements BidPolicy {
+  constructor(private readonly opts: ProportionalBidPolicyOpts) {
+    if (opts.shareBps < 0 || opts.shareBps > 10_000) {
+      throw Error(`Invalid shareBps=${opts.shareBps}, must be within [0, 10000]`);
+    }
+
+    if (opts.minValueGwei < 0) {
+      throw Error(`Invalid minValueGwei=${opts.minValueGwei}, must be a positive number`);
+    }
+
+    if (opts.maxValueGwei !== undefined && opts.maxValueGwei < opts.minValueGwei) {
+      throw Error(
+        `Invalid maxValueGwei=${opts.maxValueGwei}, must be greater than or equal to minValueGwei=${opts.minValueGwei}`
+      );
+    }
+  }
+
+  computeValue({payloadValueGwei, coverableGwei}: BidContext): number | null {
+    const share = Math.floor((payloadValueGwei * this.opts.shareBps) / 10_000) - this.opts.fixedCostGwei;
+    // This will override `fixedCostGwei` for the sake of fulfilling `minValueGwei`
+    let value = Math.max(this.opts.minValueGwei, share);
+    if (this.opts.maxValueGwei !== undefined) {
+      value = Math.min(value, this.opts.maxValueGwei);
+    }
+    if (value > coverableGwei) {
+      return null;
+    }
+    return value;
+  }
+}

--- a/packages/builder/src/services/bidPolicy.ts
+++ b/packages/builder/src/services/bidPolicy.ts
@@ -27,8 +27,8 @@ export type ProportionalBidPolicyOpts = {
  */
 export class ProportionalBidPolicy implements BidPolicy {
   constructor(private readonly opts: ProportionalBidPolicyOpts) {
-    if (opts.shareBps < 0 || opts.shareBps > 10_000) {
-      throw Error(`Invalid shareBps=${opts.shareBps}, must be within [0, 10000]`);
+    if (!Number.isSafeInteger(opts.shareBps) || opts.shareBps < 0 || opts.shareBps > 10_000) {
+      throw Error(`Invalid shareBps=${opts.shareBps}, must be an integer within [0, 10000]`);
     }
 
     if (opts.minValueGwei < 0) {

--- a/packages/builder/src/services/bidPolicy.ts
+++ b/packages/builder/src/services/bidPolicy.ts
@@ -31,13 +31,20 @@ export class ProportionalBidPolicy implements BidPolicy {
       throw Error(`Invalid shareBps=${opts.shareBps}, must be an integer within [0, 10000]`);
     }
 
-    if (opts.minValueGwei < 0) {
-      throw Error(`Invalid minValueGwei=${opts.minValueGwei}, must be a positive number`);
+    if (!Number.isSafeInteger(opts.fixedCostGwei) || opts.fixedCostGwei < 0) {
+      throw Error(`Invalid fixedCostGwei=${opts.fixedCostGwei}, must be a nonnegative safe integer`);
     }
 
-    if (opts.maxValueGwei !== undefined && opts.maxValueGwei < opts.minValueGwei) {
+    if (!Number.isSafeInteger(opts.minValueGwei) || opts.minValueGwei < 0) {
+      throw Error(`Invalid minValueGwei=${opts.minValueGwei}, must be a nonnegative safe integer`);
+    }
+
+    if (
+      opts.maxValueGwei !== undefined &&
+      (!Number.isSafeInteger(opts.maxValueGwei) || opts.maxValueGwei < opts.minValueGwei)
+    ) {
       throw Error(
-        `Invalid maxValueGwei=${opts.maxValueGwei}, must be greater than or equal to minValueGwei=${opts.minValueGwei}`
+        `Invalid maxValueGwei=${opts.maxValueGwei}, must be a safe integer greater than or equal to minValueGwei=${opts.minValueGwei}`
       );
     }
   }

--- a/packages/builder/src/services/bidPolicy.ts
+++ b/packages/builder/src/services/bidPolicy.ts
@@ -32,11 +32,11 @@ export class ProportionalBidPolicy implements BidPolicy {
     }
 
     if (!Number.isSafeInteger(opts.fixedCostGwei) || opts.fixedCostGwei < 0) {
-      throw Error(`Invalid fixedCostGwei=${opts.fixedCostGwei}, must be a nonnegative safe integer`);
+      throw Error(`Invalid fixedCostGwei=${opts.fixedCostGwei}, must be a non-negative safe integer`);
     }
 
     if (!Number.isSafeInteger(opts.minValueGwei) || opts.minValueGwei < 0) {
-      throw Error(`Invalid minValueGwei=${opts.minValueGwei}, must be a nonnegative safe integer`);
+      throw Error(`Invalid minValueGwei=${opts.minValueGwei}, must be a non-negative safe integer`);
     }
 
     if (

--- a/packages/builder/src/services/bidPolicy.ts
+++ b/packages/builder/src/services/bidPolicy.ts
@@ -43,7 +43,8 @@ export class ProportionalBidPolicy implements BidPolicy {
   }
 
   computeValue({payloadValueGwei, coverableGwei}: BidContext): number | null {
-    const share = Math.floor((payloadValueGwei * this.opts.shareBps) / 10_000) - this.opts.fixedCostGwei;
+    const proportionalValue = Number((BigInt(payloadValueGwei) * BigInt(this.opts.shareBps)) / 10_000n);
+    const share = proportionalValue - this.opts.fixedCostGwei;
     // This will override `fixedCostGwei` for the sake of fulfilling `minValueGwei`
     let value = Math.max(this.opts.minValueGwei, share);
     if (this.opts.maxValueGwei !== undefined) {

--- a/packages/builder/test/unit/services/bidPolicy.test.ts
+++ b/packages/builder/test/unit/services/bidPolicy.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from "vitest";
+import {ProportionalBidPolicy} from "../../../src/services/bidPolicy.js";
+
+describe("ProportionalBidPolicy", () => {
+  it("offers a share of the payload value", () => {
+    const policy = new ProportionalBidPolicy({shareBps: 9000, fixedCostGwei: 0, minValueGwei: 0});
+    expect(policy.computeValue({payloadValueGwei: 1_000_000, coverableGwei: 10_000_000})).toEqual(900_000);
+  });
+
+  it("deducts the fixed cost", () => {
+    const policy = new ProportionalBidPolicy({shareBps: 10_000, fixedCostGwei: 100, minValueGwei: 0});
+    expect(policy.computeValue({payloadValueGwei: 1_000, coverableGwei: 10_000})).toEqual(900);
+  });
+
+  it("never bids below the minimum value", () => {
+    const policy = new ProportionalBidPolicy({shareBps: 5000, fixedCostGwei: 0, minValueGwei: 800});
+    expect(policy.computeValue({payloadValueGwei: 1_000, coverableGwei: 10_000})).toEqual(800);
+  });
+
+  it("never bids below zero", () => {
+    const policy = new ProportionalBidPolicy({shareBps: 5000, fixedCostGwei: 1_000, minValueGwei: 0});
+    expect(policy.computeValue({payloadValueGwei: 100, coverableGwei: 10_000})).toEqual(0);
+  });
+
+  it("caps at the maximum value", () => {
+    const policy = new ProportionalBidPolicy({shareBps: 10_000, fixedCostGwei: 0, minValueGwei: 0, maxValueGwei: 500});
+    expect(policy.computeValue({payloadValueGwei: 1_000, coverableGwei: 10_000})).toEqual(500);
+  });
+
+  it("declines if the builder cannot cover the value", () => {
+    const policy = new ProportionalBidPolicy({shareBps: 10_000, fixedCostGwei: 0, minValueGwei: 0});
+    expect(policy.computeValue({payloadValueGwei: 1_000, coverableGwei: 999})).toBeNull();
+  });
+
+  it("rejects an invalid share", () => {
+    expect(() => new ProportionalBidPolicy({shareBps: 10_001, fixedCostGwei: 0, minValueGwei: 0})).toThrow();
+  });
+
+  it("rejects an invalid min and max configuration", () => {
+    expect(
+      () => new ProportionalBidPolicy({shareBps: 10_000, fixedCostGwei: 0, minValueGwei: 1, maxValueGwei: 0})
+    ).toThrow();
+  });
+});

--- a/packages/builder/test/unit/services/bidPolicy.test.ts
+++ b/packages/builder/test/unit/services/bidPolicy.test.ts
@@ -53,4 +53,8 @@ describe("ProportionalBidPolicy", () => {
     const policy = new ProportionalBidPolicy({shareBps: 3333, fixedCostGwei: 2, minValueGwei: 0});
     expect(policy.computeValue({payloadValueGwei: 10, coverableGwei: 100})).toBe(1);
   });
+
+  it("rejects a non-integer shareBps value", () => {
+    expect(() => new ProportionalBidPolicy({shareBps: 12.5, fixedCostGwei: 2, minValueGwei: 0})).toThrow();
+  });
 });

--- a/packages/builder/test/unit/services/bidPolicy.test.ts
+++ b/packages/builder/test/unit/services/bidPolicy.test.ts
@@ -42,6 +42,20 @@ describe("ProportionalBidPolicy", () => {
     ).toThrow();
   });
 
+  describe.each(["fixedCostGwei", "minValueGwei", "maxValueGwei"] as const)("%s validation", (option) => {
+    it.each([-1, 0.5, NaN, Infinity, -Infinity, Number.MAX_SAFE_INTEGER + 1])("rejects %s", (value) => {
+      expect(
+        () => new ProportionalBidPolicy({shareBps: 10_000, fixedCostGwei: 0, minValueGwei: 0, [option]: value})
+      ).toThrow(`Invalid ${option}=`);
+    });
+
+    it.each([0, Number.MAX_SAFE_INTEGER])("accepts %s", (value) => {
+      expect(
+        () => new ProportionalBidPolicy({shareBps: 10_000, fixedCostGwei: 0, minValueGwei: 0, [option]: value})
+      ).not.toThrow();
+    });
+  });
+
   it("computes a full-value bid without unsafe intermediate arithmetic", () => {
     const policy = new ProportionalBidPolicy({shareBps: 10_000, fixedCostGwei: 0, minValueGwei: 0});
     expect(

--- a/packages/builder/test/unit/services/bidPolicy.test.ts
+++ b/packages/builder/test/unit/services/bidPolicy.test.ts
@@ -41,4 +41,16 @@ describe("ProportionalBidPolicy", () => {
       () => new ProportionalBidPolicy({shareBps: 10_000, fixedCostGwei: 0, minValueGwei: 1, maxValueGwei: 0})
     ).toThrow();
   });
+
+  it("computes a full-value bid without unsafe intermediate arithmetic", () => {
+    const policy = new ProportionalBidPolicy({shareBps: 10_000, fixedCostGwei: 0, minValueGwei: 0});
+    expect(
+      policy.computeValue({payloadValueGwei: Number.MAX_SAFE_INTEGER, coverableGwei: Number.MAX_SAFE_INTEGER})
+    ).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("rounds a proportional value down before deducting the fixed cost", () => {
+    const policy = new ProportionalBidPolicy({shareBps: 3333, fixedCostGwei: 2, minValueGwei: 0});
+    expect(policy.computeValue({payloadValueGwei: 10, coverableGwei: 100})).toBe(1);
+  });
 });


### PR DESCRIPTION
**Description**

- Basic bid policy, which determines how much to pay the proposer.
- `BidPolicy` serves as an interface for pluggable custom bidding policies, `ProportionalBidPolicy` is a default implementation using a configurable share formula.
- Core is present inside the compute value function, which takes in `payloadValueGwei` and `coverableGwei` from `BidContext`. The function returns the value for proposer payment.
- Returning `null` means we shouldn't bid, currently only when the bid is not coverable / there aren't sufficient funds.
- Not wired in.
