### PR TITLE
fix: do not import orphaned payload envelopes of old blocks in range sync

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -25,7 +25,17 @@ import {
   isStatePostAltair,
   isStatePostBellatrix,
 } from "@lodestar/state-transition";
-import {Attestation, BeaconBlock, altair, capella, electra, isGloasBeaconBlock, phase0, ssz} from "@lodestar/types";
+import {
+  Attestation,
+  BeaconBlock,
+  Epoch,
+  altair,
+  capella,
+  electra,
+  isGloasBeaconBlock,
+  phase0,
+  ssz,
+} from "@lodestar/types";
 import {isErrorAborted, toRootHex} from "@lodestar/utils";
 import {GENESIS_SLOT, ZERO_HASH_HEX} from "../../constants/index.js";
 import {callInNextEventLoop} from "../../util/eventLoop.js";
@@ -43,7 +53,16 @@ import {getCheckpointFromState} from "./utils/checkpoint.js";
 /**
  * Fork-choice allows to import attestations from current (0) or past (1) epoch.
  */
-export const FORK_CHOICE_ATT_EPOCH_LIMIT = 1;
+const FORK_CHOICE_ATT_EPOCH_LIMIT = 1;
+/**
+ * Whether the attestations of a block at `blockEpoch` are imported into fork choice
+ */
+export function importsBlockAttestations(opts: ImportBlockOpts, blockEpoch: Epoch, currentEpoch: Epoch): boolean {
+  return (
+    opts.importAttestations === AttestationImportOpt.Force ||
+    (opts.importAttestations !== AttestationImportOpt.Skip && blockEpoch >= currentEpoch - FORK_CHOICE_ATT_EPOCH_LIMIT)
+  );
+}
 /**
  * Emit eventstream events for block contents events only for blocks that are recent enough to clock
  */
