### PR TITLE
fix(network): skip impossible payload envelope sync targets

### DIFF
--- a/packages/beacon-node/src/network/processor/executionPayloadEnvelopeEligibility.ts
+++ b/packages/beacon-node/src/network/processor/executionPayloadEnvelopeEligibility.ts
@@ -1,0 +1,13 @@
+import {ForkSeq, GENESIS_SLOT} from "@lodestar/params";
+import {Slot} from "@lodestar/types";
+
+export function canKnownBlockRequireExecutionPayloadEnvelope(
+  forkSeqAtSlot: (slot: Slot) => ForkSeq,
+  knownBlock: {slot: Slot} | null
+): boolean {
+  if (knownBlock === null) {
+    return true;
+  }
+
+  return knownBlock.slot > GENESIS_SLOT && forkSeqAtSlot(knownBlock.slot) >= ForkSeq.gloas;
+}

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -32,6 +32,7 @@ import {
   GossipValidatorFn,
 } from "../gossip/interface.js";
 import {MAX_PEERS_PER_ROOT} from "./constants.js";
+import {canKnownBlockRequireExecutionPayloadEnvelope} from "./executionPayloadEnvelopeEligibility.js";
 import {createExtractBlockSlotRootFns} from "./extractSlotRootFns.js";
 import {GossipHandlerOpts, ValidatorFnsModules, getGossipHandlers} from "./gossipHandlers.js";
 import {createGossipQueues} from "./gossipQueues/index.js";
