### PR TITLE
refactor: simplify supported block proposal fields

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -880,6 +880,11 @@ export function getValidatorApi(
 
   return {
     async produceBlockV3({slot, randaoReveal, graffiti, skipRandaoVerification, builderBoostFactor, ...opts}) {
+      const fork = config.getForkName(slot);
+      if (!isForkPostFulu(fork)) {
+        throw new ApiError(400, `produceBlockV3 not supported for pre-fulu fork=${fork}`);
+      }
+
       const {data, ...meta} = await produceEngineOrBuilderBlock(
         slot,
         randaoReveal,
@@ -889,8 +894,8 @@ export function getValidatorApi(
         opts
       );
 
-      const fork = ForkSeq[meta.version];
-      if (opts.blindedLocal === true && fork >= ForkSeq.bellatrix && fork < ForkSeq.gloas) {
+      const forkSeq = ForkSeq[meta.version];
+      if (opts.blindedLocal === true && forkSeq >= ForkSeq.bellatrix && forkSeq < ForkSeq.gloas) {
         if (meta.executionPayloadBlinded) {
           return {data, meta};
         }

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -69,7 +69,7 @@ import {kzg} from "../../util/kzg.js";
 import type {BeaconChain} from "../chain.js";
 import {CommonBlockBody} from "../interface.js";
 import {ProposerPreferencesPool} from "../opPools/index.js";
-import {validateBlobsAndKzgCommitments, validateCellsAndKzgCommitments} from "./validateBlobsAndKzgCommitments.js";
+import {validateCellsAndKzgCommitments} from "./validateBlobsAndKzgCommitments.js";
 
 // Time to provide the EL to generate a payload from new payload id
 const PAYLOAD_GENERATION_TIME_MS = 500;
@@ -528,23 +528,19 @@ export async function produceBlockBody<T extends BlockType>(
         }
       }
 
-      if (ForkSeq[fork] >= ForkSeq.deneb) {
-        const {blobKzgCommitments} = builderRes;
-        if (blobKzgCommitments === undefined) {
-          throw Error(`Invalid builder getHeader response for fork=${fork}, missing blobKzgCommitments`);
-        }
-
-        (blockBody as deneb.BlindedBeaconBlockBody).blobKzgCommitments = blobKzgCommitments;
-        Object.assign(logMeta, {blobs: blobKzgCommitments.length});
+      const {blobKzgCommitments} = builderRes;
+      if (blobKzgCommitments === undefined) {
+        throw Error(`Invalid builder getHeader response for fork=${fork}, missing blobKzgCommitments`);
       }
 
-      if (ForkSeq[fork] >= ForkSeq.electra) {
-        const {executionRequests} = builderRes;
-        if (executionRequests === undefined) {
-          throw Error(`Invalid builder getHeader response for fork=${fork}, missing executionRequests`);
-        }
-        (blockBody as electra.BlindedBeaconBlockBody).executionRequests = executionRequests;
+      (blockBody as deneb.BlindedBeaconBlockBody).blobKzgCommitments = blobKzgCommitments;
+      Object.assign(logMeta, {blobs: blobKzgCommitments.length});
+
+      const {executionRequests} = builderRes;
+      if (executionRequests === undefined) {
+        throw Error(`Invalid builder getHeader response for fork=${fork}, missing executionRequests`);
       }
+      (blockBody as electra.BlindedBeaconBlockBody).executionRequests = executionRequests;
     }
 
     // blockType === BlockType.Full
@@ -622,51 +618,34 @@ export async function produceBlockBody<T extends BlockType>(
           this.metrics?.blockPayload.emptyPayloads.inc({prepType});
         }
 
-        if (ForkSeq[fork] >= ForkSeq.fulu) {
-          if (blobsBundle === undefined) {
-            throw Error(`Missing blobsBundle response from getPayload at fork=${fork}`);
+        if (blobsBundle === undefined) {
+          throw Error(`Missing blobsBundle response from getPayload at fork=${fork}`);
+        }
+        // NOTE: Even though the fulu.BlobsBundle type is superficially the same as deneb.BlobsBundle, it is NOT.
+        // In fulu, proofs are _cell_ proofs, vs in deneb they are _blob_ proofs.
+
+        const timer = this?.metrics?.peerDas.dataColumnSidecarComputationTime.startTimer();
+        const cells = blobsBundle.blobs.map((blob) => kzg.computeCells(blob));
+        timer?.();
+        if (this.opts.sanityCheckExecutionEngineBlobs) {
+          const validationTimer = this.metrics?.peerDas.kzgVerificationDataColumnBatchTime.startTimer();
+          try {
+            await validateCellsAndKzgCommitments(blobsBundle.commitments, blobsBundle.proofs, cells);
+          } finally {
+            validationTimer?.();
           }
-          // NOTE: Even though the fulu.BlobsBundle type is superficially the same as deneb.BlobsBundle, it is NOT.
-          // In fulu, proofs are _cell_ proofs, vs in deneb they are _blob_ proofs.
-
-          const timer = this?.metrics?.peerDas.dataColumnSidecarComputationTime.startTimer();
-          const cells = blobsBundle.blobs.map((blob) => kzg.computeCells(blob));
-          timer?.();
-          if (this.opts.sanityCheckExecutionEngineBlobs) {
-            const validationTimer = this.metrics?.peerDas.kzgVerificationDataColumnBatchTime.startTimer();
-            try {
-              await validateCellsAndKzgCommitments(blobsBundle.commitments, blobsBundle.proofs, cells);
-            } finally {
-              validationTimer?.();
-            }
-          }
-
-          (blockBody as deneb.BeaconBlockBody).blobKzgCommitments = blobsBundle.commitments;
-          (produceResult as ProduceFullFulu).blobsBundle = blobsBundle;
-          (produceResult as ProduceFullFulu).cells = cells;
-
-          Object.assign(logMeta, {blobs: blobsBundle.commitments.length});
-        } else if (ForkSeq[fork] >= ForkSeq.deneb) {
-          if (blobsBundle === undefined) {
-            throw Error(`Missing blobsBundle response from getPayload at fork=${fork}`);
-          }
-
-          if (this.opts.sanityCheckExecutionEngineBlobs) {
-            await validateBlobsAndKzgCommitments(blobsBundle.commitments, blobsBundle.proofs, blobsBundle.blobs);
-          }
-
-          (blockBody as deneb.BeaconBlockBody).blobKzgCommitments = blobsBundle.commitments;
-          (produceResult as ProduceFullDeneb).blobsBundle = blobsBundle;
-
-          Object.assign(logMeta, {blobs: blobsBundle.commitments.length});
         }
 
-        if (ForkSeq[fork] >= ForkSeq.electra) {
-          if (executionRequests === undefined) {
-            throw Error(`Missing executionRequests response from getPayload at fork=${fork}`);
-          }
-          (blockBody as electra.BeaconBlockBody).executionRequests = executionRequests;
+        (blockBody as deneb.BeaconBlockBody).blobKzgCommitments = blobsBundle.commitments;
+        (produceResult as ProduceFullFulu).blobsBundle = blobsBundle;
+        (produceResult as ProduceFullFulu).cells = cells;
+
+        Object.assign(logMeta, {blobs: blobsBundle.commitments.length});
+
+        if (executionRequests === undefined) {
+          throw Error(`Missing executionRequests response from getPayload at fork=${fork}`);
         }
+        (blockBody as electra.BeaconBlockBody).executionRequests = executionRequests;
       }
     }
   } else {
@@ -905,39 +884,35 @@ function preparePayloadAttributes(
     suggestedFeeRecipient: feeRecipient,
   };
 
-  if (ForkSeq[fork] >= ForkSeq.capella) {
-    if (!isStatePostCapella(prepareState)) {
-      throw new Error("Expected Capella state for withdrawals");
-    }
+  if (!isStatePostCapella(prepareState)) {
+    throw new Error("Expected Capella state for withdrawals");
+  }
 
-    if (isStatePostGloas(prepareState)) {
-      const isExtendingPayload = byteArrayEquals(parentBlockHash, prepareState.latestExecutionPayloadBid.blockHash);
-      if (isExtendingPayload) {
-        // applyParentExecutionPayload sets latestBlockHash = parentBid.blockHash, so a mismatch
-        // here means the caller did not apply parent payload to prepareState
-        if (!byteArrayEquals(prepareState.latestBlockHash, prepareState.latestExecutionPayloadBid.blockHash)) {
-          throw new Error("Expected state with parent execution payload applied for withdrawals");
-        }
-        (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
-          prepareState.getExpectedWithdrawals().expectedWithdrawals;
-      } else {
-        // When the parent block is empty, state.payloadExpectedWithdrawals holds a batch
-        // already deducted from CL balances but never credited on the EL (the envelope
-        // was not delivered). The next payload must carry those same withdrawals to
-        // restore CL/EL consistency, otherwise validators permanently lose that balance.
-        (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
-          prepareState.payloadExpectedWithdrawals;
+  if (isStatePostGloas(prepareState)) {
+    const isExtendingPayload = byteArrayEquals(parentBlockHash, prepareState.latestExecutionPayloadBid.blockHash);
+    if (isExtendingPayload) {
+      // applyParentExecutionPayload sets latestBlockHash = parentBid.blockHash, so a mismatch
+      // here means the caller did not apply parent payload to prepareState
+      if (!byteArrayEquals(prepareState.latestBlockHash, prepareState.latestExecutionPayloadBid.blockHash)) {
+        throw new Error("Expected state with parent execution payload applied for withdrawals");
       }
-    } else {
-      // withdrawals logic is now fork aware as it changes on electra fork post capella
       (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
         prepareState.getExpectedWithdrawals().expectedWithdrawals;
+    } else {
+      // When the parent block is empty, state.payloadExpectedWithdrawals holds a batch
+      // already deducted from CL balances but never credited on the EL (the envelope
+      // was not delivered). The next payload must carry those same withdrawals to
+      // restore CL/EL consistency, otherwise validators permanently lose that balance.
+      (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
+        prepareState.payloadExpectedWithdrawals;
     }
+  } else {
+    // withdrawals logic is now fork aware as it changes on electra fork post capella
+    (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
+      prepareState.getExpectedWithdrawals().expectedWithdrawals;
   }
 
-  if (ForkSeq[fork] >= ForkSeq.deneb) {
-    (payloadAttributes as deneb.SSEPayloadAttributes["payloadAttributes"]).parentBeaconBlockRoot = parentBlockRoot;
-  }
+  (payloadAttributes as deneb.SSEPayloadAttributes["payloadAttributes"]).parentBeaconBlockRoot = parentBlockRoot;
 
   if (ForkSeq[fork] >= ForkSeq.gloas) {
     if (!isStatePostGloas(prepareState)) {
@@ -1050,7 +1025,18 @@ export async function produceCommonBlockBody<T extends BlockType>(
     step: BlockProductionStep.attestations,
   });
 
-  const blockBody: Omit<CommonBlockBody, "blsToExecutionChanges" | "syncAggregate"> = {
+  const endSyncAggregate = stepsMetrics?.startTimer();
+  const parentBlockRoot = fromHex(parentBlock.blockRoot);
+  const previousSlot = slot - 1;
+  const syncAggregate = this.syncContributionAndProofPool.getAggregate(previousSlot, parentBlockRoot);
+  this.metrics?.production.producedSyncAggregateParticipants.observe(
+    syncAggregate.syncCommitteeBits.getTrueBitIndexes().length
+  );
+  endSyncAggregate?.({
+    step: BlockProductionStep.syncAggregate,
+  });
+
+  const blockBody: CommonBlockBody = {
     randaoReveal,
     graffiti,
     // Eth1 data voting is no longer required since electra
@@ -1062,25 +1048,9 @@ export async function produceCommonBlockBody<T extends BlockType>(
     // we no longer support handling deposits from earlier forks.
     deposits: [],
     voluntaryExits,
+    blsToExecutionChanges,
+    syncAggregate,
   };
-
-  if (ForkSeq[fork] >= ForkSeq.capella) {
-    (blockBody as CommonBlockBody).blsToExecutionChanges = blsToExecutionChanges;
-  }
-
-  const endSyncAggregate = stepsMetrics?.startTimer();
-  if (ForkSeq[fork] >= ForkSeq.altair) {
-    const parentBlockRoot = fromHex(parentBlock.blockRoot);
-    const previousSlot = slot - 1;
-    const syncAggregate = this.syncContributionAndProofPool.getAggregate(previousSlot, parentBlockRoot);
-    this.metrics?.production.producedSyncAggregateParticipants.observe(
-      syncAggregate.syncCommitteeBits.getTrueBitIndexes().length
-    );
-    (blockBody as CommonBlockBody).syncAggregate = syncAggregate;
-  }
-  endSyncAggregate?.({
-    step: BlockProductionStep.syncAggregate,
-  });
 
   return blockBody as CommonBlockBody;
 }

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -528,23 +528,18 @@ export async function produceBlockBody<T extends BlockType>(
         }
       }
 
-      if (ForkSeq[fork] >= ForkSeq.deneb) {
-        const {blobKzgCommitments} = builderRes;
-        if (blobKzgCommitments === undefined) {
-          throw Error(`Invalid builder getHeader response for fork=${fork}, missing blobKzgCommitments`);
-        }
-
-        (blockBody as deneb.BlindedBeaconBlockBody).blobKzgCommitments = blobKzgCommitments;
-        Object.assign(logMeta, {blobs: blobKzgCommitments.length});
+      const {blobKzgCommitments, executionRequests} = builderRes;
+      if (blobKzgCommitments === undefined) {
+        throw Error(`Invalid builder getHeader response for fork=${fork}, missing blobKzgCommitments`);
       }
 
-      if (ForkSeq[fork] >= ForkSeq.electra) {
-        const {executionRequests} = builderRes;
-        if (executionRequests === undefined) {
-          throw Error(`Invalid builder getHeader response for fork=${fork}, missing executionRequests`);
-        }
-        (blockBody as electra.BlindedBeaconBlockBody).executionRequests = executionRequests;
+      (blockBody as BlindedBeaconBlockBody<ForkName.fulu>).blobKzgCommitments = blobKzgCommitments;
+      Object.assign(logMeta, {blobs: blobKzgCommitments.length});
+
+      if (executionRequests === undefined) {
+        throw Error(`Invalid builder getHeader response for fork=${fork}, missing executionRequests`);
       }
+      (blockBody as BlindedBeaconBlockBody<ForkName.fulu>).executionRequests = executionRequests;
     }
 
     // blockType === BlockType.Full
@@ -899,45 +894,38 @@ function preparePayloadAttributes(
 ): SSEPayloadAttributes["payloadAttributes"] {
   const timestamp = computeTimeAtSlot(chain.config, prepareSlot, prepareState.genesisTime);
   const prevRandao = prepareState.getRandaoMix(prepareState.epoch);
-  const payloadAttributes = {
+  if (!isStatePostCapella(prepareState)) {
+    throw new Error("Expected Capella state for withdrawals");
+  }
+
+  let withdrawals: capella.Withdrawal[];
+  if (isStatePostGloas(prepareState)) {
+    const isExtendingPayload = byteArrayEquals(parentBlockHash, prepareState.latestExecutionPayloadBid.blockHash);
+    if (isExtendingPayload) {
+      // applyParentExecutionPayload sets latestBlockHash = parentBid.blockHash, so a mismatch
+      // here means the caller did not apply parent payload to prepareState
+      if (!byteArrayEquals(prepareState.latestBlockHash, prepareState.latestExecutionPayloadBid.blockHash)) {
+        throw new Error("Expected state with parent execution payload applied for withdrawals");
+      }
+      withdrawals = prepareState.getExpectedWithdrawals().expectedWithdrawals;
+    } else {
+      // When the parent block is empty, state.payloadExpectedWithdrawals holds a batch
+      // already deducted from CL balances but never credited on the EL (the envelope
+      // was not delivered). The next payload must carry those same withdrawals to
+      // restore CL/EL consistency, otherwise validators permanently lose that balance.
+      withdrawals = prepareState.payloadExpectedWithdrawals;
+    }
+  } else {
+    withdrawals = prepareState.getExpectedWithdrawals().expectedWithdrawals;
+  }
+
+  const payloadAttributes: deneb.SSEPayloadAttributes["payloadAttributes"] = {
     timestamp,
     prevRandao,
     suggestedFeeRecipient: feeRecipient,
+    withdrawals,
+    parentBeaconBlockRoot: parentBlockRoot,
   };
-
-  if (ForkSeq[fork] >= ForkSeq.capella) {
-    if (!isStatePostCapella(prepareState)) {
-      throw new Error("Expected Capella state for withdrawals");
-    }
-
-    if (isStatePostGloas(prepareState)) {
-      const isExtendingPayload = byteArrayEquals(parentBlockHash, prepareState.latestExecutionPayloadBid.blockHash);
-      if (isExtendingPayload) {
-        // applyParentExecutionPayload sets latestBlockHash = parentBid.blockHash, so a mismatch
-        // here means the caller did not apply parent payload to prepareState
-        if (!byteArrayEquals(prepareState.latestBlockHash, prepareState.latestExecutionPayloadBid.blockHash)) {
-          throw new Error("Expected state with parent execution payload applied for withdrawals");
-        }
-        (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
-          prepareState.getExpectedWithdrawals().expectedWithdrawals;
-      } else {
-        // When the parent block is empty, state.payloadExpectedWithdrawals holds a batch
-        // already deducted from CL balances but never credited on the EL (the envelope
-        // was not delivered). The next payload must carry those same withdrawals to
-        // restore CL/EL consistency, otherwise validators permanently lose that balance.
-        (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
-          prepareState.payloadExpectedWithdrawals;
-      }
-    } else {
-      // withdrawals logic is now fork aware as it changes on electra fork post capella
-      (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
-        prepareState.getExpectedWithdrawals().expectedWithdrawals;
-    }
-  }
-
-  if (ForkSeq[fork] >= ForkSeq.deneb) {
-    (payloadAttributes as deneb.SSEPayloadAttributes["payloadAttributes"]).parentBeaconBlockRoot = parentBlockRoot;
-  }
 
   if (ForkSeq[fork] >= ForkSeq.gloas) {
     if (!isStatePostGloas(prepareState)) {
@@ -1050,37 +1038,28 @@ export async function produceCommonBlockBody<T extends BlockType>(
     step: BlockProductionStep.attestations,
   });
 
-  const blockBody: Omit<CommonBlockBody, "blsToExecutionChanges" | "syncAggregate"> = {
-    randaoReveal,
-    graffiti,
-    // Eth1 data voting is no longer required since electra
-    eth1Data: currentState.eth1Data,
-    proposerSlashings: this.opts.disableProposerSlashings === true ? [] : proposerSlashings,
-    attesterSlashings,
-    attestations,
-    // Since electra, deposits are processed by the execution layer,
-    // we no longer support handling deposits from earlier forks.
-    deposits: [],
-    voluntaryExits,
-  };
-
-  if (ForkSeq[fork] >= ForkSeq.capella) {
-    (blockBody as CommonBlockBody).blsToExecutionChanges = blsToExecutionChanges;
-  }
-
   const endSyncAggregate = stepsMetrics?.startTimer();
-  if (ForkSeq[fork] >= ForkSeq.altair) {
-    const parentBlockRoot = fromHex(parentBlock.blockRoot);
-    const previousSlot = slot - 1;
-    const syncAggregate = this.syncContributionAndProofPool.getAggregate(previousSlot, parentBlockRoot);
-    this.metrics?.production.producedSyncAggregateParticipants.observe(
-      syncAggregate.syncCommitteeBits.getTrueBitIndexes().length
-    );
-    (blockBody as CommonBlockBody).syncAggregate = syncAggregate;
-  }
+  const parentBlockRoot = fromHex(parentBlock.blockRoot);
+  const previousSlot = slot - 1;
+  const syncAggregate = this.syncContributionAndProofPool.getAggregate(previousSlot, parentBlockRoot);
+  this.metrics?.production.producedSyncAggregateParticipants.observe(
+    syncAggregate.syncCommitteeBits.getTrueBitIndexes().length
+  );
   endSyncAggregate?.({
     step: BlockProductionStep.syncAggregate,
   });
 
-  return blockBody as CommonBlockBody;
+  // Live proposal production is supported from Fulu onward.
+  return {
+    randaoReveal,
+    graffiti,
+    eth1Data: currentState.eth1Data,
+    proposerSlashings: this.opts.disableProposerSlashings === true ? [] : proposerSlashings,
+    attesterSlashings,
+    attestations,
+    deposits: [],
+    voluntaryExits,
+    blsToExecutionChanges,
+    syncAggregate,
+  };
 }

--- a/packages/beacon-node/test/e2e/api/impl/beacon/node/endpoints.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/beacon/node/endpoints.test.ts
@@ -69,6 +69,10 @@ describe("beacon node api", () => {
           ...chainConfigDef,
           ALTAIR_FORK_EPOCH: 0,
           BELLATRIX_FORK_EPOCH: 0,
+          CAPELLA_FORK_EPOCH: 0,
+          DENEB_FORK_EPOCH: 0,
+          ELECTRA_FORK_EPOCH: 0,
+          FULU_FORK_EPOCH: 0,
         },
         options: {
           sync: {isSingleNode: true},

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -15,7 +15,7 @@ import {PayloadIdCache} from "../../../../../src/execution/index.js";
 import {SyncState} from "../../../../../src/sync/interface.js";
 import {toGraffitiBytes} from "../../../../../src/util/graffiti.js";
 import {ApiTestModules, getApiTestModules} from "../../../../utils/api.js";
-import {generateCachedBellatrixState, zeroProtoBlock} from "../../../../utils/state.js";
+import {generateCachedElectraState, zeroProtoBlock} from "../../../../utils/state.js";
 import {generateProtoBlock} from "../../../../utils/typeGenerator.js";
 
 describe("api/validator - produceBlockV3", () => {
@@ -38,7 +38,7 @@ describe("api/validator - produceBlockV3", () => {
   beforeEach(() => {
     modules = getApiTestModules({config});
     api = getValidatorApi(defaultApiOptions, {...modules, config});
-    state = new BeaconStateView(generateCachedBellatrixState());
+    state = new BeaconStateView(generateCachedElectraState());
 
     modules.chain.executionBuilder.status = BuilderStatus.enabled;
   });
@@ -325,9 +325,9 @@ describe("api/validator - produceBlockV3", () => {
   });
 
   it("correctly use passed feeRecipient in notifyForkchoiceUpdate", async () => {
-    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+    const fullBlock = ssz.fulu.BeaconBlock.defaultValue();
     const executionPayloadValue = ssz.Wei.defaultValue();
-    const slot = 1 * SLOTS_PER_EPOCH;
+    const slot = 2 * SLOTS_PER_EPOCH;
     const randaoReveal = fullBlock.body.randaoReveal;
     const graffiti = "a".repeat(32);
     const feeRecipient = "0xccccccccccccccccccccccccccccccccccccccaa";
@@ -348,8 +348,10 @@ describe("api/validator - produceBlockV3", () => {
     modules.chain["executionEngine"].payloadIdCache = new PayloadIdCache();
     modules.chain["executionEngine"].notifyForkchoiceUpdate.mockResolvedValue("0x");
     modules.chain["executionEngine"].getPayload.mockResolvedValue({
-      executionPayload: ssz.bellatrix.ExecutionPayload.defaultValue(),
+      executionPayload: ssz.fulu.ExecutionPayload.defaultValue(),
       executionPayloadValue,
+      blobsBundle: ssz.fulu.BlobsBundle.defaultValue(),
+      executionRequests: ssz.electra.ExecutionRequests.defaultValue(),
     });
 
     // Helper function to create a mock common block body promise
@@ -379,7 +381,7 @@ describe("api/validator - produceBlockV3", () => {
     });
 
     expect(modules.chain["executionEngine"].notifyForkchoiceUpdate).toBeCalledWith(
-      ForkName.bellatrix,
+      ForkName.fulu,
       ZERO_HASH_HEX,
       ZERO_HASH_HEX,
       ZERO_HASH_HEX,
@@ -387,6 +389,8 @@ describe("api/validator - produceBlockV3", () => {
         timestamp: computeTimeAtSlot(modules.config, state.slot, state.genesisTime),
         prevRandao: new Uint8Array(32),
         suggestedFeeRecipient: feeRecipient,
+        withdrawals: [],
+        parentBeaconBlockRoot: new Uint8Array(32),
       }
     );
 
@@ -404,7 +408,7 @@ describe("api/validator - produceBlockV3", () => {
     });
 
     expect(modules.chain["executionEngine"].notifyForkchoiceUpdate).toBeCalledWith(
-      ForkName.bellatrix,
+      ForkName.fulu,
       ZERO_HASH_HEX,
       ZERO_HASH_HEX,
       ZERO_HASH_HEX,
@@ -412,6 +416,8 @@ describe("api/validator - produceBlockV3", () => {
         timestamp: computeTimeAtSlot(modules.config, state.slot, state.genesisTime),
         prevRandao: new Uint8Array(32),
         suggestedFeeRecipient: "0x fee recipient address",
+        withdrawals: [],
+        parentBeaconBlockRoot: new Uint8Array(32),
       }
     );
   });

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -27,6 +27,10 @@ describe("api/validator - produceBlockV3", () => {
     ...defaultChainConfig,
     ALTAIR_FORK_EPOCH: 0,
     BELLATRIX_FORK_EPOCH: 1,
+    CAPELLA_FORK_EPOCH: 2,
+    DENEB_FORK_EPOCH: 2,
+    ELECTRA_FORK_EPOCH: 2,
+    FULU_FORK_EPOCH: 2,
   });
   const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
   const config = createBeaconConfig(chainConfig, genesisValidatorsRoot);
@@ -41,6 +45,30 @@ describe("api/validator - produceBlockV3", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("rejects block production before Fulu", async () => {
+    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+    const slot = 1 * SLOTS_PER_EPOCH;
+
+    vi.spyOn(modules.chain.clock, "currentSlot", "get").mockReturnValue(slot);
+    vi.spyOn(modules.sync, "state", "get").mockReturnValue(SyncState.Synced);
+    modules.chain.getProposerHead.mockReturnValue({blockRoot: toRootHex(fullBlock.parentRoot)} as ProtoBlock);
+    modules.chain.produceBlock.mockResolvedValue({
+      block: fullBlock,
+      executionPayloadValue: BigInt(0),
+      consensusBlockValue: BigInt(0),
+    });
+
+    await expect(
+      api.produceBlockV3({
+        slot,
+        randaoReveal: fullBlock.body.randaoReveal,
+      })
+    ).rejects.toThrow("produceBlockV3 not supported for pre-fulu fork=bellatrix");
+
+    expect(modules.chain.produceBlock).not.toHaveBeenCalled();
+    expect(modules.chain.produceBlindedBlock).not.toHaveBeenCalled();
   });
 
   const testCases: [routes.validator.BuilderSelection, number | null, number | null, number, boolean, string][] = [
@@ -79,10 +107,10 @@ describe("api/validator - produceBlockV3", () => {
     finalSelection,
   ] of testCases) {
     it(`produceBlockV3  - ${finalSelection} produces block`, async () => {
-      const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
-      const blindedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
+      const fullBlock = ssz.fulu.BeaconBlock.defaultValue();
+      const blindedBlock = ssz.fulu.BlindedBeaconBlock.defaultValue();
 
-      const slot = 1 * SLOTS_PER_EPOCH;
+      const slot = 2 * SLOTS_PER_EPOCH;
       const randaoReveal = fullBlock.body.randaoReveal;
       const graffiti = "a".repeat(32);
       const feeRecipient = "0xccccccccccccccccccccccccccccccccccccccaa";
@@ -161,9 +189,9 @@ describe("api/validator - produceBlockV3", () => {
   }
 
   it("treats deprecated builderonly selection as builderalways", async () => {
-    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
-    const blindedBlock = ssz.bellatrix.BlindedBeaconBlock.defaultValue();
-    const slot = 1 * SLOTS_PER_EPOCH;
+    const fullBlock = ssz.fulu.BeaconBlock.defaultValue();
+    const blindedBlock = ssz.fulu.BlindedBeaconBlock.defaultValue();
+    const slot = 2 * SLOTS_PER_EPOCH;
 
     vi.spyOn(modules.chain.clock, "currentSlot", "get").mockReturnValue(slot);
     vi.spyOn(modules.sync, "state", "get").mockReturnValue(SyncState.Synced);
@@ -211,8 +239,8 @@ describe("api/validator - produceBlockV3", () => {
   });
 
   it("rejects block production if parent block is optimistic", async () => {
-    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
-    const slot = 1 * SLOTS_PER_EPOCH;
+    const fullBlock = ssz.fulu.BeaconBlock.defaultValue();
+    const slot = 2 * SLOTS_PER_EPOCH;
 
     vi.spyOn(modules.chain.clock, "currentSlot", "get").mockReturnValue(slot);
     vi.spyOn(modules.sync, "state", "get").mockReturnValue(SyncState.Synced);
@@ -235,7 +263,7 @@ describe("api/validator - produceBlockV3", () => {
   });
 
   it("correctly pass feeRecipient to produceBlock", async () => {
-    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
+    const fullBlock = ssz.fulu.BeaconBlock.defaultValue();
     const executionPayloadValue = ssz.Wei.defaultValue();
     const consensusBlockValue = ssz.Wei.defaultValue();
 
@@ -299,7 +327,7 @@ describe("api/validator - produceBlockV3", () => {
   it("correctly use passed feeRecipient in notifyForkchoiceUpdate", async () => {
     const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
     const executionPayloadValue = ssz.Wei.defaultValue();
-    const slot = 100000;
+    const slot = 1 * SLOTS_PER_EPOCH;
     const randaoReveal = fullBlock.body.randaoReveal;
     const graffiti = "a".repeat(32);
     const feeRecipient = "0xccccccccccccccccccccccccccccccccccccccaa";

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -2,26 +2,21 @@ import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {routes} from "@lodestar/api";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
-import {ForkName, SLOTS_PER_EPOCH, ZERO_HASH_HEX} from "@lodestar/params";
-import {BeaconStateView, G2_POINT_AT_INFINITY, computeTimeAtSlot} from "@lodestar/state-transition";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {getValidatorApi} from "../../../../../src/api/impl/validator/index.js";
 import {defaultApiOptions} from "../../../../../src/api/options.js";
-import {BeaconChain} from "../../../../../src/chain/chain.js";
-import {BlockType, produceBlockBody} from "../../../../../src/chain/produceBlock/index.js";
 import {BuilderStatus} from "../../../../../src/execution/builder/http.js";
-import {PayloadIdCache} from "../../../../../src/execution/index.js";
 import {SyncState} from "../../../../../src/sync/interface.js";
 import {toGraffitiBytes} from "../../../../../src/util/graffiti.js";
 import {ApiTestModules, getApiTestModules} from "../../../../utils/api.js";
-import {generateCachedBellatrixState, zeroProtoBlock} from "../../../../utils/state.js";
+import {zeroProtoBlock} from "../../../../utils/state.js";
 import {generateProtoBlock} from "../../../../utils/typeGenerator.js";
 
 describe("api/validator - produceBlockV3", () => {
   let modules: ApiTestModules;
   let api: ReturnType<typeof getValidatorApi>;
-  let state: BeaconStateView;
 
   const chainConfig = createChainForkConfig({
     ...defaultChainConfig,
@@ -34,7 +29,6 @@ describe("api/validator - produceBlockV3", () => {
   beforeEach(() => {
     modules = getApiTestModules({config});
     api = getValidatorApi(defaultApiOptions, {...modules, config});
-    state = new BeaconStateView(generateCachedBellatrixState());
 
     modules.chain.executionBuilder.status = BuilderStatus.enabled;
   });
@@ -294,97 +288,5 @@ describe("api/validator - produceBlockV3", () => {
       feeRecipient: undefined,
       commonBlockBodyPromise: expect.any(Promise),
     });
-  });
-
-  it("correctly use passed feeRecipient in notifyForkchoiceUpdate", async () => {
-    const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
-    const executionPayloadValue = ssz.Wei.defaultValue();
-    const slot = 100000;
-    const randaoReveal = fullBlock.body.randaoReveal;
-    const graffiti = "a".repeat(32);
-    const feeRecipient = "0xccccccccccccccccccccccccccccccccccccccaa";
-
-    const headSlot = 0;
-    modules.chain.getProposerHead.mockReturnValue(generateProtoBlock({slot: headSlot}));
-
-    modules.chain.recomputeForkChoiceHead.mockReturnValue(generateProtoBlock({slot: headSlot}));
-    modules.chain["opPool"].getSlashingsAndExits.mockReturnValue([[], [], [], []]);
-    modules.chain["aggregatedAttestationPool"].getAttestationsForBlock.mockReturnValue([]);
-    modules.chain["syncContributionAndProofPool"].getAggregate.mockReturnValue({
-      syncCommitteeBits: ssz.altair.SyncCommitteeBits.defaultValue(),
-      syncCommitteeSignature: G2_POINT_AT_INFINITY,
-    });
-    modules.forkChoice.getConfirmedBlock.mockReturnValue(generateProtoBlock());
-    modules.forkChoice.getFinalizedBlock.mockReturnValue(generateProtoBlock());
-
-    modules.chain["executionEngine"].payloadIdCache = new PayloadIdCache();
-    modules.chain["executionEngine"].notifyForkchoiceUpdate.mockResolvedValue("0x");
-    modules.chain["executionEngine"].getPayload.mockResolvedValue({
-      executionPayload: ssz.bellatrix.ExecutionPayload.defaultValue(),
-      executionPayloadValue,
-    });
-
-    // Helper function to create a mock common block body promise
-    const createCommonBlockBodyPromise = async () => ({
-      attestations: [],
-      attesterSlashings: [],
-      proposerSlashings: [],
-      voluntaryExits: [],
-      blsToExecutionChanges: [],
-      syncAggregate: ssz.altair.SyncAggregate.defaultValue(),
-      eth1Data: ssz.phase0.Eth1Data.defaultValue(),
-      deposits: [],
-      randaoReveal,
-      graffiti: toGraffitiBytes(graffiti),
-    });
-
-    // use fee recipient passed in produceBlockBody call for payload gen in engine notifyForkchoiceUpdate
-    await produceBlockBody.call(modules.chain as unknown as BeaconChain, BlockType.Full, state, {
-      randaoReveal,
-      graffiti: toGraffitiBytes(graffiti),
-      slot,
-      feeRecipient,
-      parentBlock: generateProtoBlock({blockRoot: ZERO_HASH_HEX}),
-      proposerIndex: 0,
-      proposerPubKey: new Uint8Array(32).fill(1),
-      commonBlockBodyPromise: createCommonBlockBodyPromise(),
-    });
-
-    expect(modules.chain["executionEngine"].notifyForkchoiceUpdate).toBeCalledWith(
-      ForkName.bellatrix,
-      ZERO_HASH_HEX,
-      ZERO_HASH_HEX,
-      ZERO_HASH_HEX,
-      {
-        timestamp: computeTimeAtSlot(modules.config, state.slot, state.genesisTime),
-        prevRandao: new Uint8Array(32),
-        suggestedFeeRecipient: feeRecipient,
-      }
-    );
-
-    // use fee recipient set in beaconProposerCacheStub if none passed
-    modules.chain["beaconProposerCache"].getOrDefault.mockReturnValue("0x fee recipient address");
-
-    await produceBlockBody.call(modules.chain as unknown as BeaconChain, BlockType.Full, state, {
-      randaoReveal,
-      graffiti: toGraffitiBytes(graffiti),
-      slot,
-      parentBlock: generateProtoBlock({blockRoot: ZERO_HASH_HEX}),
-      proposerIndex: 0,
-      proposerPubKey: new Uint8Array(32).fill(1),
-      commonBlockBodyPromise: createCommonBlockBodyPromise(),
-    });
-
-    expect(modules.chain["executionEngine"].notifyForkchoiceUpdate).toBeCalledWith(
-      ForkName.bellatrix,
-      ZERO_HASH_HEX,
-      ZERO_HASH_HEX,
-      ZERO_HASH_HEX,
-      {
-        timestamp: computeTimeAtSlot(modules.config, state.slot, state.genesisTime),
-        prevRandao: new Uint8Array(32),
-        suggestedFeeRecipient: "0x fee recipient address",
-      }
-    );
   });
 });

--- a/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
+++ b/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
@@ -1,15 +1,18 @@
 import {Mock, MockInstance, afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {routes} from "@lodestar/api";
+import {createBeaconConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
+import {getConfig} from "@lodestar/config/test-utils";
 import {ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {BeaconStateView} from "@lodestar/state-transition";
+import {BeaconStateView, createCachedBeaconState} from "@lodestar/state-transition";
 import {IChainOptions} from "../../../src/chain/options.js";
 import {PrepareNextSlotScheduler} from "../../../src/chain/prepareNextSlot.js";
 import {PayloadIdCache} from "../../../src/execution/engine/payloadIdCache.js";
 import {MockedLogger, getMockedLogger} from "../../mocks/loggerMock.js";
 import {MockedBeaconChain, getMockedBeaconChain} from "../../mocks/mockedBeaconChain.js";
-import {generateCachedBellatrixState, zeroProtoBlock} from "../../utils/state.js";
+import {generateCachedBellatrixState, generateState, zeroProtoBlock} from "../../utils/state.js";
 
 describe("PrepareNextSlot scheduler", () => {
   const abortController = new AbortController();
@@ -116,18 +119,29 @@ describe("PrepareNextSlot scheduler", () => {
     expect(regenStub.getBlockSlotState).toHaveBeenCalledOnce();
   });
 
-  it("bellatrix - should prepare payload", async () => {
+  it("fulu - should prepare payload and emit payload attributes", async () => {
     const spy = vi.fn();
     chainStub.emitter.on(routes.events.EventType.payloadAttributes, spy);
-    getForkStub.mockReturnValue(ForkName.bellatrix);
+    getForkStub.mockReturnValue(ForkName.fulu);
     chainStub.recomputeForkChoiceHead.mockReturnValue({...zeroProtoBlock, slot: SLOTS_PER_EPOCH - 3} as ProtoBlock);
     chainStub.predictProposerHead.mockReturnValue({...zeroProtoBlock, slot: SLOTS_PER_EPOCH - 3} as ProtoBlock);
     forkChoiceStub.getConfirmedBlock.mockReturnValue({...zeroProtoBlock, slot: SLOTS_PER_EPOCH - 3} as ProtoBlock);
     forkChoiceStub.getFinalizedBlock.mockReturnValue({...zeroProtoBlock, slot: SLOTS_PER_EPOCH - 3} as ProtoBlock);
     updateBuilderStatus.mockReturnValue(void 0);
-    const state = generateCachedBellatrixState();
-    vi.spyOn(state.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
-    regenStub.getBlockSlotState.mockResolvedValue(new BeaconStateView(state));
+    forkChoiceStub.getFinalizedCheckpoint.mockReturnValue({
+      epoch: 0,
+      root: new Uint8Array(32),
+      rootHex: zeroProtoBlock.blockRoot,
+    });
+    const fuluConfig = createBeaconConfig(getConfig(ForkName.fulu), new Uint8Array(32));
+    const makeState = (slot: number) =>
+      new BeaconStateView(
+        createCachedBeaconState(generateState({slot}, fuluConfig, true), {config: fuluConfig, pubkeyCache})
+      );
+    const headState = makeState(SLOTS_PER_EPOCH - 3);
+    vi.spyOn(headState, "getBeaconProposer").mockReturnValue(proposerIndex);
+    chainStub.getHeadState.mockReturnValue(headState);
+    regenStub.getBlockSlotState.mockResolvedValue(makeState(SLOTS_PER_EPOCH - 1));
     beaconProposerCacheStub.get.mockReturnValue("0x fee recipient address");
     (executionEngineStub as unknown as {payloadIdCache: PayloadIdCache}).payloadIdCache = new PayloadIdCache();
 
@@ -141,7 +155,15 @@ describe("PrepareNextSlot scheduler", () => {
     expect(updateBuilderStatus).toHaveBeenCalledOnce();
     expect(forkChoiceStub.getFinalizedBlock).toHaveBeenCalledTimes(2);
     expect(executionEngineStub.notifyForkchoiceUpdate).toHaveBeenCalledTimes(1);
+    expect(executionEngineStub.notifyForkchoiceUpdate).toHaveBeenCalledWith(
+      ForkName.fulu,
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({withdrawals: [], parentBeaconBlockRoot: expect.any(Uint8Array)})
+    );
     expect(spy).toHaveBeenCalledTimes(1);
+    expect(loggerStub.error).not.toHaveBeenCalled();
   });
 
   it("post-fulu - should read proposer from head state and dial only the proposer head on reorg", async () => {

--- a/packages/beacon-node/test/unit/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/unit/chain/produceBlock/produceBlockBody.test.ts
@@ -1,0 +1,245 @@
+import {describe, expect, it, vi} from "vitest";
+import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
+import {createBeaconConfig} from "@lodestar/config";
+import {getConfig} from "@lodestar/config/test-utils";
+import {ForkName} from "@lodestar/params";
+import {BeaconStateView, createCachedBeaconState, isStatePostFulu} from "@lodestar/state-transition";
+import {ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {BeaconChain} from "../../../../src/chain/chain.js";
+import {
+  BlockType,
+  getPayloadAttributesForSSE,
+  produceBlockBody,
+  produceCommonBlockBody,
+} from "../../../../src/chain/produceBlock/produceBlockBody.js";
+import {PayloadIdCache} from "../../../../src/execution/index.js";
+import {getApiTestModules} from "../../../utils/api.js";
+import {generateState} from "../../../utils/state.js";
+import {generateProtoBlock} from "../../../utils/typeGenerator.js";
+
+function setup(fork: ForkName.fulu | ForkName.gloas | ForkName.heze = ForkName.fulu) {
+  const slot = 2;
+  const config = createBeaconConfig(getConfig(fork), new Uint8Array(32));
+  const state = new BeaconStateView(
+    createCachedBeaconState(generateState({slot}, config, true), {config, pubkeyCache})
+  );
+  const modules = getApiTestModules({config});
+  if (!isStatePostFulu(state)) throw new Error("Expected supported proposal state");
+  const chain = modules.chain as unknown as BeaconChain;
+  const parentBlockRoot = new Uint8Array(32).fill(1);
+  const parentBlock = generateProtoBlock({slot: slot - 1, blockRoot: toRootHex(parentBlockRoot)});
+  const attrs = {
+    slot,
+    parentBlock,
+    randaoReveal: new Uint8Array(96).fill(2),
+    graffiti: new Uint8Array(32).fill(3),
+  };
+  const {
+    executionPayload: _executionPayload,
+    blobKzgCommitments: _blobKzgCommitments,
+    executionRequests: _executionRequests,
+    ...common
+  } = ssz.fulu.BeaconBlockBody.defaultValue();
+  common.blsToExecutionChanges = [ssz.capella.SignedBLSToExecutionChange.defaultValue()];
+  common.syncAggregate.syncCommitteeBits.set(1, true);
+  modules.chain.opPool.getSlashingsAndExits.mockReturnValue([
+    common.attesterSlashings,
+    common.proposerSlashings,
+    common.voluntaryExits,
+    common.blsToExecutionChanges,
+  ]);
+  modules.chain.aggregatedAttestationPool.getAttestationsForBlock.mockReturnValue(common.attestations);
+  modules.chain.syncContributionAndProofPool.getAggregate.mockReturnValue(common.syncAggregate);
+  modules.forkChoice.getConfirmedBlock.mockReturnValue(parentBlock);
+  modules.forkChoice.getFinalizedBlock.mockReturnValue(parentBlock);
+  return {slot, config, state, modules, chain, attrs, common, parentBlockRoot};
+}
+
+describe("supported proposal body fields", () => {
+  for (const fork of [ForkName.fulu, ForkName.gloas, ForkName.heze] as const) {
+    for (const blockType of [BlockType.Full, BlockType.Blinded]) {
+      it(`${fork} ${blockType} includes selected operations and the parent sync aggregate`, async () => {
+        const {state, modules, chain, attrs, common, parentBlockRoot} = setup(fork);
+        const body = await produceCommonBlockBody.call(chain, blockType, state, attrs);
+        expect(body).toEqual({
+          randaoReveal: attrs.randaoReveal,
+          graffiti: attrs.graffiti,
+          eth1Data: state.eth1Data,
+          proposerSlashings: common.proposerSlashings,
+          attesterSlashings: common.attesterSlashings,
+          attestations: common.attestations,
+          deposits: [],
+          voluntaryExits: common.voluntaryExits,
+          blsToExecutionChanges: common.blsToExecutionChanges,
+          syncAggregate: common.syncAggregate,
+        });
+        expect(modules.chain.syncContributionAndProofPool.getAggregate).toHaveBeenCalledExactlyOnceWith(
+          attrs.slot - 1,
+          parentBlockRoot
+        );
+      });
+    }
+  }
+});
+
+describe("Fulu builder body", () => {
+  function setupBuilder() {
+    const context = setup();
+    const response = {
+      header: ssz.fulu.ExecutionPayloadHeader.defaultValue(),
+      executionPayloadValue: 123n,
+      blobKzgCommitments: [new Uint8Array(48).fill(4)],
+      executionRequests: ssz.electra.ExecutionRequests.defaultValue(),
+    };
+    response.executionRequests.deposits.push(ssz.electra.DepositRequest.defaultValue());
+    context.modules.chain.executionBuilder.getHeader = vi.fn().mockResolvedValue(response);
+    context.modules.chain.executionBuilder.getValidatorRegistration = vi.fn();
+    const produce = () =>
+      produceBlockBody.call(context.chain, BlockType.Blinded, context.state, {
+        ...context.attrs,
+        proposerIndex: 0,
+        proposerPubKey: new Uint8Array(48),
+        commonBlockBodyPromise: Promise.resolve(context.common),
+      });
+    return {...context, response, produce};
+  }
+
+  it("copies required builder fields without mutating the shared common body", async () => {
+    const {response, produce, common} = setupBuilder();
+    const before = structuredClone(common);
+    const result = await produce();
+    expect(result.body).toEqual({
+      ...common,
+      executionPayloadHeader: response.header,
+      blobKzgCommitments: response.blobKzgCommitments,
+      executionRequests: response.executionRequests,
+    });
+    expect(result.executionPayloadValue).toBe(response.executionPayloadValue);
+    expect(common).toEqual(before);
+  });
+
+  for (const field of ["blobKzgCommitments", "executionRequests"] as const) {
+    it(`rejects a builder response missing ${field}`, async () => {
+      const {modules, response, produce} = setupBuilder();
+      modules.chain.executionBuilder.getHeader.mockResolvedValue({...response, [field]: undefined});
+      await expect(produce()).rejects.toThrow(`missing ${field}`);
+    });
+  }
+});
+
+describe("Fulu engine body", () => {
+  for (const requested of [true, false]) {
+    it(`uses the ${requested ? "requested" : "cached"} fee recipient for payload preparation`, async () => {
+      const {state, modules, chain, attrs, common, parentBlockRoot} = setup();
+      const requestedRecipient = "0xccccccccccccccccccccccccccccccccccccccaa";
+      const cachedRecipient = "0xccccccccccccccccccccccccccccccccccccccbb";
+      modules.chain.beaconProposerCache.getOrDefault.mockReturnValue(cachedRecipient);
+      modules.chain.executionEngine.payloadIdCache = new PayloadIdCache();
+      modules.chain.executionEngine.notifyForkchoiceUpdate.mockResolvedValue("0x1234");
+      modules.chain.executionEngine.getPayload.mockResolvedValue({
+        executionPayload: ssz.fulu.ExecutionPayload.defaultValue(),
+        executionPayloadValue: 456n,
+        blobsBundle: ssz.fulu.BlobsBundle.defaultValue(),
+        executionRequests: ssz.electra.ExecutionRequests.defaultValue(),
+      });
+      const result = await produceBlockBody.call(chain, BlockType.Full, state, {
+        ...attrs,
+        feeRecipient: requested ? requestedRecipient : undefined,
+        proposerIndex: 0,
+        proposerPubKey: new Uint8Array(48),
+        commonBlockBodyPromise: Promise.resolve(common),
+      });
+      expect(modules.chain.executionEngine.notifyForkchoiceUpdate).toHaveBeenCalledExactlyOnceWith(
+        ForkName.fulu,
+        toRootHex(state.latestExecutionPayloadHeader.blockHash),
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({
+          suggestedFeeRecipient: requested ? requestedRecipient : cachedRecipient,
+          withdrawals: [],
+          parentBeaconBlockRoot: parentBlockRoot,
+        })
+      );
+      expect(result.executionPayloadValue).toBe(456n);
+      expect(result.produceResult).toMatchObject({fork: ForkName.fulu, type: BlockType.Full, cells: []});
+    });
+  }
+});
+
+describe("supported payload attributes", () => {
+  it("rejects an unapplied full Gloas parent before preparing withdrawals", () => {
+    const {state, chain, slot, parentBlockRoot} = setup(ForkName.gloas);
+    const parentBlockHash = new Uint8Array(32).fill(5);
+    vi.spyOn(state, "latestExecutionPayloadBid", "get").mockReturnValue({
+      ...ssz.gloas.ExecutionPayloadBid.defaultValue(),
+      blockHash: parentBlockHash,
+    });
+    vi.spyOn(state, "latestBlockHash", "get").mockReturnValue(new Uint8Array(32).fill(6));
+    const withdrawalSpy = vi.spyOn(state, "getExpectedWithdrawals");
+    expect(() =>
+      getPayloadAttributesForSSE(ForkName.gloas, chain, {
+        prepareState: state,
+        prepareSlot: slot,
+        parentBlockRoot,
+        parentBlockHash,
+        feeRecipient: "0xccccccccccccccccccccccccccccccccccccccaa",
+      })
+    ).toThrow("Expected state with parent execution payload applied for withdrawals");
+    expect(withdrawalSpy).not.toHaveBeenCalled();
+  });
+  for (const fork of [ForkName.fulu, ForkName.gloas, ForkName.heze] as const) {
+    for (const fullParent of fork === ForkName.fulu ? [true] : [true, false]) {
+      it(`${fork} builds on a ${fullParent ? "full" : "empty"} parent with the correct withdrawals`, () => {
+        const {state, chain, modules, slot, parentBlockRoot} = setup(fork);
+        const parentBlockHash = new Uint8Array(32).fill(fullParent ? 5 : 6);
+        const computed = [{...ssz.capella.Withdrawal.defaultValue(), amount: 7n}];
+        const carried = [{...ssz.capella.Withdrawal.defaultValue(), amount: 8n}];
+        const withdrawalSpy = vi.spyOn(state, "getExpectedWithdrawals").mockReturnValue({
+          expectedWithdrawals: computed,
+          processedBuilderWithdrawalsCount: 0,
+          processedPartialWithdrawalsCount: 0,
+          processedBuildersSweepCount: 0,
+          processedValidatorSweepCount: 0,
+        });
+        if (fork !== ForkName.fulu) {
+          vi.spyOn(state, "latestExecutionPayloadBid", "get").mockReturnValue({
+            ...ssz.gloas.ExecutionPayloadBid.defaultValue(),
+            blockHash: new Uint8Array(32).fill(5),
+          });
+          vi.spyOn(state, "latestBlockHash", "get").mockReturnValue(new Uint8Array(32).fill(5));
+          vi.spyOn(state, "payloadExpectedWithdrawals", "get").mockReturnValue(carried);
+          modules.forkChoice.getBlockHexDefaultStatus.mockReturnValue(null);
+          modules.forkChoice.getBlockHexAndBlockHash.mockReturnValue(
+            generateProtoBlock({
+              executionPayloadBlockHash: toRootHex(parentBlockHash),
+              executionPayloadGasLimit: 30_000_000,
+            })
+          );
+        }
+        vi.spyOn(state, "getBeaconProposer").mockReturnValue(0);
+        const result = getPayloadAttributesForSSE(fork, chain, {
+          prepareState: state,
+          prepareSlot: slot,
+          parentBlockRoot,
+          parentBlockHash,
+          feeRecipient: "0xccccccccccccccccccccccccccccccccccccccaa",
+        });
+        expect(result.payloadAttributes).toMatchObject({
+          withdrawals: fullParent ? computed : carried,
+          parentBeaconBlockRoot: parentBlockRoot,
+          suggestedFeeRecipient: "0xccccccccccccccccccccccccccccccccccccccaa",
+        });
+        expect(withdrawalSpy).toHaveBeenCalledTimes(fullParent ? 1 : 0);
+        if (fork !== ForkName.fulu) {
+          expect(result.payloadAttributes).toMatchObject({slotNumber: slot, targetGasLimit: 30_000_000n});
+          expect(result).not.toHaveProperty("parentBlockNumber");
+        } else {
+          expect(result).toHaveProperty("parentBlockNumber", state.payloadBlockNumber);
+          expect(result.payloadAttributes).not.toHaveProperty("slotNumber");
+        }
+        if (fork === ForkName.heze) expect(result.payloadAttributes).toHaveProperty("inclusionListTransactions", []);
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Motivation

Live block production is supported from Fulu onward. The proposal path still conditionally adds fields introduced before Fulu, making required fields look optional and assembling complete objects through casts.

Use that existing support boundary to simplify proposal assembly. No new API rejection or support-policy change is needed.

## Changes

- Return a complete common body, including BLS-to-execution changes and the parent-slot sync aggregate, without conditional field attachment or a return cast.
- Require builder commitments and execution requests directly, retaining the existing missing-field errors.
- Construct payload attributes with withdrawals and the parent beacon block root already present. Keep Gloas full/empty-parent withdrawal selection, the applied-parent check, and Gloas/Heze additions intact.
- Exercise the assembly functions directly with Fulu/Gloas/Heze fixtures. Move the engine fee-recipient test out of the API suite and cover successful next-slot preparation with a Fulu state.

This replaces the earlier API-guard approach. Blob-proof/sidecar removal is left to its separate workstream. Historical sync, serving, state transitions, and API selection logic are unchanged.

> This PR was rewritten with assistance from Hermes Agent using Astra.
