### PR TITLE
fix(archive): prune by block and payload level data

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -164,16 +164,28 @@ export async function archiveBlocks(
     }
   }
 
-  // deleteNonCanonicalBlocks
-  // loop through forkchoice single time
-
+  // We prune by payload-level and block-level by keeping two root sets:
+  // 1) `nonCanonicalBlockRoots`
+  //   Payload-level data (blob/data column sidecars, execution payload envelopes) belongs to one variant. Prune it
+  //   for every non-ancestor variant over the losing FULL sibling of an EMPTY-finalized block. Deleting by
+  //   root cannot hurt canonical blocks: the code above already migrated their payload data to the cold DB.
+  // 2) `nonCanonicalDistinctBlockRoots`
+  //   Block-level data (block, light client witness and header) exists once per root. A sibling variant of a
+  //   canonical block is the same block, so never prune it as non-canonical. Nothing migrates light client data,
+  //   so pruning it by the wrong root loses it permanently.
   const nonCanonicalBlockRoots = finalizedNonCanonicalBlocks.map((summary) => fromHex(summary.blockRoot));
+  const canonicalBlockRootHexes = new Set(finalizedCanonicalBlocks.map((block) => block.blockRoot));
+  const nonCanonicalDistinctBlocks = finalizedNonCanonicalBlocks.filter(
+    (summary) => !canonicalBlockRootHexes.has(summary.blockRoot)
+  );
+  const nonCanonicalDistinctBlockRoots = nonCanonicalDistinctBlocks.map((summary) => fromHex(summary.blockRoot));
+
   if (nonCanonicalBlockRoots.length > 0) {
     if (persistOrphanedBlocks) {
       // Persist orphaned blocks to disk before deleting them from hot db
       await Promise.all(
-        nonCanonicalBlockRoots.map(async (root, index) => {
-          const block = finalizedNonCanonicalBlocks[index];
+        nonCanonicalDistinctBlockRoots.map(async (root, index) => {
+          const block = nonCanonicalDistinctBlocks[index];
           const blockBytes = await db.block.getBinary(root);
           const blockLogCtx = {slot: block.slot, root: block.blockRoot};
           if (blockBytes) {
@@ -195,8 +207,14 @@ export async function archiveBlocks(
       slotRange: prettyPrintIndices(nonCanonicalSlots),
     };
 
-    await db.block.batchDelete(nonCanonicalBlockRoots);
-    logger.verbose("Deleted non canonical blocks from hot DB", nonCanonicalLogCtx);
+    if (nonCanonicalDistinctBlockRoots.length > 0) {
+      await db.block.batchDelete(nonCanonicalDistinctBlockRoots);
+      logger.verbose("Deleted non canonical blocks from hot DB", {
+        ...logCtx,
+        count: nonCanonicalDistinctBlockRoots.length,
+        slotRange: prettyPrintIndices(nonCanonicalDistinctBlocks.map((summary) => summary.slot).sort((a, b) => a - b)),
+      });
+    }
 
     if (finalizedPostDeneb) {
       await db.blobSidecars.batchDelete(nonCanonicalBlockRoots);
@@ -274,9 +292,11 @@ export async function archiveBlocks(
     }
   }
 
-  // Prunning potential checkpoint data
+  // Pruning potential checkpoint data
   const finalizedCanonicalNonCheckpointBlocks = getNonCheckpointBlocks(finalizedCanonicalBlockRoots);
-  const nonCheckpointBlockRoots: Uint8Array[] = [...nonCanonicalBlockRoots];
+  // Prune by non canonical distinct blocks, never prune
+  // block-level light client data for sibling payload variants of canonical blocks
+  const nonCheckpointBlockRoots: Uint8Array[] = [...nonCanonicalDistinctBlockRoots];
   for (const block of finalizedCanonicalNonCheckpointBlocks) {
     nonCheckpointBlockRoots.push(block.root);
   }

--- a/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
+++ b/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
@@ -267,8 +267,8 @@ describe("block archiver task", () => {
     const pruneSpy = vi.spyOn(lightclientServer, "pruneNonCheckpointData").mockResolvedValue(undefined);
 
     const root = (i: number): string => toHexString(Buffer.alloc(32, i));
-    // Canonical chain: 
-    // slot 32 (epoch boundary, finalized via EMPTY), 
+    // Canonical chain:
+    // slot 32 (epoch boundary, finalized via EMPTY),
     // slot 31 (finalized via FULL),
     // slot 30 orphaned block
     const boundaryEmpty = generateProtoBlock({slot: 32, blockRoot: root(1), payloadStatus: PayloadStatus.EMPTY});

--- a/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
+++ b/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
@@ -250,6 +250,74 @@ describe("block archiver task", () => {
     ]);
   });
 
+  it("does not treat sibling payload variants of canonical blocks as non-canonical", async () => {
+    // Post-gloas a block has three fork choice nodes (PENDING/EMPTY/FULL) sharing one blockRoot. Fork choice drops
+    // PENDING from nonAncestors, and only one of EMPTY/FULL is on the ancestor walk, so the other sibling shows up in
+    // nonAncestors. Block-level data (block, light client witness/header) must not be pruned for it, while
+    // payload-level data (sidecars) of the losing variant must still be pruned.
+    const config = createChainForkConfig({
+      ...defaultConfig,
+      FULU_FORK_EPOCH: 0,
+      MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS: 2,
+    });
+    const blockBytes = ssz.fulu.SignedBeaconBlock.serialize(ssz.fulu.SignedBeaconBlock.defaultValue());
+    vi.spyOn(dbStub.block, "getBinary").mockResolvedValue(blockBytes);
+    vi.spyOn(dbStub.dataColumnSidecar, "valuesStreamBinary").mockReturnValue(toAsyncIterable([]));
+    vi.spyOn(dbStub.dataColumnSidecarArchive, "keys").mockResolvedValue([]);
+    const pruneSpy = vi.spyOn(lightclientServer, "pruneNonCheckpointData").mockResolvedValue(undefined);
+
+    const root = (i: number): string => toHexString(Buffer.alloc(32, i));
+    // Canonical chain: 
+    // slot 32 (epoch boundary, finalized via EMPTY), 
+    // slot 31 (finalized via FULL),
+    // slot 30 orphaned block
+    const boundaryEmpty = generateProtoBlock({slot: 32, blockRoot: root(1), payloadStatus: PayloadStatus.EMPTY});
+    const boundaryFull = generateProtoBlock({slot: 32, blockRoot: root(1), payloadStatus: PayloadStatus.FULL});
+    const parentFull = generateProtoBlock({slot: 31, blockRoot: root(2), payloadStatus: PayloadStatus.FULL});
+    const parentEmpty = generateProtoBlock({slot: 31, blockRoot: root(2), payloadStatus: PayloadStatus.EMPTY});
+    const orphan = generateProtoBlock({slot: 30, blockRoot: root(3), payloadStatus: PayloadStatus.FULL});
+    const canonicalBlocks = [boundaryEmpty, parentFull];
+    const nonCanonicalBlocks = [boundaryFull, parentEmpty, orphan];
+
+    vi.spyOn(forkChoiceStub, "getAllAncestorAndNonAncestorBlocksDefaultStatus").mockReturnValue({
+      ancestors: canonicalBlocks,
+      nonAncestors: nonCanonicalBlocks,
+    });
+
+    await archiveBlocks(
+      config,
+      dbStub,
+      forkChoiceStub,
+      lightclientServer,
+      logger,
+      {epoch: 1, root: fromHexString(root(1)), rootHex: root(1)},
+      2,
+      null,
+      false
+    );
+
+    // Block-level: delete only the orphan as non-canonical
+    expect(dbStub.block.batchDelete).toBeCalledWith([fromHexString(root(3))]);
+    for (const [roots] of vi.mocked(dbStub.block.batchDelete).mock.calls) {
+      const hexes = roots.map((r) => toHexString(r));
+      if (hexes.includes(root(3))) {
+        expect(hexes).toEqual([root(3)]);
+      }
+    }
+
+    // Payload-level: sibling variants are still pruned (the losing FULL payload of the EMPTY-finalized block)
+    expect(dbStub.dataColumnSidecar.deleteMany).toBeCalledWith(
+      nonCanonicalBlocks.map((block) => fromHexString(block.blockRoot))
+    );
+
+    // Keep light client data of canonical blocks, prune the orphan and the canonical non-checkpoint block
+    expect(pruneSpy).toHaveBeenCalledTimes(1);
+    const pruned = pruneSpy.mock.calls[0][0].map((r) => toHexString(r));
+    expect(pruned).toContain(root(3)); // orphan
+    expect(pruned).toContain(root(2)); // canonical but not an epoch boundary block
+    expect(pruned).not.toContain(root(1)); // canonical epoch boundary block
+  });
+
   it("is a no-op when ancestors and non-ancestors are empty", async () => {
     const config = createChainForkConfig({
       ...defaultConfig,


### PR DESCRIPTION
First raised in #9199, see https://github.com/ChainSafe/lodestar/discussions/9199#discussioncomment-18280128
supersedes #10017

**Motivation**

The main issue is that archiveBlocks and indiscriminately pruned canonical block-level data, and permanently deleted the light client data.

Post-gloas a block occupies several ProtoArray nodes (PENDING/EMPTY/FULL) sharing one blockRoot and only one of them is on the ancestor walk, so getAllAncestorAndNonAncestorBlocks reports the sibling variants of every canonical block as non-ancestors. archiveBlocks keyed all deletions by blockRoot, which is fine for payload-level data (envelopes, data columns: canonical ones were migrated to the cold DB first) but permanently deleted the light client witness and header of canonical epoch boundary blocks, which are never migrated. Bootstrap for any finalized root older than the current checkpoint then failed with RESOURCE_UNAVAILABLE.

**Description**

We keep a distinct root set for block-level data that excludes sibling
variants of canonical blocks, and keep pruning payload-level data for all
non-ancestor variants so a losing FULL sibling is still cleaned up.

**AI Assistance Disclosure**

created with the assistance of fable