### PR TITLE
fix: serve closest head state if head block post-state is not available

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -15,7 +15,9 @@ import {
 } from "@lodestar/types";
 import {byteArrayEquals, fromHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../../chain/index.js";
+import {GENESIS_EPOCH} from "../../../../constants/index.js";
 import {IBeaconSync} from "../../../../sync/index.js";
+import {isOptimisticBlock} from "../../../../util/forkChoice.js";
 import {ApiError, ValidationError} from "../../errors.js";
 import {notWhileSyncing} from "../../utils.js";
 
@@ -63,6 +65,19 @@ export async function getStateResponseWithRegen(
   // dashboards, validator client checks) even while syncing; guard only the regen-capable lookups.
   if (inStateId !== "head" && inStateId !== "finalized" && inStateId !== "justified" && inStateId !== "genesis") {
     notWhileSyncing(chain, sync.state);
+  }
+
+  if (inStateId === "head") {
+    const head = chain.forkChoice.getHead();
+    // Head block's post-state is not cached after init from an anchor state at a skipped boundary slot,
+    // it does not exist anywhere and regen has no seed for it, serve the closest head state instead
+    const state = chain.regen.getStateSync(head.stateRoot) ?? chain.getHeadState();
+    const finalizedEpoch = chain.forkChoice.getFinalizedCheckpoint().epoch;
+    return {
+      state,
+      executionOptimistic: isOptimisticBlock(head),
+      finalized: state.epoch <= finalizedEpoch && finalizedEpoch !== GENESIS_EPOCH,
+    };
   }
 
   const stateId = resolveStateId(chain.forkChoice, inStateId);

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -25,10 +25,6 @@ export function resolveStateId(
   forkChoice: IForkChoice,
   stateId: routes.beacon.StateId
 ): RootHex | Slot | CheckpointWithHex {
-  if (stateId === "head") {
-    return forkChoice.getHead().stateRoot;
-  }
-
   if (stateId === "genesis") {
     return GENESIS_SLOT;
   }

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -25,6 +25,10 @@ export function resolveStateId(
   forkChoice: IForkChoice,
   stateId: routes.beacon.StateId
 ): RootHex | Slot | CheckpointWithHex {
+  if (stateId === "head") {
+    return forkChoice.getHead().stateRoot;
+  }
+
   if (stateId === "genesis") {
     return GENESIS_SLOT;
   }

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -1,5 +1,6 @@
-import {describe, expect, it} from "vitest";
+import {Mock, describe, expect, it, vi} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
+import {ExecutionStatus} from "@lodestar/fork-choice";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {BeaconStateView} from "@lodestar/state-transition";
 import {getStateResponseWithRegen, getStateValidatorIndex} from "../../../../../../src/api/impl/beacon/state/utils.js";
@@ -78,6 +79,7 @@ describe("beacon state api utils", () => {
         getJustifiedCheckpoint: () => ({rootHex: "0x00", epoch: 0}),
         getFinalizedBlock: () => ({slot: 0}),
       },
+      regen: {getStateSync: () => servedResponse.state},
       getStateByStateRoot: () => Promise.resolve(servedResponse),
       getStateOrBytesByCheckpoint: () => Promise.resolve(servedResponse),
       getStateBySlot: () => Promise.resolve(servedResponse),
@@ -94,6 +96,44 @@ describe("beacon state api utils", () => {
       for (const stateId of ["head", "finalized", "justified", "genesis"] as const) {
         await expect(getStateResponseWithRegen(syncingChain, sync, stateId), stateId).resolves.toBeDefined();
       }
+    });
+  });
+
+  describe("getStateResponseWithRegen head", () => {
+    const head = {slot: 15902, stateRoot: "0xaa", executionStatus: ExecutionStatus.Valid};
+    const headPostState = {epoch: 496, slot: 15902};
+    // Anchor state at the epoch boundary after the head block, slots 15903-15904 skipped
+    const anchorState = {epoch: 497, slot: 15904};
+    const sync = {state: SyncState.Synced} as unknown as IBeaconSync;
+
+    function getChain(cachedState: unknown): {chain: IBeaconChain; getHeadState: Mock} {
+      const getHeadState = vi.fn(() => anchorState);
+      const chain = {
+        forkChoice: {
+          getHead: () => head,
+          getFinalizedCheckpoint: () => ({rootHex: "0xbb", epoch: 497}),
+        },
+        regen: {getStateSync: (stateRoot: string) => (stateRoot === head.stateRoot ? cachedState : null)},
+        getHeadState,
+      } as unknown as IBeaconChain;
+      return {chain, getHeadState};
+    }
+
+    it("serves the head block's post-state from the block state cache", async () => {
+      const {chain, getHeadState} = getChain(headPostState);
+      const res = await getStateResponseWithRegen(chain, sync, "head");
+      expect(res.state).toBe(headPostState);
+      expect(res.finalized).toBe(true);
+      expect(res.executionOptimistic).toBe(false);
+      expect(getHeadState).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the closest head state if the head block's post-state is not cached (anchor at skipped boundary slot)", async () => {
+      const {chain, getHeadState} = getChain(null);
+      const res = await getStateResponseWithRegen(chain, sync, "head");
+      expect(res.state).toBe(anchorState);
+      expect(res.finalized).toBe(true);
+      expect(getHeadState).toHaveBeenCalledOnce();
     });
   });
 });


### PR DESCRIPTION
after a restart from a db or checkpoint state at an epoch boundary whose boundary slot was skipped, the head block's post-state does not exist anywhere. the anchor state is the boundary state (slot > head block slot) and is only cached under its own root, regen walks ancestors only and the anchor has none. every `head` state request (`getStateFinalityCheckpoints`, `getEpochCommittees`, `postStateValidators`, ...) fails with `REGEN_ERROR_NO_SEED_STATE` until the first new block is imported, seen on glamsterdam-devnet-9 after restarts with anchor state slot 16000 and head block 15999.

serve the closest head state in that case, same as `chain.getHeadState()` does internally. the cached head post-state is still preferred when it exists.
