### PR TITLE
fix: run cheap bid rejects before expensive validation

### DIFF
--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -104,6 +104,28 @@ export async function validateApiExecutionPayloadBid(
   const bid = signedExecutionPayloadBid.message;
   const bidParentBlockRoot = toRootHex(bid.parentBlockRoot);
 
+  // [REJECT] `bid.execution_payment` is zero.
+  if (bid.executionPayment !== 0n) {
+    throw new ExecutionPayloadBidError(GossipAction.REJECT, {
+      code: ExecutionPayloadBidErrorCode.NON_ZERO_EXECUTION_PAYMENT,
+      builderIndex: bid.builderIndex,
+      executionPayment: bid.executionPayment,
+    });
+  }
+
+  // [REJECT] The length of KZG commitments is less than or equal to the limitation defined in the
+  // consensus layer -- i.e. validate that
+  // `len(bid.blob_kzg_commitments) <= get_blob_parameters(compute_epoch_at_slot(bid.slot)).max_blobs_per_block`.
+  const blobKzgCommitmentsLen = bid.blobKzgCommitments.length;
+  const maxBlobsPerBlock = chain.config.getMaxBlobsPerBlock(computeEpochAtSlot(bid.slot));
+  if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
+    throw new ExecutionPayloadBidError(GossipAction.REJECT, {
+      code: ExecutionPayloadBidErrorCode.TOO_MANY_KZG_COMMITMENTS,
+      blobKzgCommitmentsLen,
+      commitmentLimit: maxBlobsPerBlock,
+    });
+  }
+
   // [IGNORE] `bid.slot` is the current slot, or the next slot (`bid.slot - 1` is current), allowing for `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
   if (
     !chain.clock.isCurrentSlotGivenGossipDisparity(bid.slot) &&
@@ -135,28 +157,6 @@ export async function validateApiExecutionPayloadBid(
       code: ExecutionPayloadBidErrorCode.NOT_LATER_THAN_PARENT,
       parentSlot: parentBlock.slot,
       slot: bid.slot,
-    });
-  }
-
-  // [REJECT] `bid.execution_payment` is zero.
-  if (bid.executionPayment !== 0n) {
-    throw new ExecutionPayloadBidError(GossipAction.REJECT, {
-      code: ExecutionPayloadBidErrorCode.NON_ZERO_EXECUTION_PAYMENT,
-      builderIndex: bid.builderIndex,
-      executionPayment: bid.executionPayment,
-    });
-  }
-
-  // [REJECT] The length of KZG commitments is less than or equal to the limitation defined in the
-  // consensus layer -- i.e. validate that
-  // `len(bid.blob_kzg_commitments) <= get_blob_parameters(compute_epoch_at_slot(bid.slot)).max_blobs_per_block`.
-  const blobKzgCommitmentsLen = bid.blobKzgCommitments.length;
-  const maxBlobsPerBlock = chain.config.getMaxBlobsPerBlock(computeEpochAtSlot(bid.slot));
-  if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
-    throw new ExecutionPayloadBidError(GossipAction.REJECT, {
-      code: ExecutionPayloadBidErrorCode.TOO_MANY_KZG_COMMITMENTS,
-      blobKzgCommitmentsLen,
-      commitmentLimit: maxBlobsPerBlock,
     });
   }
 
@@ -256,6 +256,28 @@ async function validateExecutionPayloadBid(
   const bid = signedExecutionPayloadBid.message;
   const bidParentBlockRoot = toRootHex(bid.parentBlockRoot);
   const bidParentBlockHash = toRootHex(bid.parentBlockHash);
+
+  // [REJECT] `bid.execution_payment` is zero.
+  if (bid.executionPayment !== 0n) {
+    throw new ExecutionPayloadBidError(GossipAction.REJECT, {
+      code: ExecutionPayloadBidErrorCode.NON_ZERO_EXECUTION_PAYMENT,
+      builderIndex: bid.builderIndex,
+      executionPayment: bid.executionPayment,
+    });
+  }
+
+  // [REJECT] The length of KZG commitments is less than or equal to the limitation defined in the
+  // consensus layer -- i.e. validate that
+  // `len(bid.blob_kzg_commitments) <= get_blob_parameters(compute_epoch_at_slot(bid.slot)).max_blobs_per_block`.
+  const blobKzgCommitmentsLen = bid.blobKzgCommitments.length;
+  const maxBlobsPerBlock = chain.config.getMaxBlobsPerBlock(computeEpochAtSlot(bid.slot));
+  if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
+    throw new ExecutionPayloadBidError(GossipAction.REJECT, {
+      code: ExecutionPayloadBidErrorCode.TOO_MANY_KZG_COMMITMENTS,
+      blobKzgCommitmentsLen,
+      commitmentLimit: maxBlobsPerBlock,
+    });
+  }
 
   // [IGNORE] `bid.slot` is the current slot, or the next slot (`bid.slot - 1` is current), allowing for `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
   if (
@@ -402,15 +424,6 @@ async function validateExecutionPayloadBid(
     });
   }
 
