### PR TITLE
chore: log block and payload import errors by severity

### DIFF
--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -11,7 +11,7 @@ import {ForkchoiceCaller} from "../forkChoice/index.js";
 import {BlockProcessOpts} from "../options.js";
 import {IBlockInput} from "./blockInput/types.js";
 import {importBlock, importsBlockAttestations} from "./importBlock.js";
-import {PayloadError, PayloadErrorCode, importExecutionPayload} from "./importExecutionPayload.js";
+import {PayloadError, importExecutionPayload} from "./importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {FullyVerifiedBlock, ImportBlockOpts, ProcessBlocksResult} from "./types.js";
 import {getBlockErrorLogLevel} from "./utils/blockErrorLogLevel.js";
@@ -199,7 +199,7 @@ export async function processBlocks(
       this.logger.debug("Neither BlockError nor PayloadError received", {}, err);
     } else if (err instanceof PayloadError) {
       if (!opts.disableOnBlockError) {
-        logBlockOrPayloadError.call(this, "Payload error", err.type.code, err.payloadInput, err);
+        logBlockOrPayloadError.call(this, "Payload error", err, err.payloadInput);
       }
       // The envelope came from an untrusted range peer, drop it from the shared cache so the retried batch
       // downloads it again instead of re-verifying the same bytes. Gossip does the same on REJECT
@@ -218,13 +218,7 @@ export async function processBlocks(
       }
 
       if (!opts.disableOnBlockError) {
-        logBlockOrPayloadError.call(
-          this,
-          "Block error",
-          err.type.code,
-          {slot: err.signedBlock.message.slot, blockRootHex},
-          err
-        );
+        logBlockOrPayloadError.call(this, "Block error", err, {slot: err.signedBlock.message.slot, blockRootHex});
         if (err.type.code === BlockErrorCode.INVALID_SIGNATURE) {
           const {signedBlock} = err;
           const blockSlot = signedBlock.message.slot;
@@ -261,13 +255,16 @@ export async function processBlocks(
 function logBlockOrPayloadError(
   this: BeaconChain,
   message: string,
-  code: BlockErrorCode | PayloadErrorCode,
-  {slot, blockRootHex}: {slot: Slot; blockRootHex: RootHex},
-  err: Error
+  err: BlockError | PayloadError,
+  {slot, blockRootHex}: {slot: Slot; blockRootHex: RootHex}
 ): void {
-  const key = `${code}:${blockRootHex}`;
+  const {code} = err.type;
   let level = getBlockErrorLogLevel(code);
   if (level !== LogLevel.debug) {
+    // BEACON_CHAIN_ERROR, PRESTATE_MISSING and PER_BLOCK_PROCESSING_ERROR wrap the actual error, a different one for
+    // the same block is not a repeat
+    const wrapped = (err.type as {error?: Error}).error?.message ?? "";
+    const key = `${code}:${blockRootHex}:${wrapped}`;
     if (this.reportedBlockErrors.has(key)) {
       level = LogLevel.debug;
     } else {

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -1,7 +1,7 @@
 import {PayloadStatus} from "@lodestar/fork-choice";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
-import {SignedBeaconBlock, Slot} from "@lodestar/types";
-import {isErrorAborted, toRootHex} from "@lodestar/utils";
+import {RootHex, SignedBeaconBlock, Slot} from "@lodestar/types";
+import {LogLevel, isErrorAborted, pruneSetToMax, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {nextEventLoop} from "../../util/eventLoop.js";
 import {JobItemQueue, isQueueErrorAborted} from "../../util/queue/index.js";
@@ -11,9 +11,10 @@ import {ForkchoiceCaller} from "../forkChoice/index.js";
 import {BlockProcessOpts} from "../options.js";
 import {IBlockInput} from "./blockInput/types.js";
 import {importBlock, importsBlockAttestations} from "./importBlock.js";
-import {PayloadError, importExecutionPayload} from "./importExecutionPayload.js";
+import {PayloadError, PayloadErrorCode, importExecutionPayload} from "./importExecutionPayload.js";
 import {PayloadEnvelopeInput} from "./payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {FullyVerifiedBlock, ImportBlockOpts, ProcessBlocksResult} from "./types.js";
+import {getBlockErrorLogLevel} from "./utils/blockErrorLogLevel.js";
 import {OrphanedPayloadEnvelope, assertLinearChainSegment} from "./utils/chainSegment.js";
 import {isPeerAttributableFailure} from "./utils/peerAttributableError.js";
 import {verifyBlocksInEpoch} from "./verifyBlock.js";
@@ -23,6 +24,8 @@ import {verifyPayloadsDataAvailability} from "./verifyPayloadsDataAvailability.j
 export {AttestationImportOpt, type ImportBlockOpts} from "./types.js";
 
 const QUEUE_MAX_LENGTH = 256;
+/** Block or payload errors already logged above debug level, bounded to the most recent ones */
+const MAX_REPORTED_BLOCK_ERRORS = 1024;
 
 /**
  * BlockProcessor processes block jobs in a queued fashion, one after the other.
@@ -196,11 +199,7 @@ export async function processBlocks(
       this.logger.debug("Neither BlockError nor PayloadError received", {}, err);
     } else if (err instanceof PayloadError) {
       if (!opts.disableOnBlockError) {
-        this.logger.debug(
-          "Payload error",
-          {slot: err.payloadInput.slot, blockRoot: err.payloadInput.blockRootHex},
-          err
-        );
+        logBlockOrPayloadError.call(this, "Payload error", err.type.code, err.payloadInput, err);
       }
       // The envelope came from an untrusted range peer, drop it from the shared cache so the retried batch
       // downloads it again instead of re-verifying the same bytes. Gossip does the same on REJECT
@@ -208,14 +207,20 @@ export async function processBlocks(
         this.seenPayloadEnvelopeInputCache.prune(err.payloadInput.blockRootHex);
       }
     } else if (!opts.disableOnBlockError) {
-      this.logger.debug("Block error", {slot: err.signedBlock.message.slot}, err);
+      const blockRootHex =
+        blocks.find((blockInput) => blockInput.getBlock() === err.signedBlock)?.blockRootHex ??
+        toRootHex(
+          this.config.getForkTypes(err.signedBlock.message.slot).BeaconBlock.hashTreeRoot(err.signedBlock.message)
+        );
+      logBlockOrPayloadError.call(
+        this,
+        "Block error",
+        err.type.code,
+        {slot: err.signedBlock.message.slot, blockRootHex},
+        err
+      );
       if (isPeerAttributableFailure(err.type.code)) {
         // Same for the block, its signature or data may be bad while the root matches the canonical block
-        const blockRootHex =
-          blocks.find((blockInput) => blockInput.getBlock() === err.signedBlock)?.blockRootHex ??
-          toRootHex(
-            this.config.getForkTypes(err.signedBlock.message.slot).BeaconBlock.hashTreeRoot(err.signedBlock.message)
-          );
         this.seenBlockInputCache.prune(blockRootHex);
       }
 
@@ -244,6 +249,31 @@ export async function processBlocks(
 
     throw err;
   }
+}
+
+/**
+ * The first occurrence of an error for a block is logged at the level of the error, repeats of the same error for the
+ * same block are only logged at debug level. Range sync retries a failed batch several times and unknown block sync
+ * retries a block, both would otherwise repeat the same warning for a block that cannot be imported.
+ */
+function logBlockOrPayloadError(
+  this: BeaconChain,
+  message: string,
+  code: BlockErrorCode | PayloadErrorCode,
+  {slot, blockRootHex}: {slot: Slot; blockRootHex: RootHex},
+  err: Error
+): void {
+  const key = `${code}:${blockRootHex}`;
+  let level = getBlockErrorLogLevel(code);
+  if (level !== LogLevel.debug) {
+    if (this.reportedBlockErrors.has(key)) {
+      level = LogLevel.debug;
+    } else {
+      this.reportedBlockErrors.add(key);
+      pruneSetToMax(this.reportedBlockErrors, MAX_REPORTED_BLOCK_ERRORS);
+    }
+  }
+  this.logger[level](message, {slot, blockRoot: blockRootHex}, err);
 }
 
 /**

--- a/packages/beacon-node/src/chain/blocks/utils/blockErrorLogLevel.ts
+++ b/packages/beacon-node/src/chain/blocks/utils/blockErrorLogLevel.ts
@@ -1,0 +1,38 @@
+import {LogLevel} from "@lodestar/utils";
+import {BlockErrorCode} from "../../errors/index.js";
+import {PayloadErrorCode} from "../importExecutionPayload.js";
+import {isPeerAttributableFailure} from "./peerAttributableError.js";
+
+export type BlockErrorLogLevel = LogLevel.error | LogLevel.warn | LogLevel.debug;
+
+/**
+ * Log level of a block or payload import error. Most of them are expected during normal operation, the block is
+ * already known, its parent is not known yet, its data is not available yet, the execution client is offline (which
+ * is reported separately), so they are only useful at debug level. An invalid block or payload, or an internal error,
+ * is rare and may leave the node stuck if it is served for the canonical chain, so it is surfaced.
+ */
+export function getBlockErrorLogLevel(code: BlockErrorCode | PayloadErrorCode): BlockErrorLogLevel {
+  switch (code) {
+    // not caused by the block, something is wrong on our side
+    case BlockErrorCode.BEACON_CHAIN_ERROR:
+    case BlockErrorCode.PRESTATE_MISSING:
+      return LogLevel.error;
+    // the block violates a consensus rule, a fault of the proposer or of the peer that served it
+    case BlockErrorCode.INCORRECT_PROPOSER:
+    case BlockErrorCode.PROPOSAL_SIGNATURE_INVALID:
+    case BlockErrorCode.UNKNOWN_PROPOSER:
+    case BlockErrorCode.NOT_LATER_THAN_PARENT:
+    case BlockErrorCode.STATE_ROOT_MISMATCH:
+    case BlockErrorCode.INCORRECT_TIMESTAMP:
+    case BlockErrorCode.TOO_MUCH_GAS_USED:
+    case BlockErrorCode.SAME_PARENT_HASH:
+    case BlockErrorCode.TRANSACTIONS_TOO_BIG:
+    case BlockErrorCode.TOO_MANY_KZG_COMMITMENTS:
+    case BlockErrorCode.TOO_MANY_BLOCK_OPERATIONS:
+    case BlockErrorCode.BID_PARENT_ROOT_MISMATCH:
+      return LogLevel.warn;
+    default:
+      // invalid signature or state root, INVALID from the execution client, inconsistent segment, ...
+      return isPeerAttributableFailure(code) ? LogLevel.warn : LogLevel.debug;
+  }
+}

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -213,6 +213,8 @@ export class BeaconChain implements IBeaconChain {
   readonly seenAttestationDatas: SeenAttestationDatas;
   readonly seenBlockInputCache: SeenBlockInput;
   readonly seenPayloadEnvelopeInputCache: SeenPayloadEnvelopeInput;
+  /** Block or payload errors (code and block root) already logged above debug level, see `processBlocks` */
+  readonly reportedBlockErrors = new Set<string>();
   // Seen cache for liveness checks
   readonly seenBlockAttesters = new SeenBlockAttesters();
 

--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -184,6 +184,7 @@ vi.mock("../../src/chain/chain.js", async (importActual) => {
         prune: vi.fn(),
       },
       seenPayloadEnvelope: vi.fn(),
+      reportedBlockErrors: new Set<string>(),
       shufflingCache: new ShufflingCache(),
       pubkeyCache,
       produceCommonBlockBody: vi.fn(),

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -493,6 +493,27 @@ describe("chain / blocks / processBlocks", () => {
     expect(chain.logger.warn).toHaveBeenCalledWith("Block error", {slot, blockRoot}, otherErr);
   });
 
+  it("logs a different wrapped error for the same block at error level", async () => {
+    const first = new BlockError(blockInput.getBlock(), {
+      code: BlockErrorCode.BEACON_CHAIN_ERROR,
+      error: new Error("a"),
+    });
+    const second = new BlockError(blockInput.getBlock(), {
+      code: BlockErrorCode.BEACON_CHAIN_ERROR,
+      error: new Error("b"),
+    });
+    for (const err of [first, first, second]) {
+      vi.mocked(verifyBlocksInEpoch).mockRejectedValue(err);
+      await expect(processBlocks.call(chain, [blockInput], null, {})).rejects.toBe(err);
+    }
+
+    const context = {slot: blockInput.getBlock().message.slot, blockRoot: blockInput.blockRootHex};
+    expect(chain.logger.error).toHaveBeenCalledTimes(2);
+    expect(chain.logger.error).toHaveBeenCalledWith("Block error", context, first);
+    expect(chain.logger.error).toHaveBeenCalledWith("Block error", context, second);
+    expect(chain.logger.debug).toHaveBeenCalledExactlyOnceWith("Block error", context, first);
+  });
+
   function createImportError(
     message: string,
     code: BlockErrorCode | PayloadErrorCode

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -5,7 +5,7 @@ import {ExecutionStatus} from "@lodestar/fork-choice";
 import {ForkName} from "@lodestar/params";
 import {DataAvailabilityStatus, IBeaconStateView} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
-import {toRootHex} from "@lodestar/utils";
+import {LogLevel, toRootHex} from "@lodestar/utils";
 import {BlockInputNoData} from "../../../../src/chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource} from "../../../../src/chain/blocks/blockInput/types.js";
 import {importBlock} from "../../../../src/chain/blocks/importBlock.js";
@@ -452,6 +452,60 @@ describe("chain / blocks / processBlocks", () => {
       expect(chain.seenBlockInputCache.prune).not.toHaveBeenCalled();
     }
   });
+
+  it.each([
+    {message: "Block error", code: BlockErrorCode.PARENT_BLOCK_UNKNOWN, level: LogLevel.debug},
+    {message: "Block error", code: BlockErrorCode.NON_LINEAR_PARENT_ROOTS, level: LogLevel.warn},
+    {message: "Block error", code: BlockErrorCode.INCORRECT_TIMESTAMP, level: LogLevel.warn},
+    {message: "Block error", code: BlockErrorCode.BEACON_CHAIN_ERROR, level: LogLevel.error},
+    {message: "Payload error", code: PayloadErrorCode.EXECUTION_ENGINE_ERROR, level: LogLevel.debug},
+    {message: "Payload error", code: PayloadErrorCode.EXECUTION_ENGINE_INVALID, level: LogLevel.warn},
+  ])("logs $message $code at $level level", async ({message, code, level}) => {
+    const {err, slot, blockRoot} = createImportError(message, code);
+    vi.mocked(verifyBlocksInEpoch).mockRejectedValue(err);
+
+    await expect(processBlocks.call(chain, [blockInput], null, {})).rejects.toBe(err);
+
+    expect(chain.logger[level]).toHaveBeenCalledExactlyOnceWith(message, {slot, blockRoot}, err);
+    for (const other of [LogLevel.error, LogLevel.warn, LogLevel.debug].filter((l) => l !== level)) {
+      expect(chain.logger[other]).not.toHaveBeenCalledWith(message, expect.anything(), expect.anything());
+    }
+  });
+
+  it("logs repeats of the same error for the same block at debug level", async () => {
+    const {err, slot, blockRoot} = createImportError("Block error", BlockErrorCode.NON_LINEAR_PARENT_ROOTS);
+    vi.mocked(verifyBlocksInEpoch).mockRejectedValue(err);
+
+    await expect(processBlocks.call(chain, [blockInput], null, {})).rejects.toBe(err);
+    await expect(processBlocks.call(chain, [blockInput], null, {})).rejects.toBe(err);
+
+    expect(chain.logger.warn).toHaveBeenCalledExactlyOnceWith("Block error", {slot, blockRoot}, err);
+    expect(chain.logger.debug).toHaveBeenCalledExactlyOnceWith("Block error", {slot, blockRoot}, err);
+
+    // a different error for the same block is not a repeat
+    const {err: otherErr} = createImportError("Block error", BlockErrorCode.BLACKLISTED_BLOCK);
+    vi.mocked(verifyBlocksInEpoch).mockRejectedValue(otherErr);
+
+    await expect(processBlocks.call(chain, [blockInput], null, {})).rejects.toBe(otherErr);
+
+    expect(chain.logger.warn).toHaveBeenCalledWith("Block error", {slot, blockRoot}, otherErr);
+  });
+
+  function createImportError(
+    message: string,
+    code: BlockErrorCode | PayloadErrorCode
+  ): {err: BlockError | PayloadError; slot: number; blockRoot: string} {
+    if (message === "Block error") {
+      const err = new BlockError(blockInput.getBlock(), {
+        code,
+        error: new Error("boom"),
+      } as unknown as BlockError["type"]);
+      return {err, slot: blockInput.getBlock().message.slot, blockRoot: blockInput.blockRootHex};
+    }
+    const payloadInput = {slot: 1, blockRootHex: "0x1234"} as unknown as PayloadEnvelopeInput;
+    const err = new PayloadError(payloadInput, {code, errorMessage: "bad payload"} as unknown as PayloadError["type"]);
+    return {err, slot: 1, blockRoot: "0x1234"};
+  }
 
   // Contrast: a plain error (not a Block/Payload error) IS wrapped, which is why the passthrough above
   // has to be selective.

--- a/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/processBlocks.test.ts
@@ -18,6 +18,7 @@ import {processBlocks} from "../../../../src/chain/blocks/index.js";
 import {PayloadEnvelopeInput} from "../../../../src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.js";
 import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
 import {AttestationImportOpt} from "../../../../src/chain/blocks/types.js";
+import {BlockErrorLogLevel} from "../../../../src/chain/blocks/utils/blockErrorLogLevel.js";
 import {assertLinearChainSegment} from "../../../../src/chain/blocks/utils/chainSegment.js";
 import {verifyBlocksInEpoch} from "../../../../src/chain/blocks/verifyBlock.js";
 import {verifyBlocksSanityChecks} from "../../../../src/chain/blocks/verifyBlocksSanityChecks.js";
@@ -453,7 +454,7 @@ describe("chain / blocks / processBlocks", () => {
     }
   });
 
-  it.each([
+  it.each<{message: string; code: BlockErrorCode | PayloadErrorCode; level: BlockErrorLogLevel}>([
     {message: "Block error", code: BlockErrorCode.PARENT_BLOCK_UNKNOWN, level: LogLevel.debug},
     {message: "Block error", code: BlockErrorCode.NON_LINEAR_PARENT_ROOTS, level: LogLevel.warn},
     {message: "Block error", code: BlockErrorCode.INCORRECT_TIMESTAMP, level: LogLevel.warn},
@@ -467,7 +468,8 @@ describe("chain / blocks / processBlocks", () => {
     await expect(processBlocks.call(chain, [blockInput], null, {})).rejects.toBe(err);
 
     expect(chain.logger[level]).toHaveBeenCalledExactlyOnceWith(message, {slot, blockRoot}, err);
-    for (const other of [LogLevel.error, LogLevel.warn, LogLevel.debug].filter((l) => l !== level)) {
+    const levels: BlockErrorLogLevel[] = [LogLevel.error, LogLevel.warn, LogLevel.debug];
+    for (const other of levels.filter((l) => l !== level)) {
       expect(chain.logger[other]).not.toHaveBeenCalledWith(message, expect.anything(), expect.anything());
     }
   });


### PR DESCRIPTION
Block and payload import errors are all logged at debug level, an invalid block served for the canonical chain or an internal error like the one fixed in #10011 is invisible unless debug logs are enabled.

- `BEACON_CHAIN_ERROR` and `PRESTATE_MISSING` are logged at error level, these are not caused by the block
- consensus rule violations and peer attributable failures (invalid signature or state root, `INVALID` from the execution client, inconsistent segment, ...) are logged at warn level
- expected errors (already known, parent unknown, data unavailable, execution client offline, ...) stay at debug level
- repeats of the same error for the same block are logged at debug level, range sync retries a failed batch and unknown block sync retries the block, both would otherwise repeat the warning

Complements #10029 which reports when range sync gives up on a batch. Stacked on #10028 for `isPeerAttributableFailure`.

Closes https://github.com/ChainSafe/lodestar/issues/7560
