### PR TITLE
fix: derive earliestAvailableSlot from DB instead of freezing at anchor slot

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
+++ b/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
@@ -260,6 +260,11 @@ export class ArchiveStore {
       await updateBackfillRange({chain: this.chain, db: this.db, logger: this.logger}, finalized);
       timer?.({source: ArchiveStoreTask.UpdateBackfillRange});
 
+      // Keep the advertised earliestAvailableSlot in sync with what the node still retains after
+      // archiving/pruning (and any backfill progress), so peers do not request ranges we can no
+      // longer serve (issue #8147). Runs after updateBackfillRange so it sees this cycle's ranges.
+      await this.chain.updateEarliestAvailableSlot();
+
       this.logger.verbose("Finish processing finalized checkpoint", {
         epoch: finalizedEpoch,
         rootHex: finalized.rootHex,

--- a/packages/beacon-node/src/chain/archiveStore/utils/computeEarliestAvailableSlot.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/computeEarliestAvailableSlot.ts
@@ -1,0 +1,64 @@
+import {Slot} from "@lodestar/types";
+import {IBeaconDb} from "../../../db/interface.js";
+
+/**
+ * Compute the earliest slot for which this node can fully serve by-range requests, derived from
+ * what is actually persisted in the DB rather than from a static anchor slot.
+ *
+ * A node advertises this value in its Fulu `Status` (`earliestAvailableSlot`) and the by-range
+ * handlers reject any request that falls entirely below it. If the advertised value does not match
+ * the data the node actually holds, syncing peers either skip it or receive 0 results and can get
+ * stuck (see https://github.com/ChainSafe/lodestar/issues/8147).
+ *
+ * Per the spec (`fulu/p2p-interface.md`) this is the earliest slot from which the node can serve
+ * everything a peer requests together, so we take the most restrictive (highest) lower bound across
+ * blocks + blob sidecars + custody (data column) sidecars; we never advertise a slot we cannot fully
+ * serve. Sidecars are pruned to a rolling retention window and are usually the binding constraint.
+ *
+ * The block bound is the oldest slot *contiguously connected to the anchor* (not the global oldest
+ * archived block): a node that checkpoint-synced ahead of pre-existing DB data holds a gap below its
+ * new anchor, and advertising below that gap would strand peers requesting the missing range.
+ */
+export async function computeEarliestAvailableSlot(db: IBeaconDb, anchorSlot: Slot): Promise<Slot> {
+  let earliestAvailableSlot = await oldestContiguousBlockSlot(db, anchorSlot);
+
+  // Blob sidecars (Deneb+) are pruned to MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS, raising the bound.
+  const oldestBlobSlot = await db.blobSidecarsArchive.firstKey();
+  if (oldestBlobSlot != null) {
+    earliestAvailableSlot = Math.max(earliestAvailableSlot, oldestBlobSlot);
+  }
+
+  // Data column sidecars (Fulu+) are pruned to MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS. The
+  // archive is keyed by (slot, columnIndex); the first ascending key holds the oldest slot.
+  const [oldestColumnKey] = await db.dataColumnSidecarArchive.keys({limit: 1});
+  if (oldestColumnKey != null) {
+    earliestAvailableSlot = Math.max(earliestAvailableSlot, oldestColumnKey.prefix);
+  }
+
+  return earliestAvailableSlot;
+}
+
+/**
+ * Oldest block slot contiguously connected to `anchorSlot` (and therefore to head), using the
+ * verified `backfilledRanges` (each entry maps an upper slot back to the lower slot it is
+ * contiguously filled down to). Starts at the anchor and repeatedly extends the lower bound through
+ * abutting ranges; ranges that do not connect to the contiguous window - e.g. stale archived data
+ * sitting below a checkpoint-sync-ahead gap - are ignored, so we never advertise below a gap.
+ */
+async function oldestContiguousBlockSlot(db: IBeaconDb, anchorSlot: Slot): Promise<Slot> {
+  const ranges = await db.backfilledRanges.entries();
+
+  let lower = anchorSlot;
+  for (let extended = true; extended; ) {
+    extended = false;
+    for (const {key: upper, value: rangeLower} of ranges) {
+      // Range [rangeLower, upper] abuts/overlaps the current contiguous window and reaches lower.
+      if (rangeLower < lower && upper >= lower) {
+        lower = rangeLower;
+        extended = true;
+      }
+    }
+  }
+
+  return lower;
+}

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -76,6 +76,7 @@ import {JobItemQueue} from "../util/queue/itemQueue.js";
 import {SerializedCache} from "../util/serializedCache.js";
 import {getSlotFromSignedBeaconBlockSerialized} from "../util/sszBytes.js";
 import {ArchiveStore} from "./archiveStore/archiveStore.js";
+import {computeEarliestAvailableSlot} from "./archiveStore/utils/computeEarliestAvailableSlot.js";
 import {CheckpointBalancesCache} from "./balancesCache.js";
 import {BeaconProposerCache} from "./beaconProposerCache.js";
 import {IBlockInput, isBlockInputBlobs, isBlockInputColumns} from "./blocks/blockInput/index.js";
@@ -256,6 +257,22 @@ export class BeaconChain implements IBeaconChain {
     if (this._earliestAvailableSlot !== slot) {
       this._earliestAvailableSlot = slot;
       this.emitter.emit(ChainEvent.updateStatus);
+    }
+  }
+
+  /**
+   * Recompute {@link earliestAvailableSlot} from what is actually persisted in the DB and, if it
+   * changed, update the advertised Status. Called at startup and after each finalized-checkpoint
+   * archive/prune cycle so the value tracks both the node's retained history and sidecar pruning,
+   * instead of staying frozen at the anchor slot.
+   */
+  async updateEarliestAvailableSlot(): Promise<void> {
+    const prev = this._earliestAvailableSlot;
+    const next = await computeEarliestAvailableSlot(this.db, this.anchorStateLatestBlockSlot);
+    if (next !== prev) {
+      this.logger.verbose("Updated earliestAvailableSlot", {prev, next});
+      // Uses the setter, which emits ChainEvent.updateStatus so peers receive the new value.
+      this.earliestAvailableSlot = next;
     }
   }
 
@@ -547,6 +564,7 @@ export class BeaconChain implements IBeaconChain {
   async init(): Promise<void> {
     await this.archiveStore.init();
     await this.loadFromDisk();
+    await this.updateEarliestAvailableSlot();
   }
 
   async close(): Promise<void> {

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -97,6 +97,8 @@ export interface IBeaconChain {
   readonly genesisTime: UintNum64;
   readonly genesisValidatorsRoot: Root;
   readonly earliestAvailableSlot: Slot;
+  /** Recompute {@link earliestAvailableSlot} from the DB (at startup and after archiving/pruning). */
+  updateEarliestAvailableSlot(): Promise<void>;
   readonly executionEngine: IExecutionEngine;
   readonly executionBuilder?: IExecutionBuilder;
   readonly builderCircuitBreaker: BuilderCircuitBreaker;

--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -193,6 +193,7 @@ vi.mock("../../src/chain/chain.js", async (importActual) => {
       getCanonicalBlockAtSlot: vi.fn(),
       getBlockByRoot: vi.fn(),
       recomputeForkChoiceHead: vi.fn(),
+      updateEarliestAvailableSlot: vi.fn(),
       predictProposerHead: vi.fn(),
       getHeadStateAtCurrentEpoch: vi.fn(),
       getHeadState: vi.fn(),

--- a/packages/beacon-node/test/mocks/mockedBeaconDb.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconDb.ts
@@ -4,6 +4,7 @@ import {BeaconDb} from "../../src/db/index.js";
 import {
   AttesterSlashingRepository,
   BLSToExecutionChangeRepository,
+  BackfilledRanges,
   BlobSidecarsArchiveRepository,
   BlobSidecarsRepository,
   BlockArchiveRepository,
@@ -26,6 +27,7 @@ export type MockedBeaconDb = Mocked<BeaconDb> & {
   dataColumnSidecarArchive: Mocked<DataColumnSidecarArchiveRepository>;
 
   stateArchive: Mocked<StateArchiveRepository>;
+  backfilledRanges: Mocked<BackfilledRanges>;
 
   voluntaryExit: Mocked<VoluntaryExitRepository>;
   blsToExecutionChange: Mocked<BLSToExecutionChangeRepository>;
@@ -43,6 +45,7 @@ vi.mock("../../src/db/index.js", async (importActual) => {
       block: vi.mocked(new BlockRepository({} as any, {} as any)),
       blockArchive: vi.mocked(new BlockArchiveRepository({} as any, {} as any)),
       stateArchive: vi.mocked(new StateArchiveRepository({} as any, {} as any)),
+      backfilledRanges: vi.mocked(new BackfilledRanges({} as any, {} as any)),
 
       voluntaryExit: vi.mocked(new VoluntaryExitRepository({} as any, {} as any)),
       blsToExecutionChange: vi.mocked(new BLSToExecutionChangeRepository({} as any, {} as any)),

--- a/packages/beacon-node/test/unit/chain/archiveStore/computeEarliestAvailableSlot.test.ts
+++ b/packages/beacon-node/test/unit/chain/archiveStore/computeEarliestAvailableSlot.test.ts
@@ -1,0 +1,66 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+import {Slot} from "@lodestar/types";
+import {computeEarliestAvailableSlot} from "../../../../src/chain/archiveStore/utils/computeEarliestAvailableSlot.js";
+import {MockedBeaconDb, getMockedBeaconDb} from "../../../mocks/mockedBeaconDb.js";
+
+// `backfilledRanges` entries map an upper slot back to the lower slot it is contiguous down to.
+type Range = {key: Slot; value: Slot};
+
+function setDb(db: MockedBeaconDb, {ranges, blob, column}: {ranges?: Range[]; blob?: Slot; column?: Slot}): void {
+  db.backfilledRanges.entries = vi.fn<() => Promise<Range[]>>().mockResolvedValue(ranges ?? []);
+  db.blobSidecarsArchive.firstKey = vi.fn<() => Promise<Slot | null>>().mockResolvedValue(blob ?? null);
+  db.dataColumnSidecarArchive.keys = vi
+    .fn<() => Promise<{prefix: Slot; id: number}[]>>()
+    .mockResolvedValue(column == null ? [] : [{prefix: column, id: 0}]);
+}
+
+describe("computeEarliestAvailableSlot", () => {
+  const anchorSlot = 1000;
+  let db: MockedBeaconDb;
+
+  beforeEach(() => {
+    db = getMockedBeaconDb();
+    setDb(db, {});
+  });
+
+  it("returns the anchor slot when nothing else is retained", async () => {
+    expect(await computeEarliestAvailableSlot(db, anchorSlot)).toBe(anchorSlot);
+  });
+
+  it("lowers to the original anchor when a range connects it contiguously to head", async () => {
+    // Node checkpoint-synced at slot 100 and forward-synced; restart re-anchors at 1000.
+    setDb(db, {ranges: [{key: 1000, value: 100}]});
+    expect(await computeEarliestAvailableSlot(db, anchorSlot)).toBe(100);
+  });
+
+  it("walks multiple abutting ranges down to the deepest contiguous slot", async () => {
+    setDb(db, {
+      ranges: [
+        {key: 1000, value: 500}, // forward range [500, 1000]
+        {key: 500, value: 100}, // backfilled range [100, 500]
+      ],
+    });
+    expect(await computeEarliestAvailableSlot(db, anchorSlot)).toBe(100);
+  });
+
+  it("does NOT advertise below a gap (stale data not connected to head)", async () => {
+    // Node had old data [0, 200] then checkpoint-synced ahead to 1000: hole [200, 1000].
+    setDb(db, {ranges: [{key: 200, value: 0}]});
+    expect(await computeEarliestAvailableSlot(db, anchorSlot)).toBe(anchorSlot);
+  });
+
+  it("raises the bound to the oldest retained custody column slot", async () => {
+    setDb(db, {ranges: [{key: 1000, value: 100}], column: 500});
+    expect(await computeEarliestAvailableSlot(db, anchorSlot)).toBe(500);
+  });
+
+  it("takes the most restrictive (highest) lower bound across blocks, blobs and columns", async () => {
+    setDb(db, {ranges: [{key: 1000, value: 100}], blob: 700, column: 500});
+    expect(await computeEarliestAvailableSlot(db, anchorSlot)).toBe(700);
+  });
+
+  it("ignores sidecar bounds below the contiguous block slot", async () => {
+    setDb(db, {ranges: [{key: 1000, value: 800}], blob: 300, column: 400});
+    expect(await computeEarliestAvailableSlot(db, anchorSlot)).toBe(800);
+  });
+});


### PR DESCRIPTION
## Motivation

`earliestAvailableSlot` (advertised in the Fulu `Status`, and enforced by the
`beaconBlocksByRange` / `dataColumnSidecarsByRange` / `executionPayloadEnvelopesByRange`
handlers) is set exactly once, in the `BeaconChain` constructor, to `anchorState.slot`, and
the setter that is supposed to move it is dead code — nothing ever calls it. So the value is
frozen at the anchor slot for the node's entire life: it never lowers to reflect what is
actually in the DB, and never advances as sidecars are pruned.

Because a restart re-anchors from the last finalized state (`initStateFromDb` →
`db.stateArchive.lastBinary()`), every restart ratchets the advertised slot **up** to
finalized. After a coordinated restart (e.g. an image rollout) every node advertises
`earliestAvailableSlot = finalized` and then rejects any by-range request that falls entirely
below it — even though the blocks are still in `blockArchive` from the original checkpoint
forward. The whole network restarts at once, no peer will serve the pre-finalized range, and
sync gets stuck.

Fixes the stuck-sync symptom in #8147. Addresses the "expiry" half of #7997.

## Description

Derive `earliestAvailableSlot` from what is actually persisted in the DB instead of freezing
it at the anchor slot.

`computeEarliestAvailableSlot(db, anchorSlot)` returns the **most restrictive (highest) lower
bound** across the data a peer may request together, which matches the spec definition in
[consensus-specs `fulu/p2p-interface.md`](https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/p2p-interface.md)
(the earliest slot from which the node can serve *everything* — all blocks and all their
sidecars):

- **Block bound** — the oldest slot *contiguously connected to the anchor* (and therefore to
  head), walked from `backfilledRanges`. This is deliberately **not** the global oldest archived
  block: a node that checkpoint-synced ahead of pre-existing DB data holds a gap below its new
  anchor, and advertising below that gap would strand peers requesting the missing range (the
  same #8147 failure, in reverse). In the common no-gap case (plain checkpoint sync / restart)
  this resolves to the original weak-subjectivity anchor.
- **Sidecar bounds** — raised to the oldest retained blob sidecar and oldest retained data-column
  (custody) sidecar, since sidecars are pruned to their retention window and are usually the
  binding constraint.

`BeaconChain.updateEarliestAvailableSlot()` recomputes the value and, when it changed, assigns
it through the (previously dead) setter so `ChainEvent.updateStatus` fires and peers receive the
update. It is called:

- in `chain.init()` — at startup, so a restart no longer ratchets the advertised slot up to
  finalized; it reflects the oldest contiguous data the node actually holds.
- in `archiveStore.processFinalizedCheckpoint()`, after `updateBackfillRange` — so the value
  advances as blob/column sidecars expire out of the retention window, and lowers as backfill
  extends the contiguous range.

## Scope

This covers the startup ratchet + sidecar-expiry updates and is safe in the checkpoint-sync-ahead
(gap) case. It does **not** yet implement the custody-group-count-change case
([`fulu/validator.md`](https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/validator.md):
`earliest_available_slot` should reflect the slot at which the custody count changed) — that is a
separate follow-up.

## Testing

- Unit test for `computeEarliestAvailableSlot` covering: anchor-only fallback, lowering to the
  original anchor via a contiguous range, walking multiple abutting ranges, **not advertising
  below a gap**, and raising / max-ing across blob and custody-column bounds.
- `check-types`, `biome` and the existing `archiveStore` unit test pass.

🤖 Generated with AI assistance
