### PR TITLE
fix: handle orphaned parent payload envelope in range sync batches

### DIFF
--- a/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
+++ b/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
@@ -37,23 +37,28 @@ export function assertLinearChainSegment(
 
   const warnings: OrphanedPayloadEnvelope[] = [];
 
-  let parentExecHash: string | null = parentBlock?.executionPayloadBlockHash ?? null;
-  if (parentBlock !== null) {
-    const parentPayloadInput = payloadEnvelopes?.get(parentBlock.slot);
-    if (parentPayloadInput?.hasPayloadEnvelope()) {
-      // Checkpoint-sync first batch: the anchor is stored PENDING with the inherited (grandparent)
-      // hash, not its own payload. Its payload envelope is in this batch, so use that blockHash as
-      // the real parent EL head.
-      parentExecHash = parentPayloadInput.getBlockHashHex();
-    }
-  }
-
   // Track the expected execution payload block hash through the segment, seeded from the FIRST
   // block's own bid
   const firstBlockMessage = blocks[0].getBlock().message;
   let currentExecHash: string | null = isGloasBeaconBlock(firstBlockMessage)
     ? toRootHex(firstBlockMessage.body.signedExecutionPayloadBid.message.parentBlockHash)
     : null;
+
+  let parentExecHash: string | null = parentBlock?.executionPayloadBlockHash ?? null;
+  if (parentBlock !== null) {
+    const parentPayloadInput = payloadEnvelopes?.get(parentBlock.slot);
+    if (parentPayloadInput?.hasPayloadEnvelope()) {
+      const parentPayloadBlockHash = parentPayloadInput.getBlockHashHex();
+      if (currentExecHash === parentPayloadBlockHash) {
+        // Checkpoint-sync first batch: the anchor is stored PENDING with the inherited (grandparent)
+        // hash, its own payload is in this batch and is the real parent EL head
+        parentExecHash = parentPayloadBlockHash;
+      } else {
+        // First block builds on the parent's EMPTY variant, the parent's payload in this batch is orphaned
+        warnings.push({slot: parentBlock.slot, payloadEnvelopeInput: parentPayloadInput});
+      }
+    }
+  }
 
   // First block must build on the parent's EL head. PARENT_PAYLOAD_UNKNOWN (vs the in-segment
   // NON_LINEAR_PAYLOAD_ROOTS below) tells range sync this is a parent-link problem, not an in-batch one.

--- a/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
@@ -258,4 +258,37 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment bound
     const {warnings} = assertLinearChainSegment(config, [bi1], envelopes, parentBlock);
     expect(warnings).toBe(null);
   });
+
+  it("reports the parent's envelope as orphaned when the first block builds on the parent's EMPTY variant", () => {
+    // Range sync batch starting at an already imported block whose late payload was orphaned, peers
+    // still serve the envelope by range so it is in the batch but must not become the parent EL head
+    const grandparentHash = Buffer.alloc(32, 0x11); // parent's EMPTY variant hash (inherited)
+    const orphanedPayloadHash = Buffer.alloc(32, 0x22); // parent's own, orphaned payload
+    const parentBlock = {slot: 9, executionPayloadBlockHash: toRootHex(grandparentHash)} as unknown as ProtoBlock;
+
+    const parentInput = gloasBlockInput(9, Buffer.alloc(32, 0xdd), Buffer.alloc(32, 0x00), orphanedPayloadHash);
+    const parentPayload = payloadInputFor(parentInput, orphanedPayloadHash);
+    const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), grandparentHash);
+
+    const envelopes = new Map<Slot, PayloadEnvelopeInput>([[9, parentPayload]]);
+    const {warnings} = assertLinearChainSegment(config, [bi1], envelopes, parentBlock);
+    expect(warnings).toEqual([{slot: 9, payloadEnvelopeInput: parentPayload}]);
+  });
+
+  it("throws PARENT_PAYLOAD_UNKNOWN when the first block builds on neither the parent's EL head nor its envelope", () => {
+    const grandparentHash = Buffer.alloc(32, 0x11);
+    const parentPayloadHash = Buffer.alloc(32, 0x22);
+    const unknownHash = Buffer.alloc(32, 0x33);
+    const parentBlock = {slot: 9, executionPayloadBlockHash: toRootHex(grandparentHash)} as unknown as ProtoBlock;
+
+    const parentInput = gloasBlockInput(9, Buffer.alloc(32, 0xdd), Buffer.alloc(32, 0x00), parentPayloadHash);
+    const parentPayload = payloadInputFor(parentInput, parentPayloadHash);
+    const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), unknownHash);
+
+    const envelopes = new Map<Slot, PayloadEnvelopeInput>([[9, parentPayload]]);
+    expectThrowsLodestarError(
+      () => assertLinearChainSegment(config, [bi1], envelopes, parentBlock),
+      BlockErrorCode.PARENT_PAYLOAD_UNKNOWN
+    );
+  });
 });


### PR DESCRIPTION
lodestar-geth-2 on glamsterdam-devnet-9 was stuck at head 16192 for 20+ minutes after a restart, every range sync batch starting at 16192 failed with `BLOCK_ERROR_PARENT_PAYLOAD_UNKNOWN` at 16193 (~1000 errors, 190+ sync chain restarts) until a Prysm peer happened to serve the batch without the 16192 envelope.

the payload of 16192 was revealed late and orphaned, 16193 builds on the EMPTY variant of 16192 (its `bid.parent_block_hash` is the 16191 payload hash). block 16192 was already imported as target of the previous finalized sync chain, so the batch is processed as `[16193, ...]` with parent 16192 EMPTY from fork choice, which is correct. but peers still serve the orphaned 16192 envelope in `execution_payload_envelopes_by_range` and `assertLinearChainSegment` unconditionally takes an envelope for the parent slot as the parent EL head, so the first block check fails against the orphaned payload hash and the batch is retried forever.

only take the parent envelope as EL head if the first block actually builds on it (the checkpoint sync anchor case this was added for), otherwise keep the fork choice parent and report the envelope as orphaned, same as in-segment orphans.

replayed the real 16192/16193 blocks and 16192 envelope from the devnet through `assertLinearChainSegment`, unstable throws `PARENT_PAYLOAD_UNKNOWN`, with this change it passes and reports slot 16192 as orphaned.