@@ -310,6 +311,17 @@ export class NetworkProcessor {
     if (this.chain.seenPayloadEnvelope(root)) {
       return;
     }
+
+    // Skip roots that can never have an execution payload envelope: a known genesis block
+    // (slot 0, no envelope) or a known pre-Gloas block. Unknown roots are kept so sync can
+    // still recover a real post-Gloas block's envelope.
+    const knownBlock = this.chain.forkChoice.getBlockHexDefaultStatus(root);
+    if (
+      !canKnownBlockRequireExecutionPayloadEnvelope((blockSlot) => this.chain.config.getForkSeq(blockSlot), knownBlock)
+    ) {
+      return;
+    }
+
     const peersForRoot = this.unknownEnvelopesBySlot.getOrDefault(slot);
     // capture "already searching" BEFORE getOrDefault(root) creates the entry
     const alreadySearching = peersForRoot.has(root) || this.awaitingMessagesByPayloadBlockRoot.has(root);

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -302,6 +302,20 @@ export class NetworkProcessor {
   }
 
   /**
+   * Whether a payload block root could ever have an execution payload envelope. Unknown roots
+   * qualify (a real post-Gloas block may still need one); known genesis / pre-Gloas roots never do.
+   * Callers must not await an envelope (or search for one) for a root this rejects, otherwise the
+   * awaiting message is never expired (pruning only traverses `unknownEnvelopesBySlot`).
+   */
+  private canRootRequireEnvelope(root: RootHex): boolean {
+    const knownBlock = this.chain.forkChoice.getBlockHexDefaultStatus(root);
+    return canKnownBlockRequireExecutionPayloadEnvelope(
+      (blockSlot) => this.chain.config.getForkSeq(blockSlot),
+      knownBlock
+    );
+  }
+
+  /**
    * Search envelope via `ChainEvent.unknownEnvelopeBlockRoot` event
    * Slot is the message slot, which is not necessarily the same as the envelope's slot, but it can be used for a good prune strategy.
    * In the rare case, if 2 messages on 2 slots search for the same root (for example beacon_attestation) we may emit the same root twice but BlockInputSync should handle it well.
@@ -312,13 +326,8 @@ export class NetworkProcessor {
       return;
     }
 
-    // Skip roots that can never have an execution payload envelope: a known genesis block
-    // (slot 0, no envelope) or a known pre-Gloas block. Unknown roots are kept so sync can
-    // still recover a real post-Gloas block's envelope.
-    const knownBlock = this.chain.forkChoice.getBlockHexDefaultStatus(root);
-    if (
-      !canKnownBlockRequireExecutionPayloadEnvelope((blockSlot) => this.chain.config.getForkSeq(blockSlot), knownBlock)
-    ) {
+    // Skip roots that can never have an execution payload envelope (known genesis / pre-Gloas).
+    if (!this.canRootRequireEnvelope(root)) {
       return;
     }
 
@@ -441,7 +450,7 @@ export class NetworkProcessor {
             topicType === GossipType.beacon_attestation
               ? getDataIndexFromSingleAttestationSerialized(fork, message.msg.data)
               : getDataIndexFromSignedAggregateAndProofSerialized(message.msg.data);
-          if (attIndex === 1 && !this.chain.forkChoice.hasPayloadHexUnsafe(root)) {
+          if (attIndex === 1 && !this.chain.forkChoice.hasPayloadHexUnsafe(root) && this.canRootRequireEnvelope(root)) {
             // attestation votes that the payload is available but it is not yet known
             this.searchUnknownEnvelope(
               {slot, root},
@@ -516,7 +525,11 @@ export class NetworkProcessor {
               preprocessResult = {action: PreprocessAction.AwaitBlock, root: parentBlockRoot};
             } else if (
               protoBlock.executionPayloadBlockHash &&
-              protoBlock.executionPayloadBlockHash !== parentBlockHash
+              protoBlock.executionPayloadBlockHash !== parentBlockHash &&
+              canKnownBlockRequireExecutionPayloadEnvelope(
+                (blockSlot) => this.chain.config.getForkSeq(blockSlot),
+                protoBlock
+              )
             ) {
               this.searchUnknownEnvelope(
                 {slot, root: parentBlockRoot},

--- a/packages/beacon-node/test/unit/network/processor.executionPayloadEnvelopeEligibility.test.ts
+++ b/packages/beacon-node/test/unit/network/processor.executionPayloadEnvelopeEligibility.test.ts
@@ -1,0 +1,24 @@
+import {describe, expect, it} from "vitest";
+import {ForkSeq} from "@lodestar/params";
+import {canKnownBlockRequireExecutionPayloadEnvelope} from "../../../src/network/processor/executionPayloadEnvelopeEligibility.js";
+
+describe("canKnownBlockRequireExecutionPayloadEnvelope", () => {
+  const gloasFromSlot1 = (slot: number): ForkSeq => (slot >= 1 ? ForkSeq.gloas : ForkSeq.deneb);
+
+  it("returns false for genesis even when current fork is gloas-era", () => {
+    expect(canKnownBlockRequireExecutionPayloadEnvelope(gloasFromSlot1, {slot: 0})).toBe(false);
+  });
+
+  it("returns false for known pre-gloas blocks", () => {
+    expect(canKnownBlockRequireExecutionPayloadEnvelope(() => ForkSeq.deneb, {slot: 64})).toBe(false);
+  });
+
+  it("returns true for known post-gloas non-genesis blocks", () => {
+    expect(canKnownBlockRequireExecutionPayloadEnvelope(() => ForkSeq.gloas, {slot: 1})).toBe(true);
+    expect(canKnownBlockRequireExecutionPayloadEnvelope(() => ForkSeq.gloas, {slot: 128})).toBe(true);
+  });
+
+  it("returns true for unknown blocks so sync can still recover real post-gloas roots", () => {
+    expect(canKnownBlockRequireExecutionPayloadEnvelope(() => ForkSeq.gloas, null)).toBe(true);
+  });
+});


### PR DESCRIPTION
Rebase of #9281 onto latest unstable, per @nflaig's request to re-evaluate it on top of current code. #9281 is now `CONFLICTING` because `searchUnknownEnvelope` was refactored since its base, so this is a fresh PR with the same fix applied to the new structure. Supersedes #9281 (will close it in favor of this).

### Re-evaluation: still an issue on unstable
Verified against latest unstable — the bug still reproduces and nothing merged since covers it:
- The enqueue path in `NetworkProcessor.searchUnknownEnvelope` only checks `chain.seenPayloadEnvelope(root)` and then enqueues; there is **no** known-block / genesis guard.
- Anchor seeding only seeds the seen-envelope cache for `anchorBlockSlot > 0`, so on a fresh `gloas_fork_epoch: 0` devnet the **genesis root is never "seen"** → a gossip message referencing it enqueues a payload-by-root target → `BlockInputSync` retries an impossible genesis-envelope download forever with growing backoff (issue #9921, genesis-envelope variant).
- twoeths' #9923 / #9924 (peer-selection balancer) fix a *different* symptom (empty peer selection for real targets) and don't touch this enqueue-eligibility path.

### Fix
Guard `searchUnknownEnvelope` with `canKnownBlockRequireExecutionPayloadEnvelope(forkSeqAtSlot, knownBlock)`:
- known genesis block (`slot === GENESIS_SLOT`) → skip (genesis has no envelope)
- known pre-Gloas block → skip
- unknown root → keep searching (a real post-Gloas block may genuinely need its envelope)

### Verification
- New unit test `processor.executionPayloadEnvelopeEligibility.test.ts` (4 cases) — passes.
- `@lodestar/beacon-node` `tsc` build passes (guard integrates with `forkChoice.getBlockHexDefaultStatus` / `config.getForkSeq`), biome clean.
- Empirical kurtosis `gloas_fork_epoch: 0` repro: the mechanism is verifiably present in the code above; I'll run the devnet repro to confirm the retry-loop is gone with this guard and report back on the issue thread.

Closes the genesis-envelope variant of #9921.

🤖 Generated with AI assistance
