### PR TITLE
chore: copy packages/builder/package.json in Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -33,6 +33,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY patches ./patches
 COPY packages/api/package.json packages/api/
 COPY packages/beacon-node/package.json packages/beacon-node/
+COPY packages/builder/package.json packages/builder/
 COPY packages/cli/package.json packages/cli/
 COPY packages/config/package.json packages/config/
 COPY packages/db/package.json packages/db/


### PR DESCRIPTION
Extracts the one-line `Dockerfile.dev` fix noticed in #10017 into its own PR (per @nflaig's request), since #10017 is an unrelated fork-choice change that may not merge.

The `builder` package's `package.json` COPY line was missing from the dev Dockerfile's dependency-install block — omitted when the `builder` package was added. Without it, `pnpm install` in the dev image can't resolve the `builder` workspace package and its Docker layer caching is broken.

Verified `builder` was the only omission: the COPY block now matches all 17 directories under `packages/`.

Refs #10017

🤖 Generated with AI assistance
