### PR TITLE
feat(ci): opt-in mirror of lodestar image to Swarm registry (Uncloud Registry)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,6 +93,30 @@ jobs:
             chainsafe/lodestar:${{ inputs.tag }}-amd64 \
             chainsafe/lodestar:${{ inputs.tag }}-arm64
 
+      - name: Mirror lodestar manifest to Swarm registry (Uncloud Registry)
+        # Opt-in mirror of the multi-arch lodestar manifest to a Swarm-backed
+        # OCI registry (Ethereum Swarm via the Uncloud Registry). Inert unless
+        # the SWARM_REGISTRY repo variable is set, so it is a no-op by default.
+        # PoC: https://github.com/lodekeeper/lodestar-swarm-registry-poc
+        if: ${{ vars.SWARM_REGISTRY != '' }}
+        env:
+          SWARM_REGISTRY: ${{ vars.SWARM_REGISTRY }}
+          SWARM_REGISTRY_USERNAME: ${{ secrets.SWARM_REGISTRY_USERNAME }}
+          SWARM_REGISTRY_PASSWORD: ${{ secrets.SWARM_REGISTRY_PASSWORD }}
+        run: |
+          if [ -n "$SWARM_REGISTRY_USERNAME" ]; then
+            echo "$SWARM_REGISTRY_PASSWORD" | docker login "$SWARM_REGISTRY" -u "$SWARM_REGISTRY_USERNAME" --password-stdin
+          fi
+          EXTRA_TAGS=""
+          if [ -n "${{ inputs.extra-tags }}" ]; then
+            for t in $(echo "${{ inputs.extra-tags }}" | tr ',' ' '); do
+              EXTRA_TAGS="$EXTRA_TAGS -t $SWARM_REGISTRY/chainsafe/lodestar:$t"
+            done
+          fi
+          docker buildx imagetools create \
+            -t "$SWARM_REGISTRY/chainsafe/lodestar:${{ inputs.tag }}" $EXTRA_TAGS \
+            "chainsafe/lodestar:${{ inputs.tag }}"
+
       - name: Create and push grafana manifest
         run: |
           docker buildx imagetools create -t chainsafe/lodestar-grafana:${{ inputs.tag }} \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,6 +98,12 @@ jobs:
         # OCI registry (Ethereum Swarm via the Uncloud Registry). Inert unless
         # the SWARM_REGISTRY repo variable is set, so it is a no-op by default.
         # PoC: https://github.com/lodekeeper/lodestar-swarm-registry-poc
+        #
+        # Uses `regctl image copy` rather than `docker buildx imagetools create`:
+        # the target is a separate registry that does not already hold the layers,
+        # and imagetools create only writes the top-level index (its referenced
+        # blobs must already exist in the destination), so a real registry-to-registry
+        # copy of the manifest list + child manifests + blobs is required.
         if: ${{ vars.SWARM_REGISTRY != '' }}
         env:
           SWARM_REGISTRY: ${{ vars.SWARM_REGISTRY }}
@@ -107,15 +113,16 @@ jobs:
           if [ -n "$SWARM_REGISTRY_USERNAME" ]; then
             echo "$SWARM_REGISTRY_PASSWORD" | docker login "$SWARM_REGISTRY" -u "$SWARM_REGISTRY_USERNAME" --password-stdin
           fi
-          EXTRA_TAGS=""
+          # regctl does a full multi-arch registry-to-registry copy (manifests + blobs),
+          # reading the docker login credentials above from ~/.docker/config.json.
+          curl -fsSL -o regctl "https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64"
+          chmod +x regctl
+          ./regctl image copy "chainsafe/lodestar:${{ inputs.tag }}" "$SWARM_REGISTRY/chainsafe/lodestar:${{ inputs.tag }}"
           if [ -n "${{ inputs.extra-tags }}" ]; then
             for t in $(echo "${{ inputs.extra-tags }}" | tr ',' ' '); do
-              EXTRA_TAGS="$EXTRA_TAGS -t $SWARM_REGISTRY/chainsafe/lodestar:$t"
+              ./regctl image copy "chainsafe/lodestar:${{ inputs.tag }}" "$SWARM_REGISTRY/chainsafe/lodestar:$t"
             done
           fi
