### PR TITLE
fix: omit GAS_LIMIT_SCHEDULE from getSpec until Gloas

### DIFF
--- a/packages/beacon-node/src/api/impl/config/index.ts
+++ b/packages/beacon-node/src/api/impl/config/index.ts
@@ -20,10 +20,13 @@ export function renderJsonSpec(config: ChainConfig): routes.config.Spec {
   const presetJson = presetToJson(activePreset);
   const constantsJson = specValuesToJson(specConstants);
 
-  // TODO Fulu: remove this check once interop issues are resolved
+  // TODO Fulu/Gloas: remove these checks once interop issues are resolved
   // see https://github.com/attestantio/go-eth2-client/issues/230
   if (config.FULU_FORK_EPOCH === Infinity) {
     delete configJson.BLOB_SCHEDULE;
+  }
+  if (config.GLOAS_FORK_EPOCH === Infinity || config.GAS_LIMIT_SCHEDULE.length === 0) {
+    delete configJson.GAS_LIMIT_SCHEDULE;
   }
 
   return {...configJson, ...presetJson, ...constantsJson};

--- a/packages/beacon-node/src/api/impl/config/index.ts
+++ b/packages/beacon-node/src/api/impl/config/index.ts
@@ -25,7 +25,7 @@ export function renderJsonSpec(config: ChainConfig): routes.config.Spec {
   if (config.FULU_FORK_EPOCH === Infinity) {
     delete configJson.BLOB_SCHEDULE;
   }
-  if (config.GLOAS_FORK_EPOCH === Infinity || config.GAS_LIMIT_SCHEDULE.length === 0) {
+  if (config.GLOAS_FORK_EPOCH === Infinity) {
     delete configJson.GAS_LIMIT_SCHEDULE;
   }
 

--- a/packages/beacon-node/test/unit/api/impl/config/config.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/config/config.test.ts
@@ -75,7 +75,7 @@ describe("config api implementation", () => {
       expect(specJson.GAS_LIMIT_SCHEDULE).toEqual([{EPOCH: "10", GAS_LIMIT: "60000000"}]);
     });
 
-    it("still omits BLOB_SCHEDULE when Fulu is unscheduled", () => {
+    it("omits BLOB_SCHEDULE when Fulu is unscheduled", () => {
       const specJson = renderJsonSpec(
         createChainForkConfig({
           ...defaultChainConfig,

--- a/packages/beacon-node/test/unit/api/impl/config/config.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/config/config.test.ts
@@ -51,7 +51,7 @@ describe("config api implementation", () => {
       expect(specJson).not.toHaveProperty("GAS_LIMIT_SCHEDULE");
     });
 
-    it("omits GAS_LIMIT_SCHEDULE when the schedule is empty", () => {
+    it("includes empty GAS_LIMIT_SCHEDULE when Gloas is scheduled", () => {
       const specJson = renderJsonSpec(
         createChainForkConfig({
           ...defaultChainConfig,
@@ -60,7 +60,7 @@ describe("config api implementation", () => {
         })
       );
 
-      expect(specJson).not.toHaveProperty("GAS_LIMIT_SCHEDULE");
+      expect(specJson.GAS_LIMIT_SCHEDULE).toEqual([]);
     });
 
     it("includes GAS_LIMIT_SCHEDULE when Gloas is scheduled with entries", () => {

--- a/packages/beacon-node/test/unit/api/impl/config/config.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/config/config.test.ts
@@ -1,5 +1,6 @@
 import {beforeEach, describe, expect, it} from "vitest";
 import {routes} from "@lodestar/api";
+import {createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
 import {getConfigApi, renderJsonSpec} from "../../../../../src/api/impl/config/index.js";
 
@@ -36,6 +37,54 @@ describe("config api implementation", () => {
       expect(specJson.SECONDS_PER_ETH1_BLOCK).toBe("14");
       expect(specJson.DEPOSIT_CONTRACT_ADDRESS).toBe("0x00000000219ab540356cbb839cbe05303d7705fa");
       expect(specJson.DEPOSIT_REQUEST_TYPE).toBe("0x00");
+    });
+
+    it("omits GAS_LIMIT_SCHEDULE when Gloas is unscheduled", () => {
+      const specJson = renderJsonSpec(
+        createChainForkConfig({
+          ...defaultChainConfig,
+          GLOAS_FORK_EPOCH: Infinity,
+          GAS_LIMIT_SCHEDULE: [],
+        })
+      );
+
+      expect(specJson).not.toHaveProperty("GAS_LIMIT_SCHEDULE");
+    });
+
+    it("omits GAS_LIMIT_SCHEDULE when the schedule is empty", () => {
+      const specJson = renderJsonSpec(
+        createChainForkConfig({
+          ...defaultChainConfig,
+          GLOAS_FORK_EPOCH: 10,
+          GAS_LIMIT_SCHEDULE: [],
+        })
+      );
+
+      expect(specJson).not.toHaveProperty("GAS_LIMIT_SCHEDULE");
+    });
+
+    it("includes GAS_LIMIT_SCHEDULE when Gloas is scheduled with entries", () => {
+      const specJson = renderJsonSpec(
+        createChainForkConfig({
+          ...defaultChainConfig,
+          GLOAS_FORK_EPOCH: 10,
+          GAS_LIMIT_SCHEDULE: [{EPOCH: 10, GAS_LIMIT: 60_000_000}],
+        })
+      );
+
+      expect(specJson.GAS_LIMIT_SCHEDULE).toEqual([{EPOCH: "10", GAS_LIMIT: "60000000"}]);
+    });
+
+    it("still omits BLOB_SCHEDULE when Fulu is unscheduled", () => {
+      const specJson = renderJsonSpec(
+        createChainForkConfig({
+          ...defaultChainConfig,
+          FULU_FORK_EPOCH: Infinity,
+          BLOB_SCHEDULE: [],
+        })
+      );
+
+      expect(specJson).not.toHaveProperty("BLOB_SCHEDULE");
     });
   });
 });


### PR DESCRIPTION
Empty array values break older VCs (e.g. Nimbus) that only allowlist blob_schedule as non-string in getSpec.

**Motivation**

Lodestar `v1.47.0` always returns `GAS_LIMIT_SCHEDULE` from `GET /eth/v1/config/spec`, including as `[]` on mainnet. That breaks Nimbus VC `v26.8.0` (and similarly strict clients), which fail to decode the array and mark the BN Offline in a ~2s Online/Offline flap. Emitting the field before Gloas is scheduled has no operational value under EIP-8261.

**Description**

Omit `GAS_LIMIT_SCHEDULE` from `renderJsonSpec()` when `GLOAS_FORK_EPOCH === Infinity` or the schedule is empty, mirroring the existing `BLOB_SCHEDULE` interop guard. Include it only when Gloas is scheduled and the schedule has entries. Adds unit coverage for omit/include behavior.

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

> This PR was written primarily with Cursor AI assistance. I reviewed the root cause and the proposed change before submitting.