### PR TITLE
fix: prune rejected blocks from the seen cache in range sync

### DIFF
--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -207,8 +207,7 @@ export async function processBlocks(
       if (isPeerAttributableFailure(err.type.code)) {
         this.seenPayloadEnvelopeInputCache.prune(err.payloadInput.blockRootHex);
       }
-    } else if (!opts.disableOnBlockError) {
-      this.logger.debug("Block error", {slot: err.signedBlock.message.slot}, err);
+    } else {
       if (isPeerAttributableFailure(err.type.code)) {
         // Same for the block, its signature or data may be bad while the root matches the canonical block
         const blockRootHex =
@@ -219,26 +218,29 @@ export async function processBlocks(
         this.seenBlockInputCache.prune(blockRootHex);
       }
 
-      if (err.type.code === BlockErrorCode.INVALID_SIGNATURE) {
-        const {signedBlock} = err;
-        const blockSlot = signedBlock.message.slot;
-        const {state} = err.type;
-        const forkTypes = this.config.getForkTypes(blockSlot);
-        this.persistInvalidSszValue(forkTypes.SignedBeaconBlock, signedBlock, `${blockSlot}_invalid_signature`);
-        this.persistInvalidSszBytes("BeaconState", state.serialize(), `${state.slot}_invalid_signature`);
-      } else if (err.type.code === BlockErrorCode.INVALID_STATE_ROOT) {
-        const {signedBlock} = err;
-        const blockSlot = signedBlock.message.slot;
-        const {preState, postState} = err.type;
-        const preRoot = preState.hashTreeRoot();
-        const postRoot = postState.hashTreeRoot();
-        this.persistInvalidStateRoot(preState, postState, signedBlock).catch((e) => {
-          this.logger.error(
-            "Error persisting invalid state root objects",
-            {slot: blockSlot, preStateRoot: toRootHex(preRoot), postStateRoot: toRootHex(postRoot)},
-            e
-          );
-        });
+      if (!opts.disableOnBlockError) {
+        this.logger.debug("Block error", {slot: err.signedBlock.message.slot}, err);
+        if (err.type.code === BlockErrorCode.INVALID_SIGNATURE) {
+          const {signedBlock} = err;
+          const blockSlot = signedBlock.message.slot;
+          const {state} = err.type;
+          const forkTypes = this.config.getForkTypes(blockSlot);
+          this.persistInvalidSszValue(forkTypes.SignedBeaconBlock, signedBlock, `${blockSlot}_invalid_signature`);
+          this.persistInvalidSszBytes("BeaconState", state.serialize(), `${state.slot}_invalid_signature`);
+        } else if (err.type.code === BlockErrorCode.INVALID_STATE_ROOT) {
+          const {signedBlock} = err;
+          const blockSlot = signedBlock.message.slot;
+          const {preState, postState} = err.type;
+          const preRoot = preState.hashTreeRoot();
+          const postRoot = postState.hashTreeRoot();
+          this.persistInvalidStateRoot(preState, postState, signedBlock).catch((e) => {
+            this.logger.error(
+              "Error persisting invalid state root objects",
+              {slot: blockSlot, preStateRoot: toRootHex(preRoot), postStateRoot: toRootHex(postRoot)},
+              e
+            );
+          });
+        }
       }
     }
 

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -11,10 +11,11 @@ import {ForkchoiceCaller} from "../forkChoice/index.js";
 import {BlockProcessOpts} from "../options.js";
 import {IBlockInput} from "./blockInput/types.js";
 import {importBlock, importsBlockAttestations} from "./importBlock.js";
-import {PayloadError, PayloadErrorCode, importExecutionPayload} from "./importExecutionPayload.js";
+import {PayloadError, importExecutionPayload} from "./importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {FullyVerifiedBlock, ImportBlockOpts, ProcessBlocksResult} from "./types.js";
 import {OrphanedPayloadEnvelope, assertLinearChainSegment} from "./utils/chainSegment.js";
+import {isPeerAttributableFailure} from "./utils/peerAttributableError.js";
 import {verifyBlocksInEpoch} from "./verifyBlock.js";
 import {verifyBlocksSanityChecks} from "./verifyBlocksSanityChecks.js";
 import {verifyPayloadsDataAvailability} from "./verifyPayloadsDataAvailability.js";
@@ -22,13 +23,6 @@ import {verifyPayloadsDataAvailability} from "./verifyPayloadsDataAvailability.j
 export {AttestationImportOpt, type ImportBlockOpts} from "./types.js";
 
 const QUEUE_MAX_LENGTH = 256;
-
-/** Payload errors caused by the envelope itself rather than by our own state or the execution client being unavailable */
-const REJECTED_PAYLOAD_ERROR_CODES = new Set<PayloadErrorCode>([
-  PayloadErrorCode.INVALID_SIGNATURE,
-  PayloadErrorCode.ENVELOPE_VERIFICATION_ERROR,
-  PayloadErrorCode.EXECUTION_ENGINE_INVALID,
-]);
 
 /**
  * BlockProcessor processes block jobs in a queued fashion, one after the other.
@@ -210,11 +204,20 @@ export async function processBlocks(
       }
       // The envelope came from an untrusted range peer, drop it from the shared cache so the retried batch
       // downloads it again instead of re-verifying the same bytes. Gossip does the same on REJECT
-      if (REJECTED_PAYLOAD_ERROR_CODES.has(err.type.code)) {
+      if (isPeerAttributableFailure(err.type.code)) {
         this.seenPayloadEnvelopeInputCache.prune(err.payloadInput.blockRootHex);
       }
     } else if (!opts.disableOnBlockError) {
       this.logger.debug("Block error", {slot: err.signedBlock.message.slot}, err);
+      if (isPeerAttributableFailure(err.type.code)) {
+        // Same for the block, its signature or data may be bad while the root matches the canonical block
+        const blockRootHex =
+          blocks.find((blockInput) => blockInput.getBlock() === err.signedBlock)?.blockRootHex ??
+          toRootHex(
+            this.config.getForkTypes(err.signedBlock.message.slot).BeaconBlock.hashTreeRoot(err.signedBlock.message)
+          );
+        this.seenBlockInputCache.prune(blockRootHex);
+      }
 
       if (err.type.code === BlockErrorCode.INVALID_SIGNATURE) {
         const {signedBlock} = err;

--- a/packages/beacon-node/src/chain/blocks/utils/peerAttributableError.ts
+++ b/packages/beacon-node/src/chain/blocks/utils/peerAttributableError.ts
@@ -1,0 +1,33 @@
+import {BlockErrorCode} from "../../errors/index.js";
+import {PayloadErrorCode} from "../importExecutionPayload.js";
+
+/**
+ * Whether a block or payload error is caused by the data a peer served rather than by our own state or the
+ * execution client being unavailable. Range sync attributes these failures to the peer and drops the inputs from the
+ * seen caches so a retry downloads them again.
+ */
+export function isPeerAttributableFailure(code: BlockErrorCode | PayloadErrorCode | null): boolean {
+  switch (code) {
+    // EL returned a definitive INVALID verdict on the payload
+    case BlockErrorCode.EXECUTION_ENGINE_INVALID:
+    case PayloadErrorCode.EXECUTION_ENGINE_INVALID:
+    // a block or envelope signature is invalid
+    case BlockErrorCode.INVALID_SIGNATURE:
+    case PayloadErrorCode.INVALID_SIGNATURE:
+    // the block's state transition produced an invalid state root, or failed per_slot/per_block processing
+    case BlockErrorCode.INVALID_STATE_ROOT:
+    case BlockErrorCode.PER_BLOCK_PROCESSING_ERROR:
+    // the segment this peer served is internally inconsistent (in-segment link breaks, see PR #9684)
+    case BlockErrorCode.NON_LINEAR_SLOTS:
+    case BlockErrorCode.NON_LINEAR_PARENT_ROOTS:
+    case BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS:
+    // the envelope references a mismatched block root, or fails field verification
+    case BlockErrorCode.ENVELOPE_BLOCK_ROOT_MISMATCH:
+    case PayloadErrorCode.ENVELOPE_VERIFICATION_ERROR:
+    // the peer served a block we have explicitly blacklisted
+    case BlockErrorCode.BLACKLISTED_BLOCK:
+      return true;
+    default:
+      return false;
+  }
+}

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -7,6 +7,7 @@ import {IBlockInput} from "../../chain/blocks/blockInput/types.js";
 import {isDaOutOfRange} from "../../chain/blocks/blockInput/utils.js";
 import {PayloadError, PayloadErrorCode} from "../../chain/blocks/importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "../../chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
+import {isPeerAttributableFailure} from "../../chain/blocks/utils/peerAttributableError.js";
 import {BlockError, BlockErrorCode} from "../../chain/errors/index.js";
 import {ZERO_HASH} from "../../constants/constants.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
@@ -834,28 +835,3 @@ function isExecutionEngineFailure(code: BlockErrorCode | PayloadErrorCode | null
 /**
  * Based on an error code, return if peer is attributable for FailedAttempt.
  */
-function isPeerAttributableFailure(code: BlockErrorCode | PayloadErrorCode | null): boolean {
-  switch (code) {
-    // EL returned a definitive INVALID verdict on the payload
-    case BlockErrorCode.EXECUTION_ENGINE_INVALID:
-    case PayloadErrorCode.EXECUTION_ENGINE_INVALID:
-    // a block or envelope signature is invalid
-    case BlockErrorCode.INVALID_SIGNATURE:
-    case PayloadErrorCode.INVALID_SIGNATURE:
-    // the block's state transition produced an invalid state root, or failed per_slot/per_block processing
-    case BlockErrorCode.INVALID_STATE_ROOT:
-    case BlockErrorCode.PER_BLOCK_PROCESSING_ERROR:
-    // the segment this peer served is internally inconsistent (in-segment link breaks, see PR #9684)
-    case BlockErrorCode.NON_LINEAR_SLOTS:
-    case BlockErrorCode.NON_LINEAR_PARENT_ROOTS:
-    case BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS:
-    // the envelope references a mismatched block root, or fails field verification
-    case BlockErrorCode.ENVELOPE_BLOCK_ROOT_MISMATCH:
-    case PayloadErrorCode.ENVELOPE_VERIFICATION_ERROR:
-    // the peer served a block we have explicitly blacklisted
-    case BlockErrorCode.BLACKLISTED_BLOCK:
-      return true;
-    default:
-      return false;
-  }
-}

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -431,6 +431,28 @@ describe("chain / blocks / processBlocks", () => {
     }
   });
 
+  it.each([
+    // INVALID_SIGNATURE is persisted for debugging on the error path, needs a serializable state
+    {code: BlockErrorCode.INVALID_SIGNATURE, pruned: true, state: {slot: 1, serialize: () => new Uint8Array()}},
+    {code: BlockErrorCode.NON_LINEAR_PARENT_ROOTS, pruned: true},
+    {code: BlockErrorCode.BLACKLISTED_BLOCK, pruned: true},
+    {code: BlockErrorCode.PARENT_BLOCK_UNKNOWN, pruned: false},
+    {code: BlockErrorCode.WOULD_REVERT_FINALIZED_SLOT, pruned: false},
+  ])("prunes the rejected block from the seen cache: $code -> $pruned", async ({code, pruned, state}) => {
+    const blockError = new BlockError(blockInput.getBlock(), {code, state} as unknown as BlockError["type"]);
+    vi.mocked(verifyBlocksInEpoch).mockRejectedValue(blockError);
+    // debug artefacts written on the error path, not part of the mocked chain
+    Object.assign(chain, {persistInvalidSszValue: vi.fn(), persistInvalidSszBytes: vi.fn()});
+
+    await expect(processBlocks.call(chain, [blockInput], null, {})).rejects.toBe(blockError);
+
+    if (pruned) {
+      expect(chain.seenBlockInputCache.prune).toHaveBeenCalledExactlyOnceWith(blockInput.blockRootHex);
+    } else {
+      expect(chain.seenBlockInputCache.prune).not.toHaveBeenCalled();
+    }
+  });
+
   // Contrast: a plain error (not a Block/Payload error) IS wrapped, which is why the passthrough above
   // has to be selective.
   it("wraps a non-Block/Payload error into BEACON_CHAIN_ERROR", async () => {

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -453,6 +453,16 @@ describe("chain / blocks / processBlocks", () => {
     }
   });
 
+  it("prunes the rejected block from the seen cache with disableOnBlockError", async () => {
+    const blockError = new BlockError(blockInput.getBlock(), {code: BlockErrorCode.NON_LINEAR_PARENT_ROOTS});
+    vi.mocked(verifyBlocksInEpoch).mockRejectedValue(blockError);
+
+    await expect(processBlocks.call(chain, [blockInput], null, {disableOnBlockError: true})).rejects.toBe(blockError);
+
+    expect(chain.seenBlockInputCache.prune).toHaveBeenCalledExactlyOnceWith(blockInput.blockRootHex);
+    expect(chain.logger.debug).not.toHaveBeenCalledWith("Block error", expect.anything(), expect.anything());
+  });
+
   // Contrast: a plain error (not a Block/Payload error) IS wrapped, which is why the passthrough above
   // has to be selective.
   it("wraps a non-Block/Payload error into BEACON_CHAIN_ERROR", async () => {


### PR DESCRIPTION
same as #10025 for blocks: when a range sync batch fails on a `BlockError` caused by the data the peer served, the retried batch reuses the `BlockInput` from `seenBlockInputCache` (`downloadByRange` keeps the existing entry, `throwOnDuplicateAdd: false`) and fails the same way. the two `TODO(fulu): need to remove the bad blocks from the SeenBlockInputCache` in `batch.ts`.

prune the failing block in the `BlockError` branch of `processBlocks()` for peer-attributable errors, using range sync's `isPeerAttributableFailure()` moved to `chain/blocks/utils` so `processBlocks()` and `batch.ts` share one list (also used for the envelope prune of #10025).

the block content is committed by its root, so what a re-download can actually fix is limited: the block signature on any fork, and the blobs or columns attached to the input pre-gloas. post-gloas the columns live on the payload envelope input, covered by #10025.

stacked on #10025
