### PR TITLE
fix(lightclient): serve bootstrap for the checkpoint-sync anchor block

### DIFF
--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -58,6 +58,8 @@ import {
   getCurrentSyncCommitteeBranch,
   getNextSyncCommitteeBranch,
 } from "./proofs.js";
+import {getBlockBodyExecutionHeaderProof, getCurrentSyncCommitteeBranch, getNextSyncCommitteeBranch} from "./proofs.js";
+import type {SyncCommitteeWitness} from "./types.js";
 
 export type LightClientServerOpts = {
   disableLightClientServerOnImportBlockHead?: boolean;
@@ -391,6 +393,60 @@ export class LightClientServer {
     ]);
   }
 
+  /**
+   * Persist the data needed to serve `LightClientBootstrap` for the checkpoint-sync anchor block.
+   */
+  async persistAnchorBootstrapData(
+    anchorBlock: BeaconBlock<ForkPostAltair>,
+    anchorState: IBeaconStateViewAltair
+  ): Promise<void> {
+    const fork = this.config.getForkName(anchorBlock.slot);
+    const header = blockToLightClientHeader(fork, anchorBlock);
+    const blockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(header.beacon);
+    const syncCommitteeWitness = anchorState.getSyncCommitteesWitness();
+
+    await this.storeCurrentSyncCommittees(anchorState, syncCommitteeWitness, anchorBlock.slot);
+    await this.persistWitnessAndHeader(blockRoot, syncCommitteeWitness, header);
+
+    this.logger.debug("Stored light client bootstrap data for anchor block", {
+      slot: anchorBlock.slot,
+      root: toRootHex(blockRoot),
+    });
+  }
+
+  /**
+   * Store `currentSyncCommittee` and `nextSyncCommittee` referenced by a witness, only once per run
+   */
+  private async storeCurrentSyncCommittees(
+    postState: IBeaconStateViewAltair,
+    syncCommitteeWitness: SyncCommitteeWitness,
+    slot: Slot
+  ): Promise<void> {
+    if (this.storedCurrentSyncCommittee) {
+      return;
+    }
+    await Promise.all([
+      this.storeSyncCommittee(postState.currentSyncCommittee, syncCommitteeWitness.currentSyncCommitteeRoot),
+      this.storeSyncCommittee(postState.nextSyncCommittee, syncCommitteeWitness.nextSyncCommitteeRoot),
+    ]);
+    this.storedCurrentSyncCommittee = true;
+    this.logger.debug("Stored currentSyncCommittee", {slot});
+  }
+
+  /**
+   * Persist the witness and header that `getBootstrap` needs for `blockRoot`.
+   * Referenced sync committees must already be persisted.
+   */
+  private async persistWitnessAndHeader(
+    blockRoot: Uint8Array,
+    syncCommitteeWitness: SyncCommitteeWitness,
+    header: LightClientHeader
+  ): Promise<void> {
+    await this.db.syncCommitteeWitness.put(blockRoot, syncCommitteeWitness);
+    // Store header in case it is referenced later by a future finalized checkpoint
+    await this.db.checkpointHeader.put(blockRoot, header);
+  }
+
   private async persistPostBlockImportData(
     block: BeaconBlock<ForkPostAltair>,
     postState: IBeaconStateViewAltair,
@@ -405,15 +461,7 @@ export class LightClientServer {
 
     const syncCommitteeWitness = postState.getSyncCommitteesWitness();
 
-    // Only store current sync committee once per run
-    if (!this.storedCurrentSyncCommittee) {
-      await Promise.all([
-        this.storeSyncCommittee(postState.currentSyncCommittee, syncCommitteeWitness.currentSyncCommitteeRoot),
-        this.storeSyncCommittee(postState.nextSyncCommittee, syncCommitteeWitness.nextSyncCommitteeRoot),
-      ]);
-      this.storedCurrentSyncCommittee = true;
-      this.logger.debug("Stored currentSyncCommittee", {slot: blockSlot});
-    }
+    await this.storeCurrentSyncCommittees(postState, syncCommitteeWitness, blockSlot);
 
     // Only store next sync committee once per dependent root
     const parentBlockPeriod = computeSyncPeriodAtSlot(parentBlockSlot);
@@ -430,10 +478,7 @@ export class LightClientServer {
     }
 
     // Ensure referenced syncCommittee are persisted before persiting this one
-    await this.db.syncCommitteeWitness.put(blockRoot, syncCommitteeWitness);
-
-    // Store header in case it is referenced latter by a future finalized checkpoint
-    await this.db.checkpointHeader.put(blockRoot, header);
+    await this.persistWitnessAndHeader(blockRoot, syncCommitteeWitness, header);
 
     // Store finalized checkpoint data
     const finalizedCheckpoint = postState.finalizedCheckpoint;

--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -395,6 +395,8 @@ export class LightClientServer {
 
   /**
    * Persist the data needed to serve `LightClientBootstrap` for the checkpoint-sync anchor block.
+   *
+   * https://github.com/ethereum/consensus-specs/blob/master/specs/altair/light-client/sync-protocol.md#lightclientbootstrap
    */
   async persistAnchorBootstrapData(
     anchorBlock: BeaconBlock<ForkPostAltair>,

--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -58,7 +58,6 @@ import {
   getCurrentSyncCommitteeBranch,
   getNextSyncCommitteeBranch,
 } from "./proofs.js";
-import {getBlockBodyExecutionHeaderProof, getCurrentSyncCommitteeBranch, getNextSyncCommitteeBranch} from "./proofs.js";
 import type {SyncCommitteeWitness} from "./types.js";
 
 export type LightClientServerOpts = {

--- a/packages/beacon-node/src/sync/backfill/backfill.ts
+++ b/packages/beacon-node/src/sync/backfill/backfill.ts
@@ -1,9 +1,9 @@
 import {EventEmitter} from "node:events";
 import {StrictEventEmitter} from "strict-event-emitter-types";
 import {BeaconConfig, ChainForkConfig} from "@lodestar/config";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {IBeaconStateView, blockToHeader} from "@lodestar/state-transition";
-import {Root, SignedBeaconBlock, Slot, phase0, ssz} from "@lodestar/types";
+import {ForkPostAltair, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {IBeaconStateView, blockToHeader, isStatePostAltair} from "@lodestar/state-transition";
+import {BeaconBlock, Root, SignedBeaconBlock, Slot, phase0, ssz} from "@lodestar/types";
 import {ErrorAborted, Logger, byteArrayEquals, sleep, toRootHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../chain/index.js";
 import {GENESIS_SLOT, ZERO_HASH} from "../../constants/index.js";
@@ -146,6 +146,10 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
   private backfillStartFromSlot: Slot;
   private backfillRangeWrittenSlot: Slot | null;
 
+  /** State the node started from, needed to serve light client bootstrap for its block once retrieved */
+  private readonly anchorState: IBeaconStateView;
+  private readonly anchorStateBlockRoot: Root;
+
   private processor = new ItTrigger();
   private peers = new Set<PeerIdStr>();
   private status: BackfillSyncStatus = BackfillSyncStatus.pending;
@@ -166,6 +170,8 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
     this.config = modules.config;
     this.logger = modules.logger;
     this.metrics = modules.metrics;
+    this.anchorState = modules.anchorState;
+    this.anchorStateBlockRoot = modules.anchorState.computeAnchorCheckpoint().checkpoint.root;
 
     this.opts = opts;
     this.network.events.on(NetworkEvent.peerConnected, this.addPeer);
@@ -663,6 +669,7 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
     }
     let anchorBlock = await this.db.blockArchive.getByRoot(anchorBlockRoot);
     if (!anchorBlock) return false;
+    this.maybePersistAnchorLightClientData(anchorBlockRoot, anchorBlock);
 
     if (expectedSlot !== null && anchorBlock.message.slot !== expectedSlot)
       throw Error(
@@ -742,6 +749,23 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
     return true;
   }
 
+  /**
+   * The light client server never sees the anchor block being imported, so once we hold the block that
+   * the anchor state was computed from, persist the bootstrap data for it (spec: full nodes SHOULD serve
+   * `LightClientBootstrap` for all finalized epoch boundary blocks, which includes the checkpoint root).
+   */
+  private maybePersistAnchorLightClientData(blockRoot: Root, block: SignedBeaconBlock): void {
+    if (!byteArrayEquals(blockRoot, this.anchorStateBlockRoot)) return;
+    const {lightClientServer} = this.chain;
+    if (!lightClientServer || !isStatePostAltair(this.anchorState)) return;
+
+    lightClientServer
+      .persistAnchorBootstrapData(block.message as BeaconBlock<ForkPostAltair>, this.anchorState)
+      .catch((e) => {
+        this.logger.warn("Error persisting light client data for anchor block", {slot: block.message.slot}, e);
+      });
+  }
+
   private async syncBlockByRoot(peer: PeerIdStr, anchorBlockRoot: Root): Promise<void> {
     const res = await this.network.sendBeaconBlocksByRoot(peer, [anchorBlockRoot]);
     if (res.length < 1) throw new Error("InvalidBlockSyncedFromPeer");
@@ -769,6 +793,7 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
       anchorSlot: anchorBlock.message.slot,
       lastBackSyncedBlock: {root: anchorBlockRoot, slot: anchorBlock.message.slot, block: anchorBlock},
     };
+    this.maybePersistAnchorLightClientData(anchorBlockRoot, anchorBlock);
 
     this.metrics?.backfillSync.totalBlocks.inc({method: BackfillSyncMethod.blockbyroot});
 

--- a/packages/beacon-node/test/unit/chain/lightclient/anchorBootstrap.test.ts
+++ b/packages/beacon-node/test/unit/chain/lightclient/anchorBootstrap.test.ts
@@ -1,0 +1,79 @@
+import {describe, expect, it, vi} from "vitest";
+import {BeaconStateView, isStatePostAltair} from "@lodestar/state-transition";
+import {LightClientBootstrap, ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {LightClientServer} from "../../../../src/chain/lightClient/index.js";
+import {IBeaconDb} from "../../../../src/db/index.js";
+import {generateCachedAltairState} from "../../../utils/state.js";
+
+/**
+ * After checkpoint sync the anchor block is never imported through `onImportBlockHead`, so the server
+ * must be able to persist bootstrap data for it from the anchor state alone (plus the block once fetched).
+ */
+describe("LightClientServer anchor bootstrap", () => {
+  it("persists witness, header and committees so getBootstrap works for the anchor root", async () => {
+    const cachedState = generateCachedAltairState({slot: 8});
+    const anchorState = new BeaconStateView(cachedState);
+    if (!isStatePostAltair(anchorState)) throw Error("expected altair state");
+
+    const anchorBlock = ssz.altair.BeaconBlock.defaultValue();
+    anchorBlock.slot = 8;
+    anchorBlock.stateRoot = cachedState.hashTreeRoot();
+    const anchorRoot = ssz.altair.BeaconBlock.hashTreeRoot(anchorBlock);
+
+    // In-memory stand-ins for the three repositories getBootstrap reads
+    const witnesses = new Map<string, unknown>();
+    const committees = new Map<string, Uint8Array>();
+    const headers = new Map<string, unknown>();
+    const db = {
+      syncCommitteeWitness: {
+        put: vi.fn(async (root: Uint8Array, w: unknown) => void witnesses.set(toRootHex(root), w)),
+        get: vi.fn(async (root: Uint8Array) => witnesses.get(toRootHex(root)) ?? null),
+      },
+      syncCommittee: {
+        has: vi.fn(async (root: Uint8Array) => committees.has(toRootHex(root))),
+        putBinary: vi.fn(async (root: Uint8Array, bytes: Uint8Array) => void committees.set(toRootHex(root), bytes)),
+        get: vi.fn(async (root: Uint8Array) => {
+          const bytes = committees.get(toRootHex(root));
+          return bytes ? ssz.altair.SyncCommittee.deserialize(bytes) : null;
+        }),
+      },
+      checkpointHeader: {
+        put: vi.fn(async (root: Uint8Array, h: unknown) => void headers.set(toRootHex(root), h)),
+        get: vi.fn(async (root: Uint8Array) => headers.get(toRootHex(root)) ?? null),
+      },
+    } as unknown as IBeaconDb;
+
+    const server = new LightClientServer(
+      {},
+      {
+        config: cachedState.config,
+        db,
+        clock: {} as never,
+        metrics: null,
+        emitter: {} as never,
+        logger: {debug: vi.fn(), error: vi.fn()} as never,
+        signal: new AbortController().signal,
+      }
+    );
+
+    // Before: nothing persisted for the anchor root
+    await expect(server.getBootstrap(anchorRoot)).rejects.toThrow(/syncCommitteeWitness not available/);
+
+    await server.persistAnchorBootstrapData(anchorBlock, anchorState);
+
+    const bootstrap: LightClientBootstrap = await server.getBootstrap(anchorRoot);
+    expect(ssz.phase0.BeaconBlockHeader.hashTreeRoot(bootstrap.header.beacon)).toEqual(anchorRoot);
+    expect(ssz.altair.SyncCommittee.hashTreeRoot(bootstrap.currentSyncCommittee)).toEqual(
+      ssz.altair.SyncCommittee.hashTreeRoot(anchorState.currentSyncCommittee)
+    );
+    expect(bootstrap.currentSyncCommitteeBranch.length).toBeGreaterThan(0);
+
+    // Both committees referenced by the witness were stored, each exactly once
+    expect(db.syncCommittee.putBinary).toHaveBeenCalledTimes(2);
+
+    // Calling again is idempotent and does not re-store committees
+    await server.persistAnchorBootstrapData(anchorBlock, anchorState);
+    expect(db.syncCommittee.putBinary).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
**Motivation**

We're missing data related to a `LightClientBootstrap` when syncing from a checkpoint,  because the data is only persisted by [`persistPostBlockImportData()`](https://github.com/ChainSafe/lodestar/blob/0dbea0de1b39ab8d2064660dd074900ad04b3334/packages/beacon-node/src/chain/lightClient/index.ts#L394) during block import.

This technically is just a nice-to-have because we self-heal after the next checkpoint and we serve this eventually

**Description**

Fix: derive the bootstrap data from the anchor state the node already has.

followup to #9687 

**AI Assistance Disclosure**

Found this bug first with fable which was used to fix my own proxy impl, now making this upstream fix with fable
