### PR TITLE
refactor(builder): builder identity polling

### DIFF
--- a/packages/builder/src/identity.ts
+++ b/packages/builder/src/identity.ts
@@ -146,11 +146,9 @@ async function fetchBuilder(
 }
 
 function msToNextEpochPoll(clock: IClock): number {
-  // wait a slot past the epoch boundary so the BN has processed the transition
   return clock.msToSlot(computeStartSlotAtEpoch(clock.getCurrentEpoch() + 1));
 }
 
 function msToNextSlotPoll(clock: IClock): number {
-  // builder can appear in state any slot once the deposit is processed
   return clock.msToSlot(clock.getCurrentSlot() + 1);
 }

--- a/packages/builder/src/identity.ts
+++ b/packages/builder/src/identity.ts
@@ -85,7 +85,7 @@ async function waitForBuilder(
           currentEpoch,
           slot: clock.getCurrentSlot(),
         });
-        await sleep(msToNextEpochPoll(clock), signal);
+        await sleep(msToNextSlotPoll(clock), signal);
         continue;
       }
       throw e;
@@ -99,10 +99,11 @@ async function waitForBuilder(
     }
     if (builder?.status === "pending") {
       logger.info("Waiting for builder deposit to be finalized", {id, slot: clock.getCurrentSlot()});
+      await sleep(msToNextEpochPoll(clock), signal);
     } else {
       logger.info("Waiting for builder to be known to the beacon node", {id, slot: clock.getCurrentSlot()});
+      await sleep(msToNextSlotPoll(clock), signal);
     }
-    await sleep(msToNextEpochPoll(clock), signal);
   }
   throw new ErrorAborted("waitForBuilder");
 }
@@ -147,4 +148,9 @@ async function fetchBuilder(
 function msToNextEpochPoll(clock: IClock): number {
   // wait a slot past the epoch boundary so the BN has processed the transition
   return clock.msToSlot(computeStartSlotAtEpoch(clock.getCurrentEpoch() + 1) + 1);
+}
+
+function msToNextSlotPoll(clock: IClock): number {
+  // builder can appear in state any slot once the deposit is processed
+  return clock.msToSlot(clock.getCurrentSlot() + 1);
 }

--- a/packages/builder/src/identity.ts
+++ b/packages/builder/src/identity.ts
@@ -147,7 +147,7 @@ async function fetchBuilder(
 
 function msToNextEpochPoll(clock: IClock): number {
   // wait a slot past the epoch boundary so the BN has processed the transition
-  return clock.msToSlot(computeStartSlotAtEpoch(clock.getCurrentEpoch() + 1) + 1);
+  return clock.msToSlot(computeStartSlotAtEpoch(clock.getCurrentEpoch() + 1));
 }
 
 function msToNextSlotPoll(clock: IClock): number {

--- a/packages/builder/src/identity.ts
+++ b/packages/builder/src/identity.ts
@@ -1,11 +1,9 @@
 import {ApiClient, ApiError, HttpStatusCode, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
-import {IClock} from "@lodestar/state-transition";
+import {IClock, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {BuilderIndex, BuilderStatus} from "@lodestar/types";
 import {ErrorAborted, Logger, TimeoutError, isFetchError, sleep, toHex} from "@lodestar/utils";
-
-export const WAITING_FOR_BUILDER_POLL_MS = 10 * 1000;
 
 export async function resolveBuilderIdentity(
   api: ApiClient,
@@ -71,7 +69,7 @@ async function waitForBuilder(
         currentEpoch,
         slot: clock.getCurrentSlot(),
       });
-      await sleep(WAITING_FOR_BUILDER_POLL_MS, signal);
+      await sleep(msToNextEpochPoll(clock), signal);
       continue;
     }
 
@@ -87,7 +85,7 @@ async function waitForBuilder(
           currentEpoch,
           slot: clock.getCurrentSlot(),
         });
-        await sleep(WAITING_FOR_BUILDER_POLL_MS, signal);
+        await sleep(msToNextEpochPoll(clock), signal);
         continue;
       }
       throw e;
@@ -104,7 +102,7 @@ async function waitForBuilder(
     } else {
       logger.info("Waiting for builder to be known to the beacon node", {id, slot: clock.getCurrentSlot()});
     }
-    await sleep(WAITING_FOR_BUILDER_POLL_MS, signal);
+    await sleep(msToNextEpochPoll(clock), signal);
   }
   throw new ErrorAborted("waitForBuilder");
 }
