### PR TITLE
feat(builder): publish execution payload bids

### DIFF
--- a/packages/builder/src/services/bidLedger.ts
+++ b/packages/builder/src/services/bidLedger.ts
@@ -23,6 +23,7 @@ type RevealedPayload = {
 
 type MutableBidLedgerRecord = SubmittedBid & {
   wonBlockRoots: Set<RootHex>;
+  paymentSettled: boolean;
 };
 
 export enum BidLedgerErrorCode {
@@ -56,8 +57,8 @@ export type BidLedgerErrorType =
 
 export class BidLedgerError extends LodestarError<BidLedgerErrorType> {}
 
-const UNSETTLED_EPOCHS = 2;
-const KEEP_SLOTS = (UNSETTLED_EPOCHS + 1) * SLOTS_PER_EPOCH;
+const RECORD_RETENTION_EPOCHS = 3;
+const KEEP_SLOTS = RECORD_RETENTION_EPOCHS * SLOTS_PER_EPOCH;
 
 /** Tracks one-shot bids and reveal obligations without owning signing, publication, or persistence. */
 export class BidLedger {
@@ -95,7 +96,7 @@ export class BidLedger {
       );
     }
 
-    const record = {...bid, wonBlockRoots: new Set<RootHex>()};
+    const record = {...bid, wonBlockRoots: new Set<RootHex>(), paymentSettled: false};
     bidsForSlot.set(key, record);
     return toRecord(record);
   }
@@ -107,6 +108,17 @@ export class BidLedger {
     }
 
     record.wonBlockRoots.add(blockRoot);
+    return toRecord(record);
+  }
+
+  /** Release a winning bid liability only after its payment is known to be reflected in Builder balance. */
+  recordPaymentSettled(identity: BidIdentity): BidLedgerRecord | null {
+    const record = this.getBid(identity.slot, identity.parentBlockHash, identity.parentBlockRoot);
+    if (record === null || record.blockHash !== identity.blockHash || record.wonBlockRoots.size === 0) {
+      return null;
+    }
+
+    record.paymentSettled = true;
     return toRecord(record);
   }
 
