### PR TITLE
test(builder): add builder sidecar kurtosis config and run script

### DIFF
--- a/scripts/kurtosis/builder-dev.yaml
+++ b/scripts/kurtosis/builder-dev.yaml
@@ -1,0 +1,57 @@
+participants:
+  - el_type: geth
+    el_image: ethpandaops/geth:glamsterdam-devnet-8
+    cl_type: lodestar
+    cl_image: local/lodestar:builder-dev
+    cl_log_level: debug
+    validator_count: 0
+  - el_type: geth
+    el_image: ethpandaops/geth:glamsterdam-devnet-8
+    cl_type: lodestar
+    cl_image: local/lodestar:builder-dev
+    vc_image: local/lodestar:builder-dev
+    cl_log_level: debug
+    vc_log_level: debug
+    vc_extra_params:
+      - --graffiti=builder-dev
+    supernode: true
+    validator_count: 64
+
+# The legacy single Buildoor mode is intentional here: it derives the builder key
+# after all participant validators and always targets participant 1. Lifecycle
+# registration takes roughly three minimal-preset epochs before bidding starts.
+mev_type: buildoor
+buildoor_params:
+  image: ethpandaops/buildoor@sha256:501764a3c43e6289fa1b85df9e7489f1d2de24e1efe0a65c4d316bd340166991
+  builder_api: true
+  epbs_builder: true
+  lifecycle: true
+  extra_args:
+    - --log-level=debug
+
+network_params:
+  preset: minimal
+  seconds_per_slot: 6
+  gloas_fork_epoch: 0
+  attestation_due_bps_gloas: 2500
+  withdrawal_type: "0x01"
+  validator_balance: 32
+  builder_count: 1
+  builder_balance: 100
+  deploy_eip8282_contracts: true
+
+additional_services:
+  - dora
+  - prometheus
+
+dora_params:
+  image: ethpandaops/dora:master-latest
+
+port_publisher:
+  cl:
+    enabled: true
+    public_port_start: 37000
+  additional_services:
+    enabled: true
+
+global_log_level: info

--- a/scripts/kurtosis/builder-dev.yaml
+++ b/scripts/kurtosis/builder-dev.yaml
@@ -23,7 +23,6 @@ participants:
 mev_type: buildoor
 buildoor_params:
   image: ethpandaops/buildoor@sha256:501764a3c43e6289fa1b85df9e7489f1d2de24e1efe0a65c4d316bd340166991
-  builder_api: true
   epbs_builder: true
   lifecycle: true
   extra_args:
@@ -33,12 +32,8 @@ network_params:
   preset: minimal
   seconds_per_slot: 6
   gloas_fork_epoch: 0
-  attestation_due_bps_gloas: 2500
   withdrawal_type: "0x01"
-  validator_balance: 32
   builder_count: 1
-  builder_balance: 100
-  deploy_eip8282_contracts: true
 
 additional_services:
   - dora
@@ -53,5 +48,3 @@ port_publisher:
     public_port_start: 37000
   additional_services:
     enabled: true
-
-global_log_level: info

--- a/scripts/kurtosis/run-builder.sh
+++ b/scripts/kurtosis/run-builder.sh
@@ -55,4 +55,4 @@ echo '  --executionFeeRecipient 0x8943545177806ed17b9f23f0a21ee5948ecaa776 \'
 echo '  --paramsFile ./temp/builder-dev/netcfg/config.yaml'
 echo
 echo "don't forget to clean up later"
-echo 'kurtosis enclave rm -f builder-dev && kurtosis engine stop && rm -rf ./temp/builder-dev'
+echo 'kurtosis enclave rm -f builder-dev && kurtosis engine stop'

--- a/scripts/kurtosis/run-builder.sh
+++ b/scripts/kurtosis/run-builder.sh
@@ -13,44 +13,46 @@ kurtosis enclave rm -f builder-dev 2>/dev/null || true
 
 # settled image name
 LODESTAR_IMAGE="local/lodestar:builder-dev"
