### PR TITLE
test: enable payload attestation spec tests

### DIFF
--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -80,7 +80,6 @@ export const defaultSkipOpts: SkipOpts = {
     /^fulu\/ssz_static\/PartialDataColumn(GroupID|Header|PartsMetadata|Sidecar)\/.*$/,
     /^gloas\/ssz_static\/PartialDataColumn(GroupID|PartsMetadata|Sidecar)\/.*$/,
     /^heze\/ssz_static\/PartialDataColumn(GroupID|PartsMetadata|Sidecar)\/.*$/,
-    /^heze\/fork_choice\/on_payload_attestation_message\/.*$/,
     // TODO GLOAS: enable this after gloas fork choice is ready
     /^gloas\/fork_choice_compliance\/.*/,
     /^heze\/fork_choice_compliance\/.*/,

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -80,10 +80,6 @@ export const defaultSkipOpts: SkipOpts = {
     /^fulu\/ssz_static\/PartialDataColumn(GroupID|Header|PartsMetadata|Sidecar)\/.*$/,
     /^gloas\/ssz_static\/PartialDataColumn(GroupID|PartsMetadata|Sidecar)\/.*$/,
     /^heze\/ssz_static\/PartialDataColumn(GroupID|PartsMetadata|Sidecar)\/.*$/,
-    // TODO-GLOAS: re-enable after on_payload_attestation_message (PTC) fork choice is implemented.
-    // New test suite added in v1.7.0-alpha.8 (consensus-specs #5206); gloas PTC fork choice
-    // handling is not yet implemented in Lodestar.
-    /^gloas\/fork_choice\/on_payload_attestation_message\/.*$/,
     /^heze\/fork_choice\/on_payload_attestation_message\/.*$/,
     // TODO GLOAS: enable this after gloas fork choice is ready
     /^gloas\/fork_choice_compliance\/.*/,


### PR DESCRIPTION
the on_payload_attestation_message fork choice tests were implemented in #9384, but the Gloas skip was later reintroduced and Heze was still skipped

removes both stale skips and enables all 14 Gloas and Heze beta.0 vectors