@@ -144,4 +142,9 @@ async function fetchBuilder(
     }
     throw e;
   }
+}
+
+function msToNextEpochPoll(clock: IClock): number {
+  // wait a slot past the epoch boundary so the BN has processed the transition
+  return clock.msToSlot(computeStartSlotAtEpoch(clock.getCurrentEpoch() + 1) + 1);
 }

--- a/packages/builder/test/unit/identity.test.ts
+++ b/packages/builder/test/unit/identity.test.ts
@@ -1,8 +1,9 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {createChainForkConfig} from "@lodestar/config";
-import {PAYLOAD_BUILDER_VERSION} from "@lodestar/params";
+import {PAYLOAD_BUILDER_VERSION, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {ErrorAborted, FetchError, TimeoutError, toHex} from "@lodestar/utils";
-import {WAITING_FOR_BUILDER_POLL_MS, getBuilderStatus, resolveBuilderIdentity} from "../../src/identity.js";
+import {getBuilderStatus, resolveBuilderIdentity} from "../../src/identity.js";
 import {getApiClientStub, mockApiErrorResponse, mockApiResponse} from "./utils/apiStub.js";
 import {ClockMock} from "./utils/clock.js";
 import {getMockedLogger} from "./utils/logger.js";
@@ -20,6 +21,8 @@ describe("Identity", () => {
   const version = PAYLOAD_BUILDER_VERSION;
   // ClockMock reports currentEpoch=0, use GLOAS_FORK_EPOCH=0 so tests query the beacon node without waiting for the fork
   const config = createChainForkConfig({GLOAS_FORK_EPOCH: 0});
+  // waitForBuilder polls one slot past the next epoch boundary
+  const epochPollMs = clock.msToSlot(computeStartSlotAtEpoch(1) + 1);
 
   let abortController: AbortController;
 
@@ -96,7 +99,7 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
-    await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
+    await vi.advanceTimersByTimeAsync(epochPollMs);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
   });
@@ -110,7 +113,12 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
-    await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
+
+    // Does not re-poll before one slot past the next epoch boundary
+    await vi.advanceTimersByTimeAsync(epochPollMs - 1);
+    expect(api.beacon.getStateBuilders).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(1);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
   });
@@ -120,7 +128,7 @@ describe("Identity", () => {
     // ClockMock reports currentEpoch=0, so a future fork epoch keeps the builder in the pre-fork wait loop
     const futureForkConfig = createChainForkConfig({GLOAS_FORK_EPOCH: 1});
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, futureForkConfig);
-    await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
+    await vi.advanceTimersByTimeAsync(clock.msToSlot(1));
 
     expect(api.beacon.getStateBuilders).not.toHaveBeenCalled();
     expect(logger.info).toHaveBeenCalledWith(
@@ -139,7 +147,7 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
-    await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
+    await vi.advanceTimersByTimeAsync(epochPollMs);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
   });
@@ -154,12 +162,13 @@ describe("Identity", () => {
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, forkClock, forkConfig);
 
     // Pre-fork: the builder waits without querying the beacon node
-    await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
+    const pollMs = forkClock.msToSlot(computeStartSlotAtEpoch(1) + 1);
+    await vi.advanceTimersByTimeAsync(pollMs - 1);
     expect(api.beacon.getStateBuilders).not.toHaveBeenCalled();
 
     // Gloas fork reached: the builder queries the beacon node and resolves
-    forkClock.currentEpoch = 1;
-    await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
+    forkClock.currentSlot = SLOTS_PER_EPOCH;
+    await vi.advanceTimersByTimeAsync(1);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(1);
   });
@@ -187,7 +196,7 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
-    await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
+    await vi.advanceTimersByTimeAsync(epochPollMs);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
   });
@@ -206,7 +215,7 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
-    await vi.advanceTimersByTimeAsync(WAITING_FOR_BUILDER_POLL_MS);
+    await vi.advanceTimersByTimeAsync(epochPollMs);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
   });

--- a/packages/builder/test/unit/identity.test.ts
+++ b/packages/builder/test/unit/identity.test.ts
@@ -99,7 +99,10 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
-    await vi.advanceTimersByTimeAsync(epochPollMs);
+    await vi.advanceTimersByTimeAsync(clock.msToSlot(1) - 1);
+    expect(api.beacon.getStateBuilders).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(1);
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
   });
