### PR TITLE
chore: track awaiting queues of NetworkProcessor on Grafana

### DIFF
--- a/dashboards/lodestar_networking.json
+++ b/dashboards/lodestar_networking.json
@@ -4091,6 +4091,88 @@
       "gridPos": {
         "h": 8,
         "w": 12,
+        "x": 0,
+        "y": 162
+      },
+      "id": 643,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(lodestar_awaiting_block_gossip_messages_total[$rate_interval]) * 12",
+          "instant": false,
+          "legendFormat": "{{topic}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Awaiting queue per slot",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
         "x": 12,
         "y": 162
       },
@@ -6928,6 +7010,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Duration of **prioritizePeers()**, the core peer selection/pruning algorithm run each heartbeat.\n\n**Metric:** `lodestar_peer_manager_prioritize_peers_seconds`\n\n- Shows **avg**.\n- Divide by *Peers evaluated* (panel below) for time-per-peer.\n- Split out of total heartbeat duration to attribute cost to this phase.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -7005,14 +7088,14 @@
         }
       ],
       "title": "prioritizePeers duration",
-      "type": "timeseries",
-      "description": "Duration of **prioritizePeers()**, the core peer selection/pruning algorithm run each heartbeat.\n\n**Metric:** `lodestar_peer_manager_prioritize_peers_seconds`\n\n- Shows **avg**.\n- Divide by *Peers evaluated* (panel below) for time-per-peer.\n- Split out of total heartbeat duration to attribute cost to this phase."
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Duration of the peer score store update (exponential decay + prune over every tracked peer) each heartbeat.\n\n**Metric:** `lodestar_peer_score_update_seconds`\n\n- Shows **avg**.\n- This loop iterates the whole score store, so divide by *score map size* (Map sizes panel) for time-per-peer — **not** by peers evaluated.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -7090,14 +7173,14 @@
         }
       ],
       "title": "Peer score store update duration",
-      "type": "timeseries",
-      "description": "Duration of the peer score store update (exponential decay + prune over every tracked peer) each heartbeat.\n\n**Metric:** `lodestar_peer_score_update_seconds`\n\n- Shows **avg**.\n- This loop iterates the whole score store, so divide by *score map size* (Map sizes panel) for time-per-peer — **not** by peers evaluated."
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Number of connected healthy peers **prioritizePeers()** evaluated per heartbeat.\n\n**Metric:** `lodestar_peer_manager_peers_evaluated_count`\n\n- The denominator for *prioritizePeers duration* time-per-peer.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -7175,14 +7258,14 @@
         }
       ],
       "title": "Peers evaluated per heartbeat",
-      "type": "timeseries",
-      "description": "Number of connected healthy peers **prioritizePeers()** evaluated per heartbeat.\n\n**Metric:** `lodestar_peer_manager_peers_evaluated_count`\n\n- The denominator for *prioritizePeers duration* time-per-peer."
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Rate of peer score state crossings (Healthy / Disconnected / Banned), per minute, by transition.\n\n**Metric:** `lodestar_peer_score_state_transitions_total`\n\n- Sensitive to the decay formula, thresholds, and gossip-score weighting.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -7260,14 +7343,14 @@
         }
       ],
       "title": "Peer score state transitions (rate / min)",
-      "type": "timeseries",
-      "description": "Rate of peer score state crossings (Healthy / Disconnected / Banned), per minute, by transition.\n\n**Metric:** `lodestar_peer_score_state_transitions_total`\n\n- Sensitive to the decay formula, thresholds, and gossip-score weighting."
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Rate of peers the manager intends to disconnect, per minute, by reason.\n\n**Metric:** `lodestar_peer_manager_peers_pruned_total`\n\n- Covers both top-of-heartbeat bad-score disconnects (`banned` / `score_too_low`) and prioritization reasons.\n- Counts **intent**, not completion (goodbye is fire-and-forget).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -7345,14 +7428,14 @@
         }
       ],
       "title": "Peers pruned (rate / min)",
-      "type": "timeseries",
-      "description": "Rate of peers the manager intends to disconnect, per minute, by reason.\n\n**Metric:** `lodestar_peer_manager_peers_pruned_total`\n\n- Covers both top-of-heartbeat bad-score disconnects (`banned` / `score_too_low`) and prioritization reasons.\n- Counts **intent**, not completion (goodbye is fire-and-forget)."
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Rate of peer relevance checks on Status, per minute, by result.\n\n**Metric:** `lodestar_peer_relevance_check_total`\n\n- `result` is `relevant`, an irrelevant reason code (fork digest / clock skew / finalized mismatch / missing earliestAvailableSlot), or `error`.\n- Fires on every status evaluation.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -7430,14 +7513,14 @@
         }
       ],
       "title": "Peer relevance checks (rate / min)",
-      "type": "timeseries",
-      "description": "Rate of peer relevance checks on Status, per minute, by result.\n\n**Metric:** `lodestar_peer_relevance_check_total`\n\n- `result` is `relevant`, an irrelevant reason code (fork digest / clock skew / finalized mismatch / missing earliestAvailableSlot), or `error`.\n- Fires on every status evaluation."
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Connected peer count per active subnet (avg per type).\n\n**Metric:** `lodestar_peer_manager_peers_per_active_subnet` (label `type=attnets|syncnets`)\n\n- Checks the min-peers-per-subnet invariant.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -7526,14 +7609,14 @@
         }
       ],
       "title": "Peers per active subnet",
-      "type": "timeseries",
-      "description": "Connected peer count per active subnet (avg per type).\n\n**Metric:** `lodestar_peer_manager_peers_per_active_subnet` (label `type=attnets|syncnets`)\n\n- Checks the min-peers-per-subnet invariant."
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Ratio of outbound to total connected healthy peers.\n\n**Metric:** `lodestar_peer_manager_outbound_peers_ratio`\n\n- Verifies the OUTBOUND_PEERS_RATIO floor (~10%, see issue #2215).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -7611,14 +7694,14 @@
         }
       ],
       "title": "Outbound peers ratio",
-      "type": "timeseries",
-      "description": "Ratio of outbound to total connected healthy peers.\n\n**Metric:** `lodestar_peer_manager_outbound_peers_ratio`\n\n- Verifies the OUTBOUND_PEERS_RATIO floor (~10%, see issue #2215)."
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Entry counts of peer manager data structures (**not bytes**).\n\n**Metrics:** `lodestar_peer_manager_score_map_size`, `lodestar_peer_manager_connected_peers_map_size`, `libp2p_peers`\n\n- *connected peers map* should track *libp2p_peers*; a persistent gap indicates a connection leak.\n- *score map* reflects prune-to-MAX_ENTRIES / SCORE_THRESHOLD retention.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -7718,8 +7801,7 @@
         }
       ],
       "title": "Peer manager map sizes",
-      "type": "timeseries",
-      "description": "Entry counts of peer manager data structures (**not bytes**).\n\n**Metrics:** `lodestar_peer_manager_score_map_size`, `lodestar_peer_manager_connected_peers_map_size`, `libp2p_peers`\n\n- *connected peers map* should track *libp2p_peers*; a persistent gap indicates a connection leak.\n- *score map* reflects prune-to-MAX_ENTRIES / SCORE_THRESHOLD retention."
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",


### PR DESCRIPTION
- track awaiting queues of NetworkProcessor on grafana
- here's how it look on devnet 8

<img width="1393" height="468" alt="Screenshot 2026-09-09 at 13 27 34" src="https://github.com/user-attachments/assets/cafc1953-4df9-489c-b4f8-2825517f4642" />
