### PR TITLE
fix: prune rejected payload envelopes from the seen cache in range sync

### DIFF
--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -11,7 +11,7 @@ import {ForkchoiceCaller} from "../forkChoice/index.js";
 import {BlockProcessOpts} from "../options.js";
 import {IBlockInput} from "./blockInput/types.js";
 import {importBlock, importsBlockAttestations} from "./importBlock.js";
-import {PayloadError, importExecutionPayload} from "./importExecutionPayload.js";
+import {PayloadError, PayloadErrorCode, importExecutionPayload} from "./importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {FullyVerifiedBlock, ImportBlockOpts, ProcessBlocksResult} from "./types.js";
 import {OrphanedPayloadEnvelope, assertLinearChainSegment} from "./utils/chainSegment.js";
@@ -22,6 +22,13 @@ import {verifyPayloadsDataAvailability} from "./verifyPayloadsDataAvailability.j
 export {AttestationImportOpt, type ImportBlockOpts} from "./types.js";
 
 const QUEUE_MAX_LENGTH = 256;
+
+/** Payload errors caused by the envelope itself rather than by our own state or the execution client being unavailable */
+const REJECTED_PAYLOAD_ERROR_CODES = new Set<PayloadErrorCode>([
+  PayloadErrorCode.INVALID_SIGNATURE,
+  PayloadErrorCode.ENVELOPE_VERIFICATION_ERROR,
+  PayloadErrorCode.EXECUTION_ENGINE_INVALID,
+]);
 
 /**
  * BlockProcessor processes block jobs in a queued fashion, one after the other.
@@ -200,6 +207,11 @@ export async function processBlocks(
           {slot: err.payloadInput.slot, blockRoot: err.payloadInput.blockRootHex},
           err
         );
+      }
+      // The envelope came from an untrusted range peer, drop it from the shared cache so the retried batch
+      // downloads it again instead of re-verifying the same bytes. Gossip does the same on REJECT
+      if (REJECTED_PAYLOAD_ERROR_CODES.has(err.type.code)) {
+        this.seenPayloadEnvelopeInputCache.prune(err.payloadInput.blockRootHex);
       }
     } else if (!opts.disableOnBlockError) {
       this.logger.debug("Block error", {slot: err.signedBlock.message.slot}, err);

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -405,6 +405,32 @@ describe("chain / blocks / processBlocks", () => {
     await expect(processBlocks.call(chain, [blockInput], null, {})).rejects.toBe(payloadError);
   });
 
+  it.each([
+    {code: PayloadErrorCode.INVALID_SIGNATURE, pruned: true},
+    {code: PayloadErrorCode.ENVELOPE_VERIFICATION_ERROR, pruned: true},
+    {code: PayloadErrorCode.EXECUTION_ENGINE_INVALID, pruned: true},
+    {code: PayloadErrorCode.EXECUTION_ENGINE_ERROR, pruned: false},
+    {code: PayloadErrorCode.MISS_BLOCK_STATE, pruned: false},
+  ])("prunes the rejected envelope from the seen cache: $code -> $pruned", async ({code, pruned}) => {
+    const payloadInput = {slot: 1, blockRootHex: "0x1234"} as unknown as PayloadEnvelopeInput;
+    const type = {
+      code,
+      execStatus: ExecutionPayloadStatus.INVALID,
+      errorMessage: "bad payload",
+      message: "bad payload",
+      blockRootHex: "0x1234",
+    } as unknown as PayloadError["type"];
+    vi.mocked(verifyBlocksInEpoch).mockRejectedValue(new PayloadError(payloadInput, type));
+
+    await expect(processBlocks.call(chain, [blockInput], null, {})).rejects.toBeInstanceOf(PayloadError);
+
+    if (pruned) {
+      expect(chain.seenPayloadEnvelopeInputCache.prune).toHaveBeenCalledExactlyOnceWith("0x1234");
+    } else {
+      expect(chain.seenPayloadEnvelopeInputCache.prune).not.toHaveBeenCalled();
+    }
+  });
+
   // Contrast: a plain error (not a Block/Payload error) IS wrapped, which is why the passthrough above
   // has to be selective.
   it("wraps a non-Block/Payload error into BEACON_CHAIN_ERROR", async () => {


### PR DESCRIPTION
when a range sync batch fails on a `PayloadError`, the batch is re-downloaded but `downloadByRange` reuses the existing `PayloadEnvelopeInput` from `seenPayloadEnvelopeInputCache`, envelope included, so the retry from another peer verifies the same bytes again and fails the same way. the gossip handler already prunes the entry on `REJECT`, the range path never did.

prune the entry in the `PayloadError` branch of `processBlocks()` for the codes caused by the envelope itself: `INVALID_SIGNATURE`, `ENVELOPE_VERIFICATION_ERROR` and `EXECUTION_ENGINE_INVALID`. `EXECUTION_ENGINE_ERROR`, `BLOCK_NOT_IN_FORK_CHOICE` and `MISS_BLOCK_STATE` are left alone, those are the EL being unavailable or our own state, not the peer's data.

the same gap exists for blocks (`TODO(fulu): need to remove the bad blocks from the SeenBlockInputCache` in `batch.ts`), not touched here since it needs a mapping from `BlockErrorCode` to peer-caused errors.

fixes #9660
