### PR TITLE
chore: fix typo in persisted keys comment

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/persistedKeys.ts
+++ b/packages/cli/src/cmds/validator/keymanager/persistedKeys.ts
@@ -123,7 +123,7 @@ export class PersistedKeysBackend implements IPersistedKeysBackend {
     persistIfDuplicate: boolean;
   }): boolean {
     // Validate Keystore JSON + pubkey format.
-    // Note: while this is currently redundant, it's free to check that format is correct before writting
+    // Note: while this is currently redundant, it's free to check that format is correct before writing
     const keystore = Keystore.parse(keystoreStr);
     const pubkeyHex = getPubkeyHexFromKeystore(keystore);
 


### PR DESCRIPTION
fix `writting` typo in a comment in `persistedKeys.ts`