### PR TITLE
test: accept zero finalizedBlockHash in mock execution engine

### DIFF
--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -296,7 +296,10 @@ export class ExecutionEngineMockBackend implements JsonRpcBackend {
 
     // 5. Client software MUST update its forkchoice state if payloads referenced by forkchoiceState.headBlockHash and
     //    forkchoiceState.finalizedBlockHash are VALID.
-    if (!this.validBlocks.has(finalizedBlockHash)) {
+    //
+    // A zero finalizedBlockHash means "no finalized execution block" (e.g. the finalized checkpoint has no execution
+    // payload, pre-merge/pre-TTD). Real EL clients accept this, so the mock must not treat it as an unknown block.
+    if (finalizedBlockHash !== ZERO_HASH_HEX && !this.validBlocks.has(finalizedBlockHash)) {
       throw Error(`Unknown finalizedBlockHash ${finalizedBlockHash}`);
     }
     this.headBlockHash = headBlockHash;


### PR DESCRIPTION
**Motivation**

`fast_confirmation.test.ts` floods the spec-test logs with:

```
[spec-test] error: Error pushing notifyForkchoiceUpdate() headBlockHash=0x… finalizedBlockHash=0x00…00 - Unknown finalizedBlockHash 0x00…00
```

On block import the chain calls `notifyForkchoiceUpdate` with `finalizedBlockHash = getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX`. The import guard only skips a zero *head* hash, not a zero *finalized* hash — deliberately, because a real EL accepts a zero finalized hash post-TTD (there's a comment in `importBlock.ts` saying exactly that).

But `ExecutionEngineMockBackend.notifyForkchoiceUpdate()` throws whenever the finalized hash is not in `validBlocks`, and `ZERO_HASH` is never seeded there. So the mock is stricter than a real EL; the promise rejects and `importBlock`'s `.catch` logs it at `error`, once per block import.

**Description**

Skip the `validBlocks` check when `finalizedBlockHash === ZERO_HASH_HEX`, matching real EL behavior (a zero finalized hash means "no finalized execution block"). A genuinely unknown non-zero hash still throws.

No existing test asserts the mock throws on an unknown finalized hash.
