### PR TITLE
feat: track stateTransition steps in metrics

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
@@ -1,6 +1,7 @@
 import {ForkName} from "@lodestar/params";
 import {
   BeaconStateTransitionMetrics,
+  BlockProcessStep,
   EpochTransitionStep,
   ProposerRewardType,
   StateCloneSource,
@@ -70,9 +71,14 @@ export function createHistoricalStateTransitionMetrics(
     processBlockTime: metricsRegister.histogram({
       name: "lodestar_historical_state_stfn_process_block_seconds",
       help: "Time to process a single block in seconds",
-      // TODO: Add metrics for each step
       // Block processing can take 5-40ms, 100ms max
       buckets: [0.005, 0.01, 0.02, 0.05, 0.1, 1],
+    }),
+    processBlockStepTime: metricsRegister.histogram<{step: BlockProcessStep}>({
+      name: "lodestar_historical_state_stfn_process_block_step_seconds",
+      help: "Time to call each step of process block in seconds",
+      labelNames: ["step"],
+      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5],
     }),
     processBlockCommitTime: metricsRegister.histogram({
       name: "lodestar_historical_state_stfn_process_block_commit_seconds",

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
@@ -5,7 +5,6 @@ import {
   ProposerRewardType,
   StateCloneSource,
   StateHashTreeRootSource,
-  StateTransitionStep,
 } from "@lodestar/state-transition";
 import {Gauge, Histogram} from "@lodestar/utils";
 import {RegistryMetricCreator} from "../../../metrics/index.js";
@@ -46,12 +45,6 @@ export function createHistoricalStateTransitionMetrics(
       help: "Time to call each step of epoch transition in seconds",
       labelNames: ["step"],
       buckets: [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1],
-    }),
-    stateTransitionStepTime: metricsRegister.histogram<{step: StateTransitionStep}>({
-      name: "lodestar_historical_state_stfn_state_transition_step_seconds",
-      help: "Time to call each step of state transition in seconds",
-      labelNames: ["step"],
-      buckets: [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1, 1.25, 1.5],
     }),
     forkUpgradeTime: metricsRegister.histogram<{fork: ForkName}>({
       name: "lodestar_historical_state_stfn_fork_upgrade_seconds",

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
@@ -3,6 +3,7 @@ import {
   BeaconStateTransitionMetrics,
   BlockProcessStep,
   EpochTransitionStep,
+  ProcessOperationsStep,
   ProposerRewardType,
   StateCloneSource,
   StateHashTreeRootSource,
@@ -77,6 +78,12 @@ export function createHistoricalStateTransitionMetrics(
     processBlockStepTime: metricsRegister.histogram<{step: BlockProcessStep}>({
       name: "lodestar_historical_state_stfn_process_block_step_seconds",
       help: "Time to call each step of process block in seconds",
+      labelNames: ["step"],
+      buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1],
+    }),
+    processOperationsStepTime: metricsRegister.histogram<{step: ProcessOperationsStep}>({
+      name: "lodestar_historical_state_stfn_process_operations_step_seconds",
+      help: "Time to call each step of process operations in seconds",
       labelNames: ["step"],
       buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1],
     }),

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
@@ -5,6 +5,7 @@ import {
   ProposerRewardType,
   StateCloneSource,
   StateHashTreeRootSource,
+  StateTransitionStep,
 } from "@lodestar/state-transition";
 import {Gauge, Histogram} from "@lodestar/utils";
 import {RegistryMetricCreator} from "../../../metrics/index.js";
@@ -45,6 +46,12 @@ export function createHistoricalStateTransitionMetrics(
       help: "Time to call each step of epoch transition in seconds",
       labelNames: ["step"],
       buckets: [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1],
+    }),
+    stateTransitionStepTime: metricsRegister.histogram<{step: StateTransitionStep}>({
+      name: "lodestar_historical_state_stfn_state_transition_step_seconds",
+      help: "Time to call each step of state transition in seconds",
+      labelNames: ["step"],
+      buckets: [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1, 1.25, 1.5],
     }),
     forkUpgradeTime: metricsRegister.histogram<{fork: ForkName}>({
       name: "lodestar_historical_state_stfn_fork_upgrade_seconds",

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
@@ -78,7 +78,7 @@ export function createHistoricalStateTransitionMetrics(
       name: "lodestar_historical_state_stfn_process_block_step_seconds",
       help: "Time to call each step of process block in seconds",
       labelNames: ["step"],
-      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5],
+      buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1],
     }),
     processBlockCommitTime: metricsRegister.histogram({
       name: "lodestar_historical_state_stfn_process_block_commit_seconds",

--- a/packages/state-transition/src/block/index.ts
+++ b/packages/state-transition/src/block/index.ts
@@ -20,7 +20,7 @@ import {processPayloadAttestation} from "./processPayloadAttestation.js";
 import {processRandao} from "./processRandao.js";
 import {processSyncAggregate} from "./processSyncCommittee.js";
 import {processWithdrawals} from "./processWithdrawals.js";
-import {ProcessBlockOpts, ProposerRewardType} from "./types.js";
+import {BlockProcessStep, ProcessBlockOpts, ProposerRewardType} from "./types.js";
 
 // Spec tests
 export {
@@ -60,21 +60,31 @@ export function processBlock(
   // Apply the parent's deferred payload effects before everything else. Must run before
   // processBlockHeader and processExecutionPayloadBid so subsequent steps see the updated state.
   if (fork >= ForkSeq.gloas) {
+    const timer = metrics?.processBlockStepTime.startTimer({step: BlockProcessStep.processParentExecutionPayload});
     processParentExecutionPayload(state as CachedBeaconStateGloas, block as BeaconBlock<ForkPostGloas>);
+    timer?.();
   }
 
-  processBlockHeader(state, block);
+  {
+    const timer = metrics?.processBlockStepTime.startTimer({step: BlockProcessStep.processBlockHeader});
+    processBlockHeader(state, block);
+    timer?.();
+  }
 
-  if (fork >= ForkSeq.gloas) {
-    // Parent payload's execution requests were already applied by processParentExecutionPayload above
-    processWithdrawals(fork, state as CachedBeaconStateGloas);
-  } else if (fork >= ForkSeq.capella) {
-    const fullOrBlindedPayload = getFullOrBlindedPayload(block);
-    processWithdrawals(
-      fork,
-      state as CachedBeaconStateCapella,
-      fullOrBlindedPayload as capella.FullOrBlindedExecutionPayload
-    );
+  if (fork >= ForkSeq.capella) {
+    const timer = metrics?.processBlockStepTime.startTimer({step: BlockProcessStep.processWithdrawals});
+    if (fork >= ForkSeq.gloas) {
+      // Parent payload's execution requests were already applied by processParentExecutionPayload above
+      processWithdrawals(fork, state as CachedBeaconStateGloas);
+    } else {
+      const fullOrBlindedPayload = getFullOrBlindedPayload(block);
+      processWithdrawals(
+        fork,
+        state as CachedBeaconStateCapella,
+        fullOrBlindedPayload as capella.FullOrBlindedExecutionPayload
+      );
+    }
+    timer?.();
   }
 
   // The call to the process_execution_payload must happen before the call to the process_randao as the former depends
@@ -87,25 +97,48 @@ export function processBlock(
     fork >= ForkSeq.bellatrix &&
     isExecutionEnabled(state as CachedBeaconStateBellatrix, block)
   ) {
+    const timer = metrics?.processBlockStepTime.startTimer({step: BlockProcessStep.processExecutionPayload});
     processExecutionPayload(fork, state as CachedBeaconStateBellatrix, block.body, externalData);
+    timer?.();
   }
 
   if (fork >= ForkSeq.gloas) {
+    const timer = metrics?.processBlockStepTime.startTimer({step: BlockProcessStep.processExecutionPayloadBid});
     processExecutionPayloadBid(
       state as CachedBeaconStateGloas,
       (block as BeaconBlock<ForkPostGloas>).body.signedExecutionPayloadBid
     );
+    timer?.();
   }
 
-  processRandao(state, block, verifySignatures);
-  processEth1Data(state, block.body.eth1Data);
-  processOperations(fork, state, block.body, parentSlot, opts, metrics);
+  {
+    const timer = metrics?.processBlockStepTime.startTimer({step: BlockProcessStep.processRandao});
+    processRandao(state, block, verifySignatures);
+    timer?.();
+  }
+
+  {
+    const timer = metrics?.processBlockStepTime.startTimer({step: BlockProcessStep.processEth1Data});
+    processEth1Data(state, block.body.eth1Data);
+    timer?.();
+  }
+
+  {
+    const timer = metrics?.processBlockStepTime.startTimer({step: BlockProcessStep.processOperations});
+    processOperations(fork, state, block.body, parentSlot, opts, metrics);
+    timer?.();
+  }
+
   if (fork >= ForkSeq.altair) {
+    const timer = metrics?.processBlockStepTime.startTimer({step: BlockProcessStep.processSyncAggregate});
     processSyncAggregate(state, block as altair.BeaconBlock, verifySignatures);
+    timer?.();
   }
 
   if (fork >= ForkSeq.deneb) {
+    const timer = metrics?.processBlockStepTime.startTimer({step: BlockProcessStep.processBlobKzgCommitments});
     processBlobKzgCommitments(externalData);
+    timer?.();
     // Only throw PreData so beacon can also sync/process blocks optimistically
     // and let forkChoice handle it
     if (externalData.dataAvailabilityStatus === DataAvailabilityStatus.PreData) {

--- a/packages/state-transition/src/block/processOperations.ts
+++ b/packages/state-transition/src/block/processOperations.ts
@@ -26,7 +26,7 @@ import {processPayloadAttestation} from "./processPayloadAttestation.js";
 import {processProposerSlashing} from "./processProposerSlashing.js";
 import {processVoluntaryExit} from "./processVoluntaryExit.js";
 import {processWithdrawalRequest} from "./processWithdrawalRequest.js";
-import {ProcessBlockOpts} from "./types.js";
+import {ProcessBlockOpts, ProcessOperationsStep} from "./types.js";
 
 export {
   processProposerSlashing,
@@ -61,50 +61,95 @@ export function processOperations(
     );
   }
 
-  for (const proposerSlashing of body.proposerSlashings) {
-    processProposerSlashing(fork, state, proposerSlashing, opts.verifySignatures);
-  }
-  for (const attesterSlashing of body.attesterSlashings) {
-    processAttesterSlashing(fork, state, attesterSlashing, opts.verifySignatures);
-  }
-
-  processAttestations(fork, state, body.attestations, parentSlot, opts.verifySignatures, metrics);
-
-  for (const deposit of body.deposits) {
-    processDeposit(fork, state, deposit);
+  {
+    const timer = metrics?.processOperationsStepTime.startTimer({step: ProcessOperationsStep.processProposerSlashing});
+    for (const proposerSlashing of body.proposerSlashings) {
+      processProposerSlashing(fork, state, proposerSlashing, opts.verifySignatures);
+    }
+    timer?.();
   }
 
-  for (const voluntaryExit of body.voluntaryExits) {
-    processVoluntaryExit(fork, state, voluntaryExit, opts.verifySignatures);
+  {
+    const timer = metrics?.processOperationsStepTime.startTimer({step: ProcessOperationsStep.processAttesterSlashing});
+    for (const attesterSlashing of body.attesterSlashings) {
+      processAttesterSlashing(fork, state, attesterSlashing, opts.verifySignatures);
+    }
+    timer?.();
+  }
+
+  {
+    const timer = metrics?.processOperationsStepTime.startTimer({step: ProcessOperationsStep.processAttestations});
+    processAttestations(fork, state, body.attestations, parentSlot, opts.verifySignatures, metrics);
+    timer?.();
+  }
+
+  {
+    const timer = metrics?.processOperationsStepTime.startTimer({step: ProcessOperationsStep.processDeposit});
+    for (const deposit of body.deposits) {
+      processDeposit(fork, state, deposit);
+    }
+    timer?.();
+  }
+
+  {
+    const timer = metrics?.processOperationsStepTime.startTimer({step: ProcessOperationsStep.processVoluntaryExit});
+    for (const voluntaryExit of body.voluntaryExits) {
+      processVoluntaryExit(fork, state, voluntaryExit, opts.verifySignatures);
+    }
+    timer?.();
   }
 
   if (fork >= ForkSeq.capella) {
+    const timer = metrics?.processOperationsStepTime.startTimer({
+      step: ProcessOperationsStep.processBlsToExecutionChange,
+    });
     for (const blsToExecutionChange of (body as capella.BeaconBlockBody).blsToExecutionChanges) {
       processBlsToExecutionChange(state as CachedBeaconStateCapella, blsToExecutionChange);
     }
+    timer?.();
   }
 
   if (fork >= ForkSeq.electra && fork < ForkSeq.gloas) {
     const stateElectra = state as CachedBeaconStateElectra;
     const bodyElectra = body as electra.BeaconBlockBody;
 
-    for (const depositRequest of bodyElectra.executionRequests.deposits) {
-      processDepositRequest(fork, stateElectra, depositRequest);
+    {
+      const timer = metrics?.processOperationsStepTime.startTimer({step: ProcessOperationsStep.processDepositRequest});
+      for (const depositRequest of bodyElectra.executionRequests.deposits) {
+        processDepositRequest(fork, stateElectra, depositRequest);
+      }
+      timer?.();
     }
 
-    for (const elWithdrawalRequest of bodyElectra.executionRequests.withdrawals) {
-      processWithdrawalRequest(fork, stateElectra, elWithdrawalRequest);
+    {
+      const timer = metrics?.processOperationsStepTime.startTimer({
+        step: ProcessOperationsStep.processWithdrawalRequest,
+      });
+      for (const elWithdrawalRequest of bodyElectra.executionRequests.withdrawals) {
+        processWithdrawalRequest(fork, stateElectra, elWithdrawalRequest);
+      }
+      timer?.();
     }
 
-    for (const elConsolidationRequest of bodyElectra.executionRequests.consolidations) {
-      processConsolidationRequest(stateElectra, elConsolidationRequest);
+    {
+      const timer = metrics?.processOperationsStepTime.startTimer({
+        step: ProcessOperationsStep.processConsolidationRequest,
+      });
+      for (const elConsolidationRequest of bodyElectra.executionRequests.consolidations) {
+        processConsolidationRequest(stateElectra, elConsolidationRequest);
+      }
+      timer?.();
     }
   }
 
   if (fork >= ForkSeq.gloas) {
+    const timer = metrics?.processOperationsStepTime.startTimer({
+      step: ProcessOperationsStep.processPayloadAttestation,
+    });
     for (const payloadAttestation of (body as gloas.BeaconBlockBody).payloadAttestations) {
       processPayloadAttestation(state as CachedBeaconStateGloas, payloadAttestation);
     }
+    timer?.();
   }
 }
 

--- a/packages/state-transition/src/block/types.ts
+++ b/packages/state-transition/src/block/types.ts
@@ -23,3 +23,19 @@ export enum BlockProcessStep {
   processSyncAggregate = "processSyncAggregate",
   processBlobKzgCommitments = "processBlobKzgCommitments",
 }
+
+/**
+ * Steps of `processOperations()` tracked in metrics
+ */
+export enum ProcessOperationsStep {
+  processProposerSlashing = "processProposerSlashing",
+  processAttesterSlashing = "processAttesterSlashing",
+  processAttestations = "processAttestations",
+  processDeposit = "processDeposit",
+  processVoluntaryExit = "processVoluntaryExit",
+  processBlsToExecutionChange = "processBlsToExecutionChange",
+  processDepositRequest = "processDepositRequest",
+  processWithdrawalRequest = "processWithdrawalRequest",
+  processConsolidationRequest = "processConsolidationRequest",
+  processPayloadAttestation = "processPayloadAttestation",
+}

--- a/packages/state-transition/src/block/types.ts
+++ b/packages/state-transition/src/block/types.ts
@@ -7,3 +7,19 @@ export enum ProposerRewardType {
   syncAggregate = "sync_aggregate",
   slashing = "slashing",
 }
+
+/**
+ * Steps of `processBlock()` tracked in metrics
+ */
+export enum BlockProcessStep {
+  processParentExecutionPayload = "processParentExecutionPayload",
+  processBlockHeader = "processBlockHeader",
+  processWithdrawals = "processWithdrawals",
+  processExecutionPayload = "processExecutionPayload",
+  processExecutionPayloadBid = "processExecutionPayloadBid",
+  processRandao = "processRandao",
+  processEth1Data = "processEth1Data",
+  processOperations = "processOperations",
+  processSyncAggregate = "processSyncAggregate",
+  processBlobKzgCommitments = "processBlobKzgCommitments",
+}

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -13,7 +13,7 @@ export {
 } from "./block/processVoluntaryExit.js";
 // Withdrawals for new blocks
 export {getExpectedWithdrawals} from "./block/processWithdrawals.js";
-export {BlockProcessStep, ProposerRewardType} from "./block/types.js";
+export {BlockProcessStep, ProcessOperationsStep, ProposerRewardType} from "./block/types.js";
 export {
   type EffectiveBalanceIncrements,
   getEffectiveBalanceIncrementsWithLen,

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -13,7 +13,7 @@ export {
 } from "./block/processVoluntaryExit.js";
 // Withdrawals for new blocks
 export {getExpectedWithdrawals} from "./block/processWithdrawals.js";
-export {ProposerRewardType} from "./block/types.js";
+export {BlockProcessStep, ProposerRewardType} from "./block/types.js";
 export {
   type EffectiveBalanceIncrements,
   getEffectiveBalanceIncrementsWithLen,

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -1,6 +1,6 @@
 import {ForkName} from "@lodestar/params";
 import {MetricsRegister} from "@lodestar/utils";
-import {BlockProcessStep, ProposerRewardType} from "./block/types.js";
+import {BlockProcessStep, ProcessOperationsStep, ProposerRewardType} from "./block/types.js";
 import {EpochTransitionStep} from "./epoch/index.js";
 import {StateCloneSource, StateHashTreeRootSource} from "./stateTransition.js";
 import {CachedBeaconStateAllForks} from "./types.js";
@@ -63,6 +63,12 @@ export function getMetrics(register: MetricsRegister) {
     processBlockStepTime: register.histogram<{step: BlockProcessStep}>({
       name: "lodestar_stfn_process_block_step_seconds",
       help: "Time to call each step of process block in seconds",
+      labelNames: ["step"],
+      buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1],
+    }),
+    processOperationsStepTime: register.histogram<{step: ProcessOperationsStep}>({
+      name: "lodestar_stfn_process_operations_step_seconds",
+      help: "Time to call each step of process operations in seconds",
       labelNames: ["step"],
       buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1],
     }),

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -2,7 +2,7 @@ import {ForkName} from "@lodestar/params";
 import {MetricsRegister} from "@lodestar/utils";
 import {ProposerRewardType} from "./block/types.js";
 import {EpochTransitionStep} from "./epoch/index.js";
-import {StateCloneSource, StateHashTreeRootSource, StateTransitionStep} from "./stateTransition.js";
+import {StateCloneSource, StateHashTreeRootSource} from "./stateTransition.js";
 import {CachedBeaconStateAllForks} from "./types.js";
 import {isViewDUNodesPopulated} from "./util/ssz.js";
 
@@ -31,12 +31,6 @@ export function getMetrics(register: MetricsRegister) {
       help: "Time to call each step of epoch transition in seconds",
       labelNames: ["step"],
       buckets: [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1],
-    }),
-    stateTransitionStepTime: register.histogram<{step: StateTransitionStep}>({
-      name: "lodestar_stfn_state_transition_step_seconds",
-      help: "Time to call each step of state transition in seconds",
-      labelNames: ["step"],
-      buckets: [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1, 1.25, 1.5],
     }),
     forkUpgradeTime: register.histogram<{fork: ForkName}>({
       name: "lodestar_stfn_fork_upgrade_seconds",

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -64,7 +64,7 @@ export function getMetrics(register: MetricsRegister) {
       name: "lodestar_stfn_process_block_step_seconds",
       help: "Time to call each step of process block in seconds",
       labelNames: ["step"],
-      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5],
+      buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1],
     }),
     processBlockCommitTime: register.histogram({
       name: "lodestar_stfn_process_block_commit_seconds",

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -2,7 +2,7 @@ import {ForkName} from "@lodestar/params";
 import {MetricsRegister} from "@lodestar/utils";
 import {ProposerRewardType} from "./block/types.js";
 import {EpochTransitionStep} from "./epoch/index.js";
-import {StateCloneSource, StateHashTreeRootSource} from "./stateTransition.js";
+import {StateCloneSource, StateHashTreeRootSource, StateTransitionStep} from "./stateTransition.js";
 import {CachedBeaconStateAllForks} from "./types.js";
 import {isViewDUNodesPopulated} from "./util/ssz.js";
 
@@ -31,6 +31,12 @@ export function getMetrics(register: MetricsRegister) {
       help: "Time to call each step of epoch transition in seconds",
       labelNames: ["step"],
       buckets: [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1],
+    }),
+    stateTransitionStepTime: register.histogram<{step: StateTransitionStep}>({
+      name: "lodestar_stfn_state_transition_step_seconds",
+      help: "Time to call each step of state transition in seconds",
+      labelNames: ["step"],
+      buckets: [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1, 1.25, 1.5],
     }),
     forkUpgradeTime: register.histogram<{fork: ForkName}>({
       name: "lodestar_stfn_fork_upgrade_seconds",

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -1,6 +1,6 @@
 import {ForkName} from "@lodestar/params";
 import {MetricsRegister} from "@lodestar/utils";
-import {ProposerRewardType} from "./block/types.js";
+import {BlockProcessStep, ProposerRewardType} from "./block/types.js";
 import {EpochTransitionStep} from "./epoch/index.js";
 import {StateCloneSource, StateHashTreeRootSource} from "./stateTransition.js";
 import {CachedBeaconStateAllForks} from "./types.js";
@@ -57,9 +57,14 @@ export function getMetrics(register: MetricsRegister) {
     processBlockTime: register.histogram({
       name: "lodestar_stfn_process_block_seconds",
       help: "Time to process a single block in seconds",
-      // TODO: Add metrics for each step
       // Block processing can take 5-40ms, 100ms max
       buckets: [0.005, 0.01, 0.02, 0.05, 0.1, 1],
+    }),
+    processBlockStepTime: register.histogram<{step: BlockProcessStep}>({
+      name: "lodestar_stfn_process_block_step_seconds",
+      help: "Time to call each step of process block in seconds",
+      labelNames: ["step"],
+      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5],
     }),
     processBlockCommitTime: register.histogram({
       name: "lodestar_stfn_process_block_commit_seconds",

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -81,6 +81,15 @@ export enum StateHashTreeRootSource {
 }
 
 /**
+ * Epoch transition steps tracked in metrics
+ */
+export enum StateTransitionStep {
+  stateClone = "stateClone",
+  processSlots = "processSlots",
+  verifyProposerSignature = "verifyProposerSignature",
+}
+
+/**
  * Implementation Note: follows the optimizations in protolambda's eth2fastspec (https://github.com/protolambda/eth2fastspec)
  */
 export function stateTransition(
@@ -99,7 +108,9 @@ export function stateTransition(
   const blockSlot = block.slot;
 
   // .clone() before mutating state in state transition
+  const cloneTimer = metrics?.stateTransitionStepTime.startTimer({step: StateTransitionStep.stateClone});
   let postState = state.clone(options.dontTransferCache);
+  cloneTimer?.();
 
   if (metrics) {
     onStateCloneMetrics(postState, metrics, StateCloneSource.stateTransition);
@@ -110,11 +121,18 @@ export function stateTransition(
 
   // Process slots (including those with no blocks) since block.
   // Includes state upgrades
+  const processSlotsTimer = metrics?.stateTransitionStepTime.startTimer({step: StateTransitionStep.processSlots});
   postState = processSlotsWithTransientCache(postState, blockSlot, options, {metrics, validatorMonitor});
+  processSlotsTimer?.();
 
   // Verify proposer signature only
-  if (verifyProposer && !verifyProposerSignature(postState.config, signedBlock)) {
-    throw new Error("Invalid block signature");
+  if (verifyProposer) {
+    const timer = metrics?.stateTransitionStepTime.startTimer({step: StateTransitionStep.verifyProposerSignature});
+    const isValidProposerSignature = verifyProposerSignature(postState.config, signedBlock);
+    timer?.();
+    if (!isValidProposerSignature) {
+      throw new Error("Invalid block signature");
+    }
   }
 
   // Process block

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -81,15 +81,6 @@ export enum StateHashTreeRootSource {
 }
 
 /**
- * Epoch transition steps tracked in metrics
- */
-export enum StateTransitionStep {
-  stateClone = "stateClone",
-  processSlots = "processSlots",
-  verifyProposerSignature = "verifyProposerSignature",
-}
-
-/**
  * Implementation Note: follows the optimizations in protolambda's eth2fastspec (https://github.com/protolambda/eth2fastspec)
  */
 export function stateTransition(
@@ -108,9 +99,7 @@ export function stateTransition(
   const blockSlot = block.slot;
 
   // .clone() before mutating state in state transition
-  const cloneTimer = metrics?.stateTransitionStepTime.startTimer({step: StateTransitionStep.stateClone});
   let postState = state.clone(options.dontTransferCache);
-  cloneTimer?.();
 
   if (metrics) {
     onStateCloneMetrics(postState, metrics, StateCloneSource.stateTransition);
@@ -121,18 +110,11 @@ export function stateTransition(
 
   // Process slots (including those with no blocks) since block.
   // Includes state upgrades
-  const processSlotsTimer = metrics?.stateTransitionStepTime.startTimer({step: StateTransitionStep.processSlots});
   postState = processSlotsWithTransientCache(postState, blockSlot, options, {metrics, validatorMonitor});
-  processSlotsTimer?.();
 
   // Verify proposer signature only
-  if (verifyProposer) {
-    const timer = metrics?.stateTransitionStepTime.startTimer({step: StateTransitionStep.verifyProposerSignature});
-    const isValidProposerSignature = verifyProposerSignature(postState.config, signedBlock);
-    timer?.();
-    if (!isValidProposerSignature) {
-      throw new Error("Invalid block signature");
-    }
+  if (verifyProposer && !verifyProposerSignature(postState.config, signedBlock)) {
+    throw new Error("Invalid block signature");
   }
 
   // Process block


### PR DESCRIPTION
**Motivation**

Add stateTransition step metrics.

**Description**

Added the missing metrics requested via #9989.
Steps covered: `stateClone`, `processSlots` and `verifyProposerSignature`
Doesn't touch previously existing metrics.

Note: Buckets have headroom up to 1.5s, that seemed enough but might need adjustment.

Closes #9989