+TEMP="./temp/builder-dev"
+
+# create ./temp/builder-dev
+mkdir -p "$TEMP"
 
 # build image if there isn't one
 if ! docker image inspect "$LODESTAR_IMAGE" >/dev/null 2>&1; then
   docker build -t "$LODESTAR_IMAGE" .
 fi
-# start devnet
+# start devnet, we want to use latest ethereum-package
 kurtosis run --enclave builder-dev --args-file ./scripts/kurtosis/builder-dev.yaml github.com/ethpandaops/ethereum-package
-# made at ethereum-package commit: 5ec41d44ae23fb01b036c11b25d98547cc9c3be4
+# last verified against ethereum-package: 4667e182e0459dee043a2f918d2845d6a66c96a1
 
-# assemble ./test-builder
-if [ ! -d "./test-builder" ]; then
-  # derive builder key
-  docker run --rm -v "$(pwd)/temp:/data" \
-    protolambda/eth2-val-tools:latest keystores \
+if [ ! -d "$TEMP"/derived ]; then
+  # derive the builder key
+  docker run --rm -v "$(pwd)/$TEMP:/data" \
+    protolambda/eth2-val-tools@sha256:46147228f291266148a6a21a2b9541367ad5f70e619d79cd5393459baf539f58 keystores \
     --source-mnemonic="$MNEMONIC" \
     --source-min=0 --source-max=1 \
-    --out-loc="/data/builder-keys"
-  # move into the dir
-  mkdir -p ./temp/test-builder
-  cp "$(find ./temp/builder-keys/keys -name voting-keystore.json | head -n1)" ./temp/test-builder/keystore.json
-  cp "$(find ./temp/builder-keys/secrets -type f | head -n1)" ./temp/test-builder/password.txt
+    --out-loc="/data/derived"
+  # isolate keystore and it's password
+  cp "$(find "$TEMP"/derived/keys -name voting-keystore.json | head -n1)" "$TEMP"/keystore.json
+  cp "$(find "$TEMP"/derived/secrets -type f | head -n1)" "$TEMP"/password.txt
 fi
 
 # download network config
-kurtosis files download builder-dev el_cl_genesis_data ./temp/netcfg
+kurtosis files download builder-dev el_cl_genesis_data "$TEMP"/netcfg
 
 # builder running note
 echo
 echo "devnet up. run the sidecar in another terminal:"
 echo
 echo 'LODESTAR_PRESET=minimal ./lodestar builder \'
-echo '  --keystore ./temp/test-builder/keystore.json \'
-echo '  --keystorePassword ./temp/test-builder/password.txt \'
+echo '  --keystore ./temp/builder-dev/keystore.json \'
+echo '  --keystorePassword ./temp/builder-dev/password.txt \'
 echo '  --builderPubkey 0x8ec9cc826ea7735329831dbe89c28ae700e39b51c817f1086483621a2104145343f912b3bf167027256780a62a1995bd \'
 # make sure to place the correct url
 echo '  --beaconNodeUrl "http://127.0.0.1:37001" \'
 echo '  --executionFeeRecipient 0x8943545177806ed17b9f23f0a21ee5948ecaa776 \'
-echo '  --paramsFile ./temp/netcfg/config.yaml'
+echo '  --paramsFile ./temp/builder-dev/netcfg/config.yaml'
 echo
 echo "don't forget to clean up later"
-echo 'kurtosis enclave rm -f builder-dev && kurtosis engine stop'
+echo 'kurtosis enclave rm -f builder-dev && kurtosis engine stop && rm -rf ./temp/builder-dev'

