### PR TITLE
refactor: rename getLcExecutionRoot to getLightClientExecutionRoot

### DIFF
--- a/packages/beacon-node/test/spec/presets/light_client/sync.ts
+++ b/packages/beacon-node/test/spec/presets/light_client/sync.ts
@@ -6,7 +6,7 @@ import {InputType} from "@lodestar/spec-test-util";
 import {computeSyncPeriodAtSlot} from "@lodestar/state-transition";
 import {
   LightclientSpec,
-  getLcExecutionRoot,
+  getLightClientExecutionRoot,
   toLightClientUpdateSummary,
   upgradeLightClientBootstrap,
   upgradeLightClientStore,
@@ -129,7 +129,7 @@ export const sync: TestRunnerFn<SyncTestCase, void> = (_fork) => {
           msg
         );
         if (expectedHeader.execution_root !== undefined) {
-          expect(toHex(getLcExecutionRoot(config, actualHeader))).equals(
+          expect(toHex(getLightClientExecutionRoot(config, actualHeader))).equals(
             expectedHeader.execution_root,
             `${msg} executionRoot`
           );

--- a/packages/state-transition/src/lightClient/spec/index.ts
+++ b/packages/state-transition/src/lightClient/spec/index.ts
@@ -32,7 +32,7 @@ export {
   type SyncCommitteeFast,
 } from "./store.js";
 export {
-  getLcExecutionRoot,
+  getLightClientExecutionRoot,
   getSafetyThreshold,
   isFinalityUpdate,
   isSyncCommitteeUpdate,

--- a/packages/state-transition/src/lightClient/spec/utils.ts
+++ b/packages/state-transition/src/lightClient/spec/utils.ts
@@ -207,9 +207,7 @@ function getGindexIndex(gindex: number): number {
  * Gloas headers removed `execution` so Pre-Gloas headers upgraded to the Gloas format
  * require reconstruction of the original execution payload header root.
  *
- * Named `get_lc_execution_root` in the spec.
- *
- * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.8/specs/gloas/light-client/sync-protocol.md#modified-get_lc_execution_root
+ * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.14/specs/gloas/light-client/sync-protocol.md#modified-get_lc_execution_root
  */
 export function getLightClientExecutionRoot(config: ChainForkConfig, header: LightClientHeader): Uint8Array {
   const epoch = computeEpochAtSlot(header.beacon.slot);

--- a/packages/state-transition/src/lightClient/spec/utils.ts
+++ b/packages/state-transition/src/lightClient/spec/utils.ts
@@ -207,9 +207,11 @@ function getGindexIndex(gindex: number): number {
  * Gloas headers removed `execution` so Pre-Gloas headers upgraded to the Gloas format
  * require reconstruction of the original execution payload header root.
  *
- * Spec: https://github.com/ethereum/consensus-specs/blob/e762dd6e2c45ee05648b5787e7d261279aec226a/specs/gloas/light-client/sync-protocol.md#modified-get_lc_execution_root
+ * Named `get_lc_execution_root` in the spec.
+ *
+ * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.8/specs/gloas/light-client/sync-protocol.md#modified-get_lc_execution_root
  */
-export function getLcExecutionRoot(config: ChainForkConfig, header: LightClientHeader): Uint8Array {
+export function getLightClientExecutionRoot(config: ChainForkConfig, header: LightClientHeader): Uint8Array {
   const epoch = computeEpochAtSlot(header.beacon.slot);
 
   if (!isGloasLightClientHeader(header)) {


### PR DESCRIPTION
Follow-up to review feedback on #9687 (thanks @nflaig).

- Rename `getLcExecutionRoot` → `getLightClientExecutionRoot` to spell out the `lc` abbreviation, matching the sibling light-client helpers (`upgradeLightClientHeader`, `isGloasLightClientHeader`, `upgradeLightClientHeaderToGloas`, …). Kept a `Named get_lc_execution_root in the spec` note since the spec itself keeps the abbreviation.
- Swap the spec reference in that JSDoc from a commit hash to the `v1.7.0-alpha.8` release tag (already pinned elsewhere in the repo for gloas, e.g. `specTestIterator.ts`) — verified that tag contains the `Modified get_lc_execution_root` section.

Pure rename (4 refs across 3 files) + doc reference, no behaviour change.

Verified locally: `getLcExecutionRoot` → 0 remaining refs, `getLightClientExecutionRoot` → 4 (def + re-export + import + caller); biome clean on the touched files; `@lodestar/state-transition` `tsc` build passes.

🤖 Generated with AI assistance
