### PR TITLE
docs: update historical fork support boundaries

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -43,6 +43,7 @@ FINDNODE
 FX
 Flamegraph
 Flamegraphs
+Fulu
 GPG
 Geth
 Github

--- a/docs/pages/run/beacon-management/historical-fork-support.md
+++ b/docs/pages/run/beacon-management/historical-fork-support.md
@@ -6,8 +6,8 @@ title: Historical Fork Support
 
 Lodestar supports different historical fork ranges depending on the beacon node activity. This matrix documents the earliest supported fork for each activity, so operators and contributors can reason about support without relying on a single broad statement.
 
-|                    | Syncing | Following head | Block production |
-| ------------------ | ------- | -------------- | ---------------- |
-| **Supported from** | Phase0  | Phase0         | Electra          |
+|                    | Syncing and serving | Following head | Block production |
+| ------------------ | ------------------- | -------------- | ---------------- |
+| **Supported from** | Phase0              | Fulu           | Fulu             |
 
-Future support policy for historical forks can be revisited as the network and maintenance needs change. For example, a release may choose to preserve older syncing and head-following paths while intentionally narrowing validator duties such as block production.
+Sync support includes both downloading and serving historical blocks. It does not imply support for following the head or producing blocks on those historical forks.

--- a/docs/pages/run/beacon-management/historical-fork-support.md
+++ b/docs/pages/run/beacon-management/historical-fork-support.md
@@ -10,4 +10,4 @@ Lodestar supports different historical fork ranges depending on the beacon node 
 | ------------------ | ------------------- | -------------- | ---------------- |
 | **Supported from** | Phase0              | Fulu           | Fulu             |
 
-Sync support includes both downloading and serving historical blocks. It does not imply support for following the head or producing blocks on those historical forks.
+Sync support includes both downloading and serving historical blocks. It does not imply support for following the head or producing blocks on those historical forks. These are operational support boundaries, not a list of fork-specific types and code paths retained for historical sync, replay, and tests.


### PR DESCRIPTION
## Summary

- document Phase0 as the earliest supported fork for historical syncing and serving
- document Fulu as the earliest supported fork for following head and block production
- clarify that historical sync support does not imply support for live head following or block production on old forks

This reflects the head-following boundary after #9959.

## AI assistance

Created with Hermes Agent.