### PR TITLE
fix: check the parent envelope block root in chain segment assertion

### DIFF
--- a/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
+++ b/packages/beacon-node/src/chain/blocks/utils/chainSegment.ts
@@ -22,7 +22,7 @@ export type ChainSegmentResult = {warnings: OrphanedPayloadEnvelope[] | null};
  * - Verifies parent root + slot linearity
  * - For gloas: verifies bid.parentBlockHash matches the tracked execution hash; if not, the
  *   previous FULL envelope is treated as orphaned (segment continues as if previous slot was EMPTY)
- * - If an envelope exists for this slot: verifies it references this block's root
+ * - If an envelope exists for this slot (or the parent's slot): verifies it references this block's root
  * - Advances the tracked execution hash (FULL if envelope present, EMPTY if not)
  */
 export function assertLinearChainSegment(
@@ -48,6 +48,15 @@ export function assertLinearChainSegment(
   if (parentBlock !== null) {
     const parentPayloadInput = payloadEnvelopes?.get(parentBlock.slot);
     if (parentPayloadInput?.hasPayloadEnvelope()) {
+      // Envelopes are served by slot, the one at the parent's slot must reference the parent block. Without this
+      // check an envelope of a sibling block is taken as orphaned and only fails downstream in the payload import
+      if (parentPayloadInput.blockRootHex !== parentBlock.blockRoot) {
+        throw new BlockError(blocks[0].getBlock(), {
+          code: BlockErrorCode.ENVELOPE_BLOCK_ROOT_MISMATCH,
+          envelopeBlockRoot: parentPayloadInput.blockRootHex,
+          blockRoot: parentBlock.blockRoot,
+        });
+      }
       const parentPayloadBlockHash = parentPayloadInput.getBlockHashHex();
       if (currentExecHash === parentPayloadBlockHash) {
         // Checkpoint-sync first batch: the anchor is stored PENDING with the inherited (grandparent)

--- a/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/utils/chainSegment.test.ts
@@ -248,10 +248,13 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment bound
     // parent reference must advance from the envelope so the first-block check passes.
     const grandparentHash = Buffer.alloc(32, 0x11); // anchor's stored (inherited) hash
     const anchorPayloadHash = Buffer.alloc(32, 0x22); // anchor's own revealed payload
-    const parentBlock = {slot: 9, executionPayloadBlockHash: toRootHex(grandparentHash)} as unknown as ProtoBlock;
-
     const anchorInput = gloasBlockInput(9, Buffer.alloc(32, 0xdd), Buffer.alloc(32, 0x00), anchorPayloadHash);
     const anchorPayload = payloadInputFor(anchorInput, anchorPayloadHash);
+    const parentBlock = {
+      slot: 9,
+      blockRoot: anchorInput.blockRootHex,
+      executionPayloadBlockHash: toRootHex(grandparentHash),
+    } as unknown as ProtoBlock;
     const bi1 = gloasBlockInput(12, Buffer.alloc(32, 0xaa), anchorPayloadHash);
 
     const envelopes = new Map<Slot, PayloadEnvelopeInput>([[9, anchorPayload]]);
@@ -264,10 +267,13 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment bound
     // still serve the envelope by range so it is in the batch but must not become the parent EL head
     const grandparentHash = Buffer.alloc(32, 0x11); // parent's EMPTY variant hash (inherited)
     const orphanedPayloadHash = Buffer.alloc(32, 0x22); // parent's own, orphaned payload
-    const parentBlock = {slot: 9, executionPayloadBlockHash: toRootHex(grandparentHash)} as unknown as ProtoBlock;
-
     const parentInput = gloasBlockInput(9, Buffer.alloc(32, 0xdd), Buffer.alloc(32, 0x00), orphanedPayloadHash);
     const parentPayload = payloadInputFor(parentInput, orphanedPayloadHash);
+    const parentBlock = {
+      slot: 9,
+      blockRoot: parentInput.blockRootHex,
+      executionPayloadBlockHash: toRootHex(grandparentHash),
+    } as unknown as ProtoBlock;
     const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), grandparentHash);
 
     const envelopes = new Map<Slot, PayloadEnvelopeInput>([[9, parentPayload]]);
@@ -279,16 +285,40 @@ describe("chain / blocks / utils / chainSegment / assertLinearChainSegment bound
     const grandparentHash = Buffer.alloc(32, 0x11);
     const parentPayloadHash = Buffer.alloc(32, 0x22);
     const unknownHash = Buffer.alloc(32, 0x33);
-    const parentBlock = {slot: 9, executionPayloadBlockHash: toRootHex(grandparentHash)} as unknown as ProtoBlock;
-
     const parentInput = gloasBlockInput(9, Buffer.alloc(32, 0xdd), Buffer.alloc(32, 0x00), parentPayloadHash);
     const parentPayload = payloadInputFor(parentInput, parentPayloadHash);
+    const parentBlock = {
+      slot: 9,
+      blockRoot: parentInput.blockRootHex,
+      executionPayloadBlockHash: toRootHex(grandparentHash),
+    } as unknown as ProtoBlock;
     const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), unknownHash);
 
     const envelopes = new Map<Slot, PayloadEnvelopeInput>([[9, parentPayload]]);
     expectThrowsLodestarError(
       () => assertLinearChainSegment(config, [bi1], envelopes, parentBlock),
       BlockErrorCode.PARENT_PAYLOAD_UNKNOWN
+    );
+  });
+
+  it("throws ENVELOPE_BLOCK_ROOT_MISMATCH when the envelope at the parent's slot references another block", () => {
+    const grandparentHash = Buffer.alloc(32, 0x11);
+    const siblingPayloadHash = Buffer.alloc(32, 0x22);
+    const parentInput = gloasBlockInput(9, Buffer.alloc(32, 0xdd), Buffer.alloc(32, 0x00));
+    const parentBlock = {
+      slot: 9,
+      blockRoot: parentInput.blockRootHex,
+      executionPayloadBlockHash: toRootHex(grandparentHash),
+    } as unknown as ProtoBlock;
+    // A different block at the parent's slot, peers serve its envelope for that slot
+    const siblingInput = gloasBlockInput(9, Buffer.alloc(32, 0xee), Buffer.alloc(32, 0x00), siblingPayloadHash);
+    const siblingPayload = payloadInputFor(siblingInput, siblingPayloadHash);
+    const bi1 = gloasBlockInput(10, Buffer.alloc(32, 0xaa), grandparentHash);
+
+    const envelopes = new Map<Slot, PayloadEnvelopeInput>([[9, siblingPayload]]);
+    expectThrowsLodestarError(
+      () => assertLinearChainSegment(config, [bi1], envelopes, parentBlock),
+      BlockErrorCode.ENVELOPE_BLOCK_ROOT_MISMATCH
     );
   });
 });


### PR DESCRIPTION
`assertLinearChainSegment` looks up the parent's envelope by slot and never checks that it references the parent block, every in-segment envelope gets that check. An envelope of a sibling block at the parent's slot is reported as orphaned instead, imported near the tip (#10005) and only fails in `importExecutionPayload` with `BLOCK_NOT_IN_FORK_CHOICE`, which is not peer attributable: the envelope stays cached, the batch retries the same bytes until max attempts and the peer is not penalized.

Throw `ENVELOPE_BLOCK_ROOT_MISMATCH` for the parent's envelope as well, the batch is re-downloaded and the peer scored like for any other inconsistent segment.

Follow-up to https://github.com/ChainSafe/lodestar/pull/10002#discussion_r3929962388
