### PR TITLE
chore: make dashboard ad hoc filters usable outside our own Grafana

### DIFF
--- a/dashboards/lodestar_beacon_chain.json
+++ b/dashboards/lodestar_beacon_chain.json
@@ -1964,16 +1964,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_block_processor.json
+++ b/dashboards/lodestar_block_processor.json
@@ -7393,16 +7393,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_block_production.json
+++ b/dashboards/lodestar_block_production.json
@@ -4112,16 +4112,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_bls_thread_pool.json
+++ b/dashboards/lodestar_bls_thread_pool.json
@@ -1526,16 +1526,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_debug_gossipsub.json
+++ b/dashboards/lodestar_debug_gossipsub.json
@@ -9413,16 +9413,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_discv5.json
+++ b/dashboards/lodestar_discv5.json
@@ -2161,16 +2161,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_execution_engine.json
+++ b/dashboards/lodestar_execution_engine.json
@@ -1725,16 +1725,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_fork_choice.json
+++ b/dashboards/lodestar_fork_choice.json
@@ -1929,16 +1929,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_historical_state_regen.json
+++ b/dashboards/lodestar_historical_state_regen.json
@@ -2594,16 +2594,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_libp2p.json
+++ b/dashboards/lodestar_libp2p.json
@@ -1626,16 +1626,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_multinode.json
+++ b/dashboards/lodestar_multinode.json
@@ -837,16 +837,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_networking.json
+++ b/dashboards/lodestar_networking.json
@@ -7826,16 +7826,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_peerdas.json
+++ b/dashboards/lodestar_peerdas.json
@@ -2028,16 +2028,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_rest_api.json
+++ b/dashboards/lodestar_rest_api.json
@@ -642,16 +642,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_state_cache_regen.json
+++ b/dashboards/lodestar_state_cache_regen.json
@@ -3575,16 +3575,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -3257,16 +3257,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_sync.json
+++ b/dashboards/lodestar_sync.json
@@ -2900,16 +2900,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_validator_client.json
+++ b/dashboards/lodestar_validator_client.json
@@ -2809,16 +2809,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_validator_monitor.json
+++ b/dashboards/lodestar_validator_monitor.json
@@ -1889,16 +1889,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -5921,16 +5921,9 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus_local"
+          "uid": "${DS_PROMETHEUS}"
         },
-        "filters": [
-          {
-            "condition": "",
-            "key": "instance",
-            "operator": "=",
-            "value": "unstable-super"
-          }
-        ],
+        "filters": [],
         "hide": 0,
         "name": "Filters",
         "skipUrlSync": false,

--- a/scripts/lint-grafana-dashboard.mjs
+++ b/scripts/lint-grafana-dashboard.mjs
@@ -236,18 +236,18 @@ export function lintGrafanaDashboard(json) {
   });
 
   assertTemplatingListItemContent(json, variableNameFilters, {
+    // Must track the datasource variable, like panels do. Ad hoc filters only
+    // apply to queries using the filter's own datasource, so a hardcoded uid
+    // that does not exist on the importing Grafana leaves the filter inert:
+    // it cannot list label keys and it filters nothing.
     datasource: {
       type: "prometheus",
-      uid: "prometheus_local",
+      uid: `\${${variableNameDatasource}}`,
     },
-    filters: [
-      {
-        condition: "",
-        key: "instance",
-        operator: "=",
-        value: "unstable-super",
-      },
-    ],
+    // Ship no filters. A default filter is applied on load, so pinning one
+    // here points every panel at a single node that only exists on the
+    // Grafana the dashboard was exported from.
+    filters: [],
     hide: 0,
     name: "Filters",
     skipUrlSync: false,


### PR DESCRIPTION
**Motivation**

The `Filters` ad hoc variable is force-written by `scripts/lint-grafana-dashboard.mjs` with two values that only make sense on the Grafana the dashboards were originally exported from:

- `datasource.uid: "prometheus_local"`
- a default filter `instance = "unstable-super"`

Because the linter replaces the whole variable on every run, correcting the dashboard JSON by hand doesn't stick — `validate-grafana-dashboards.sh` then fails on the drift. This is why #5210, which moved panels off `prometheus_local`, didn't move this one: panels go through `assertPanels`, the variable goes through `assertTemplatingListItemContent`.

On any Grafana other than the export source, this breaks the dashboards two ways:

1. Ad hoc filters are only applied to queries whose datasource matches the filter's own datasource. `prometheus_local` doesn't exist elsewhere, so the filter is inert — it can't enumerate label keys and it filters nothing. Grafana's import can't repair this either, because `prometheus_local` is a literal rather than a `${...}` input placeholder, so there is nothing for it to substitute.
2. The default `instance="unstable-super"` filter is applied on load, pinning every panel to a node that doesn't exist on the importing instance. The dashboard reads as completely empty.

This came up because the Lodestar dashboards on ethPandaOps' Grafana were reported as out of date. They had these same defaults saved into them, pinned to a devnet that has since been torn down, so every panel was blank.

**Description**

Two lines in `scripts/lint-grafana-dashboard.mjs`:

- point the `Filters` variable at `${DS_PROMETHEUS}`, which is what panels already use, so the filter follows the datasource chosen at import time
- ship `filters: []`, so dashboards don't arrive pre-filtered to one node

The 20 dashboard JSON files are regenerated output of the linter, not hand edits. `scripts/validate-grafana-dashboards.sh` passes and the linter is idempotent.

Verified by importing `lodestar_block_processor.json` before and after into a clean Grafana 11.6.2 with a single Prometheus datasource `promtest`:

| | Filters datasource | default filters |
|---|---|---|
| before | `prometheus_local` | `instance=unstable-super` |
| after | `promtest` | none |

No change to any panel, query or metric name.

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

This PR was investigated and written with Claude Code, under my review. It started from a report that the Lodestar dashboards on our Grafana were stale; the ad hoc filter behaviour and the linter's role in it were traced from the repo's git history and confirmed with the before/after import test described above rather than assumed. I understand the change and can answer questions on it.