@@ -149,10 +168,7 @@ export async function importBlock(
   // Only process attestations of blocks with relevant attestations for the fork-choice:
   // If current epoch is N, and block is epoch X, block may include attestations for epoch X or X - 1.
   // The latest block that is useful is at epoch N - 1 which may include attestations for epoch N - 1 or N - 2.
-  if (
-    opts.importAttestations === AttestationImportOpt.Force ||
-    (opts.importAttestations !== AttestationImportOpt.Skip && blockEpoch >= currentEpoch - FORK_CHOICE_ATT_EPOCH_LIMIT)
-  ) {
+  if (importsBlockAttestations(opts, blockEpoch, currentEpoch)) {
     const attestations = block.message.body.attestations;
     const rootCache = new RootCache(postState);
     const invalidAttestationErrorsByCode = new Map<string, {error: Error; count: number}>();

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -43,7 +43,7 @@ import {getCheckpointFromState} from "./utils/checkpoint.js";
 /**
  * Fork-choice allows to import attestations from current (0) or past (1) epoch.
  */
-const FORK_CHOICE_ATT_EPOCH_LIMIT = 1;
+export const FORK_CHOICE_ATT_EPOCH_LIMIT = 1;
 /**
  * Emit eventstream events for block contents events only for blocks that are recent enough to clock
  */

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -80,9 +80,10 @@ export async function processBlocks(
       payloadEnvelopes,
       parentBlock
     );
-    // Without the block attestations an orphaned payload is a FULL variant without descendants that ties at zero
-    // weight with the EMPTY variant carrying the chain and wins the payload status tiebreaker, parking the head.
-    // Recent orphaned payloads are still imported, attestation weight decides and a reorg could still build on them.
+    // Orphaned payloads of recent blocks are still imported, a reorg of the child could make the payload canonical
+    // again and later blocks build on it. Older ones are skipped: without the block attestations the orphaned FULL
+    // variant has no descendants and ties at zero weight with the EMPTY variant carrying the chain, the payload
+    // status tiebreaker then picks FULL and parks the head there.
     const blockEpoch = computeEpochAtSlot(relevantBlocks[0].getBlock().message.slot);
     const importsAttestations = importsBlockAttestations(opts, blockEpoch, this.clock.currentEpoch);
     let payloadEnvelopesToImport = payloadEnvelopes;

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -79,9 +79,14 @@ export async function processBlocks(
       payloadEnvelopes,
       parentBlock
     );
-    if (orphanedPayloads != null) {
+    // The chain did not build on an orphaned payload, importing it only adds a FULL fork choice variant without
+    // descendants that wins the zero-weight tiebreaker during range sync and gets stuck as head
+    let payloadEnvelopesToImport = payloadEnvelopes;
+    if (orphanedPayloads != null && payloadEnvelopes !== null) {
+      payloadEnvelopesToImport = new Map(payloadEnvelopes);
       for (const orphaned of orphanedPayloads) {
-        this.logger.debug("Orphaned payload envelope in chain segment", {
+        payloadEnvelopesToImport.delete(orphaned.slot);
+        this.logger.debug("Skipping orphaned payload envelope in chain segment", {
           slot: orphaned.slot,
           blockRoot: orphaned.payloadEnvelopeInput.blockRootHex,
         });
@@ -97,7 +102,7 @@ export async function processBlocks(
       proposerBalanceDeltas,
       segmentExecStatus,
       indexedAttestationsByBlock,
-    } = await verifyBlocksInEpoch.call(this, parentBlock, relevantBlocks, payloadEnvelopes, opts);
+    } = await verifyBlocksInEpoch.call(this, parentBlock, relevantBlocks, payloadEnvelopesToImport, opts);
 
     // If segmentExecStatus has lvhForkchoice then, the entire segment should be invalid
     // and we need to further propagate
@@ -132,8 +137,8 @@ export async function processBlocks(
     }
 
     const slotSet = new Set<Slot>(blocks.map((b) => b.getBlock().message.slot));
-    if (payloadEnvelopes) {
-      for (const slot of payloadEnvelopes.keys()) slotSet.add(slot);
+    if (payloadEnvelopesToImport) {
+      for (const slot of payloadEnvelopesToImport.keys()) slotSet.add(slot);
     }
     const slots = Array.from(slotSet).sort((a, b) => a - b);
     for (const slot of slots) {
@@ -146,7 +151,7 @@ export async function processBlocks(
       // PayloadEnvelopeInput is shared and may receive an envelope after the DA snapshot was taken.
       const payloadDA = payloadDAStatuses.get(slot);
       if (payloadDA !== undefined) {
-        const payloadInput = payloadEnvelopes?.get(slot);
+        const payloadInput = payloadEnvelopesToImport?.get(slot);
         if (payloadInput === undefined) {
           throw new Error(`Missing payload input for slot ${slot} after DA verification`);
         }

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -8,10 +8,10 @@ import type {BeaconChain} from "../chain.js";
 import {BlockError, BlockErrorCode, isBlockErrorAborted} from "../errors/index.js";
 import {BlockProcessOpts} from "../options.js";
 import {IBlockInput} from "./blockInput/types.js";
-import {FORK_CHOICE_ATT_EPOCH_LIMIT, importBlock} from "./importBlock.js";
+import {importBlock, importsBlockAttestations} from "./importBlock.js";
 import {PayloadError, importExecutionPayload} from "./importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
-import {AttestationImportOpt, FullyVerifiedBlock, ImportBlockOpts} from "./types.js";
+import {FullyVerifiedBlock, ImportBlockOpts} from "./types.js";
 import {assertLinearChainSegment} from "./utils/chainSegment.js";
 import {verifyBlocksInEpoch} from "./verifyBlock.js";
 import {verifyBlocksSanityChecks} from "./verifyBlocksSanityChecks.js";
@@ -80,14 +80,11 @@ export async function processBlocks(
       payloadEnvelopes,
       parentBlock
     );
-    // Same condition as importBlock() for importing the block's attestations into fork choice. Without them an
-    // orphaned payload is a FULL variant without descendants that ties at zero weight with the EMPTY variant
-    // carrying the chain and wins the payload status tiebreaker, parking the head. With attestations weight decides.
+    // Without the block attestations an orphaned payload is a FULL variant without descendants that ties at zero
+    // weight with the EMPTY variant carrying the chain and wins the payload status tiebreaker, parking the head.
+    // Recent orphaned payloads are still imported, attestation weight decides and a reorg could still build on them.
     const blockEpoch = computeEpochAtSlot(relevantBlocks[0].getBlock().message.slot);
-    const importsAttestations =
-      opts.importAttestations === AttestationImportOpt.Force ||
-      (opts.importAttestations !== AttestationImportOpt.Skip &&
-        blockEpoch >= this.clock.currentEpoch - FORK_CHOICE_ATT_EPOCH_LIMIT);
+    const importsAttestations = importsBlockAttestations(opts, blockEpoch, this.clock.currentEpoch);
     let payloadEnvelopesToImport = payloadEnvelopes;
     if (orphanedPayloads != null && payloadEnvelopes !== null && !importsAttestations) {
       payloadEnvelopesToImport = new Map(payloadEnvelopes);

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -1,3 +1,4 @@
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {SignedBeaconBlock, Slot} from "@lodestar/types";
 import {isErrorAborted, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
@@ -7,10 +8,10 @@ import type {BeaconChain} from "../chain.js";
 import {BlockError, BlockErrorCode, isBlockErrorAborted} from "../errors/index.js";
 import {BlockProcessOpts} from "../options.js";
 import {IBlockInput} from "./blockInput/types.js";
-import {importBlock} from "./importBlock.js";
+import {FORK_CHOICE_ATT_EPOCH_LIMIT, importBlock} from "./importBlock.js";
 import {PayloadError, importExecutionPayload} from "./importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
-import {FullyVerifiedBlock, ImportBlockOpts} from "./types.js";
+import {AttestationImportOpt, FullyVerifiedBlock, ImportBlockOpts} from "./types.js";
 import {assertLinearChainSegment} from "./utils/chainSegment.js";
 import {verifyBlocksInEpoch} from "./verifyBlock.js";
 import {verifyBlocksSanityChecks} from "./verifyBlocksSanityChecks.js";
@@ -79,13 +80,21 @@ export async function processBlocks(
       payloadEnvelopes,
       parentBlock
     );
-    // The chain did not build on an orphaned payload, importing it only adds a FULL fork choice variant without
-    // descendants that wins the zero-weight tiebreaker during range sync and gets stuck as head
+    // Same condition as importBlock() for importing the block's attestations into fork choice. Without them an
+    // orphaned payload is a FULL variant without descendants that ties at zero weight with the EMPTY variant
+    // carrying the chain and wins the payload status tiebreaker, parking the head. With attestations weight decides.
+    const blockEpoch = computeEpochAtSlot(relevantBlocks[0].getBlock().message.slot);
+    const importsAttestations =
+      opts.importAttestations === AttestationImportOpt.Force ||
+      (opts.importAttestations !== AttestationImportOpt.Skip &&
+        blockEpoch >= this.clock.currentEpoch - FORK_CHOICE_ATT_EPOCH_LIMIT);
     let payloadEnvelopesToImport = payloadEnvelopes;
-    if (orphanedPayloads != null && payloadEnvelopes !== null) {
+    if (orphanedPayloads != null && payloadEnvelopes !== null && !importsAttestations) {
       payloadEnvelopesToImport = new Map(payloadEnvelopes);
       for (const orphaned of orphanedPayloads) {
         payloadEnvelopesToImport.delete(orphaned.slot);
+        // never validated, drop it from the shared cache so gossip or by-root can still deliver a valid one
+        this.seenPayloadEnvelopeInputCache.prune(orphaned.payloadEnvelopeInput.blockRootHex);
         this.logger.debug("Skipping orphaned payload envelope in chain segment", {
           slot: orphaned.slot,
           blockRoot: orphaned.payloadEnvelopeInput.blockRootHex,

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -91,7 +91,8 @@ export async function processBlocks(
       payloadEnvelopesToImport = new Map(payloadEnvelopes);
       for (const orphaned of orphanedPayloads) {
         payloadEnvelopesToImport.delete(orphaned.slot);
-        // never validated, drop it from the shared cache so gossip or by-root can still deliver a valid one
+        // never validated, drop it from the shared cache so it is not served to peers, by-root sync reloads the
+        // entry from db if the payload is ever needed
         this.seenPayloadEnvelopeInputCache.prune(orphaned.payloadEnvelopeInput.blockRootHex);
         this.logger.debug("Skipping orphaned payload envelope in chain segment", {
           slot: orphaned.slot,

--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -181,6 +181,7 @@ vi.mock("../../src/chain/chain.js", async (importActual) => {
       seenPayloadEnvelopeInputCache: {
         get: vi.fn(),
         getOrReload: vi.fn(),
+        prune: vi.fn(),
       },
       seenPayloadEnvelope: vi.fn(),
       shufflingCache: new ShufflingCache(),

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -17,6 +17,7 @@ import {
 import {processBlocks} from "../../../../src/chain/blocks/index.js";
 import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
+import {AttestationImportOpt} from "../../../../src/chain/blocks/types.js";
 import {assertLinearChainSegment} from "../../../../src/chain/blocks/utils/chainSegment.js";
 import {verifyBlocksInEpoch} from "../../../../src/chain/blocks/verifyBlock.js";
 import {verifyBlocksSanityChecks} from "../../../../src/chain/blocks/verifyBlocksSanityChecks.js";
@@ -208,7 +209,13 @@ describe("chain / blocks / processBlocks", () => {
     }
   });
 
-  it("does not import payload envelopes the chain segment reports as orphaned", async () => {
+  it.each([
+    {name: "does not import orphaned payload envelopes when attestations are not imported", skipAttestations: true},
+    {
+      name: "imports orphaned payload envelopes when attestations are imported, weight decides",
+      skipAttestations: false,
+    },
+  ])("$name", async ({skipAttestations}) => {
     const gloasConfig = createChainForkConfig({...config, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
     chain = getMockedBeaconChain({config: gloasConfig});
     Object.defineProperty(chain, "seenBlockProposers", {value: seenBlockProposers});
@@ -270,15 +277,28 @@ describe("chain / blocks / processBlocks", () => {
       [slot - 1, parent.payloadInput],
       [slot, current.payloadInput],
     ]);
-    await processBlocks.call(chain, [current.blockInput], payloadEnvelopes, {});
+    await processBlocks.call(
+      chain,
+      [current.blockInput],
+      payloadEnvelopes,
+      skipAttestations ? {importAttestations: AttestationImportOpt.Skip} : {}
+    );
 
     const envelopesForDa = vi.mocked(verifyBlocksInEpoch).mock.calls[0][2];
-    expect([...(envelopesForDa?.keys() ?? [])]).toEqual([slot]);
-    expect(importExecutionPayload).toHaveBeenCalledExactlyOnceWith(
-      current.payloadInput,
-      DataAvailabilityStatus.NotRequired,
-      {validSignature: false}
-    );
+    if (skipAttestations) {
+      expect([...(envelopesForDa?.keys() ?? [])]).toEqual([slot]);
+      expect(importExecutionPayload).toHaveBeenCalledExactlyOnceWith(
+        current.payloadInput,
+        DataAvailabilityStatus.NotRequired,
+        {validSignature: false}
+      );
+      expect(chain.seenPayloadEnvelopeInputCache.prune).toHaveBeenCalledExactlyOnceWith(
+        parent.payloadInput.blockRootHex
+      );
+    } else {
+      expect([...(envelopesForDa?.keys() ?? [])]).toEqual([slot - 1, slot]);
+      expect(chain.seenPayloadEnvelopeInputCache.prune).not.toHaveBeenCalled();
+    }
     // the batch's own map is left untouched, range sync still owns it
     expect(payloadEnvelopes.size).toBe(2);
   });

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -28,7 +28,10 @@ import {MockedBeaconChain, getMockedBeaconChain} from "../../../mocks/mockedBeac
 import {MockBlockInput} from "../../../utils/blockInput.js";
 import {generateProtoBlock} from "../../../utils/typeGenerator.js";
 
-vi.mock("../../../../src/chain/blocks/importBlock.js");
+vi.mock("../../../../src/chain/blocks/importBlock.js", async (importActual) => {
+  const actual = await importActual<typeof import("../../../../src/chain/blocks/importBlock.js")>();
+  return {...actual, importBlock: vi.fn()};
+});
 vi.mock("../../../../src/chain/blocks/importExecutionPayload.js", async (importActual) => {
   const mod = await importActual<typeof import("../../../../src/chain/blocks/importExecutionPayload.js")>();
   return {...mod, importExecutionPayload: vi.fn()};

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -208,6 +208,81 @@ describe("chain / blocks / processBlocks", () => {
     }
   });
 
+  it("does not import payload envelopes the chain segment reports as orphaned", async () => {
+    const gloasConfig = createChainForkConfig({...config, FULU_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0});
+    chain = getMockedBeaconChain({config: gloasConfig});
+    Object.defineProperty(chain, "seenBlockProposers", {value: seenBlockProposers});
+    const payloadInputFor = (blockSlot: number): {blockInput: BlockInputNoData; payloadInput: PayloadEnvelopeInput} => {
+      const block = ssz.gloas.SignedBeaconBlock.defaultValue();
+      block.message.slot = blockSlot;
+      const blockRoot = ssz.gloas.BeaconBlock.hashTreeRoot(block.message);
+      const blockRootHex = toRootHex(blockRoot);
+      const blockInput = BlockInputNoData.createFromBlock({
+        block,
+        blockRootHex,
+        forkName: ForkName.gloas,
+        daOutOfRange: false,
+        source: BlockInputSource.byRange,
+        seenTimestampSec: 0,
+      });
+      const payloadInput = PayloadEnvelopeInput.createFromBlock({
+        block,
+        blockRootHex,
+        forkName: ForkName.gloas,
+        sampledColumns: [0],
+        custodyColumns: [0],
+        daOutOfRange: false,
+        source: PayloadEnvelopeInputSource.byRange,
+        seenTimestampSec: 0,
+      });
+      const envelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+      envelope.message.beaconBlockRoot = blockRoot;
+      payloadInput.addPayloadEnvelope({envelope, source: PayloadEnvelopeInputSource.byRange, seenTimestampSec: 1});
+      return {blockInput, payloadInput};
+    };
+    // parent's payload was orphaned, the block builds on the parent's EMPTY variant but peers still serve the envelope
+    const parent = payloadInputFor(slot - 1);
+    const current = payloadInputFor(slot);
+
+    vi.mocked(verifyBlocksSanityChecks).mockReturnValue({
+      relevantBlocks: [current.blockInput],
+      parentSlots: [slot - 1],
+      parentBlock: generateProtoBlock({slot: slot - 1}),
+    });
+    vi.mocked(assertLinearChainSegment).mockReturnValue({
+      warnings: [{slot: slot - 1, payloadEnvelopeInput: parent.payloadInput}],
+    });
+    vi.mocked(verifyBlocksInEpoch).mockResolvedValue({
+      postStates: [{forkName: ForkName.gloas} as IBeaconStateView],
+      proposerBalanceDeltas: [0],
+      segmentExecStatus: {
+        execAborted: null,
+        executionStatuses: [ExecutionStatus.Valid],
+        executionTime: 0,
+      },
+      blockDAStatuses: [DataAvailabilityStatus.NotRequired],
+      payloadDAStatuses: new Map([[slot, DataAvailabilityStatus.NotRequired]]),
+      indexedAttestationsByBlock: [[]],
+    });
+    vi.mocked(importExecutionPayload).mockResolvedValue(undefined);
+
+    const payloadEnvelopes = new Map([
+      [slot - 1, parent.payloadInput],
+      [slot, current.payloadInput],
+    ]);
+    await processBlocks.call(chain, [current.blockInput], payloadEnvelopes, {});
+
+    const envelopesForDa = vi.mocked(verifyBlocksInEpoch).mock.calls[0][2];
+    expect([...(envelopesForDa?.keys() ?? [])]).toEqual([slot]);
+    expect(importExecutionPayload).toHaveBeenCalledExactlyOnceWith(
+      current.payloadInput,
+      DataAvailabilityStatus.NotRequired,
+      {validSignature: false}
+    );
+    // the batch's own map is left untouched, range sync still owns it
+    expect(payloadEnvelopes.size).toBe(2);
+  });
+
   // The gloas payload import throws a PayloadError. Range sync relies on it arriving intact so it can
   // read the INVALID/ERROR code and decide peer attribution — getBlockOrPayloadError must pass it
   // through, not flatten it into a generic BEACON_CHAIN_ERROR. (The origin is mocked here; what matters


### PR DESCRIPTION
19 of 30 lodestar nodes on glamsterdam-devnet-9 had their head parked for hours on a block whose payload was orphaned (e.g. 7264, 7584, 7745) while range sync kept importing thousands of blocks behind it. the validator client logs `Node is syncing` the whole time, `notifyForkchoiceUpdate` goes out with the stale head and the EL answers `Too deep reorg`.

range sync imports the orphaned envelope as an in-segment orphan, which adds a FULL fork choice variant without descendants. during range sync no attestations are imported (`AttestationImportOpt.Skip` on the finalized chain, blocks older than `FORK_CHOICE_ATT_EPOCH_LIMIT` otherwise) so the EMPTY variant that carries the whole chain has weight 0 as well, same root, and `getPayloadStatusTiebreaker` picks FULL for any block older than the previous slot, exactly as in the spec `get_head`. the spec never sees this tie because it feeds block attestations into `get_weight`. the head only moves again once a block with a newer justification is imported and the leaf fails `nodeIsViableForHead`, on devnet-9 that was 270 epochs later.

the chain did not build on an orphaned payload, so there is nothing to gain from importing it: fork choice does not need the variant, the EL does not need `newPayload` for it and lighthouse/prysm do not even serve those envelopes by range. skip DA verification and import for the envelopes `assertLinearChainSegment` reports as orphaned, including the parent one from #10002 which otherwise creates the same dead leaf at the batch boundary, whenever the block attestations are not imported (`importsBlockAttestations()`, same condition as `importBlock()`). orphaned payloads of recent blocks are still imported, there weight decides the variant and a reorg of the child could still build on the payload. skipped envelopes were never validated, they are pruned from `seenPayloadEnvelopeInputCache` so they are not served to peers, by-root sync reloads the entry from db if the payload is ever needed. the batch's own map is left untouched.

**verified on devnet-9**

- lodestar-erigon-1 (head parked at 7745 for 2.5h): restarted with this change it skipped the orphaned envelopes at 7264 and 7392 and the head followed the synced chain through 7264, 7392 and 7584, the slots other unpatched nodes were parked at
- lodestar-reth-1 (head parked at 7264 for 3.5h, then looping on `PARENT_PAYLOAD_UNKNOWN` at 16542 after unparking) restarted with #10002 + this change: skipped the orphaned envelopes at 16541/16548/16839/16856/16944, head tracked the imported tip the whole way and reached head
- 14 more nodes that had unparked and were looping at 16065 restarted with both changes: 0 `PARENT_PAYLOAD_UNKNOWN` since, orphaned envelopes at 16065/16096 skipped, heads followed the import and all reached head

the attestation gate and the cache prune were added in review and are covered by unit tests only, the finalized sync chain behaves the same with and without them

**known gap**: an orphaned payload of the last block in a batch (or of a count=1 target batch) has no child in the segment and is still imported, in a non-finalizing chain that FULL leaf parks the head the same way until the justified checkpoint moves. deferring the last envelope of a batch to the next one (where #10002 already classifies the parent payload) or resolving parent payloads from the seen cache would close it, left as follow-up