@@ -147,7 +150,7 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
-    await vi.advanceTimersByTimeAsync(epochPollMs);
+    await vi.advanceTimersByTimeAsync(clock.msToSlot(1));
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
   });
@@ -196,7 +199,7 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
-    await vi.advanceTimersByTimeAsync(epochPollMs);
+    await vi.advanceTimersByTimeAsync(clock.msToSlot(1));
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
   });
@@ -215,7 +218,7 @@ describe("Identity", () => {
       mockGetStateBuildersResponse(index, {status, pubkey, balance, version})
     );
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
-    await vi.advanceTimersByTimeAsync(epochPollMs);
+    await vi.advanceTimersByTimeAsync(clock.msToSlot(1));
     expect(await promise).toEqual(index);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledTimes(2);
   });

--- a/packages/builder/test/unit/identity.test.ts
+++ b/packages/builder/test/unit/identity.test.ts
@@ -21,8 +21,7 @@ describe("Identity", () => {
   const version = PAYLOAD_BUILDER_VERSION;
   // ClockMock reports currentEpoch=0, use GLOAS_FORK_EPOCH=0 so tests query the beacon node without waiting for the fork
   const config = createChainForkConfig({GLOAS_FORK_EPOCH: 0});
-  // waitForBuilder polls one slot past the next epoch boundary
-  const epochPollMs = clock.msToSlot(computeStartSlotAtEpoch(1) + 1);
+  const epochPollMs = clock.msToSlot(computeStartSlotAtEpoch(1));
 
   let abortController: AbortController;
 
@@ -117,7 +116,7 @@ describe("Identity", () => {
     );
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, clock, config);
 
-    // Does not re-poll before one slot past the next epoch boundary
+    // Does not re-poll before the next epoch boundary
     await vi.advanceTimersByTimeAsync(epochPollMs - 1);
     expect(api.beacon.getStateBuilders).toHaveBeenCalledOnce();
 
@@ -165,8 +164,7 @@ describe("Identity", () => {
     const promise = resolveBuilderIdentity(api, logger, pubkeyString, abortController.signal, forkClock, forkConfig);
 
     // Pre-fork: the builder waits without querying the beacon node
-    const pollMs = forkClock.msToSlot(computeStartSlotAtEpoch(1) + 1);
-    await vi.advanceTimersByTimeAsync(pollMs - 1);
+    await vi.advanceTimersByTimeAsync(epochPollMs - 1);
     expect(api.beacon.getStateBuilders).not.toHaveBeenCalled();
 
     // Gloas fork reached: the builder queries the beacon node and resolves

--- a/packages/builder/test/unit/utils/clock.ts
+++ b/packages/builder/test/unit/utils/clock.ts
@@ -1,10 +1,13 @@
-import {IClock} from "@lodestar/state-transition";
+import {IClock, computeEpochAtSlot} from "@lodestar/state-transition";
 import {Epoch, Slot} from "@lodestar/types";
 
 type RunEveryFn = (slot: Slot, signal: AbortSignal) => Promise<void>;
 
 export class ClockMock implements IClock {
-  currentEpoch = 0;
+  currentSlot = 0;
+  get currentEpoch(): number {
+    return computeEpochAtSlot(this.currentSlot);
+  }
   readonly genesisTime: number = 0;
   readonly secondsPerSlot: number = 12;
 
@@ -14,10 +17,10 @@ export class ClockMock implements IClock {
   start = (): void => {};
   runEverySlot = (fn: RunEveryFn): number => this.everySlot.push(fn);
   runEveryEpoch = (fn: RunEveryFn): number => this.everyEpoch.push(fn);
-  msToSlot = (_slot: number): number => 0;
+  msToSlot = (slot: number): number => (slot - this.currentSlot) * this.secondsPerSlot * 1000;
   msFromSlot = (): number => 0;
   secFromSlot = (): number => 0;
-  getCurrentSlot = (): number => 0;
+  getCurrentSlot = (): number => this.currentSlot;
   getCurrentEpoch = (): number => this.currentEpoch;
 
   async tickSlotFns(slot: Slot, signal: AbortSignal): Promise<void> {


### PR DESCRIPTION
**Motivation**

`waitForBuilder` polled every 10s. With 12s slots that drifts against slot boundaries, so every 6th poll lands in the same slot as the previous one and emits an identical log line. Builder activation (`pending` -> `active` / `exited`) only happens at epoch transitions, so polling more often than that gives no new information. 
Also polls on every slot until `pending` status is received as deposit can be processed in any slot.