### PR TITLE
feat: surface range sync batches that fail after max attempts

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -615,6 +615,11 @@ export function createLodestarMetrics(
         help: "Count of finalized sync peers by group index",
         labelNames: ["columnIndex"],
       }),
+      batchProcessError: register.gauge<{code: string}>({
+        name: "lodestar_sync_range_batch_process_error_total",
+        help: "Total number of range sync batch processing errors by block or payload error code",
+        labelNames: ["code"],
+      }),
       downloadByRange: {
         success: register.gauge({
           name: "lodestar_sync_range_download_by_range_success_total",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -615,7 +615,7 @@ export function createLodestarMetrics(
         help: "Count of finalized sync peers by group index",
         labelNames: ["columnIndex"],
       }),
-      batchProcessError: register.gauge<{code: string}>({
+      batchProcessError: register.counter<{code: string}>({
         name: "lodestar_sync_range_batch_process_error_total",
         help: "Total number of range sync batch processing errors by block or payload error code",
         labelNames: ["code"],

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -748,10 +748,13 @@ export class Batch {
 
   private routeProcessingFailure(err: Error, attempt: Attempt): void {
     const code = err instanceof BlockError || err instanceof PayloadError ? err.type.code : null;
-    // LodestarError messages are just the code, the EL verdict lives in the type
+    // LodestarError messages are just the code, the detail lives in the type: the EL verdict in `errorMessage`, the
+    // wrapped error of internal and state transition failures in `error`, envelope verification failures in `message`
     const detail =
       err instanceof BlockError || err instanceof PayloadError
-        ? (err.type as {errorMessage?: string}).errorMessage
+        ? ((err.type as {errorMessage?: string; error?: Error; message?: string}).errorMessage ??
+          (err.type as {error?: Error}).error?.message ??
+          (err.type as {message?: string}).message)
         : undefined;
     const failedAttempt: FailedAttempt = {
       ...attempt,

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -55,6 +55,9 @@ export type FailedAttempt = Attempt & {
    * True when the failure is evidence the peers served bad data, so they may be downscored..
    */
   peerAttributable: boolean;
+  /** Block or payload error code of the failure, null for unexpected errors */
+  code: BlockErrorCode | PayloadErrorCode | null;
+  message: string;
 };
 
 type TrackedRequest = {
@@ -745,7 +748,17 @@ export class Batch {
 
   private routeProcessingFailure(err: Error, attempt: Attempt): void {
     const code = err instanceof BlockError || err instanceof PayloadError ? err.type.code : null;
-    const failedAttempt: FailedAttempt = {...attempt, peerAttributable: isPeerAttributableFailure(code)};
+    // LodestarError messages are just the code, the EL verdict lives in the type
+    const detail =
+      err instanceof BlockError || err instanceof PayloadError
+        ? (err.type as {errorMessage?: string}).errorMessage
+        : undefined;
+    const failedAttempt: FailedAttempt = {
+      ...attempt,
+      peerAttributable: isPeerAttributableFailure(code),
+      code,
+      message: detail ? `${err.message}: ${detail}` : err.message,
+    };
 
     if (isExecutionEngineFailure(code)) {
       this.onExecutionEngineError(failedAttempt);
@@ -767,7 +780,9 @@ export class Batch {
   private onExecutionEngineError(attempt: FailedAttempt): void {
     this.executionErrorAttempts.push(attempt);
     if (this.executionErrorAttempts.length > MAX_BATCH_PROCESSING_ATTEMPTS) {
-      throw new BatchError(this.errorType({code: BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS}));
+      throw new BatchError(
+        this.errorType({code: BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS, lastAttempt: attempt})
+      );
     }
 
     // remove any downloaded blocks and re-attempt
@@ -778,7 +793,7 @@ export class Batch {
   private onProcessingError(attempt: FailedAttempt): void {
     this.failedProcessingAttempts.push(attempt);
     if (this.failedProcessingAttempts.length > MAX_BATCH_PROCESSING_ATTEMPTS) {
-      throw new BatchError(this.errorType({code: BatchErrorCode.MAX_PROCESSING_ATTEMPTS}));
+      throw new BatchError(this.errorType({code: BatchErrorCode.MAX_PROCESSING_ATTEMPTS, lastAttempt: attempt}));
     }
 
     // remove any downloaded blocks and re-attempt
@@ -808,8 +823,8 @@ type BatchErrorType =
   | {code: BatchErrorCode.WRONG_STATUS; expectedStatus: BatchStatus}
   | {code: BatchErrorCode.INVALID_COUNT; count: number; expected: number}
   | {code: BatchErrorCode.MAX_DOWNLOAD_ATTEMPTS}
-  | {code: BatchErrorCode.MAX_PROCESSING_ATTEMPTS}
-  | {code: BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS};
+  | {code: BatchErrorCode.MAX_PROCESSING_ATTEMPTS; lastAttempt: FailedAttempt}
+  | {code: BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS; lastAttempt: FailedAttempt};
 
 type BatchErrorMetadata = {
   startEpoch: number;

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -1,12 +1,15 @@
 import {ChainForkConfig} from "@lodestar/config";
+import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, Root, Slot, gloas} from "@lodestar/types";
 import {ErrorAborted, LodestarError, Logger, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {BlockInputErrorCode} from "../../chain/blocks/blockInput/errors.js";
 import {IBlockInput} from "../../chain/blocks/blockInput/types.js";
+import {PayloadError, PayloadErrorCode} from "../../chain/blocks/importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "../../chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {BlobSidecarErrorCode} from "../../chain/errors/blobSidecarError.js";
 import {DataColumnSidecarErrorCode} from "../../chain/errors/dataColumnSidecarError.js";
+import {BlockError, BlockErrorCode} from "../../chain/errors/index.js";
 import {Metrics} from "../../metrics/metrics.js";
 import {PeerAction, prettyPrintPeerIdStr} from "../../network/index.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
@@ -15,7 +18,12 @@ import {CustodyConfig} from "../../util/dataColumns.js";
 import {ItTrigger} from "../../util/itTrigger.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {WarnResult, wrapError} from "../../util/wrapError.js";
-import {BATCH_BUFFER_SIZE, EPOCHS_PER_BATCH, MAX_LOOK_AHEAD_EPOCHS} from "../constants.js";
+import {
+  BATCH_BUFFER_SIZE,
+  EPOCHS_PER_BATCH,
+  MAX_BATCH_PROCESSING_ATTEMPTS,
+  MAX_LOOK_AHEAD_EPOCHS,
+} from "../constants.js";
 import {DownloadByRangeError, DownloadByRangeErrorCode} from "../utils/downloadByRange.js";
 import {getRateLimitedUntilMs} from "../utils/rateLimit.js";
 import {RangeSyncType} from "../utils/remoteSyncType.js";
@@ -354,6 +362,26 @@ export class SyncChain {
 
       this.status = SyncChainStatus.Error;
       this.logger.verbose("SyncChain Error", {id: this.logId}, e as Error);
+      if (
+        e instanceof BatchError &&
+        (e.type.code === BatchErrorCode.MAX_PROCESSING_ATTEMPTS ||
+          e.type.code === BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS)
+      ) {
+        // The batch will be downloaded and processed again by the next sync chain. Surface it, until now a node
+        // stuck here (e.g. the execution client rejecting a canonical payload) only logged at debug and verbose
+        const {lastAttempt} = e.type;
+        this.logger.warn("Batch processing failed after max attempts, sync is not progressing", {
+          id: this.logId,
+          startSlot: computeStartSlotAtEpoch(e.type.startEpoch),
+          attempts: MAX_BATCH_PROCESSING_ATTEMPTS + 1,
+          code: lastAttempt.code ?? "UNKNOWN",
+          error: lastAttempt.message,
+          ...(lastAttempt.code === BlockErrorCode.EXECUTION_ENGINE_INVALID ||
+          lastAttempt.code === PayloadErrorCode.EXECUTION_ENGINE_INVALID
+            ? {hint: "the execution client rejects the payload, check it"}
+            : {}),
+        });
+      }
 
       // If a batch exceeds it's retry limit, maybe downscore peers.
       // shouldDownscoreOnBatchError() functions enforces that all BatchErrorCode values are covered
@@ -718,6 +746,9 @@ export class SyncChain {
       this.triggerBatchProcessor();
     } else {
       this.logger.verbose("Batch process error", logCtx, res.err);
+      this.metrics?.syncRange.batchProcessError.inc({
+        code: res.err instanceof BlockError || res.err instanceof PayloadError ? res.err.type.code : "UNKNOWN",
+      });
 
       const invalidatePreviousBatches = (): number => {
         let invalidatedCount = 0;

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -668,6 +668,38 @@ describe("sync / range / batch", async () => {
       blockError({code: BlockErrorCode.EXECUTION_ENGINE_ERROR, execStatus, errorMessage: "el is down"});
 
     describe("processingError", () => {
+      it.each([
+        {
+          name: "wrapped error",
+          err: blockError({code: BlockErrorCode.BEACON_CHAIN_ERROR, error: new Error("regen boom")}),
+          message: "BLOCK_ERROR_BEACON_CHAIN_ERROR: regen boom",
+        },
+        {
+          name: "execution client verdict",
+          err: blockError({
+            code: BlockErrorCode.EXECUTION_ENGINE_INVALID,
+            execStatus: ExecutionPayloadStatus.INVALID,
+            errorMessage: "bal is empty",
+          }),
+          message: "BLOCK_ERROR_EXECUTION_ENGINE_INVALID: bal is empty",
+        },
+        {
+          name: "envelope verification",
+          err: new PayloadError({slot: 1, blockRootHex: "0x1234"} as unknown as PayloadEnvelopeInput, {
+            code: PayloadErrorCode.ENVELOPE_VERIFICATION_ERROR,
+            message: "wrong parent",
+          }),
+          message: "PAYLOAD_ERROR_ENVELOPE_VERIFICATION_ERROR: wrong parent",
+        },
+      ])("records the error detail of the failed attempt: $name", ({err, message}) => {
+        const batch = downloadedBatch();
+        batch.startProcessing();
+        batch.processingError(err);
+
+        const [attempt] = [...batch.failedProcessingAttempts, ...batch.executionErrorAttempts];
+        expect(attempt.message).toBe(message);
+      });
+
       const executionEngineErrorStatuses: ExecutionEngineErrorStatus[] = [
         ExecutionPayloadStatus.ELERROR,
         ExecutionPayloadStatus.UNAVAILABLE,

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -840,14 +840,27 @@ describe("sync / range / batch", async () => {
         }
         expect(batch.executionErrorAttempts.length).toBe(3);
 
-        // the 4th EL failure exceeds MAX_BATCH_PROCESSING_ATTEMPTS
+        // the 4th EL failure exceeds MAX_BATCH_PROCESSING_ATTEMPTS, the error carries the last attempt for the log
         batch.startProcessing();
-        expectThrowsLodestarError(
-          () => batch.processingError(executionErrorBlockError(ExecutionPayloadStatus.ELERROR)),
-          new BatchError({
+        const err = (() => {
+          try {
+            batch.processingError(executionErrorBlockError(ExecutionPayloadStatus.ELERROR));
+          } catch (e) {
+            return e;
+          }
+          return null;
+        })();
+        expect(err).toBeInstanceOf(BatchError);
+        expect((err as BatchError).type).toEqual(
+          expect.objectContaining({
             code: BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS,
             startEpoch,
             status: BatchStatus.Processing,
+            lastAttempt: expect.objectContaining({
+              code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
+              peerAttributable: false,
+              message: expect.any(String),
+            }),
           })
         );
       });

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -681,7 +681,7 @@ describe("sync / range / batch", async () => {
             execStatus: ExecutionPayloadStatus.INVALID,
             errorMessage: "bal is empty",
           }),
-          message: "BLOCK_ERROR_EXECUTION_ENGINE_INVALID: bal is empty",
+          message: "BLOCK_ERROR_EXECUTION_INVALID: bal is empty",
         },
         {
           name: "envelope verification",

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, describe, expect, it, vi} from "vitest";
 import {createChainForkConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
+import {LogLevel} from "@lodestar/logger";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
@@ -594,10 +595,21 @@ describe("sync / range / chain", () => {
         });
       };
 
+      const warnSpy = vi.spyOn(logger, LogLevel.warn);
       const {reportPeerSpy, err} = await runToTeardown(RangeSyncType.Finalized, processChainSegment);
 
       expect((err as BatchError).type.code).toBe(BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS);
       expect(reportPeerSpy).toHaveBeenCalled();
+      // a node stuck on an EL rejecting a canonical payload is surfaced above debug/verbose
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Batch processing failed after max attempts, sync is not progressing",
+        expect.objectContaining({
+          code: BlockErrorCode.EXECUTION_ENGINE_INVALID,
+          error: expect.stringContaining("bal is empty"),
+          hint: expect.any(String),
+        })
+      );
+      warnSpy.mockRestore();
 
       const reportedPeers = reportPeerSpy.mock.calls.map(([peerId]) => peerId);
       // only the peers that actually served an INVALID attempt, each reported once


### PR DESCRIPTION
a node whose execution client rejects a canonical payload stops syncing without saying so above debug: `Block error ... BLOCK_ERROR_EXECUTION_ENGINE_INVALID` at debug, `Batch process error` and `SyncChain Error` at verbose, then range sync starts a new chain and repeats. lodestar-besu-2 on glamsterdam-devnet-9 sat like that for 30 minutes (besu had put a canonical block in its bad block cache) with nothing in the info logs but a frozen head, and no metric to alert on. part of what #7560 asks for, scoped to sync instead of changing the block error level globally.

- `lodestar_sync_range_batch_process_error_total{code}` counts every failed batch processing attempt by block or payload error code, the processing-side counterpart of `lodestar_sync_range_download_by_range_error_total`
- `FailedAttempt` records the error code and message, `MAX_PROCESSING_ATTEMPTS` / `MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS` batch errors carry the last attempt
- when a sync chain tears down on one of those, log a warn with the batch start slot, attempts, code and message, plus a hint to check the execution client when the code is `EXECUTION_ENGINE_INVALID`. once per teardown, so bounded while stuck
