### PR TITLE
fix(beacon-node): log builder circuit breaker init on first use, not construction

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -227,6 +227,7 @@ export function getValidatorApi(
   {chain, config, logger, metrics, network, sync}: ApiModules
 ): ApplicationMethods<routes.validator.Endpoints> {
   let genesisBlockRoot: Root | null = null;
+  let builderCircuitBreakerInitLogged = false;
 
   /**
    * Validator clock may be advanced from beacon's clock. If the validator requests a resource in a
@@ -953,6 +954,13 @@ export function getValidatorApi(
       // Post-gloas every proposal parent has an execution payload hash
       if (bidParentBlockHash === null) {
         throw new ApiError(500, `Unknown parent block hash for proposal parent ${parentBlockRootHex}`);
+      }
+      if (!builderCircuitBreakerInitLogged) {
+        builderCircuitBreakerInitLogged = true;
+        logger.info("Builder circuit breaker initialized", {
+          faultInspectionWindow: chain.builderCircuitBreaker.faultInspectionWindow,
+          allowedFaults: chain.builderCircuitBreaker.allowedFaults,
+        });
       }
       const circuitBreakerActive = chain.builderCircuitBreaker.isActive(slot, parentBlock);
 

--- a/packages/beacon-node/src/chain/builderCircuitBreaker.ts
+++ b/packages/beacon-node/src/chain/builderCircuitBreaker.ts
@@ -31,6 +31,7 @@ export class BuilderCircuitBreaker {
 
   private active = false;
   private lastUpdatedSlot = -1;
+  private hasLoggedInit = false;
 
   constructor(
     opts: BuilderCircuitBreakerOpts,
@@ -39,7 +40,6 @@ export class BuilderCircuitBreaker {
     const {faultInspectionWindow, allowedFaults} = getFaultInspectionParams(opts);
     this.faultInspectionWindow = faultInspectionWindow;
     this.allowedFaults = allowedFaults;
-    this.modules.logger.info("Builder circuit breaker initialized", {faultInspectionWindow, allowedFaults});
   }
 
   /** Whether builder bids must be ignored for a block produced at clockSlot */
@@ -53,6 +53,16 @@ export class BuilderCircuitBreaker {
       return;
     }
     this.lastUpdatedSlot = clockSlot;
+
+    // Log once when the circuit breaker is first exercised (post-gloas, on a node building blocks)
+    // rather than in the constructor, which runs for every BeaconChain instance incl. spec tests.
+    if (!this.hasLoggedInit) {
+      this.hasLoggedInit = true;
+      this.modules.logger.info("Builder circuit breaker initialized", {
+        faultInspectionWindow: this.faultInspectionWindow,
+        allowedFaults: this.allowedFaults,
+      });
+    }
 
     // Exclude clockSlot itself, its payload status may still be unresolved
     const {full, empty} = this.modules.forkChoice.getCanonicalPayloadCounts(

--- a/packages/beacon-node/src/chain/builderCircuitBreaker.ts
+++ b/packages/beacon-node/src/chain/builderCircuitBreaker.ts
@@ -31,7 +31,6 @@ export class BuilderCircuitBreaker {
 
   private active = false;
   private lastUpdatedSlot = -1;
-  private hasLoggedInit = false;
 
   constructor(
     opts: BuilderCircuitBreakerOpts,
@@ -53,16 +52,6 @@ export class BuilderCircuitBreaker {
       return;
     }
     this.lastUpdatedSlot = clockSlot;
-
-    // Log once when the circuit breaker is first exercised (post-gloas, on a node building blocks)
-    // rather than in the constructor, which runs for every BeaconChain instance incl. spec tests.
-    if (!this.hasLoggedInit) {
-      this.hasLoggedInit = true;
-      this.modules.logger.info("Builder circuit breaker initialized", {
-        faultInspectionWindow: this.faultInspectionWindow,
-        allowedFaults: this.allowedFaults,
-      });
-    }
 
     // Exclude clockSlot itself, its payload status may still be unresolved
     const {full, empty} = this.modules.forkChoice.getCanonicalPayloadCounts(


### PR DESCRIPTION
**Motivation**

`fast_confirmation.test.ts` floods the spec-test logs with hundreds of:

```
[spec-test] info: Builder circuit breaker initialized faultInspectionWindow=14, allowedFaults=3
```

The `BuilderCircuitBreaker` constructor logs this at `info`, and the constructor runs for every `BeaconChain` instance. Fork-choice-style spec tests build a fresh `BeaconChain` per test case, so the line is emitted once per case.

**Description**

Move the `info` log from the constructor to the first `update()` call. `update()` is only reached post-gloas on a node that is actually building blocks (via `prepareNextSlot` / block production), so:

- the line still surfaces exactly once per real node lifecycle, in a spot where the circuit breaker is genuinely engaged (kept at `info` per review preference, not demoted to `debug`);
- pre-gloas nodes and fork-choice spec tests — which never call `update()`/`isActive()` — no longer emit it at all.

A `hasLoggedInit` guard ensures it logs only once.