-  // [REJECT] `bid.execution_payment` is zero.
-  if (bid.executionPayment !== 0n) {
-    throw new ExecutionPayloadBidError(GossipAction.REJECT, {
-      code: ExecutionPayloadBidErrorCode.NON_ZERO_EXECUTION_PAYMENT,
-      builderIndex: bid.builderIndex,
-      executionPayment: bid.executionPayment,
-    });
-  }
-
   // [IGNORE] `bid.fee_recipient == proposer_preferences.fee_recipient`.
   if (!byteArrayEquals(bid.feeRecipient, proposerPreferences.message.feeRecipient)) {
     throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
@@ -448,19 +461,6 @@ async function validateExecutionPayloadBid(
       bidGasLimit,
       parentGasLimit,
       targetGasLimit,
-    });
-  }
-
-  // [REJECT] The length of KZG commitments is less than or equal to the limitation defined in the
-  // consensus layer -- i.e. validate that
-  // `len(bid.blob_kzg_commitments) <= get_blob_parameters(compute_epoch_at_slot(bid.slot)).max_blobs_per_block`.
-  const blobKzgCommitmentsLen = bid.blobKzgCommitments.length;
-  const maxBlobsPerBlock = chain.config.getMaxBlobsPerBlock(computeEpochAtSlot(bid.slot));
-  if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
-    throw new ExecutionPayloadBidError(GossipAction.REJECT, {
-      code: ExecutionPayloadBidErrorCode.TOO_MANY_KZG_COMMITMENTS,
-      blobKzgCommitmentsLen,
-      commitmentLimit: maxBlobsPerBlock,
     });
   }
 

--- a/packages/beacon-node/src/execution/builder/validateBid.ts
+++ b/packages/beacon-node/src/execution/builder/validateBid.ts
@@ -56,6 +56,12 @@ export async function validateBuilderApiExecutionPayloadBid(
     );
   }
 
+  const blobKzgCommitmentsLen = bid.blobKzgCommitments.length;
+  const maxBlobsPerBlock = chain.config.getMaxBlobsPerBlock(computeEpochAtSlot(bid.slot));
+  if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
+    throw Error(`Bid has too many KZG commitments len=${blobKzgCommitmentsLen} limit=${maxBlobsPerBlock}`);
+  }
+
   const totalPayment = getBuilderBidTotalGwei(bid, entry.maxExecutionPayment);
   if (totalPayment < entry.minBid) {
     throw Error(
@@ -98,12 +104,6 @@ export async function validateBuilderApiExecutionPayloadBid(
       `Bid builder pubkey=${toHex(builder.pubkey)} is not in the entry's ` +
         `builderPubkeys=${entry.builderPubkeys.map(toHex).join(",")}`
     );
-  }
-
-  const blobKzgCommitmentsLen = bid.blobKzgCommitments.length;
-  const maxBlobsPerBlock = chain.config.getMaxBlobsPerBlock(computeEpochAtSlot(bid.slot));
-  if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
-    throw Error(`Bid has too many KZG commitments len=${blobKzgCommitmentsLen} limit=${maxBlobsPerBlock}`);
   }
 
   // The coverage check only applies to the staked collateral payment, a pure execution


### PR DESCRIPTION
just moving some checks around, I think running cheap rejects early is ideal, then cheap ignores, then more expensive checks that require the state or are otherwise expensive to do, like signature verification

noticed this when working on https://github.com/ChainSafe/lodestar/pull/9972