### PR TITLE
chore: log peer client serving orphaned payloads

### DIFF
--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -14,7 +14,7 @@ import {importBlock, importsBlockAttestations} from "./importBlock.js";
 import {PayloadError, importExecutionPayload} from "./importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {FullyVerifiedBlock, ImportBlockOpts, ProcessBlocksResult} from "./types.js";
-import {assertLinearChainSegment} from "./utils/chainSegment.js";
+import {OrphanedPayloadEnvelope, assertLinearChainSegment} from "./utils/chainSegment.js";
 import {verifyBlocksInEpoch} from "./verifyBlock.js";
 import {verifyBlocksSanityChecks} from "./verifyBlocksSanityChecks.js";
 import {verifyPayloadsDataAvailability} from "./verifyPayloadsDataAvailability.js";
@@ -81,8 +81,7 @@ export async function processBlocks(
     // No relevant blocks, skip verifyBlocksInEpoch()
     if (relevantBlocks.length === 0 || parentBlock === null) {
       // parentBlock can only be null if relevantBlocks are empty
-      await importPayloadEnvelopesOfKnownBlocks.call(this, payloadEnvelopes, opts);
-      return emptyResult;
+      return await importPayloadEnvelopesOfKnownBlocks.call(this, payloadEnvelopes, opts);
     }
 
     const {warnings: orphanedPayloads} = assertLinearChainSegment(
@@ -244,15 +243,15 @@ async function importPayloadEnvelopesOfKnownBlocks(
   this: BeaconChain,
   payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
   opts: ImportBlockOpts
-): Promise<void> {
+): Promise<ProcessBlocksResult> {
   if (payloadEnvelopes === null) {
-    return;
+    return {orphaned: [], skipped: false};
   }
 
   const head = this.forkChoice.getHead();
   const currentEpoch = this.clock.currentEpoch;
   const payloadInputs: PayloadEnvelopeInput[] = [];
-  const orphanedSlots: Slot[] = [];
+  const orphaned: OrphanedPayloadEnvelope[] = [];
   for (const payloadInput of payloadEnvelopes.values()) {
     const {blockRootHex, slot} = payloadInput;
     if (
@@ -269,18 +268,17 @@ async function importPayloadEnvelopesOfKnownBlocks(
     ) {
       // never validated, see processBlocks()
       this.seenPayloadEnvelopeInputCache.prune(blockRootHex);
-      orphanedSlots.push(slot);
+      orphaned.push({slot, payloadEnvelopeInput: payloadInput});
       continue;
     }
     payloadInputs.push(payloadInput);
   }
 
-  if (orphanedSlots.length > 0) {
-    this.logger.debug("Skipping orphaned payload envelopes of known blocks", {slots: orphanedSlots.join(",")});
-  }
+  // orphaned envelopes on this path are always skipped, range sync logs them with peer/client context
+  const result: ProcessBlocksResult = {orphaned, skipped: orphaned.length > 0};
 
   if (payloadInputs.length === 0) {
-    return;
+    return result;
   }
 
   const {dataAvailabilityStatuses} = await verifyPayloadsDataAvailability(payloadInputs, new AbortController().signal);
@@ -293,6 +291,8 @@ async function importPayloadEnvelopesOfKnownBlocks(
   }
   // the new FULL variants are not seen by the head cached from the last block import
   this.recomputeForkChoiceHead(ForkchoiceCaller.importBlock);
+
+  return result;
 }
 
 function getBlockOrPayloadError(e: unknown, block: SignedBeaconBlock): BlockError | PayloadError {

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -13,7 +13,7 @@ import {IBlockInput} from "./blockInput/types.js";
 import {importBlock, importsBlockAttestations} from "./importBlock.js";
 import {PayloadError, importExecutionPayload} from "./importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
-import {FullyVerifiedBlock, ImportBlockOpts} from "./types.js";
+import {FullyVerifiedBlock, ImportBlockOpts, ProcessBlocksResult} from "./types.js";
 import {assertLinearChainSegment} from "./utils/chainSegment.js";
 import {verifyBlocksInEpoch} from "./verifyBlock.js";
 import {verifyBlocksSanityChecks} from "./verifyBlocksSanityChecks.js";
@@ -27,10 +27,16 @@ const QUEUE_MAX_LENGTH = 256;
  * BlockProcessor processes block jobs in a queued fashion, one after the other.
  */
 export class BlockProcessor {
-  readonly jobQueue: JobItemQueue<[IBlockInput[], Map<Slot, PayloadEnvelopeInput> | null, ImportBlockOpts], void>;
+  readonly jobQueue: JobItemQueue<
+    [IBlockInput[], Map<Slot, PayloadEnvelopeInput> | null, ImportBlockOpts],
+    ProcessBlocksResult
+  >;
 
   constructor(chain: BeaconChain, metrics: Metrics | null, opts: BlockProcessOpts, signal: AbortSignal) {
-    this.jobQueue = new JobItemQueue<[IBlockInput[], Map<Slot, PayloadEnvelopeInput> | null, ImportBlockOpts], void>(
+    this.jobQueue = new JobItemQueue<
+      [IBlockInput[], Map<Slot, PayloadEnvelopeInput> | null, ImportBlockOpts],
+      ProcessBlocksResult
+    >(
       (job, payloadEnvelopes, importOpts) => {
         return processBlocks.call(chain, job, payloadEnvelopes, {...opts, ...importOpts});
       },
@@ -43,8 +49,8 @@ export class BlockProcessor {
     job: IBlockInput[],
     payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
     opts: ImportBlockOpts = {}
-  ): Promise<void> {
-    await this.jobQueue.push(job, payloadEnvelopes, opts);
+  ): Promise<ProcessBlocksResult> {
+    return this.jobQueue.push(job, payloadEnvelopes, opts);
   }
 }
 
@@ -63,9 +69,10 @@ export async function processBlocks(
   blocks: IBlockInput[],
   payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
   opts: BlockProcessOpts & ImportBlockOpts
-): Promise<void> {
+): Promise<ProcessBlocksResult> {
+  const emptyResult: ProcessBlocksResult = {orphaned: [], skipped: false};
   if (blocks.length === 0) {
-    return; // TODO: or throw?
+    return emptyResult; // TODO: or throw?
   }
 
   try {
@@ -75,7 +82,7 @@ export async function processBlocks(
     if (relevantBlocks.length === 0 || parentBlock === null) {
       // parentBlock can only be null if relevantBlocks are empty
       await importPayloadEnvelopesOfKnownBlocks.call(this, payloadEnvelopes, opts);
-      return;
+      return emptyResult;
     }
 
     const {warnings: orphanedPayloads} = assertLinearChainSegment(
@@ -90,18 +97,15 @@ export async function processBlocks(
     // status tiebreaker then picks FULL and parks the head there.
     const blockEpoch = computeEpochAtSlot(relevantBlocks[0].getBlock().message.slot);
     const importsAttestations = importsBlockAttestations(opts, blockEpoch, this.clock.currentEpoch);
+    const skipped = orphanedPayloads != null && payloadEnvelopes !== null && !importsAttestations;
     let payloadEnvelopesToImport = payloadEnvelopes;
-    if (orphanedPayloads != null && payloadEnvelopes !== null && !importsAttestations) {
+    if (skipped) {
       payloadEnvelopesToImport = new Map(payloadEnvelopes);
-      for (const orphaned of orphanedPayloads) {
+      for (const orphaned of orphanedPayloads ?? []) {
         payloadEnvelopesToImport.delete(orphaned.slot);
         // never validated, drop it from the shared cache so it is not served to peers, by-root sync reloads the
         // entry from db if the payload is ever needed
         this.seenPayloadEnvelopeInputCache.prune(orphaned.payloadEnvelopeInput.blockRootHex);
-        this.logger.debug("Skipping orphaned payload envelope in chain segment", {
-          slot: orphaned.slot,
-          blockRoot: orphaned.payloadEnvelopeInput.blockRootHex,
-        });
       }
     }
 
@@ -176,9 +180,11 @@ export async function processBlocks(
 
       await nextEventLoop();
     }
+
+    return {orphaned: orphanedPayloads ?? [], skipped};
   } catch (e) {
     if (isErrorAborted(e) || isQueueErrorAborted(e) || isBlockErrorAborted(e)) {
-      return; // Ignore
+      return emptyResult; // Ignore
     }
 
     // above functions should only throw BlockError, or PayloadError from the gloas payload import

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -4,6 +4,7 @@ import {ForkSeq} from "@lodestar/params";
 import {DataAvailabilityStatus, IBeaconStateView, computeEpochAtSlot} from "@lodestar/state-transition";
 import type {IndexedAttestation, Slot, fulu} from "@lodestar/types";
 import {IBlockInput} from "./blockInput/types.js";
+import {OrphanedPayloadEnvelope} from "./utils/chainSegment.js";
 
 export enum GossipedInputType {
   block = "block",
@@ -109,4 +110,12 @@ export type FullyVerifiedBlock = {
   seenTimestampSec: number;
   /** If the execution payload couldn't be verified because of EL syncing status, used in optimistic sync */
   executionStatus: BlockExecutionStatus | PayloadExecutionStatus;
+};
+
+/**
+ * Result of processing a chain segment.
+ */
+export type ProcessBlocksResult = {
+  orphaned: OrphanedPayloadEnvelope[];
+  skipped: boolean;
 };

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -82,7 +82,7 @@ import {IBlockInput, isBlockInputBlobs, isBlockInputColumns} from "./blocks/bloc
 import {BlockProcessor, ImportBlockOpts} from "./blocks/index.js";
 import {PayloadEnvelopeInputSource} from "./blocks/payloadEnvelopeInput/index.js";
 import {PayloadEnvelopeProcessor} from "./blocks/payloadEnvelopeProcessor.js";
-import {ImportPayloadOpts} from "./blocks/types.js";
+import {ImportPayloadOpts, ProcessBlocksResult} from "./blocks/types.js";
 import {persistBlockInput} from "./blocks/writeBlockInputToDb.js";
 import {persistPayloadEnvelopeInput} from "./blocks/writePayloadEnvelopeInputToDb.js";
 import {BlsMultiThreadWorkerPool, BlsSingleThreadVerifier, IBlsVerifier} from "./bls/index.js";
@@ -1167,15 +1167,15 @@ export class BeaconChain implements IBeaconChain {
   }
 
   async processBlock(block: IBlockInput, opts?: ImportBlockOpts): Promise<void> {
-    return this.blockProcessor.processBlocksJob([block], null, opts);
+    await this.blockProcessor.processBlocksJob([block], null, opts);
   }
 
   async processChainSegment(
     blocks: IBlockInput[],
     payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
     opts?: ImportBlockOpts
-  ): Promise<void> {
-    await this.blockProcessor.processBlocksJob(blocks, payloadEnvelopes, opts);
+  ): Promise<ProcessBlocksResult> {
+    return this.blockProcessor.processBlocksJob(blocks, payloadEnvelopes, opts);
   }
 
   async processExecutionPayload(payloadInput: PayloadEnvelopeInput, opts?: ImportPayloadOpts): Promise<void> {

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -35,7 +35,7 @@ import {IArchiveStore} from "./archiveStore/interface.js";
 import {CheckpointBalancesCache} from "./balancesCache.js";
 import {BeaconProposerCache, ProposerPreparationData} from "./beaconProposerCache.js";
 import {IBlockInput} from "./blocks/blockInput/index.js";
-import {ImportBlockOpts, ImportPayloadOpts} from "./blocks/types.js";
+import {ImportBlockOpts, ImportPayloadOpts, ProcessBlocksResult} from "./blocks/types.js";
 import {IBlsVerifier} from "./bls/index.js";
 import {BuilderCircuitBreaker} from "./builderCircuitBreaker.js";
 import {ColumnReconstructionTracker} from "./ColumnReconstructionTracker.js";
@@ -262,7 +262,7 @@ export interface IBeaconChain {
     blocks: IBlockInput[],
     payloadEnvelopes: Map<Slot, PayloadEnvelopeInput> | null,
     opts?: ImportBlockOpts
-  ): Promise<void>;
+  ): Promise<ProcessBlocksResult>;
 
   /** Process execution payload envelope: verify, import to fork choice, and persist to DB */
   processExecutionPayload(payloadInput: PayloadEnvelopeInput, opts?: ImportPayloadOpts): Promise<void>;

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -217,7 +217,27 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
         }
       }
     } else {
-      await this.chain.processChainSegment(blocks, payloadEnvelopes, flags);
+      const {orphaned, skipped} = await this.chain.processChainSegment(blocks, payloadEnvelopes, flags);
+      // We log orphaned payloads to work with different clients
+      // in the future, consider applying penalties in certain conditions
+      for (const {slot, payloadEnvelopeInput} of orphaned) {
+        const peerIdStr = payloadEnvelopeInput.getPayloadEnvelopeSource().peerIdStr;
+        let client = "unknown";
+        if (peerIdStr !== undefined) {
+          try {
+            client = this.getConnectedPeerSyncMeta(peerIdStr).client;
+          } catch {
+            // peer disconnected since serving the envelope, keep "unknown"
+          }
+        }
+        this.logger.debug("Orphaned payload envelope in range sync batch", {
+          slot,
+          root: payloadEnvelopeInput.blockRootHex,
+          peer: peerIdStr ?? "unknown",
+          client,
+          skipped,
+        });
+      }
     }
   };
 

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -364,7 +364,7 @@ describe("chain / blocks / processBlocks", () => {
     Object.defineProperty(chain.forkChoice, "isDescendant", {value: vi.fn(() => headOnEmpty)});
     vi.mocked(importExecutionPayload).mockResolvedValue(undefined);
 
-    await processBlocks.call(
+    const result = await processBlocks.call(
       chain,
       [gloasBlockInput],
       new Map([[slot, payloadInput]]),
@@ -377,12 +377,15 @@ describe("chain / blocks / processBlocks", () => {
       expect(importExecutionPayload).not.toHaveBeenCalled();
       expect(chain.seenPayloadEnvelopeInputCache.prune).toHaveBeenCalledExactlyOnceWith(blockRootHex);
       expect(chain.recomputeForkChoiceHead).not.toHaveBeenCalled();
+      // the skipped orphaned envelope is returned so range sync can log the serving peer/client
+      expect(result).toEqual({orphaned: [{slot, payloadEnvelopeInput: payloadInput}], skipped: true});
     } else {
       expect(importExecutionPayload).toHaveBeenCalledExactlyOnceWith(payloadInput, DataAvailabilityStatus.NotRequired, {
         validSignature: false,
       });
       expect(chain.seenPayloadEnvelopeInputCache.prune).not.toHaveBeenCalled();
       expect(chain.recomputeForkChoiceHead).toHaveBeenCalledOnce();
+      expect(result).toEqual({orphaned: [], skipped: false});
     }
   });
 


### PR DESCRIPTION
**Motivation**

- log peer clients when it serves orphaned payloads, so that we can monitor and work with them to avoid it
- in the future, we can consider to also penalize peers in this situation

**Description**

- remove the log inside `BeaconChain.processBlocks()`
- new ProcessBlocksResult:
```typescript
export type ProcessBlocksResult = {
  orphaned: OrphanedPayloadEnvelope[];
  skipped: boolean;
};
``` 
and return it from `processChainSegments`
- then range sync pick it up and log

**AI Assistance Disclosure**

- created with the help of Claude