-          docker buildx imagetools create \
-            -t "$SWARM_REGISTRY/chainsafe/lodestar:${{ inputs.tag }}" $EXTRA_TAGS \
-            "chainsafe/lodestar:${{ inputs.tag }}"
 
       - name: Create and push grafana manifest
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,6 +98,9 @@ jobs:
         # OCI registry (Ethereum Swarm via the Uncloud Registry). Inert unless
         # the SWARM_REGISTRY repo variable is set, so it is a no-op by default.
         # PoC: https://github.com/lodekeeper/lodestar-swarm-registry-poc
+        # Durability (image not GC'd) needs an externally-funded postage batch
+        # + keeper, and the registry stack is unmaintained today — see the PoC's
+        # docs/RETENTION.md before enabling this for real releases.
         #
         # Uses `regctl image copy` rather than `docker buildx imagetools create`:
         # the target is a separate registry that does not already hold the layers,


### PR DESCRIPTION
## What

Adds an **opt-in** step to the `docker-manifest` job in `.github/workflows/docker.yml` that mirrors the multi-arch `chainsafe/lodestar` image to a **Swarm-backed OCI registry** (Ethereum Swarm, via the [Uncloud Registry](https://github.com/uncloud-registry/swarm-driver)) right after it is published to Docker Hub.

It's the minimal Lodestar-side hook for publishing images to Ethereum Swarm — the registry/infra side lives out-of-repo in a separate [PoC](https://github.com/lodekeeper/lodestar-swarm-registry-poc).

## The change (one step)

- **Inert by default** — runs only when the `SWARM_REGISTRY` repo variable is set, so existing Docker Hub publishing is completely unaffected and this is a no-op until someone opts in.
- **Full registry→registry copy** — uses `regctl image copy` (regclient) to copy the multi-arch manifest list + child manifests + **blobs** to the Swarm registry. (An earlier revision used `docker buildx imagetools create`; per Codex review that only writes the top-level index and assumes the referenced blobs already exist in the destination — which a fresh Swarm registry does not — so a real copy is required.)
- **Auth optional** — logs in only if `SWARM_REGISTRY_USERNAME`/`SWARM_REGISTRY_PASSWORD` are set (the Swarm registry can run without auth).
- Applies the same `extra-tags` (`next` / `latest` / `rc`) as the Docker Hub manifest.

## To activate (out-of-band, later)

Set repo variable `SWARM_REGISTRY` to the registry endpoint (and, if it needs auth, the two secrets). Nothing else changes.

## Operational prerequisites & caveats

Enabling this for **real releases** carries out-of-repo requirements (documented in the PoC's [`docs/RETENTION.md`](https://github.com/lodekeeper/lodestar-swarm-registry-poc/blob/poc/docs/RETENTION.md)):

- **Durable retention isn't automatic.** Swarm garbage-collects chunks when the postage batch drains. Persistence needs the batch wrapped in a [VolumeRegistry](https://github.com/shtukaresearch/swarm-volume-registry) volume + a **keeper you run** that tops it up (`trigger()` on a schedule). Relying on a third-party keeper just swaps Docker Hub for someone else's uptime.
- **Dependency ownership** — the swarm driver, the `distribution` fork, and the Bee fork were all last touched Dec 2024 / Jan 2025 (Bee carries an unmerged patch). Fine for a PoC; before mirroring real releases someone has to own/maintain that stack or it's a new single point of failure. UncloudRegistry V2 is WIP.
- **Sizing** — postage is priced by depth (not bytes) with bucket-collision derating; the ~300 MB multi-arch image fits comfortably at depth 22 (16 GiB theoretical), but real cost/month needs a funded run.
- **No auth** in the reference registry config — set the two secrets (and put auth on the registry) for anything shared.

## Notes

- Grafana/Prometheus sidecar images intentionally left out to keep this minimal — trivial to extend.
- Registry side is a separate, verified PoC (CNCF `distribution` + Swarm storage driver; pushed a real `chainsafe/lodestar` image to Swarm chunks and pulled it back): https://github.com/lodekeeper/lodestar-swarm-registry-poc
- "Swarm" here = Ethereum Swarm (Bee / postage stamps), not Docker Swarm.

---
🤖 Generated with AI assistance