@@ -141,13 +153,9 @@ export class BidLedger {
 
   getUnsettledValueGwei(currentEpoch: Epoch): number {
     let total = 0;
-    for (const [slot, bidsForSlot] of this.bidsBySlot) {
-      if (Math.floor(slot / SLOTS_PER_EPOCH) < currentEpoch - UNSETTLED_EPOCHS) {
-        continue;
-      }
-
+    for (const bidsForSlot of this.bidsBySlot.values()) {
       for (const record of bidsForSlot.values()) {
-        if (record.wonBlockRoots.size === 0) {
+        if (record.wonBlockRoots.size === 0 || record.paymentSettled) {
           continue;
         }
 
@@ -174,8 +182,15 @@ export class BidLedger {
         continue;
       }
 
-      removed += bidsForSlot.size;
-      this.bidsBySlot.delete(slot);
+      for (const [key, record] of bidsForSlot) {
+        if (record.wonBlockRoots.size === 0 || record.paymentSettled) {
+          bidsForSlot.delete(key);
+          removed++;
+        }
+      }
+      if (bidsForSlot.size === 0) {
+        this.bidsBySlot.delete(slot);
+      }
     }
 
     for (const [blockRoot, revealedPayload] of this.revealedPayloadByBlockRoot) {
@@ -196,5 +211,12 @@ function tupleKey(parentBlockHash: RootHex, parentBlockRoot: RootHex): string {
 }
 
 function toRecord(record: MutableBidLedgerRecord): BidLedgerRecord {
-  return {...record, wonBlockRoots: Array.from(record.wonBlockRoots)};
+  return {
+    slot: record.slot,
+    parentBlockHash: record.parentBlockHash,
+    parentBlockRoot: record.parentBlockRoot,
+    blockHash: record.blockHash,
+    valueGwei: record.valueGwei,
+    wonBlockRoots: Array.from(record.wonBlockRoots),
+  };
 }

--- a/packages/builder/src/services/bidLedger.ts
+++ b/packages/builder/src/services/bidLedger.ts
@@ -1,0 +1,197 @@
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import type {Epoch, RootHex, Slot} from "@lodestar/types";
+import {LodestarError} from "@lodestar/utils";
+
+export type SubmittedBid = {
+  slot: Slot;
+  parentBlockHash: RootHex;
+  parentBlockRoot: RootHex;
+  blockHash: RootHex;
+  valueGwei: number;
+};
+
+export type BidIdentity = Pick<SubmittedBid, "slot" | "parentBlockHash" | "parentBlockRoot" | "blockHash">;
+
+export type BidLedgerRecord = SubmittedBid & {
+  wonBlockRoots: RootHex[];
+};
+
+type RevealedPayload = {
+  slot: Slot;
+  blockHash: RootHex;
+};
+
+type MutableBidLedgerRecord = SubmittedBid & {
+  wonBlockRoots: Set<RootHex>;
+};
+
+export enum BidLedgerErrorCode {
+  INVALID_BID_VALUE = "BID_LEDGER_ERROR_INVALID_BID_VALUE",
+  DUPLICATE_BID = "BID_LEDGER_ERROR_DUPLICATE_BID",
+  REVEAL_CONFLICT = "BID_LEDGER_ERROR_REVEAL_CONFLICT",
+  UNSETTLED_VALUE_OVERFLOW = "BID_LEDGER_ERROR_UNSETTLED_VALUE_OVERFLOW",
+}
+
+export type BidLedgerErrorType =
+  | {
+      code: BidLedgerErrorCode.INVALID_BID_VALUE;
+      valueGwei: number;
+    }
+  | {
+      code: BidLedgerErrorCode.DUPLICATE_BID;
+      slot: Slot;
+      parentBlockHash: RootHex;
+      parentBlockRoot: RootHex;
+    }
+  | {
+      code: BidLedgerErrorCode.REVEAL_CONFLICT;
+      blockRoot: RootHex;
+      blockHash: RootHex;
+      revealedBlockHash: RootHex;
+    }
+  | {
+      code: BidLedgerErrorCode.UNSETTLED_VALUE_OVERFLOW;
+      currentEpoch: Epoch;
+    };
+
+export class BidLedgerError extends LodestarError<BidLedgerErrorType> {}
+
+const UNSETTLED_EPOCHS = 2;
+const KEEP_SLOTS = (UNSETTLED_EPOCHS + 1) * SLOTS_PER_EPOCH;
+
+/** Tracks one-shot bids and reveal obligations without owning signing, publication, or persistence. */
+export class BidLedger {
+  private readonly bidsBySlot = new Map<Slot, Map<string, MutableBidLedgerRecord>>();
+  private readonly revealedPayloadByBlockRoot = new Map<RootHex, RevealedPayload>();
+
+  hasSubmitted(slot: Slot, parentBlockHash: RootHex, parentBlockRoot: RootHex): boolean {
+    return this.bidsBySlot.get(slot)?.has(tupleKey(parentBlockHash, parentBlockRoot)) ?? false;
+  }
+
+  recordBid(bid: SubmittedBid): BidLedgerRecord {
+    if (!Number.isSafeInteger(bid.valueGwei) || bid.valueGwei < 0) {
+      throw new BidLedgerError(
+        {code: BidLedgerErrorCode.INVALID_BID_VALUE, valueGwei: bid.valueGwei},
+        `Invalid bid value valueGwei=${bid.valueGwei}`
+      );
+    }
+
+    let bidsForSlot = this.bidsBySlot.get(bid.slot);
+    if (bidsForSlot === undefined) {
+      bidsForSlot = new Map();
+      this.bidsBySlot.set(bid.slot, bidsForSlot);
+    }
+
+    const key = tupleKey(bid.parentBlockHash, bid.parentBlockRoot);
+    if (bidsForSlot.has(key)) {
+      throw new BidLedgerError(
+        {
+          code: BidLedgerErrorCode.DUPLICATE_BID,
+          slot: bid.slot,
+          parentBlockHash: bid.parentBlockHash,
+          parentBlockRoot: bid.parentBlockRoot,
+        },
+        `Bid already recorded slot=${bid.slot} parentBlockHash=${bid.parentBlockHash} parentBlockRoot=${bid.parentBlockRoot}`
+      );
+    }
+
+    const record = {...bid, wonBlockRoots: new Set<RootHex>()};
+    bidsForSlot.set(key, record);
+    return toRecord(record);
+  }
+
+  recordWin(identity: BidIdentity, blockRoot: RootHex): BidLedgerRecord | null {
+    const record = this.getBid(identity.slot, identity.parentBlockHash, identity.parentBlockRoot);
+    if (record === null || record.blockHash !== identity.blockHash) {
+      return null;
+    }
+
+    record.wonBlockRoots.add(blockRoot);
+    return toRecord(record);
+  }
+
+  canReveal(blockRoot: RootHex, blockHash: RootHex): boolean {
+    const revealedPayload = this.revealedPayloadByBlockRoot.get(blockRoot);
+    return revealedPayload === undefined || revealedPayload.blockHash === blockHash;
+  }
+
+  hasRevealed(blockRoot: RootHex): boolean {
+    return this.revealedPayloadByBlockRoot.has(blockRoot);
+  }
+
+  recordReveal(slot: Slot, blockRoot: RootHex, blockHash: RootHex): void {
+    const revealedPayload = this.revealedPayloadByBlockRoot.get(blockRoot);
+    if (revealedPayload !== undefined && revealedPayload.blockHash !== blockHash) {
+      throw new BidLedgerError(
+        {
+          code: BidLedgerErrorCode.REVEAL_CONFLICT,
+          blockRoot,
+          blockHash,
+          revealedBlockHash: revealedPayload.blockHash,
+        },
+        `Envelope already recorded blockRoot=${blockRoot} blockHash=${revealedPayload.blockHash}`
+      );
+    }
+
+    this.revealedPayloadByBlockRoot.set(blockRoot, {slot, blockHash});
+  }
+
+  getUnsettledValueGwei(currentEpoch: Epoch): number {
+    let total = 0;
+    for (const [slot, bidsForSlot] of this.bidsBySlot) {
+      if (Math.floor(slot / SLOTS_PER_EPOCH) < currentEpoch - UNSETTLED_EPOCHS) {
+        continue;
+      }
+
+      for (const record of bidsForSlot.values()) {
+        if (record.wonBlockRoots.size === 0) {
+          continue;
+        }
+
+        total += record.valueGwei;
+        if (!Number.isSafeInteger(total)) {
+          throw new BidLedgerError(
+            {code: BidLedgerErrorCode.UNSETTLED_VALUE_OVERFLOW, currentEpoch},
+            `Unsettled bid value exceeds the safe integer range currentEpoch=${currentEpoch}`
+          );
+        }
+      }
+    }
+    return total;
+  }
+
+  getBidsForSlot(slot: Slot): BidLedgerRecord[] {
+    return Array.from(this.bidsBySlot.get(slot)?.values() ?? [], toRecord);
+  }
+
+  prune(currentSlot: Slot): number {
+    let removed = 0;
+    for (const [slot, bidsForSlot] of this.bidsBySlot) {
+      if (slot >= currentSlot - KEEP_SLOTS) {
+        continue;
+      }
+
+      removed += bidsForSlot.size;
+      this.bidsBySlot.delete(slot);
+    }
+
+    for (const [blockRoot, revealedPayload] of this.revealedPayloadByBlockRoot) {
+      if (revealedPayload.slot < currentSlot - KEEP_SLOTS) {
+        this.revealedPayloadByBlockRoot.delete(blockRoot);
+      }
+    }
+    return removed;
+  }
+
+  private getBid(slot: Slot, parentBlockHash: RootHex, parentBlockRoot: RootHex): MutableBidLedgerRecord | null {
+    return this.bidsBySlot.get(slot)?.get(tupleKey(parentBlockHash, parentBlockRoot)) ?? null;
+  }
+}
+
+function tupleKey(parentBlockHash: RootHex, parentBlockRoot: RootHex): string {
+  return `${parentBlockHash}:${parentBlockRoot}`;
+}
+
+function toRecord(record: MutableBidLedgerRecord): BidLedgerRecord {
+  return {...record, wonBlockRoots: Array.from(record.wonBlockRoots)};
+}

--- a/packages/builder/src/services/bidLedger.ts
+++ b/packages/builder/src/services/bidLedger.ts
@@ -19,6 +19,8 @@ export type BidLedgerRecord = SubmittedBid & {
 type RevealedPayload = {
   slot: Slot;
   blockHash: RootHex;
+  envelopeRoot: RootHex;
+  published: boolean;
 };
 
 type MutableBidLedgerRecord = SubmittedBid & {
@@ -49,6 +51,8 @@ export type BidLedgerErrorType =
       blockRoot: RootHex;
       blockHash: RootHex;
       revealedBlockHash: RootHex;
+      envelopeRoot: RootHex;
+      revealedEnvelopeRoot: RootHex;
     }
   | {
       code: BidLedgerErrorCode.UNSETTLED_VALUE_OVERFLOW;
@@ -122,33 +126,50 @@ export class BidLedger {
     return toRecord(record);
   }
 
-  canReveal(blockRoot: RootHex, blockHash: RootHex): boolean {
+  canReveal(blockRoot: RootHex, blockHash: RootHex, envelopeRoot: RootHex): boolean {
     const revealedPayload = this.revealedPayloadByBlockRoot.get(blockRoot);
-    return revealedPayload === undefined || revealedPayload.blockHash === blockHash;
+    return (
+      revealedPayload === undefined ||
+      (revealedPayload.blockHash === blockHash && revealedPayload.envelopeRoot === envelopeRoot)
+    );
   }
 
   hasRevealed(blockRoot: RootHex): boolean {
     return this.revealedPayloadByBlockRoot.has(blockRoot);
   }
 
-  recordReveal(slot: Slot, blockRoot: RootHex, blockHash: RootHex): void {
+  hasPublishedReveal(blockRoot: RootHex): boolean {
+    return this.revealedPayloadByBlockRoot.get(blockRoot)?.published ?? false;
+  }
+
+  recordReveal(slot: Slot, blockRoot: RootHex, blockHash: RootHex, envelopeRoot: RootHex): void {
     const revealedPayload = this.revealedPayloadByBlockRoot.get(blockRoot);
     if (revealedPayload !== undefined) {
-      if (revealedPayload.blockHash !== blockHash) {
+      if (revealedPayload.blockHash !== blockHash || revealedPayload.envelopeRoot !== envelopeRoot) {
         throw new BidLedgerError(
           {
             code: BidLedgerErrorCode.REVEAL_CONFLICT,
             blockRoot,
             blockHash,
             revealedBlockHash: revealedPayload.blockHash,
+            envelopeRoot,
+            revealedEnvelopeRoot: revealedPayload.envelopeRoot,
           },
-          `Envelope already recorded blockRoot=${blockRoot} blockHash=${revealedPayload.blockHash}`
+          `Different envelope already recorded blockRoot=${blockRoot} envelopeRoot=${revealedPayload.envelopeRoot}`
         );
       }
       return;
     }
 
-    this.revealedPayloadByBlockRoot.set(blockRoot, {slot, blockHash});
+    this.revealedPayloadByBlockRoot.set(blockRoot, {slot, blockHash, envelopeRoot, published: false});
+  }
+
+  recordRevealPublished(slot: Slot, blockRoot: RootHex, blockHash: RootHex, envelopeRoot: RootHex): void {
+    this.recordReveal(slot, blockRoot, blockHash, envelopeRoot);
+    const revealedPayload = this.revealedPayloadByBlockRoot.get(blockRoot);
+    if (revealedPayload !== undefined) {
+      revealedPayload.published = true;
+    }
   }
 
   getUnsettledValueGwei(currentEpoch: Epoch): number {

--- a/packages/builder/src/services/bidLedger.ts
+++ b/packages/builder/src/services/bidLedger.ts
@@ -121,16 +121,19 @@ export class BidLedger {
 
   recordReveal(slot: Slot, blockRoot: RootHex, blockHash: RootHex): void {
     const revealedPayload = this.revealedPayloadByBlockRoot.get(blockRoot);
-    if (revealedPayload !== undefined && revealedPayload.blockHash !== blockHash) {
-      throw new BidLedgerError(
-        {
-          code: BidLedgerErrorCode.REVEAL_CONFLICT,
-          blockRoot,
-          blockHash,
-          revealedBlockHash: revealedPayload.blockHash,
-        },
-        `Envelope already recorded blockRoot=${blockRoot} blockHash=${revealedPayload.blockHash}`
-      );
+    if (revealedPayload !== undefined) {
+      if (revealedPayload.blockHash !== blockHash) {
+        throw new BidLedgerError(
+          {
+            code: BidLedgerErrorCode.REVEAL_CONFLICT,
+            blockRoot,
+            blockHash,
+            revealedBlockHash: revealedPayload.blockHash,
+          },
+          `Envelope already recorded blockRoot=${blockRoot} blockHash=${revealedPayload.blockHash}`
+        );
+      }
+      return;
     }
 
     this.revealedPayloadByBlockRoot.set(blockRoot, {slot, blockHash});

--- a/packages/builder/src/services/bidLedger.ts
+++ b/packages/builder/src/services/bidLedger.ts
@@ -8,6 +8,7 @@ export type SubmittedBid = {
   parentBlockRoot: RootHex;
   blockHash: RootHex;
   valueGwei: number;
+  signedBidRoot: RootHex;
 };
 
 export type BidIdentity = Pick<SubmittedBid, "slot" | "parentBlockHash" | "parentBlockRoot" | "blockHash">;
@@ -105,9 +106,9 @@ export class BidLedger {
     return toRecord(record);
   }
 
-  recordWin(identity: BidIdentity, blockRoot: RootHex): BidLedgerRecord | null {
+  recordWin(identity: BidIdentity & Pick<SubmittedBid, "signedBidRoot">, blockRoot: RootHex): BidLedgerRecord | null {
     const record = this.getBid(identity.slot, identity.parentBlockHash, identity.parentBlockRoot);
-    if (record === null || record.blockHash !== identity.blockHash) {
+    if (record === null || record.blockHash !== identity.blockHash || record.signedBidRoot !== identity.signedBidRoot) {
       return null;
     }
 
@@ -238,6 +239,7 @@ function toRecord(record: MutableBidLedgerRecord): BidLedgerRecord {
     parentBlockRoot: record.parentBlockRoot,
     blockHash: record.blockHash,
     valueGwei: record.valueGwei,
+    signedBidRoot: record.signedBidRoot,
     wonBlockRoots: Array.from(record.wonBlockRoots),
   };
 }

--- a/packages/builder/src/services/bidLedger.ts
+++ b/packages/builder/src/services/bidLedger.ts
@@ -65,7 +65,7 @@ export class BidLedgerError extends LodestarError<BidLedgerErrorType> {}
 const RECORD_RETENTION_EPOCHS = 3;
 const KEEP_SLOTS = RECORD_RETENTION_EPOCHS * SLOTS_PER_EPOCH;
 
-/** Tracks one-shot bids and reveal obligations without owning signing, publication, or persistence. */
+/** Tracks at most one bid per (slot, parentBlockHash, parentBlockRoot) and its reveal obligations. */
 export class BidLedger {
   private readonly bidsBySlot = new Map<Slot, Map<string, MutableBidLedgerRecord>>();
   private readonly revealedPayloadByBlockRoot = new Map<RootHex, RevealedPayload>();

--- a/packages/builder/src/services/bidPublisher.ts
+++ b/packages/builder/src/services/bidPublisher.ts
@@ -1,0 +1,73 @@
+import type {ApiClient} from "@lodestar/api";
+import type {BuilderIndex, RootHex, gloas} from "@lodestar/types";
+import {LodestarError, toRootHex} from "@lodestar/utils";
+import type {BidLedger} from "./bidLedger.js";
+import type {BuilderSigner} from "./builderSigner.js";
+
+export type BidPublisherModules = {
+  api: ApiClient;
+  signer: BuilderSigner;
+  ledger: BidLedger;
+  builderIndex: BuilderIndex;
+  hasPayload: (blockHash: RootHex) => boolean;
+};
+
+export enum BidPublisherErrorCode {
+  BUILDER_INDEX_MISMATCH = "BID_PUBLISHER_ERROR_BUILDER_INDEX_MISMATCH",
+  PAYLOAD_NOT_RETAINED = "BID_PUBLISHER_ERROR_PAYLOAD_NOT_RETAINED",
+}
+
+export type BidPublisherErrorType =
+  | {
+      code: BidPublisherErrorCode.BUILDER_INDEX_MISMATCH;
+      builderIndex: BuilderIndex;
+      bidBuilderIndex: BuilderIndex;
+    }
+  | {
+      code: BidPublisherErrorCode.PAYLOAD_NOT_RETAINED;
+      blockHash: RootHex;
+    };
+
+export class BidPublisherError extends LodestarError<BidPublisherErrorType> {}
+
+/** Signs and submits a complete bid only after its reveal material is retained locally. */
+export class BidPublisher {
+  constructor(private readonly modules: BidPublisherModules) {}
+
+  async publish(bid: gloas.ExecutionPayloadBid, signal: AbortSignal): Promise<gloas.SignedExecutionPayloadBid> {
+    signal.throwIfAborted();
+
+    const {api, builderIndex, hasPayload, ledger, signer} = this.modules;
+    if (bid.builderIndex !== builderIndex) {
+      throw new BidPublisherError(
+        {
+          code: BidPublisherErrorCode.BUILDER_INDEX_MISMATCH,
+          builderIndex,
+          bidBuilderIndex: bid.builderIndex,
+        },
+        `Bid Builder index does not match local Builder index builderIndex=${builderIndex} bidBuilderIndex=${bid.builderIndex}`
+      );
+    }
+
+    const blockHash = toRootHex(bid.blockHash);
+    if (!hasPayload(blockHash)) {
+      throw new BidPublisherError(
+        {code: BidPublisherErrorCode.PAYLOAD_NOT_RETAINED, blockHash},
+        `Bid payload is not retained blockHash=${blockHash}`
+      );
+    }
+
+    const signedExecutionPayloadBid = signer.signExecutionPayloadBid(bid);
+    ledger.recordBid({
+      slot: bid.slot,
+      parentBlockHash: toRootHex(bid.parentBlockHash),
+      parentBlockRoot: toRootHex(bid.parentBlockRoot),
+      blockHash,
+      valueGwei: bid.value,
+    });
+
+    const response = await api.beacon.publishExecutionPayloadBid({signedExecutionPayloadBid}, {signal});
+    response.assertOk();
+    return signedExecutionPayloadBid;
+  }
+}

--- a/packages/builder/src/services/bidPublisher.ts
+++ b/packages/builder/src/services/bidPublisher.ts
@@ -1,7 +1,7 @@
 import type {ApiClient} from "@lodestar/api";
 import type {BuilderIndex, RootHex, gloas} from "@lodestar/types";
 import {LodestarError, toRootHex} from "@lodestar/utils";
-import type {BidLedger} from "./bidLedger.js";
+import type {BidIdentity, BidLedger} from "./bidLedger.js";
 import type {BuilderSigner} from "./builderSigner.js";
 
 export type BidPublisherModules = {
@@ -9,7 +9,7 @@ export type BidPublisherModules = {
   signer: BuilderSigner;
   ledger: BidLedger;
   builderIndex: BuilderIndex;
-  hasPayload: (blockHash: RootHex) => boolean;
+  hasPayload: (identity: BidIdentity) => boolean;
 };
 
 export enum BidPublisherErrorCode {
@@ -25,6 +25,9 @@ export type BidPublisherErrorType =
     }
   | {
       code: BidPublisherErrorCode.PAYLOAD_NOT_RETAINED;
+      slot: BidIdentity["slot"];
+      parentBlockHash: RootHex;
+      parentBlockRoot: RootHex;
       blockHash: RootHex;
     };
 
@@ -49,22 +52,21 @@ export class BidPublisher {
       );
     }
 
-    const blockHash = toRootHex(bid.blockHash);
-    if (!hasPayload(blockHash)) {
+    const identity: BidIdentity = {
+      slot: bid.slot,
+      parentBlockHash: toRootHex(bid.parentBlockHash),
+      parentBlockRoot: toRootHex(bid.parentBlockRoot),
+      blockHash: toRootHex(bid.blockHash),
+    };
+    if (!hasPayload(identity)) {
       throw new BidPublisherError(
-        {code: BidPublisherErrorCode.PAYLOAD_NOT_RETAINED, blockHash},
-        `Bid payload is not retained blockHash=${blockHash}`
+        {code: BidPublisherErrorCode.PAYLOAD_NOT_RETAINED, ...identity},
+        `Bid payload is not retained slot=${identity.slot} parentBlockHash=${identity.parentBlockHash} parentBlockRoot=${identity.parentBlockRoot} blockHash=${identity.blockHash}`
       );
     }
 
     const signedExecutionPayloadBid = signer.signExecutionPayloadBid(bid);
-    ledger.recordBid({
-      slot: bid.slot,
-      parentBlockHash: toRootHex(bid.parentBlockHash),
-      parentBlockRoot: toRootHex(bid.parentBlockRoot),
-      blockHash,
-      valueGwei: bid.value,
-    });
+    ledger.recordBid({...identity, valueGwei: bid.value});
 
     const response = await api.beacon.publishExecutionPayloadBid({signedExecutionPayloadBid}, {signal});
     response.assertOk();

--- a/packages/builder/src/services/bidPublisher.ts
+++ b/packages/builder/src/services/bidPublisher.ts
@@ -1,5 +1,5 @@
 import type {ApiClient} from "@lodestar/api";
-import type {BuilderIndex, RootHex, gloas} from "@lodestar/types";
+import type {BuilderIndex, RootHex, gloas, heze} from "@lodestar/types";
 import {LodestarError, toRootHex} from "@lodestar/utils";
 import type {BidIdentity, BidLedger} from "./bidLedger.js";
 import type {BuilderSigner} from "./builderSigner.js";
@@ -37,6 +37,8 @@ export class BidPublisherError extends LodestarError<BidPublisherErrorType> {}
 export class BidPublisher {
   constructor(private readonly modules: BidPublisherModules) {}
 
+  publish(bid: heze.ExecutionPayloadBid, signal: AbortSignal): Promise<heze.SignedExecutionPayloadBid>;
+  publish(bid: gloas.ExecutionPayloadBid, signal: AbortSignal): Promise<gloas.SignedExecutionPayloadBid>;
   async publish(bid: gloas.ExecutionPayloadBid, signal: AbortSignal): Promise<gloas.SignedExecutionPayloadBid> {
     signal.throwIfAborted();
 

--- a/packages/builder/src/services/bidPublisher.ts
+++ b/packages/builder/src/services/bidPublisher.ts
@@ -1,11 +1,15 @@
 import type {ApiClient} from "@lodestar/api";
+import type {ChainForkConfig} from "@lodestar/config";
+import {isForkPostGloas} from "@lodestar/params";
 import type {BuilderIndex, RootHex, gloas, heze} from "@lodestar/types";
+import {sszTypesFor} from "@lodestar/types";
 import {LodestarError, toRootHex} from "@lodestar/utils";
-import type {BidIdentity, BidLedger} from "./bidLedger.js";
+import {type BidIdentity, type BidLedger, BidLedgerError, BidLedgerErrorCode} from "./bidLedger.js";
 import type {BuilderSigner} from "./builderSigner.js";
 
 export type BidPublisherModules = {
   api: ApiClient;
+  config: ChainForkConfig;
   signer: BuilderSigner;
   ledger: BidLedger;
   builderIndex: BuilderIndex;
@@ -15,9 +19,14 @@ export type BidPublisherModules = {
 export enum BidPublisherErrorCode {
   BUILDER_INDEX_MISMATCH = "BID_PUBLISHER_ERROR_BUILDER_INDEX_MISMATCH",
   PAYLOAD_NOT_RETAINED = "BID_PUBLISHER_ERROR_PAYLOAD_NOT_RETAINED",
+  PRE_GLOAS_BID = "BID_PUBLISHER_ERROR_PRE_GLOAS_BID",
 }
 
 export type BidPublisherErrorType =
+  | {
+      code: BidPublisherErrorCode.PRE_GLOAS_BID;
+      slot: BidIdentity["slot"];
+    }
   | {
       code: BidPublisherErrorCode.BUILDER_INDEX_MISMATCH;
       builderIndex: BuilderIndex;
@@ -42,7 +51,11 @@ export class BidPublisher {
   async publish(bid: gloas.ExecutionPayloadBid, signal: AbortSignal): Promise<gloas.SignedExecutionPayloadBid> {
     signal.throwIfAborted();
 
-    const {api, builderIndex, hasPayload, ledger, signer} = this.modules;
+    const {api, config, builderIndex, hasPayload, ledger, signer} = this.modules;
+    const fork = config.getForkName(bid.slot);
+    if (!isForkPostGloas(fork)) {
+      throw new BidPublisherError({code: BidPublisherErrorCode.PRE_GLOAS_BID, slot: bid.slot});
+    }
     if (bid.builderIndex !== builderIndex) {
       throw new BidPublisherError(
         {
@@ -67,8 +80,15 @@ export class BidPublisher {
       );
     }
 
+    if (ledger.hasSubmitted(identity.slot, identity.parentBlockHash, identity.parentBlockRoot)) {
+      throw new BidLedgerError({code: BidLedgerErrorCode.DUPLICATE_BID, ...identity});
+    }
+
     const signedExecutionPayloadBid = signer.signExecutionPayloadBid(bid);
-    ledger.recordBid({...identity, valueGwei: bid.value});
+    const signedBidRoot = toRootHex(
+      sszTypesFor(fork, "SignedExecutionPayloadBid").hashTreeRoot(signedExecutionPayloadBid)
+    );
+    ledger.recordBid({...identity, valueGwei: bid.value, signedBidRoot});
 
     const response = await api.beacon.publishExecutionPayloadBid({signedExecutionPayloadBid}, {signal});
     response.assertOk();

--- a/packages/builder/src/services/builderSigner.ts
+++ b/packages/builder/src/services/builderSigner.ts
@@ -1,7 +1,7 @@
 import {PublicKey, SecretKey} from "@chainsafe/lodestar-z/blst";
 import {BeaconConfig} from "@lodestar/config";
 import {getExecutionPayloadBidSigningRoot, getExecutionPayloadEnvelopeSigningRoot} from "@lodestar/state-transition";
-import {gloas} from "@lodestar/types";
+import {gloas, heze} from "@lodestar/types";
 
 export type Keypair = {publicKey: PublicKey; secretKey: SecretKey};
 
@@ -23,6 +23,8 @@ export class BuilderSigner {
     };
   }
 
+  signExecutionPayloadBid(bid: heze.ExecutionPayloadBid): heze.SignedExecutionPayloadBid;
+  signExecutionPayloadBid(bid: gloas.ExecutionPayloadBid): gloas.SignedExecutionPayloadBid;
   signExecutionPayloadBid(bid: gloas.ExecutionPayloadBid): gloas.SignedExecutionPayloadBid {
     const signingRoot = getExecutionPayloadBidSigningRoot(this.config, bid);
 

--- a/packages/builder/test/unit/services/bidLedger.test.ts
+++ b/packages/builder/test/unit/services/bidLedger.test.ts
@@ -91,7 +91,7 @@ describe("BidLedger", () => {
     });
   });
 
-  it("sums each unsettled winning bid once", () => {
+  it("sums each winning bid until its payment is explicitly settled", () => {
     const ledger = new BidLedger();
     const first = submittedBid({valueGwei: 100});
     const second = submittedBid({parentBlockRoot: root(8), blockHash: root(9), valueGwei: 50});
@@ -105,7 +105,21 @@ describe("BidLedger", () => {
 
     expect(ledger.getUnsettledValueGwei(0)).toBe(150);
     expect(ledger.getUnsettledValueGwei(2)).toBe(150);
-    expect(ledger.getUnsettledValueGwei(3)).toBe(0);
+    expect(ledger.getUnsettledValueGwei(3)).toBe(150);
+    expect(ledger.recordPaymentSettled(first)).toEqual({...first, wonBlockRoots: [root(6), root(7)]});
+    expect(ledger.recordPaymentSettled(first)).toEqual({...first, wonBlockRoots: [root(6), root(7)]});
+    expect(ledger.getUnsettledValueGwei(3)).toBe(50);
+  });
+
+  it("only settles an exact winning bid identity", () => {
+    const ledger = new BidLedger();
+    const bid = submittedBid();
+    ledger.recordBid(bid);
+
+    expect(ledger.recordPaymentSettled(bid)).toBeNull();
+    ledger.recordWin(bid, root(6));
+    expect(ledger.recordPaymentSettled({...bid, blockHash: root(7)})).toBeNull();
+    expect(ledger.getUnsettledValueGwei(4)).toBe(bid.valueGwei);
   });
 
   it("fails closed if unsettled liability exceeds the safe integer range", () => {
@@ -134,7 +148,7 @@ describe("BidLedger", () => {
     expect(ledger.getBidsForSlot(bid.slot)).toEqual([{...bid, wonBlockRoots: [root(6)]}]);
   });
 
-  it("prunes records and reveal protection after the retention boundary", () => {
+  it("retains unsettled winning bids past the retention boundary", () => {
     const ledger = new BidLedger();
     const bid = submittedBid();
     const blockRoot = root(6);
@@ -146,9 +160,22 @@ describe("BidLedger", () => {
     expect(ledger.hasSubmitted(bid.slot, bid.parentBlockHash, bid.parentBlockRoot)).toBe(true);
     expect(ledger.hasRevealed(blockRoot)).toBe(true);
 
+    expect(ledger.prune(bid.slot + 3 * SLOTS_PER_EPOCH + 1)).toBe(0);
+    expect(ledger.hasSubmitted(bid.slot, bid.parentBlockHash, bid.parentBlockRoot)).toBe(true);
+    expect(ledger.hasRevealed(blockRoot)).toBe(false);
+
+    ledger.recordPaymentSettled(bid);
     expect(ledger.prune(bid.slot + 3 * SLOTS_PER_EPOCH + 1)).toBe(1);
     expect(ledger.hasSubmitted(bid.slot, bid.parentBlockHash, bid.parentBlockRoot)).toBe(false);
-    expect(ledger.hasRevealed(blockRoot)).toBe(false);
+  });
+
+  it("prunes old bids that never won", () => {
+    const ledger = new BidLedger();
+    const bid = submittedBid();
+    ledger.recordBid(bid);
+
+    expect(ledger.prune(bid.slot + 3 * SLOTS_PER_EPOCH + 1)).toBe(1);
+    expect(ledger.hasSubmitted(bid.slot, bid.parentBlockHash, bid.parentBlockRoot)).toBe(false);
   });
 
   it("prunes reveal protection even when no winning bid record exists", () => {

--- a/packages/builder/test/unit/services/bidLedger.test.ts
+++ b/packages/builder/test/unit/services/bidLedger.test.ts
@@ -73,22 +73,40 @@ describe("BidLedger", () => {
     const ledger = new BidLedger();
     const blockRoot = root(6);
     const blockHash = root(4);
+    const envelopeRoot = root(5);
 
-    expect(ledger.canReveal(blockRoot, blockHash)).toBe(true);
-    ledger.recordReveal(1, blockRoot, blockHash);
-    ledger.recordReveal(1, blockRoot, blockHash);
+    expect(ledger.canReveal(blockRoot, blockHash, envelopeRoot)).toBe(true);
+    ledger.recordReveal(1, blockRoot, blockHash, envelopeRoot);
+    ledger.recordReveal(1, blockRoot, blockHash, envelopeRoot);
 
     expect(ledger.hasRevealed(blockRoot)).toBe(true);
-    expect(ledger.canReveal(blockRoot, blockHash)).toBe(true);
-    expect(ledger.canReveal(blockRoot, root(7))).toBe(false);
+    expect(ledger.hasPublishedReveal(blockRoot)).toBe(false);
+    expect(ledger.canReveal(blockRoot, blockHash, envelopeRoot)).toBe(true);
+    expect(ledger.canReveal(blockRoot, root(7), envelopeRoot)).toBe(false);
+    expect(ledger.canReveal(blockRoot, blockHash, root(8))).toBe(false);
 
-    const error = getBidLedgerError(() => ledger.recordReveal(1, blockRoot, root(7)));
+    const error = getBidLedgerError(() => ledger.recordReveal(1, blockRoot, root(7), root(8)));
     expect(error.type).toEqual({
       code: BidLedgerErrorCode.REVEAL_CONFLICT,
       blockRoot,
       blockHash: root(7),
       revealedBlockHash: blockHash,
+      envelopeRoot: root(8),
+      revealedEnvelopeRoot: envelopeRoot,
     });
+  });
+
+  it("records publication separately from the reveal reservation", () => {
+    const ledger = new BidLedger();
+    const blockRoot = root(6);
+    const blockHash = root(4);
+    const envelopeRoot = root(5);
+
+    ledger.recordReveal(1, blockRoot, blockHash, envelopeRoot);
+    expect(ledger.hasPublishedReveal(blockRoot)).toBe(false);
+
+    ledger.recordRevealPublished(1, blockRoot, blockHash, envelopeRoot);
+    expect(ledger.hasPublishedReveal(blockRoot)).toBe(true);
   });
 
   it("sums each winning bid until its payment is explicitly settled", () => {
@@ -154,7 +172,7 @@ describe("BidLedger", () => {
     const blockRoot = root(6);
     ledger.recordBid(bid);
     ledger.recordWin(bid, blockRoot);
-    ledger.recordReveal(bid.slot, blockRoot, bid.blockHash);
+    ledger.recordReveal(bid.slot, blockRoot, bid.blockHash, root(5));
 
     expect(ledger.prune(bid.slot + 3 * SLOTS_PER_EPOCH)).toBe(0);
     expect(ledger.hasSubmitted(bid.slot, bid.parentBlockHash, bid.parentBlockRoot)).toBe(true);
@@ -181,7 +199,7 @@ describe("BidLedger", () => {
   it("prunes reveal protection even when no winning bid record exists", () => {
     const ledger = new BidLedger();
     const blockRoot = root(6);
-    ledger.recordReveal(1, blockRoot, root(4));
+    ledger.recordReveal(1, blockRoot, root(4), root(5));
 
     expect(ledger.prune(1 + 3 * SLOTS_PER_EPOCH + 1)).toBe(0);
     expect(ledger.hasRevealed(blockRoot)).toBe(false);
@@ -191,8 +209,9 @@ describe("BidLedger", () => {
     const ledger = new BidLedger();
     const blockRoot = root(6);
     const blockHash = root(4);
-    ledger.recordReveal(10, blockRoot, blockHash);
-    ledger.recordReveal(1, blockRoot, blockHash);
+    const envelopeRoot = root(5);
+    ledger.recordReveal(10, blockRoot, blockHash, envelopeRoot);
+    ledger.recordReveal(1, blockRoot, blockHash, envelopeRoot);
 
     ledger.prune(1 + 3 * SLOTS_PER_EPOCH + 1);
 

--- a/packages/builder/test/unit/services/bidLedger.test.ts
+++ b/packages/builder/test/unit/services/bidLedger.test.ts
@@ -159,6 +159,18 @@ describe("BidLedger", () => {
     expect(ledger.prune(1 + 3 * SLOTS_PER_EPOCH + 1)).toBe(0);
     expect(ledger.hasRevealed(blockRoot)).toBe(false);
   });
+
+  it("preserves the original reveal slot on an idempotent repeat", () => {
+    const ledger = new BidLedger();
+    const blockRoot = root(6);
+    const blockHash = root(4);
+    ledger.recordReveal(10, blockRoot, blockHash);
+    ledger.recordReveal(1, blockRoot, blockHash);
+
+    ledger.prune(1 + 3 * SLOTS_PER_EPOCH + 1);
+
+    expect(ledger.hasRevealed(blockRoot)).toBe(true);
+  });
 });
 
 function submittedBid(overrides: Partial<SubmittedBid> = {}): SubmittedBid {

--- a/packages/builder/test/unit/services/bidLedger.test.ts
+++ b/packages/builder/test/unit/services/bidLedger.test.ts
@@ -1,0 +1,189 @@
+import {describe, expect, it} from "vitest";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import type {RootHex} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {BidLedger, BidLedgerError, BidLedgerErrorCode, type SubmittedBid} from "../../../src/services/bidLedger.js";
+
+describe("BidLedger", () => {
+  it("records one bid per slot and parent tuple", () => {
+    const ledger = new BidLedger();
+    const bid = submittedBid();
+
+    expect(ledger.hasSubmitted(bid.slot, bid.parentBlockHash, bid.parentBlockRoot)).toBe(false);
+    expect(ledger.recordBid(bid)).toEqual({...bid, wonBlockRoots: []});
+    expect(ledger.hasSubmitted(bid.slot, bid.parentBlockHash, bid.parentBlockRoot)).toBe(true);
+    expect(ledger.hasSubmitted(bid.slot + 1, bid.parentBlockHash, bid.parentBlockRoot)).toBe(false);
+  });
+
+  it("rejects a second bid for the same tuple with a structured error", () => {
+    const ledger = new BidLedger();
+    const bid = submittedBid();
+    ledger.recordBid(bid);
+
+    const error = getBidLedgerError(() => ledger.recordBid({...bid, blockHash: root(5)}));
+
+    expect(error.type).toEqual({
+      code: BidLedgerErrorCode.DUPLICATE_BID,
+      slot: bid.slot,
+      parentBlockHash: bid.parentBlockHash,
+      parentBlockRoot: bid.parentBlockRoot,
+    });
+    expect(ledger.getBidsForSlot(bid.slot)).toEqual([{...bid, wonBlockRoots: []}]);
+  });
+
+  it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects an invalid bid value %s",
+    (valueGwei) => {
+      const ledger = new BidLedger();
+      const error = getBidLedgerError(() => ledger.recordBid(submittedBid({valueGwei})));
+
+      expect(error.type).toEqual({code: BidLedgerErrorCode.INVALID_BID_VALUE, valueGwei});
+      expect(ledger.getBidsForSlot(1)).toEqual([]);
+    }
+  );
+
+  it("records a win only for the exact local bid identity", () => {
+    const ledger = new BidLedger();
+    const bid = submittedBid();
+    const blockRoot = root(6);
+    ledger.recordBid(bid);
+
+    expect(ledger.recordWin({...bid, blockHash: root(7)}, blockRoot)).toBeNull();
+    expect(ledger.recordWin(bid, blockRoot)).toEqual({...bid, wonBlockRoots: [blockRoot]});
+    expect(ledger.recordWin(bid, blockRoot)).toEqual({...bid, wonBlockRoots: [blockRoot]});
+  });
+
+  it("distinguishes bids with the same payload hash on different parent roots", () => {
+    const ledger = new BidLedger();
+    const first = submittedBid();
+    const second = submittedBid({parentBlockRoot: root(8)});
+    ledger.recordBid(first);
+    ledger.recordBid(second);
+
+    const secondWin = ledger.recordWin(second, root(9));
+
+    expect(secondWin).toEqual({...second, wonBlockRoots: [root(9)]});
+    expect(ledger.getBidsForSlot(first.slot)).toEqual([
+      {...first, wonBlockRoots: []},
+      {...second, wonBlockRoots: [root(9)]},
+    ]);
+  });
+
+  it("records one payload per beacon block root", () => {
+    const ledger = new BidLedger();
+    const blockRoot = root(6);
+    const blockHash = root(4);
+
+    expect(ledger.canReveal(blockRoot, blockHash)).toBe(true);
+    ledger.recordReveal(1, blockRoot, blockHash);
+    ledger.recordReveal(1, blockRoot, blockHash);
+
+    expect(ledger.hasRevealed(blockRoot)).toBe(true);
+    expect(ledger.canReveal(blockRoot, blockHash)).toBe(true);
+    expect(ledger.canReveal(blockRoot, root(7))).toBe(false);
+
+    const error = getBidLedgerError(() => ledger.recordReveal(1, blockRoot, root(7)));
+    expect(error.type).toEqual({
+      code: BidLedgerErrorCode.REVEAL_CONFLICT,
+      blockRoot,
+      blockHash: root(7),
+      revealedBlockHash: blockHash,
+    });
+  });
+
+  it("sums each unsettled winning bid once", () => {
+    const ledger = new BidLedger();
+    const first = submittedBid({valueGwei: 100});
+    const second = submittedBid({parentBlockRoot: root(8), blockHash: root(9), valueGwei: 50});
+    ledger.recordBid(first);
+    ledger.recordBid(second);
+
+    expect(ledger.getUnsettledValueGwei(0)).toBe(0);
+    ledger.recordWin(first, root(6));
+    ledger.recordWin(first, root(7));
+    ledger.recordWin(second, root(10));
+
+    expect(ledger.getUnsettledValueGwei(0)).toBe(150);
+    expect(ledger.getUnsettledValueGwei(2)).toBe(150);
+    expect(ledger.getUnsettledValueGwei(3)).toBe(0);
+  });
+
+  it("fails closed if unsettled liability exceeds the safe integer range", () => {
+    const ledger = new BidLedger();
+    const first = submittedBid({valueGwei: Number.MAX_SAFE_INTEGER});
+    const second = submittedBid({parentBlockRoot: root(8), blockHash: root(9), valueGwei: 1});
+    ledger.recordBid(first);
+    ledger.recordBid(second);
+    ledger.recordWin(first, root(6));
+    ledger.recordWin(second, root(7));
+
+    const error = getBidLedgerError(() => ledger.getUnsettledValueGwei(0));
+
+    expect(error.type).toEqual({code: BidLedgerErrorCode.UNSETTLED_VALUE_OVERFLOW, currentEpoch: 0});
+  });
+
+  it("returns snapshots that cannot mutate ledger state", () => {
+    const ledger = new BidLedger();
+    const bid = submittedBid();
+    ledger.recordBid(bid);
+    ledger.recordWin(bid, root(6));
+
+    const [snapshot] = ledger.getBidsForSlot(bid.slot);
+    snapshot?.wonBlockRoots.push(root(7));
+
+    expect(ledger.getBidsForSlot(bid.slot)).toEqual([{...bid, wonBlockRoots: [root(6)]}]);
+  });
+
+  it("prunes records and reveal protection after the retention boundary", () => {
+    const ledger = new BidLedger();
+    const bid = submittedBid();
+    const blockRoot = root(6);
+    ledger.recordBid(bid);
+    ledger.recordWin(bid, blockRoot);
+    ledger.recordReveal(bid.slot, blockRoot, bid.blockHash);
+
+    expect(ledger.prune(bid.slot + 3 * SLOTS_PER_EPOCH)).toBe(0);
+    expect(ledger.hasSubmitted(bid.slot, bid.parentBlockHash, bid.parentBlockRoot)).toBe(true);
+    expect(ledger.hasRevealed(blockRoot)).toBe(true);
+
+    expect(ledger.prune(bid.slot + 3 * SLOTS_PER_EPOCH + 1)).toBe(1);
+    expect(ledger.hasSubmitted(bid.slot, bid.parentBlockHash, bid.parentBlockRoot)).toBe(false);
+    expect(ledger.hasRevealed(blockRoot)).toBe(false);
+  });
+
+  it("prunes reveal protection even when no winning bid record exists", () => {
+    const ledger = new BidLedger();
+    const blockRoot = root(6);
+    ledger.recordReveal(1, blockRoot, root(4));
+
+    expect(ledger.prune(1 + 3 * SLOTS_PER_EPOCH + 1)).toBe(0);
+    expect(ledger.hasRevealed(blockRoot)).toBe(false);
+  });
+});
+
+function submittedBid(overrides: Partial<SubmittedBid> = {}): SubmittedBid {
+  return {
+    slot: 1,
+    parentBlockHash: root(2),
+    parentBlockRoot: root(3),
+    blockHash: root(4),
+    valueGwei: 100,
+    ...overrides,
+  };
+}
+
+function root(byte: number): RootHex {
+  return toRootHex(Uint8Array.from({length: 32}, () => byte));
+}
+
+function getBidLedgerError(fn: () => unknown): BidLedgerError {
+  try {
+    fn();
+    throw Error("Expected BidLedgerError");
+  } catch (error) {
+    if (!(error instanceof BidLedgerError)) {
+      throw error;
+    }
+    return error;
+  }
+}

--- a/packages/builder/test/unit/services/bidLedger.test.ts
+++ b/packages/builder/test/unit/services/bidLedger.test.ts
@@ -49,6 +49,9 @@ describe("BidLedger", () => {
     ledger.recordBid(bid);
 
     expect(ledger.recordWin({...bid, blockHash: root(7)}, blockRoot)).toBeNull();
+    expect(ledger.recordWin({...bid, signedBidRoot: root(8)}, blockRoot)).toBeNull();
+    expect(ledger.getBidsForSlot(bid.slot)).toEqual([{...bid, wonBlockRoots: []}]);
+    expect(ledger.getUnsettledValueGwei(0)).toBe(0);
     expect(ledger.recordWin(bid, blockRoot)).toEqual({...bid, wonBlockRoots: [blockRoot]});
     expect(ledger.recordWin(bid, blockRoot)).toEqual({...bid, wonBlockRoots: [blockRoot]});
   });
@@ -226,6 +229,7 @@ function submittedBid(overrides: Partial<SubmittedBid> = {}): SubmittedBid {
     parentBlockRoot: root(3),
     blockHash: root(4),
     valueGwei: 100,
+    signedBidRoot: root(5),
     ...overrides,
   };
 }

--- a/packages/builder/test/unit/services/bidPublisher.test.ts
+++ b/packages/builder/test/unit/services/bidPublisher.test.ts
@@ -1,0 +1,137 @@
+import {describe, expect, it, vi} from "vitest";
+import {SecretKey} from "@chainsafe/lodestar-z/blst";
+import {HttpStatusCode} from "@lodestar/api";
+import {createBeaconConfig} from "@lodestar/config";
+import {getConfig} from "@lodestar/config/test-utils";
+import {ForkName} from "@lodestar/params";
+import {RootHex, ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {BidLedger, BidLedgerErrorCode} from "../../../src/services/bidLedger.js";
+import {BidPublisher, BidPublisherError, BidPublisherErrorCode} from "../../../src/services/bidPublisher.js";
+import {BuilderSigner} from "../../../src/services/builderSigner.js";
+import {getApiClientStub, mockApiErrorResponse, mockApiResponse} from "../utils/apiStub.js";
+
+const builderIndex = 7;
+const signer = new BuilderSigner(
+  createBeaconConfig(getConfig(ForkName.gloas), Buffer.alloc(32, 9)),
+  keypair(Buffer.alloc(32, 1))
+);
+
+describe("BidPublisher", () => {
+  it("signs, records, and submits a bid with retained payload material", async () => {
+    const bid = createBid();
+    const blockHash = toRootHex(bid.blockHash);
+    const {api, ledger, publisher} = createPublisher({hasPayload: vi.fn(() => true)});
+
+    const signedBid = await publisher.publish(bid, new AbortController().signal);
+
+    expect(signedBid.message).toBe(bid);
+    expect(api.beacon.publishExecutionPayloadBid).toHaveBeenCalledWith(
+      {signedExecutionPayloadBid: signedBid},
+      {signal: expect.any(AbortSignal)}
+    );
+    expect(ledger.recordWin(bidIdentity(bid), toRootHex(Buffer.alloc(32, 8)))?.blockHash).toBe(blockHash);
+  });
+
+  it("rejects a bid for another Builder before signing or recording", async () => {
+    const bid = createBid();
+    bid.builderIndex++;
+    const {api, ledger, publisher} = createPublisher({hasPayload: vi.fn(() => true)});
+
+    await expect(publisher.publish(bid, new AbortController().signal)).rejects.toThrowError(
+      new BidPublisherError(
+        {
+          code: BidPublisherErrorCode.BUILDER_INDEX_MISMATCH,
+          builderIndex,
+          bidBuilderIndex: bid.builderIndex,
+        },
+        `Bid Builder index does not match local Builder index builderIndex=${builderIndex} bidBuilderIndex=${bid.builderIndex}`
+      )
+    );
+    expect(ledger.getBidsForSlot(bid.slot)).toEqual([]);
+    expect(api.beacon.publishExecutionPayloadBid).not.toHaveBeenCalled();
+  });
+
+  it("rejects a bid whose reveal material is not retained", async () => {
+    const bid = createBid();
+    const blockHash = toRootHex(bid.blockHash);
+    const {api, ledger, publisher} = createPublisher({hasPayload: vi.fn(() => false)});
+
+    await expect(publisher.publish(bid, new AbortController().signal)).rejects.toThrowError(
+      new BidPublisherError(
+        {code: BidPublisherErrorCode.PAYLOAD_NOT_RETAINED, blockHash},
+        `Bid payload is not retained blockHash=${blockHash}`
+      )
+    );
+    expect(ledger.getBidsForSlot(bid.slot)).toEqual([]);
+    expect(api.beacon.publishExecutionPayloadBid).not.toHaveBeenCalled();
+  });
+
+  it("rejects an already aborted call without side effects", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const hasPayload = vi.fn(() => true);
+    const {api, ledger, publisher} = createPublisher({hasPayload});
+    const bid = createBid();
+
+    await expect(publisher.publish(bid, controller.signal)).rejects.toMatchObject({name: "AbortError"});
+    expect(hasPayload).not.toHaveBeenCalled();
+    expect(ledger.getBidsForSlot(bid.slot)).toEqual([]);
+    expect(api.beacon.publishExecutionPayloadBid).not.toHaveBeenCalled();
+  });
+
+  it("enforces one submission for the same parent tuple", async () => {
+    const bid = createBid();
+    const {api, publisher} = createPublisher({hasPayload: vi.fn(() => true)});
+    const signal = new AbortController().signal;
+    await publisher.publish(bid, signal);
+
+    await expect(publisher.publish(bid, signal)).rejects.toMatchObject({
+      type: {code: BidLedgerErrorCode.DUPLICATE_BID},
+    });
+    expect(api.beacon.publishExecutionPayloadBid).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the one-shot record when the Beacon Node rejects publication", async () => {
+    const bid = createBid();
+    const {api, ledger, publisher} = createPublisher({hasPayload: vi.fn(() => true)});
+    api.beacon.publishExecutionPayloadBid.mockResolvedValue(await mockApiErrorResponse(HttpStatusCode.BAD_REQUEST));
+
+    await expect(publisher.publish(bid, new AbortController().signal)).rejects.toThrow();
+    expect(ledger.hasSubmitted(bid.slot, toRootHex(bid.parentBlockHash), toRootHex(bid.parentBlockRoot))).toBe(true);
+  });
+});
+
+function createPublisher({hasPayload}: {hasPayload: (blockHash: RootHex) => boolean}) {
+  const api = getApiClientStub();
+  Object.assign(api.beacon, {publishExecutionPayloadBid: vi.fn()});
+  api.beacon.publishExecutionPayloadBid.mockResolvedValue(mockApiResponse({}));
+  const ledger = new BidLedger();
+  const publisher = new BidPublisher({api, signer, ledger, builderIndex, hasPayload});
+  return {api, ledger, publisher};
+}
+
+function createBid(): ReturnType<typeof ssz.gloas.ExecutionPayloadBid.defaultValue> {
+  const bid = ssz.gloas.ExecutionPayloadBid.defaultValue();
+  bid.slot = 10;
+  bid.builderIndex = builderIndex;
+  bid.parentBlockHash = Buffer.alloc(32, 2);
+  bid.parentBlockRoot = Buffer.alloc(32, 3);
+  bid.blockHash = Buffer.alloc(32, 4);
+  bid.value = 5;
+  return bid;
+}
+
+function bidIdentity(bid: ReturnType<typeof createBid>) {
+  return {
+    slot: bid.slot,
+    parentBlockHash: toRootHex(bid.parentBlockHash),
+    parentBlockRoot: toRootHex(bid.parentBlockRoot),
+    blockHash: toRootHex(bid.blockHash),
+  };
+}
+
+function keypair(secretKeyBytes: Uint8Array) {
+  const secretKey = SecretKey.fromBytes(secretKeyBytes);
+  return {secretKey, publicKey: secretKey.toPublicKey()};
+}

--- a/packages/builder/test/unit/services/bidPublisher.test.ts
+++ b/packages/builder/test/unit/services/bidPublisher.test.ts
@@ -4,9 +4,9 @@ import {HttpStatusCode} from "@lodestar/api";
 import {createBeaconConfig} from "@lodestar/config";
 import {getConfig} from "@lodestar/config/test-utils";
 import {ForkName} from "@lodestar/params";
-import {RootHex, ssz} from "@lodestar/types";
+import {ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
-import {BidLedger, BidLedgerErrorCode} from "../../../src/services/bidLedger.js";
+import {type BidIdentity, BidLedger, BidLedgerErrorCode} from "../../../src/services/bidLedger.js";
 import {BidPublisher, BidPublisherError, BidPublisherErrorCode} from "../../../src/services/bidPublisher.js";
 import {BuilderSigner} from "../../../src/services/builderSigner.js";
 import {getApiClientStub, mockApiErrorResponse, mockApiResponse} from "../utils/apiStub.js";
@@ -21,11 +21,13 @@ describe("BidPublisher", () => {
   it("signs, records, and submits a bid with retained payload material", async () => {
     const bid = createBid();
     const blockHash = toRootHex(bid.blockHash);
-    const {api, ledger, publisher} = createPublisher({hasPayload: vi.fn(() => true)});
+    const hasPayload = vi.fn(() => true);
+    const {api, ledger, publisher} = createPublisher({hasPayload});
 
     const signedBid = await publisher.publish(bid, new AbortController().signal);
 
     expect(signedBid.message).toBe(bid);
+    expect(hasPayload).toHaveBeenCalledWith(bidIdentity(bid));
     expect(api.beacon.publishExecutionPayloadBid).toHaveBeenCalledWith(
       {signedExecutionPayloadBid: signedBid},
       {signal: expect.any(AbortSignal)}
@@ -54,13 +56,13 @@ describe("BidPublisher", () => {
 
   it("rejects a bid whose reveal material is not retained", async () => {
     const bid = createBid();
-    const blockHash = toRootHex(bid.blockHash);
+    const identity = bidIdentity(bid);
     const {api, ledger, publisher} = createPublisher({hasPayload: vi.fn(() => false)});
 
     await expect(publisher.publish(bid, new AbortController().signal)).rejects.toThrowError(
       new BidPublisherError(
-        {code: BidPublisherErrorCode.PAYLOAD_NOT_RETAINED, blockHash},
-        `Bid payload is not retained blockHash=${blockHash}`
+        {code: BidPublisherErrorCode.PAYLOAD_NOT_RETAINED, ...identity},
+        `Bid payload is not retained slot=${identity.slot} parentBlockHash=${identity.parentBlockHash} parentBlockRoot=${identity.parentBlockRoot} blockHash=${identity.blockHash}`
       )
     );
     expect(ledger.getBidsForSlot(bid.slot)).toEqual([]);
@@ -102,7 +104,7 @@ describe("BidPublisher", () => {
   });
 });
 
-function createPublisher({hasPayload}: {hasPayload: (blockHash: RootHex) => boolean}) {
+function createPublisher({hasPayload}: {hasPayload: (identity: BidIdentity) => boolean}) {
   const api = getApiClientStub();
   Object.assign(api.beacon, {publishExecutionPayloadBid: vi.fn()});
   api.beacon.publishExecutionPayloadBid.mockResolvedValue(mockApiResponse({}));

--- a/packages/builder/test/unit/services/bidPublisher.test.ts
+++ b/packages/builder/test/unit/services/bidPublisher.test.ts
@@ -35,6 +35,26 @@ describe("BidPublisher", () => {
     expect(ledger.recordWin(bidIdentity(bid), toRootHex(Buffer.alloc(32, 8)))?.blockHash).toBe(blockHash);
   });
 
+  it("preserves Heze bid fields through signing and publication", async () => {
+    const bid = ssz.heze.ExecutionPayloadBid.defaultValue();
+    bid.slot = 10;
+    bid.builderIndex = builderIndex;
+    bid.parentBlockHash = Buffer.alloc(32, 2);
+    bid.parentBlockRoot = Buffer.alloc(32, 3);
+    bid.blockHash = Buffer.alloc(32, 4);
+    bid.value = 5;
+    bid.inclusionListBits.set(1, true);
+    const {api, publisher} = createPublisher({hasPayload: vi.fn(() => true)});
+
+    const signedBid = await publisher.publish(bid, new AbortController().signal);
+
+    expect(signedBid.message.inclusionListBits.get(1)).toBe(true);
+    expect(api.beacon.publishExecutionPayloadBid).toHaveBeenCalledWith(
+      {signedExecutionPayloadBid: signedBid},
+      {signal: expect.any(AbortSignal)}
+    );
+  });
+
   it("rejects a bid for another Builder before signing or recording", async () => {
     const bid = createBid();
     bid.builderIndex++;

--- a/packages/builder/test/unit/services/bidPublisher.test.ts
+++ b/packages/builder/test/unit/services/bidPublisher.test.ts
@@ -1,21 +1,18 @@
 import {describe, expect, it, vi} from "vitest";
-import {SecretKey} from "@chainsafe/lodestar-z/blst";
+import {SecretKey, Signature, verify} from "@chainsafe/lodestar-z/blst";
 import {HttpStatusCode} from "@lodestar/api";
 import {createBeaconConfig} from "@lodestar/config";
 import {getConfig} from "@lodestar/config/test-utils";
 import {ForkName} from "@lodestar/params";
+import {getExecutionPayloadBidSigningRoot} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
-import {toRootHex} from "@lodestar/utils";
+import {defer, toRootHex} from "@lodestar/utils";
 import {type BidIdentity, BidLedger, BidLedgerErrorCode} from "../../../src/services/bidLedger.js";
 import {BidPublisher, BidPublisherError, BidPublisherErrorCode} from "../../../src/services/bidPublisher.js";
 import {BuilderSigner} from "../../../src/services/builderSigner.js";
 import {getApiClientStub, mockApiErrorResponse, mockApiResponse} from "../utils/apiStub.js";
 
 const builderIndex = 7;
-const signer = new BuilderSigner(
-  createBeaconConfig(getConfig(ForkName.gloas), Buffer.alloc(32, 9)),
-  keypair(Buffer.alloc(32, 1))
-);
 
 describe("BidPublisher", () => {
   it("signs, records, and submits a bid with retained payload material", async () => {
@@ -32,10 +29,13 @@ describe("BidPublisher", () => {
       {signedExecutionPayloadBid: signedBid},
       {signal: expect.any(AbortSignal)}
     );
-    expect(ledger.recordWin(bidIdentity(bid), toRootHex(Buffer.alloc(32, 8)))?.blockHash).toBe(blockHash);
+    const signedBidRoot = toRootHex(ssz.gloas.SignedExecutionPayloadBid.hashTreeRoot(signedBid));
+    expect(ledger.recordWin({...bidIdentity(bid), signedBidRoot}, toRootHex(Buffer.alloc(32, 8)))?.blockHash).toBe(
+      blockHash
+    );
   });
 
-  it("preserves Heze bid fields through signing and publication", async () => {
+  it("signs all Heze bid fields under the Heze fork", async () => {
     const bid = ssz.heze.ExecutionPayloadBid.defaultValue();
     bid.slot = 10;
     bid.builderIndex = builderIndex;
@@ -44,15 +44,25 @@ describe("BidPublisher", () => {
     bid.blockHash = Buffer.alloc(32, 4);
     bid.value = 5;
     bid.inclusionListBits.set(1, true);
-    const {api, publisher} = createPublisher({hasPayload: vi.fn(() => true)});
+    const {api, config, keys, ledger, publisher} = createPublisher({
+      hasPayload: vi.fn(() => true),
+      fork: ForkName.heze,
+    });
 
     const signedBid = await publisher.publish(bid, new AbortController().signal);
 
     expect(signedBid.message.inclusionListBits.get(1)).toBe(true);
+    const signature = Signature.fromBytes(signedBid.signature, true);
+    expect(verify(getExecutionPayloadBidSigningRoot(config, bid), keys.publicKey, signature)).toBe(true);
+    expect(ledger.getBidsForSlot(bid.slot)[0].signedBidRoot).toBe(
+      toRootHex(ssz.heze.SignedExecutionPayloadBid.hashTreeRoot(signedBid))
+    );
     expect(api.beacon.publishExecutionPayloadBid).toHaveBeenCalledWith(
       {signedExecutionPayloadBid: signedBid},
       {signal: expect.any(AbortSignal)}
     );
+    bid.inclusionListBits.set(1, false);
+    expect(verify(getExecutionPayloadBidSigningRoot(config, bid), keys.publicKey, signature)).toBe(false);
   });
 
   it("rejects a bid for another Builder before signing or recording", async () => {
@@ -104,14 +114,55 @@ describe("BidPublisher", () => {
 
   it("enforces one submission for the same parent tuple", async () => {
     const bid = createBid();
-    const {api, publisher} = createPublisher({hasPayload: vi.fn(() => true)});
+    const {api, publisher, signer} = createPublisher({hasPayload: vi.fn(() => true)});
+    const sign = vi.spyOn(signer, "signExecutionPayloadBid");
     const signal = new AbortController().signal;
     await publisher.publish(bid, signal);
 
-    await expect(publisher.publish(bid, signal)).rejects.toMatchObject({
+    await expect(publisher.publish({...bid, value: bid.value + 1}, signal)).rejects.toMatchObject({
       type: {code: BidLedgerErrorCode.DUPLICATE_BID},
     });
     expect(api.beacon.publishExecutionPayloadBid).toHaveBeenCalledOnce();
+    expect(sign).toHaveBeenCalledOnce();
+  });
+
+  it("reserves the tuple before publication completes", async () => {
+    const {api, publisher, signer} = createPublisher({hasPayload: vi.fn(() => true)});
+    const sign = vi.spyOn(signer, "signExecutionPayloadBid");
+    const response = defer<Awaited<ReturnType<typeof api.beacon.publishExecutionPayloadBid>>>();
+    api.beacon.publishExecutionPayloadBid.mockReturnValue(response.promise);
+    const bid = createBid();
+    const signal = new AbortController().signal;
+    const first = publisher.publish(bid, signal);
+
+    await expect(publisher.publish({...bid, value: 6}, signal)).rejects.toMatchObject({
+      type: {code: BidLedgerErrorCode.DUPLICATE_BID},
+    });
+    expect(sign).toHaveBeenCalledOnce();
+    expect(api.beacon.publishExecutionPayloadBid).toHaveBeenCalledOnce();
+    response.resolve(await mockApiResponse({data: undefined, meta: undefined}));
+    await first;
+  });
+
+  it("does not reserve a bid if signing fails", async () => {
+    const {api, ledger, publisher, signer} = createPublisher({hasPayload: vi.fn(() => true)});
+    vi.spyOn(signer, "signExecutionPayloadBid").mockImplementationOnce(() => {
+      throw Error("signing failed");
+    });
+    const bid = createBid();
+    await expect(publisher.publish(bid, new AbortController().signal)).rejects.toThrow("signing failed");
+    expect(ledger.getBidsForSlot(bid.slot)).toEqual([]);
+    expect(api.beacon.publishExecutionPayloadBid).not.toHaveBeenCalled();
+  });
+
+  it("rejects pre-Gloas input before signing", async () => {
+    const {api, publisher, signer} = createPublisher({hasPayload: vi.fn(() => true), fork: ForkName.fulu});
+    const sign = vi.spyOn(signer, "signExecutionPayloadBid");
+    await expect(publisher.publish(createBid(), new AbortController().signal)).rejects.toMatchObject({
+      type: {code: BidPublisherErrorCode.PRE_GLOAS_BID},
+    });
+    expect(sign).not.toHaveBeenCalled();
+    expect(api.beacon.publishExecutionPayloadBid).not.toHaveBeenCalled();
   });
 
   it("keeps the one-shot record when the Beacon Node rejects publication", async () => {
@@ -124,13 +175,22 @@ describe("BidPublisher", () => {
   });
 });
 
-function createPublisher({hasPayload}: {hasPayload: (identity: BidIdentity) => boolean}) {
+function createPublisher({
+  hasPayload,
+  fork = ForkName.gloas,
+}: {
+  hasPayload: (identity: BidIdentity) => boolean;
+  fork?: ForkName;
+}) {
+  const config = createBeaconConfig(getConfig(fork), Buffer.alloc(32, 9));
+  const keys = keypair(Buffer.alloc(32, 1));
+  const signer = new BuilderSigner(config, keys);
   const api = getApiClientStub();
   Object.assign(api.beacon, {publishExecutionPayloadBid: vi.fn()});
   api.beacon.publishExecutionPayloadBid.mockResolvedValue(mockApiResponse({}));
   const ledger = new BidLedger();
-  const publisher = new BidPublisher({api, signer, ledger, builderIndex, hasPayload});
-  return {api, ledger, publisher};
+  const publisher = new BidPublisher({api, config, signer, ledger, builderIndex, hasPayload});
+  return {api, config, keys, ledger, publisher, signer};
 }
 
 function createBid(): ReturnType<typeof ssz.gloas.ExecutionPayloadBid.defaultValue> {

--- a/packages/builder/test/unit/services/bidPublisher.test.ts
+++ b/packages/builder/test/unit/services/bidPublisher.test.ts
@@ -165,7 +165,7 @@ describe("BidPublisher", () => {
     expect(api.beacon.publishExecutionPayloadBid).not.toHaveBeenCalled();
   });
 
-  it("keeps the one-shot record when the Beacon Node rejects publication", async () => {
+  it("retains the submission record when the Beacon Node rejects publication", async () => {
     const bid = createBid();
     const {api, ledger, publisher} = createPublisher({hasPayload: vi.fn(() => true)});
     api.beacon.publishExecutionPayloadBid.mockResolvedValue(await mockApiErrorResponse(HttpStatusCode.BAD_REQUEST));

--- a/packages/builder/test/unit/services/builderSigner.test.ts
+++ b/packages/builder/test/unit/services/builderSigner.test.ts
@@ -46,6 +46,16 @@ describe("BuilderSigner", () => {
     ).toEqual(true);
   });
 
+  it("preserves Heze bid fields", () => {
+    const bid = ssz.heze.ExecutionPayloadBid.defaultValue();
+    bid.slot = 1;
+    bid.inclusionListBits.set(1, true);
+
+    const signedBid = builderSigner.signExecutionPayloadBid(bid);
+
+    expect(signedBid.message.inclusionListBits.get(1)).toBe(true);
+  });
+
   describe("negative tests - different network", () => {
     const genesisValidatorsRootOtherNetwork = Buffer.alloc(32, 8);
     const beaconConfigOtherNetwork = createBeaconConfig(chainConfig, genesisValidatorsRootOtherNetwork);

--- a/packages/builder/test/unit/services/builderSigner.test.ts
+++ b/packages/builder/test/unit/services/builderSigner.test.ts
@@ -46,14 +46,20 @@ describe("BuilderSigner", () => {
     ).toEqual(true);
   });
 
-  it("preserves Heze bid fields", () => {
+  it("signs Heze inclusion list bits", () => {
+    const hezeConfig = createBeaconConfig(getConfig(ForkName.heze), genesisValidatorsRoot);
+    const hezeSigner = new BuilderSigner(hezeConfig, {publicKey, secretKey});
     const bid = ssz.heze.ExecutionPayloadBid.defaultValue();
     bid.slot = 1;
     bid.inclusionListBits.set(1, true);
 
-    const signedBid = builderSigner.signExecutionPayloadBid(bid);
+    const signedBid = hezeSigner.signExecutionPayloadBid(bid);
 
     expect(signedBid.message.inclusionListBits.get(1)).toBe(true);
+    const signature = Signature.fromBytes(signedBid.signature, true);
+    expect(verify(getExecutionPayloadBidSigningRoot(hezeConfig, bid), publicKey, signature)).toBe(true);
+    bid.inclusionListBits.set(1, false);
+    expect(verify(getExecutionPayloadBidSigningRoot(hezeConfig, bid), publicKey, signature)).toBe(false);
   });
 
   describe("negative tests - different network", () => {


### PR DESCRIPTION
## Motivation

The Builder should not sign or submit the same slot and parent tuple twice, even after old ledger records are pruned. This PR separates signing and Beacon Node publication from payload construction and scheduling.

## Description

Adds `BidPublisher`, which checks the local Builder index and retained payload before signing, fingerprints the complete fork-correct Gloas or Heze bid, records its slot and parent tuple, and submits through `publishExecutionPayloadBid`.

A rejected or ambiguous request keeps its reservation. Ledger pruning now advances a monotonic oldest-slot cutoff, so deleting an old reservation cannot allow that slot to be signed again. This preserves bounded history without retaining every failed publication indefinitely. It is an implementation policy, not a protocol-wide restriction on bidding.

Scheduling, pricing, retries, storage, selection, reveal and runtime wiring remain separate.

## Review scope

The #9975 ledger dependency is merged. The pruning correction exposed an add/add conflict with that squash-merged parent. I merged the exact upstream base `82e7577c8bebe2c6cca1ec633d690f9bbdcab087` and preserved the tested correction.

The resulting diff contains the publisher source/tests, the Heze signer overload/tests, and the ledger cutoff correction/tests. Historical parent-only changes are no longer part of the review diff.

## Testing

At `91038c140a9b6257194d621da0d4e162d7e61d10`:

- All 40 publisher, signer and ledger tests passed.
- Regressions reproduced repeat signing after pruning for pending, failed and accepted publication before the fix.
- A backwards prune call cannot reopen an expired slot.
- Ordinary Builder type-check, changed-file Biome, build/import and diff checks passed.

These are local component checks. Fresh full hosted CI and the complete BN/EL lifecycle are not claimed.

Tracking [LOD-63](https://linear.app/kriso/issue/LOD-63).

> This PR was written primarily with Codex assistance and manually reviewed and tested against Lodestar's existing patterns.
