### PR TITLE
test: fail spec tests expecting an error if none is thrown

### DIFF
--- a/packages/beacon-node/test/spec/presets/sanity.test.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.test.ts
@@ -64,10 +64,6 @@ const sanityBlocks: TestRunnerFn<SanityBlocksTestCase, BeaconStateAllForks> = (f
       const verify = shouldVerify(testcase);
       for (let i = 0; i < testcase.meta.blocks_count; i++) {
         const signedBlock = testcase[`blocks_${i}`] as deneb.SignedBeaconBlock;
-        // Spec state_transition requires state.slot < block.slot, Lodestar dials the state forward beforehand
-        if (signedBlock.message.slot <= wrappedState.slot) {
-          throw Error(`Block slot ${signedBlock.message.slot} is not greater than state slot ${wrappedState.slot}`);
-        }
         wrappedState = stateTransition(wrappedState, signedBlock, {
           // Assume valid and available for this test
           executionPayloadStatus: ExecutionPayloadStatus.valid,

--- a/packages/beacon-node/test/spec/presets/sanity.test.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.test.ts
@@ -64,11 +64,15 @@ const sanityBlocks: TestRunnerFn<SanityBlocksTestCase, BeaconStateAllForks> = (f
       const verify = shouldVerify(testcase);
       for (let i = 0; i < testcase.meta.blocks_count; i++) {
         const signedBlock = testcase[`blocks_${i}`] as deneb.SignedBeaconBlock;
+        // Spec state_transition requires state.slot < block.slot, Lodestar dials the state forward beforehand
+        if (signedBlock.message.slot <= wrappedState.slot) {
+          throw Error(`Block slot ${signedBlock.message.slot} is not greater than state slot ${wrappedState.slot}`);
+        }
         wrappedState = stateTransition(wrappedState, signedBlock, {
           // Assume valid and available for this test
           executionPayloadStatus: ExecutionPayloadStatus.valid,
           dataAvailabilityStatus: DataAvailabilityStatus.Available,
-          verifyStateRoot: verify,
+          verifyStateRoot: true,
           verifyProposer: verify,
           verifySignatures: verify,
           assertCorrectProgressiveBalances,

--- a/packages/beacon-node/test/spec/presets/sanity.test.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.test.ts
@@ -72,6 +72,7 @@ const sanityBlocks: TestRunnerFn<SanityBlocksTestCase, BeaconStateAllForks> = (f
           // Assume valid and available for this test
           executionPayloadStatus: ExecutionPayloadStatus.valid,
           dataAvailabilityStatus: DataAvailabilityStatus.Available,
+          // Always verify the state root, it is not gated by bls_setting
           verifyStateRoot: true,
           verifyProposer: verify,
           verifySignatures: verify,

--- a/packages/spec-test-util/src/single.ts
+++ b/packages/spec-test-util/src/single.ts
@@ -128,6 +128,7 @@ export function describeDirectorySpecTest<TestCase extends {meta?: any}, Result>
           } catch (_e) {
             return;
           }
+          expect.unreachable("Expected test function to throw");
         } else {
           const result = await testFunction(testCase, name, testSubDirname);
           if (!options.getExpected) throw Error("getExpected is not defined");

--- a/packages/spec-test-util/test/e2e/single/index.test.ts
+++ b/packages/spec-test-util/test/e2e/single/index.test.ts
@@ -46,6 +46,9 @@ describeDirectorySpecTest<SimpleCase, number>(
   "single spec test",
   path.join(__dirname, "../_test_files/single"),
   (testCase) => {
+    if (!testCase.input.test) {
+      throw Error("test flag is false");
+    }
     return testCase.input.number;
   },
   {

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -212,7 +212,12 @@ function getBuildersSweepWithdrawals(
       break;
     }
 
-    // Get next builder in turn
+    // Get next builder in turn, the spec does not wrap around an out of bounds start index
+    if (n === 0 && state.nextWithdrawalBuilderIndex >= builders.length) {
+      throw Error(
+        `Next withdrawal builder index ${state.nextWithdrawalBuilderIndex} out of bounds, builders count ${builders.length}`
+      );
+    }
     const builderIndex = (state.nextWithdrawalBuilderIndex + n) % builders.length;
     const builder = builders.getReadonly(builderIndex);
 
@@ -340,7 +345,12 @@ function getValidatorsSweepWithdrawals(
       break;
     }
 
-    // Get next validator in turn
+    // Get next validator in turn, the spec does not wrap around an out of bounds start index
+    if (n === 0 && nextWithdrawalValidatorIndex >= validators.length) {
+      throw Error(
+        `Next withdrawal validator index ${nextWithdrawalValidatorIndex} out of bounds, validators count ${validators.length}`
+      );
+    }
     const validatorIndex = (nextWithdrawalValidatorIndex + n) % validators.length;
 
     const validator = validators.getReadonly(validatorIndex);


### PR DESCRIPTION
the spec test runner returned early if the test function threw but never asserted that it actually did, any test expecting an error passed silently if we accepted the input instead. asserting this surfaced 22 vectors we currently accept but should reject

- `invalid_incorrect_state_root` / `invalid_same_slot_block_transition` (all forks): the sanity runner only verified the state root if `bls_setting` was 1, this is unrelated to bls and must always be verified. the same slot vectors fail on this check as well, spec `state_transition` requires `state.slot < block.slot` but we intentionally don't enforce this in the state transition since lodestar dials the state forward before importing a block
- `invalid_builder_index_sweep` / `invalid_validator_index_sweep` (gloas, heze): the spec raw indexes the first sweep access and only wraps around on advance, we applied the modulo from the start which silently wrapped an out of bounds `next_withdrawal_*_index`. not reachable via valid state transitions but a spec divergence nonetheless

noticed this while testing the new vectors for https://github.com/ChainSafe/lodestar/pull/9972
