### PR TITLE
chore: remove bid pool addition via api path

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -1073,16 +1073,6 @@ export function getBeaconBlockApi({
       const elapsedSec = chain.clock.secFromSlot(slot, seenTimestampSec);
       metrics?.gossipExecutionPayloadBid.elapsedTimeTillReceived.observe({source: OpSource.api}, elapsedSec);
 
-      try {
-        const insertOutcome = chain.executionPayloadBidPool.add(
-          signedExecutionPayloadBid,
-          Math.floor(elapsedSec * 1000)
-        );
-        metrics?.opPool.executionPayloadBidPool.apiInsertOutcome.inc({insertOutcome});
-      } catch (e) {
-        chain.logger.error("Error adding to executionPayloadBid pool", {}, e as Error);
-      }
-
       const sentPeers = await network.publishSignedExecutionPayloadBid(signedExecutionPayloadBid);
 
       chain.emitter.emit(routes.events.EventType.executionPayloadBid, {

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1352,11 +1352,6 @@ export function createLodestarMetrics(
           help: "Total number of InsertOutcome as a result of adding an execution payload bid from gossip to the pool",
           labelNames: ["insertOutcome"],
         }),
-        apiInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
-          name: "lodestar_oppool_execution_payload_bid_pool_api_insert_outcome_total",
-          help: "Total number of InsertOutcome as a result of adding an execution payload bid from api to the pool",
-          labelNames: ["insertOutcome"],
-        }),
         apiValidationTime: register.histogram({
           name: "lodestar_api_execution_payload_bid_validation_time_seconds",
           help: "Time elapsed for signed execution payload bid validation - api path",

--- a/packages/beacon-node/test/unit/api/impl/beacon/blocks/publishExecutionPayloadBid.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/blocks/publishExecutionPayloadBid.test.ts
@@ -43,7 +43,6 @@ describe("api - beacon - publishExecutionPayloadBid", () => {
     await api.publishExecutionPayloadBid({signedExecutionPayloadBid: signedBid});
 
     expect(modules.network.publishSignedExecutionPayloadBid).toHaveBeenCalledWith(signedBid);
-    expect(modules.chain.executionPayloadBidPool.add).toHaveBeenCalled();
   });
 
   it("does not publish a bid that fails the reject checks", async () => {
@@ -60,6 +59,5 @@ describe("api - beacon - publishExecutionPayloadBid", () => {
     );
 
     expect(modules.network.publishSignedExecutionPayloadBid).not.toHaveBeenCalled();
-    expect(modules.chain.executionPayloadBidPool.add).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
**Motivation**

Bid addition to the pool via api path is deemed unnecessary.
Aside from being unnecessary, AI hallucinates vulnerabilities over it,
which is another reason to remove this piece for extra safety and cleaner work around it.

**Description**

This PR removes bid addition to the pool via api path, related metric and tweaks tests.
