### PR TITLE
fix: do not abort validator monitor epoch summaries on unknown block roots

### DIFF
--- a/packages/beacon-node/src/chain/validatorMonitor.ts
+++ b/packages/beacon-node/src/chain/validatorMonitor.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {
   IBeaconStateView,
   ParticipationFlags,
@@ -1117,7 +1117,11 @@ function isCanonical(rootCache: RootHexCache, block: AttestationBlockInclusion):
 
 /** Returns true if root at slot is the same at slot - 1 == there was no new block at slot */
 function isMissedSlot(rootCache: RootHexCache, slot: Slot): boolean {
-  return slot > 0 && rootCache.getBlockRootAtSlot(slot) === rootCache.getBlockRootAtSlot(slot - 1);
+  if (slot <= 0) {
+    return false;
+  }
+  const root = rootCache.getBlockRootAtSlot(slot);
+  return root !== null && root === rootCache.getBlockRootAtSlot(slot - 1);
 }
 
 function renderBlockProposalSummary(
@@ -1131,7 +1135,11 @@ function renderBlockProposalSummary(
     return "not_submitted";
   }
 
-  if (rootCache.getBlockRootAtSlot(proposalSlot) === proposal.blockRoot) {
+  const canonicalRoot = rootCache.getBlockRootAtSlot(proposalSlot);
+  if (canonicalRoot === null) {
+    return "unknown";
+  }
+  if (canonicalRoot === proposal.blockRoot) {
     // Canonical state includes our block
     return "canonical";
   }
@@ -1157,14 +1165,23 @@ function renderBlockProposalSummary(
  * In normal network conditions the same root is read multiple times, specially the target.
  */
 export class RootHexCache {
-  private readonly blockRootSlotCache = new Map<Slot, RootHex>();
+  private readonly blockRootSlotCache = new Map<Slot, RootHex | null>();
 
   constructor(private readonly state: IBeaconStateView) {}
 
-  getBlockRootAtSlot(slot: Slot): RootHex {
+  /**
+   * Block root at `slot`, null if the state does not cover it: slots at or after the state's own slot (an inclusion
+   * in a block the head state does not know yet, e.g. an orphaned block, or the slot after the last attestation of
+   * the epoch) or slots older than `SLOTS_PER_HISTORICAL_ROOT`. Callers treat null as unknown instead of throwing
+   * and aborting the summaries of all remaining validators.
+   */
+  getBlockRootAtSlot(slot: Slot): RootHex | null {
     let root = this.blockRootSlotCache.get(slot);
-    if (!root) {
-      root = toRootHex(this.state.getBlockRootAtSlot(slot));
+    if (root === undefined) {
+      root =
+        slot < this.state.slot && slot >= this.state.slot - SLOTS_PER_HISTORICAL_ROOT
+          ? toRootHex(this.state.getBlockRootAtSlot(slot))
+          : null;
       this.blockRootSlotCache.set(slot, root);
     }
     return root;

--- a/packages/beacon-node/test/unit/chain/validatorMonitor.test.ts
+++ b/packages/beacon-node/test/unit/chain/validatorMonitor.test.ts
@@ -2,10 +2,10 @@ import {describe, expect, it, vi} from "vitest";
 import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {testLogger} from "@lodestar/logger/test-utils";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {BeaconStateView, createCachedBeaconState} from "@lodestar/state-transition";
-import {ssz} from "@lodestar/types";
-import {createValidatorMonitor} from "../../../src/chain/validatorMonitor.js";
+import {Slot, ssz} from "@lodestar/types";
+import {RootHexCache, createValidatorMonitor} from "../../../src/chain/validatorMonitor.js";
 
 describe("ValidatorMonitor", () => {
   // Use phase0 config (no altair) to avoid needing full state with block roots
@@ -57,6 +57,38 @@ describe("ValidatorMonitor", () => {
       const indices = monitor.getMonitoredValidatorIndices();
       expect(indices).toHaveLength(1);
       expect(indices).toContain(1);
+    });
+  });
+
+  describe("RootHexCache", () => {
+    const stateSlot = SLOTS_PER_HISTORICAL_ROOT + 64;
+    function createRootCache() {
+      const getBlockRootAtSlot = vi.fn((slot: Slot) => Uint8Array.from({length: 32}, () => slot % 256));
+      const state = {slot: stateSlot, getBlockRootAtSlot} as unknown as BeaconStateView;
+      return {rootCache: new RootHexCache(state), getBlockRootAtSlot};
+    }
+
+    it("returns the root for slots covered by the state and caches it", () => {
+      const {rootCache, getBlockRootAtSlot} = createRootCache();
+      const root = rootCache.getBlockRootAtSlot(stateSlot - 1);
+      expect(root).toMatch(/^0x[0-9a-f]{64}$/);
+      expect(rootCache.getBlockRootAtSlot(stateSlot - 1)).toBe(root);
+      expect(getBlockRootAtSlot).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns null for the state's own slot and later instead of throwing", () => {
+      const {rootCache, getBlockRootAtSlot} = createRootCache();
+      // attestation included in a block the head state does not know yet, or the slot after the last attestation
+      expect(rootCache.getBlockRootAtSlot(stateSlot)).toBeNull();
+      expect(rootCache.getBlockRootAtSlot(stateSlot + 1)).toBeNull();
+      expect(getBlockRootAtSlot).not.toHaveBeenCalled();
+    });
+
+    it("returns null for slots older than SLOTS_PER_HISTORICAL_ROOT", () => {
+      const {rootCache, getBlockRootAtSlot} = createRootCache();
+      expect(rootCache.getBlockRootAtSlot(stateSlot - SLOTS_PER_HISTORICAL_ROOT)).not.toBeNull();
+      expect(rootCache.getBlockRootAtSlot(stateSlot - SLOTS_PER_HISTORICAL_ROOT - 1)).toBeNull();
+      expect(getBlockRootAtSlot).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
synced glamsterdam-devnet-9 nodes log once per epoch

```
error: Error on validator monitor onceEveryEndOfEpoch slot=N
Error: Can only get block root in the past currentSlot=N slot=N
```

`onceEveryEndOfEpoch()` renders the previous epoch summaries against the head state through `RootHexCache`, which calls `state.getBlockRootAtSlot()` and throws for any slot the state does not cover: an attestation included in a block the head state does not know yet (e.g. an orphaned block, or a state that lags the inclusion), the `next_slot_missed` check for the last attestation slot, or a proposal slot older than `SLOTS_PER_HISTORICAL_ROOT`. one such lookup aborts the whole run, so the summaries and `prevEpochAttestationSummary`/`prevEpochBlockProposalSummary` metrics of all remaining validators are lost for that epoch.

make `RootHexCache.getBlockRootAtSlot()` return `null` for slots the state does not cover and treat it as unknown: not canonical for inclusions, not missed for the skipped slot checks, `unknown` for the block proposal summary.