--- a/scripts/kurtosis/run-builder.sh
+++ b/scripts/kurtosis/run-builder.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ethereum-package public mnemonic for generating builder keys
+MNEMONIC="baby envelope toddler valid pottery buddy cash spare such hedgehog ring ramp item seminar rely select advance knife cruel cereal left father model tissue"
+
+# check dependencies
+command -v docker   >/dev/null 2>&1 || { echo "missing dependency docker"; exit 1; }
+command -v kurtosis >/dev/null 2>&1 || { echo "missing dependency kurtosis"; exit 1; }
+
+# remove enclave if there is one
+kurtosis enclave rm -f builder-dev 2>/dev/null || true
+
+# settled image name
+LODESTAR_IMAGE="local/lodestar:builder-dev"
+
+# build image if there isn't one
+if ! docker image inspect "$LODESTAR_IMAGE" >/dev/null 2>&1; then
+  docker build -t "$LODESTAR_IMAGE" .
+fi
+# start devnet
+kurtosis run --enclave builder-dev --args-file ./scripts/kurtosis/builder-dev.yaml github.com/ethpandaops/ethereum-package
+# made at ethereum-package commit: 5ec41d44ae23fb01b036c11b25d98547cc9c3be4
+
+# assemble ./test-builder
+if [ ! -d "./test-builder" ]; then
+  # derive builder key
+  docker run --rm -v "$(pwd)/temp:/data" \
+    protolambda/eth2-val-tools:latest keystores \
+    --source-mnemonic="$MNEMONIC" \
+    --source-min=0 --source-max=1 \
+    --out-loc="/data/builder-keys"
+  # move into the dir
+  mkdir -p ./temp/test-builder
+  cp "$(find ./temp/builder-keys/keys -name voting-keystore.json | head -n1)" ./temp/test-builder/keystore.json
+  cp "$(find ./temp/builder-keys/secrets -type f | head -n1)" ./temp/test-builder/password.txt
+fi
+
+# download network config
+kurtosis files download builder-dev el_cl_genesis_data ./temp/netcfg
+
+# builder running note
+echo
+echo "devnet up. run the sidecar in another terminal:"
+echo
+echo 'LODESTAR_PRESET=minimal ./lodestar builder \'
+echo '  --keystore ./temp/test-builder/keystore.json \'
+echo '  --keystorePassword ./temp/test-builder/password.txt \'
+echo '  --builderPubkey 0x8ec9cc826ea7735329831dbe89c28ae700e39b51c817f1086483621a2104145343f912b3bf167027256780a62a1995bd \'
+# make sure to place the correct url
+echo '  --beaconNodeUrl "http://127.0.0.1:37001" \'
+echo '  --executionFeeRecipient 0x8943545177806ed17b9f23f0a21ee5948ecaa776 \'
+echo '  --paramsFile ./temp/netcfg/config.yaml'
+echo
+echo "don't forget to clean up later"
+echo 'kurtosis enclave rm -f builder-dev && kurtosis engine stop'

--- a/scripts/kurtosis/run-builder.sh
+++ b/scripts/kurtosis/run-builder.sh
@@ -18,10 +18,13 @@ TEMP="./temp/builder-dev"
 # create ./temp/builder-dev
 mkdir -p "$TEMP"
 
-# build image if there isn't one
-if ! docker image inspect "$LODESTAR_IMAGE" >/dev/null 2>&1; then
-  docker build -t "$LODESTAR_IMAGE" .
+DOCKERFILE="${DOCKERFILE:-Dockerfile.dev}"
+
+# build using dockerfile
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+  docker build -f "$DOCKERFILE" -t "$LODESTAR_IMAGE" . --build-arg COMMIT="$(git rev-parse HEAD)"
 fi
+
 # start devnet, we want to use latest ethereum-package
 kurtosis run --enclave builder-dev --args-file ./scripts/kurtosis/builder-dev.yaml github.com/ethpandaops/ethereum-package
 # last verified against ethereum-package: 4667e182e0459dee043a2f918d2845d6a66c96a1


### PR DESCRIPTION
**Motivation**

Automate builder testing environment setup.
Setup is in nature an ethereum-package + builder sidecar setup.

**Description**

Contains a config describing a minimal realistic environment for a builder to run in, consists of:
- 2 beacon nodes
- 1 lodestar builder
- 1 buildoor
- independently configurable number of validators

First beacon node is working with the lodestar builder (without any validators), second one is running with validators and buildoor.
On the first beacon node it is necessary to pin down `validator_count` to zero as otherwise it will have validators running with it by default.

As additional services we have dora and prometheus.

Script helps with key derivation, sets up the environment, and prints out a command to run a sidecar so that builder output doesn't push away Kurtosis output in the same terminal window.