### PR TITLE
fix(reqresp): floor rate-limiter request cost to at least 1 token

### DIFF
--- a/packages/beacon-node/src/network/reqresp/rateLimit.ts
+++ b/packages/beacon-node/src/network/reqresp/rateLimit.ts
@@ -126,10 +126,9 @@ function getRequestCountFn<T extends ReqRespMethod>(
   const type = requestSszTypeByMethod(fork, config)[method];
   return (reqData: Uint8Array) => {
     try {
-      // A schema-valid request can still compute to 0 tokens (e.g. `BeaconBlocksByRange` with
-      // `count: 0`, or an empty-list `BeaconBlocksByRoot`). Never treat that as free: floor to 1
-      // so the request is still charged against the quota, counted, and bannable. `?? 1` only
-      // substituted for `null`/`undefined`, so a computed `0` slipped through unaccounted.
+      // A schema-valid request can compute to 0 tokens (e.g. `BeaconBlocksByRange` with `count: 0`,
+      // or an empty-list `BeaconBlocksByRoot`); floor to 1 so it is still charged, counted, and
+      // bannable rather than served for free.
       return Math.max(1, (type && fn(type.deserialize(reqData))) ?? 1);
     } catch (_e) {
       return 1;

--- a/packages/beacon-node/src/network/reqresp/rateLimit.ts
+++ b/packages/beacon-node/src/network/reqresp/rateLimit.ts
@@ -126,7 +126,11 @@ function getRequestCountFn<T extends ReqRespMethod>(
   const type = requestSszTypeByMethod(fork, config)[method];
   return (reqData: Uint8Array) => {
     try {
-      return (type && fn(type.deserialize(reqData))) ?? 1;
+      // A schema-valid request can still compute to 0 tokens (e.g. `BeaconBlocksByRange` with
+      // `count: 0`, or an empty-list `BeaconBlocksByRoot`). Never treat that as free: floor to 1
+      // so the request is still charged against the quota, counted, and bannable. `?? 1` only
+      // substituted for `null`/`undefined`, so a computed `0` slipped through unaccounted.
+      return Math.max(1, (type && fn(type.deserialize(reqData))) ?? 1);
     } catch (_e) {
       return 1;
     }

--- a/packages/beacon-node/src/network/reqresp/rateLimit.ts
+++ b/packages/beacon-node/src/network/reqresp/rateLimit.ts
@@ -126,9 +126,7 @@ function getRequestCountFn<T extends ReqRespMethod>(
   const type = requestSszTypeByMethod(fork, config)[method];
   return (reqData: Uint8Array) => {
     try {
-      // A schema-valid request can compute to 0 tokens (e.g. `BeaconBlocksByRange` with `count: 0`,
-      // or an empty-list `BeaconBlocksByRoot`); floor to 1 so it is still charged, counted, and
-      // bannable rather than served for free.
+      // A schema-valid request can cost 0 tokens; floor to 1 so it stays charged and bannable, not free.
       return Math.max(1, (type && fn(type.deserialize(reqData))) ?? 1);
     } catch (_e) {
       return 1;

--- a/packages/beacon-node/test/unit/network/reqresp/rateLimit.test.ts
+++ b/packages/beacon-node/test/unit/network/reqresp/rateLimit.test.ts
@@ -9,9 +9,6 @@ describe("network / reqresp / rateLimit getRequestCount", () => {
   const quotas = rateLimitQuotas(fork, config);
   const sszTypes = requestSszTypeByMethod(fork, config);
 
-  // Regression: a schema-valid request whose token count computes to 0 must be floored to 1, not
-  // treated as free. Before the fix the `?? 1` fallback only caught null/undefined, so a computed 0
-  // passed through and the request was never charged, counted, or bannable.
   it("floors a zero-count BeaconBlocksByRange request to 1 token", () => {
     const type = sszTypes[ReqRespMethod.BeaconBlocksByRange];
     // defaultValue has count: 0 — a schema-valid request that asks for nothing

--- a/packages/beacon-node/test/unit/network/reqresp/rateLimit.test.ts
+++ b/packages/beacon-node/test/unit/network/reqresp/rateLimit.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, it} from "vitest";
+import {config} from "@lodestar/config/default";
+import {ForkName} from "@lodestar/params";
+import {rateLimitQuotas} from "../../../../src/network/reqresp/rateLimit.js";
+import {ReqRespMethod, requestSszTypeByMethod} from "../../../../src/network/reqresp/types.js";
+
+describe("network / reqresp / rateLimit getRequestCount", () => {
+  const fork = ForkName.phase0;
+  const quotas = rateLimitQuotas(fork, config);
+  const sszTypes = requestSszTypeByMethod(fork, config);
+
+  // Regression: a schema-valid request whose token count computes to 0 must be floored to 1, not
+  // treated as free. Before the fix the `?? 1` fallback only caught null/undefined, so a computed 0
+  // passed through and the request was never charged, counted, or bannable.
+  it("floors a zero-count BeaconBlocksByRange request to 1 token", () => {
+    const type = sszTypes[ReqRespMethod.BeaconBlocksByRange];
+    // defaultValue has count: 0 — a schema-valid request that asks for nothing
+    const reqData = type.serialize(type.defaultValue());
+    expect(quotas[ReqRespMethod.BeaconBlocksByRange].getRequestCount?.(reqData)).toBe(1);
+  });
+
+  it("floors an empty-list BeaconBlocksByRoot request to 1 token", () => {
+    const type = sszTypes[ReqRespMethod.BeaconBlocksByRoot];
+    // empty root list -> length 0
+    const reqData = type.serialize(type.defaultValue());
+    expect(quotas[ReqRespMethod.BeaconBlocksByRoot].getRequestCount?.(reqData)).toBe(1);
+  });
+});

--- a/packages/beacon-node/test/unit/network/reqresp/rateLimit.test.ts
+++ b/packages/beacon-node/test/unit/network/reqresp/rateLimit.test.ts
@@ -1,8 +1,12 @@
 import {describe, expect, it} from "vitest";
-import {config} from "@lodestar/config/default";
+import {createBeaconConfig} from "@lodestar/config";
+import {chainConfig} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
+import {ZERO_HASH} from "../../../../src/constants/index.js";
 import {rateLimitQuotas} from "../../../../src/network/reqresp/rateLimit.js";
 import {ReqRespMethod, requestSszTypeByMethod} from "../../../../src/network/reqresp/types.js";
+
+const config = createBeaconConfig(chainConfig, ZERO_HASH);
 
 describe("network / reqresp / rateLimit getRequestCount", () => {
   const fork = ForkName.phase0;

--- a/packages/reqresp/src/rate_limiter/rateLimiterGRCA.ts
+++ b/packages/reqresp/src/rate_limiter/rateLimiterGRCA.ts
@@ -44,14 +44,16 @@ export class RateLimiterGRCA<Key> {
   }
 
   allows(key: Key, tokens: number): boolean {
-    if (tokens <= 0) {
-      throw new Error(`Token value should always be positive. Given: ${tokens}.`);
-    }
+    // Defense in depth: a request must never cost less than one token. Callers floor the count at
+    // the source, but if a non-positive count (e.g. a zero-length request body) still reaches here
+    // we clamp to 1 rather than throwing, so it is charged and counted instead of unwinding out of
+    // the accounting path — an uncaught throw here would let the request escape the quota and ban.
+    const chargedTokens = Math.max(1, tokens);
 
     const msSinceStart = Date.now() - this.startTimeMs;
 
     /** how long does it take to replenish these tokens */
-    const additionalTime = this.msPerToken * tokens;
+    const additionalTime = this.msPerToken * chargedTokens;
 
     if (additionalTime > this.msPerBucket) {
       // the time required to process this amount of tokens is longer than the time that makes the bucket full.

--- a/packages/reqresp/src/rate_limiter/rateLimiterGRCA.ts
+++ b/packages/reqresp/src/rate_limiter/rateLimiterGRCA.ts
@@ -44,10 +44,7 @@ export class RateLimiterGRCA<Key> {
   }
 
   allows(key: Key, tokens: number): boolean {
-    // Defense in depth: a request must never cost less than one token. Callers floor the count at
-    // the source, but if a non-positive count (e.g. a zero-length request body) still reaches here
-    // we clamp to 1 rather than throwing, so it is charged and counted instead of unwinding out of
-    // the accounting path — an uncaught throw here would let the request escape the quota and ban.
+    // Defense in depth: clamp to >=1 so a non-positive count is still charged, not skipped.
     const chargedTokens = Math.max(1, tokens);
 
     const msSinceStart = Date.now() - this.startTimeMs;

--- a/packages/reqresp/src/rate_limiter/rateLimiterGRCA.ts
+++ b/packages/reqresp/src/rate_limiter/rateLimiterGRCA.ts
@@ -44,7 +44,7 @@ export class RateLimiterGRCA<Key> {
   }
 
   allows(key: Key, tokens: number): boolean {
-    // Defense in depth: clamp to >=1 so a non-positive count is still charged, not skipped.
+    // Defense in depth: a non-positive count must still be charged, not skipped.
     const chargedTokens = Math.max(1, tokens);
 
     const msSinceStart = Date.now() - this.startTimeMs;

--- a/packages/reqresp/test/unit/rate_limiter/rateLimiterGRCA.test.ts
+++ b/packages/reqresp/test/unit/rate_limiter/rateLimiterGRCA.test.ts
@@ -17,12 +17,21 @@ describe("rateLimiterGRCA", () => {
   });
 
   describe("allows()", () => {
-    it("should throw error if requested for a zero value", () => {
-      expect(() => rateLimiter.allows(null, 0)).toThrow("Token value should always be positive. Given: 0");
+    it("should charge (not throw) a zero-token request, clamping it to 1", () => {
+      // A zero/negative token count must never escape accounting via an uncaught throw; it is
+      // clamped to 1 so it is still charged and bannable (regression: zero-token req/resp requests
+      // previously threw out of the limiter and were never counted, banned, or metered).
+      expect(rateLimiter.allows(null, 0)).toBe(true);
+      expect(rateLimiter.allows(null, -1)).toBe(true);
     });
 
-    it("should throw error if requested for a negative value", () => {
-      expect(() => rateLimiter.allows(null, -1)).toThrow("Token value should always be positive. Given: -1");
+    it("should count clamped zero-token requests against the quota until it is exhausted", () => {
+      // Each zero-token request costs 1 after clamping, so `limit` of them fill the bucket
+      // and the next one is denied (which is what triggers the ban + metric at the caller).
+      for (let i = 0; i < limit; i++) {
+        expect(rateLimiter.allows(null, 0), `zero-token request ${i} should be charged and allowed`).toBe(true);
+      }
+      expect(rateLimiter.allows(null, 0)).toBe(false);
     });
 
     it("should return valid number of requests within request window", () => {

--- a/packages/reqresp/test/unit/rate_limiter/rateLimiterGRCA.test.ts
+++ b/packages/reqresp/test/unit/rate_limiter/rateLimiterGRCA.test.ts
@@ -18,16 +18,11 @@ describe("rateLimiterGRCA", () => {
 
   describe("allows()", () => {
     it("should charge (not throw) a zero-token request, clamping it to 1", () => {
-      // A zero/negative token count must never escape accounting via an uncaught throw; it is
-      // clamped to 1 so it is still charged and bannable (regression: zero-token req/resp requests
-      // previously threw out of the limiter and were never counted, banned, or metered).
       expect(rateLimiter.allows(null, 0)).toBe(true);
       expect(rateLimiter.allows(null, -1)).toBe(true);
     });
 
     it("should count clamped zero-token requests against the quota until it is exhausted", () => {
-      // Each zero-token request costs 1 after clamping, so `limit` of them fill the bucket
-      // and the next one is denied (which is what triggers the ban + metric at the caller).
       for (let i = 0; i < limit; i++) {
         expect(rateLimiter.allows(null, 0), `zero-token request ${i} should be charged and allowed`).toBe(true);
       }


### PR DESCRIPTION
## Summary

Floor the per-request token count in the reqresp rate limiter to a minimum of `1`.

`getRequestCountFn` used `?? 1`, which only substitutes `null`/`undefined`, so a request whose computed count is `0` (e.g. an empty request body) was passed through as `0`. It now returns `Math.max(1, …)`, and `RateLimiterGRCA.allows()` clamps a non-positive token count to `1` rather than throwing.

## Testing

- Added unit coverage for a zero-count `BeaconBlocksByRange` and an empty-list `BeaconBlocksByRoot`.
- `pnpm --filter @lodestar/reqresp check-types` clean; the `rateLimiterGRCA` and new beacon-node rate-limit unit tests pass.

🤖 Generated with AI assistance
