### PR TITLE
fix: emit finalized_checkpoint event from fork choice finalized callback

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -524,19 +524,6 @@ export async function importBlock(
         this.metrics?.previousJustifiedEpoch.set(checkpointState.previousJustifiedCheckpoint.epoch);
         this.metrics?.currentJustifiedEpoch.set(justifiedCheckpoint.epoch);
       }
-      const finalizedCheckpoint = checkpointState.finalizedCheckpoint;
-      const finalizedEpoch = finalizedCheckpoint.epoch;
-      const preFinalizedEpoch = parentBlockSummary.finalizedEpoch;
-      if (finalizedEpoch > preFinalizedEpoch) {
-        this.emitter.emit(routes.events.EventType.finalizedCheckpoint, {
-          block: toRootHex(finalizedCheckpoint.root),
-          epoch: finalizedCheckpoint.epoch,
-          state: toRootHex(checkpointState.hashTreeRoot()),
-          executionOptimistic: false,
-        });
-        this.logger.verbose("Checkpoint finalized", toCheckpointHex(finalizedCheckpoint));
-        this.metrics?.finalizedEpoch.set(finalizedCheckpoint.epoch);
-      }
     }
   }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1671,7 +1671,24 @@ export class BeaconChain implements IBeaconChain {
   private async onForkChoiceFinalized(this: BeaconChain, cp: CheckpointWithHex): Promise<void> {
     this.logger.verbose("Fork choice finalized", {epoch: cp.epoch, root: cp.rootHex});
     this.metrics?.finalizedEpoch.set(cp.epoch);
-    this.emitFinalizedCheckpointEvent(cp);
+    const finalizedBlock = this.forkChoice.getBlockHexDefaultStatus(cp.rootHex);
+    if (finalizedBlock) {
+      // The callback runs synchronously inside fork choice checkpoint updates, defer writing to subscribers
+      callInNextEventLoop(() => {
+        this.emitter.emit(routes.events.EventType.finalizedCheckpoint, {
+          block: cp.rootHex,
+          epoch: cp.epoch,
+          state: finalizedBlock.stateRoot,
+          executionOptimistic: isOptimisticBlock(finalizedBlock),
+        });
+      });
+    } else {
+      this.logger.debug("Finalized block not found in fork choice, skip finalized_checkpoint event", {
+        epoch: cp.epoch,
+        root: cp.rootHex,
+      });
+    }
+
     const finalizedSlot = computeStartSlotAtEpoch(cp.epoch);
     this.seenBlockProposers.prune(finalizedSlot);
 
@@ -1693,31 +1710,6 @@ export class BeaconChain implements IBeaconChain {
     if (headState === null) {
       this.logger.verbose("Head state is null");
     }
-  }
-
-  /**
-   * Emitted from the fork choice finalized callback rather than from block import so finality carried by
-   * a block after a skipped epoch-boundary slot, or pulled up on the epoch tick, is not missed.
-   */
-  private emitFinalizedCheckpointEvent(cp: CheckpointWithHex): void {
-    const finalizedBlock = this.forkChoice.getBlockHexDefaultStatus(cp.rootHex);
-    if (!finalizedBlock) {
-      this.logger.debug("Finalized block not found in fork choice, skip finalized_checkpoint event", {
-        epoch: cp.epoch,
-        root: cp.rootHex,
-      });
-      return;
-    }
-
-    // The callback runs synchronously inside fork choice checkpoint updates, defer writing to subscribers
-    callInNextEventLoop(() => {
-      this.emitter.emit(routes.events.EventType.finalizedCheckpoint, {
-        block: cp.rootHex,
-        epoch: cp.epoch,
-        state: finalizedBlock.stateRoot,
-        executionOptimistic: isOptimisticBlock(finalizedBlock),
-      });
-    });
   }
 
   async updateBeaconProposerData(epoch: Epoch, proposers: ProposerPreparationData[]): Promise<void> {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1670,6 +1670,8 @@ export class BeaconChain implements IBeaconChain {
 
   private async onForkChoiceFinalized(this: BeaconChain, cp: CheckpointWithHex): Promise<void> {
     this.logger.verbose("Fork choice finalized", {epoch: cp.epoch, root: cp.rootHex});
+    this.metrics?.finalizedEpoch.set(cp.epoch);
+    this.emitFinalizedCheckpointEvent(cp);
     const finalizedSlot = computeStartSlotAtEpoch(cp.epoch);
     this.seenBlockProposers.prune(finalizedSlot);
 
@@ -1691,6 +1693,31 @@ export class BeaconChain implements IBeaconChain {
     if (headState === null) {
       this.logger.verbose("Head state is null");
     }
+  }
+
+  /**
+   * Emitted from the fork choice finalized callback rather than from block import so finality carried by
+   * a block after a skipped epoch-boundary slot, or pulled up on the epoch tick, is not missed.
+   */
+  private emitFinalizedCheckpointEvent(cp: CheckpointWithHex): void {
+    const finalizedBlock = this.forkChoice.getBlockHexDefaultStatus(cp.rootHex);
+    if (!finalizedBlock) {
+      this.logger.debug("Finalized block not found in fork choice, skip finalized_checkpoint event", {
+        epoch: cp.epoch,
+        root: cp.rootHex,
+      });
+      return;
+    }
+
+    // The callback runs synchronously inside fork choice checkpoint updates, defer writing to subscribers
+    callInNextEventLoop(() => {
+      this.emitter.emit(routes.events.EventType.finalizedCheckpoint, {
+        block: cp.rootHex,
+        epoch: cp.epoch,
+        state: finalizedBlock.stateRoot,
+        executionOptimistic: isOptimisticBlock(finalizedBlock),
+      });
+    });
   }
 
   async updateBeaconProposerData(epoch: Epoch, proposers: ProposerPreparationData[]): Promise<void> {

--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -33,7 +33,7 @@ export enum ChainEvent {
   /**
    * This event signals that the fork choice store has been updated.
    *
-   * This event is guaranteed to be triggered whenever the fork choice justified checkpoint is updated. This is in response to a newly processed block.
+   * This event is guaranteed to be triggered whenever the fork choice finalized checkpoint is updated. This is either in response to a newly processed block or a new clock tick.
    */
   forkChoiceFinalized = "forkChoice:finalized",
   /**

--- a/packages/beacon-node/test/unit/chain/finalizedCheckpointEvent.test.ts
+++ b/packages/beacon-node/test/unit/chain/finalizedCheckpointEvent.test.ts
@@ -1,0 +1,66 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {routes} from "@lodestar/api";
+import {CheckpointWithHex, ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
+import {fromHex} from "@lodestar/utils";
+import {BeaconChain} from "../../../src/chain/chain.js";
+import {ChainEventEmitter} from "../../../src/chain/emitter.js";
+import {getMockedLogger} from "../../mocks/loggerMock.js";
+import {generateProtoBlock} from "../../utils/typeGenerator.js";
+
+describe("BeaconChain finalized_checkpoint event", () => {
+  const rootHex = `0x${"aa".repeat(32)}`;
+  const stateRoot = `0x${"bb".repeat(32)}`;
+  const cp: CheckpointWithHex = {epoch: 2, root: fromHex(rootHex), rootHex};
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function emitFinalizedCheckpointEvent(
+    finalizedBlock: ProtoBlock | null
+  ): routes.events.EventData[routes.events.EventType.finalizedCheckpoint][] {
+    const emitter = new ChainEventEmitter();
+    const events: routes.events.EventData[routes.events.EventType.finalizedCheckpoint][] = [];
+    emitter.on(routes.events.EventType.finalizedCheckpoint, (data) => {
+      events.push(data);
+    });
+    const chain = {
+      emitter,
+      logger: getMockedLogger(),
+      forkChoice: {getBlockHexDefaultStatus: vi.fn().mockReturnValue(finalizedBlock)},
+    } as unknown as BeaconChain;
+
+    BeaconChain.prototype["emitFinalizedCheckpointEvent"].call(chain, cp);
+    return events;
+  }
+
+  it("emits the finalized block root and state root on the next event loop", async () => {
+    const events = emitFinalizedCheckpointEvent(
+      generateProtoBlock({blockRoot: rootHex, stateRoot, executionStatus: ExecutionStatus.Valid})
+    );
+
+    expect(events).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(events).toEqual([{block: rootHex, epoch: cp.epoch, state: stateRoot, executionOptimistic: false}]);
+  });
+
+  it("flags execution optimistic when the finalized block is still syncing", async () => {
+    const events = emitFinalizedCheckpointEvent(
+      generateProtoBlock({blockRoot: rootHex, stateRoot, executionStatus: ExecutionStatus.Syncing})
+    );
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(events[0]?.executionOptimistic).toBe(true);
+  });
+
+  it("does not emit when the finalized block is unknown to fork choice", async () => {
+    const events = emitFinalizedCheckpointEvent(null);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(events).toHaveLength(0);
+  });
+});

--- a/packages/beacon-node/test/unit/chain/finalizedCheckpointEvent.test.ts
+++ b/packages/beacon-node/test/unit/chain/finalizedCheckpointEvent.test.ts
@@ -1,11 +1,11 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {routes} from "@lodestar/api";
 import {CheckpointWithHex, ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
-import {fromHex} from "@lodestar/utils";
+import {defer, fromHex} from "@lodestar/utils";
 import {BeaconChain} from "../../../src/chain/chain.js";
 import {ChainEventEmitter} from "../../../src/chain/emitter.js";
 import {getMockedLogger} from "../../mocks/loggerMock.js";
-import {generateProtoBlock} from "../../utils/typeGenerator.js";
+import {generateProtoBlock, generateSignedBlockAtSlot} from "../../utils/typeGenerator.js";
 
 describe("BeaconChain finalized_checkpoint event", () => {
   const rootHex = `0x${"aa".repeat(32)}`;
@@ -20,9 +20,7 @@ describe("BeaconChain finalized_checkpoint event", () => {
     vi.useRealTimers();
   });
 
-  function emitFinalizedCheckpointEvent(
-    finalizedBlock: ProtoBlock | null
-  ): routes.events.EventData[routes.events.EventType.finalizedCheckpoint][] {
+  function onForkChoiceFinalized(finalizedBlock: ProtoBlock | null, custodyUpdate = Promise.resolve()) {
     const emitter = new ChainEventEmitter();
     const events: routes.events.EventData[routes.events.EventType.finalizedCheckpoint][] = [];
     emitter.on(routes.events.EventType.finalizedCheckpoint, (data) => {
@@ -31,36 +29,69 @@ describe("BeaconChain finalized_checkpoint event", () => {
     const chain = {
       emitter,
       logger: getMockedLogger(),
-      forkChoice: {getBlockHexDefaultStatus: vi.fn().mockReturnValue(finalizedBlock)},
-    } as unknown as BeaconChain;
+      metrics: {finalizedEpoch: {set: vi.fn()}},
+      forkChoice: {
+        getBlockHexDefaultStatus: vi.fn().mockReturnValue(finalizedBlock),
+        getHead: vi.fn().mockReturnValue(generateProtoBlock()),
+      },
+      seenBlockProposers: {prune: vi.fn()},
+      updateValidatorsCustodyRequirement: vi.fn().mockReturnValue(custodyUpdate),
+      regen: {getStateSync: vi.fn().mockReturnValue(null)},
+      getBlockByRoot: vi.fn().mockResolvedValue({block: generateSignedBlockAtSlot(0)}),
+    };
 
-    BeaconChain.prototype["emitFinalizedCheckpointEvent"].call(chain, cp);
-    return events;
+    const completed = BeaconChain.prototype["onForkChoiceFinalized"].call(chain as unknown as BeaconChain, cp);
+    return {events, chain, completed};
   }
 
   it("emits the finalized block root and state root on the next event loop", async () => {
-    const events = emitFinalizedCheckpointEvent(
+    const {events, completed} = onForkChoiceFinalized(
       generateProtoBlock({blockRoot: rootHex, stateRoot, executionStatus: ExecutionStatus.Valid})
     );
 
     expect(events).toHaveLength(0);
+    await completed;
     await vi.advanceTimersByTimeAsync(1);
     expect(events).toEqual([{block: rootHex, epoch: cp.epoch, state: stateRoot, executionOptimistic: false}]);
   });
 
   it("flags execution optimistic when the finalized block is still syncing", async () => {
-    const events = emitFinalizedCheckpointEvent(
+    const {events, completed} = onForkChoiceFinalized(
       generateProtoBlock({blockRoot: rootHex, stateRoot, executionStatus: ExecutionStatus.Syncing})
     );
 
+    await completed;
     await vi.advanceTimersByTimeAsync(1);
     expect(events[0]?.executionOptimistic).toBe(true);
   });
 
-  it("does not emit when the finalized block is unknown to fork choice", async () => {
-    const events = emitFinalizedCheckpointEvent(null);
+  it("continues finalization without emitting when the finalized block is unknown", async () => {
+    const {events, chain, completed} = onForkChoiceFinalized(null);
 
+    await completed;
     await vi.advanceTimersByTimeAsync(1);
     expect(events).toHaveLength(0);
+    expect(chain.metrics.finalizedEpoch.set).toHaveBeenCalledWith(cp.epoch);
+    expect(chain.seenBlockProposers.prune).toHaveBeenCalledOnce();
+    expect(chain.updateValidatorsCustodyRequirement).toHaveBeenCalledWith(cp);
+    expect(chain.getBlockByRoot).toHaveBeenCalledOnce();
+  });
+
+  it("emits without waiting for the custody update", async () => {
+    const {promise, resolve} = defer<void>();
+    const {events, chain, completed} = onForkChoiceFinalized(
+      generateProtoBlock({blockRoot: rootHex, stateRoot, executionStatus: ExecutionStatus.Valid}),
+      promise
+    );
+
+    try {
+      expect(events).toHaveLength(0);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(events).toEqual([{block: rootHex, epoch: cp.epoch, state: stateRoot, executionOptimistic: false}]);
+      expect(chain.getBlockByRoot).not.toHaveBeenCalled();
+    } finally {
+      resolve();
+      await completed;
+    }
   });
 });


### PR DESCRIPTION
The event was only emitted when importing a block at slot 0 of an epoch. If that slot is skipped, the block carrying the new finality is not at an epoch boundary and the event is never emitted for that epoch, since by the next boundary block the parent already has the newer finalized epoch.

Emit from the fork choice `onFinalized` callback instead, which fires on any block or clock tick that advances the store finalized checkpoint. Use the finalized block's state root from the proto block rather than hashing the checkpoint state, and derive `execution_optimistic` from its execution status.

AI assistance: the review follow-up was implemented with Codex.