### PR TITLE
refactor(fork-choice): encapsulate FCR lifecycle

### DIFF
--- a/packages/fork-choice/src/forkChoice/fastConfirmation/fastConfirmationRule.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/fastConfirmationRule.ts
@@ -16,17 +16,72 @@ export * from "./metrics.js";
 export * from "./types.js";
 
 export class FastConfirmationRule implements IFastConfirmationRule {
+  private paused = false;
+
   constructor(
     private readonly store: IFastConfirmationStore,
     readonly metrics: FastConfirmationMetrics | null,
     readonly logger?: Logger
-  ) {}
+  ) {
+    metrics?.fastConfirmation.paused.set(0);
+  }
 
   getConfirmedRoot(): RootHex {
     return this.store.confirmedRoot;
   }
 
-  onSlotStartAfterPastAttestationsApplied(ctx: FastConfirmationContext): FastConfirmationResult {
+  pause(ctx: FastConfirmationContext): void {
+    if (this.paused) return;
+    this.paused = true;
+    this.pinConfirmedRootToFinalized(ctx);
+    this.metrics?.fastConfirmation.paused.set(1);
+    this.logger?.info("Paused fast confirmation", {slot: ctx.getCurrentSlot()});
+  }
+
+  resume(ctx: FastConfirmationContext): void {
+    if (!this.paused) return;
+    this.paused = false;
+    this.metrics?.fastConfirmation.paused.set(0);
+    this.logger?.info("Resumed fast confirmation", {slot: ctx.getCurrentSlot()});
+  }
+
+  onForkChoiceUpdated(ctx: FastConfirmationContext): void {
+    const confirmedRoot = this.store.confirmedRoot;
+    if (ctx.getBlock(confirmedRoot) !== null || !ctx.hasBlock(confirmedRoot)) return;
+
+    this.pinConfirmedRootToFinalized(ctx);
+  }
+
+  onSlotStartAfterPastAttestationsApplied(ctx: FastConfirmationContext, updateHead: () => void): boolean {
+    if (this.paused) {
+      this.pinConfirmedRootToFinalized(ctx);
+      return false;
+    }
+
+    withObservedDuration(this.metrics?.fastConfirmation.totalDuration.startTimer(), () => {
+      try {
+        withObservedDuration(
+          this.metrics?.fastConfirmation.stepsDuration.startTimer({step: FastConfirmationSteps.updateHead}),
+          updateHead
+        );
+        this.updateConfirmedRoot(ctx);
+      } catch (err) {
+        this.logger?.debug(
+          "Fast confirmation failed",
+          {
+            slot: ctx.getCurrentSlot(),
+            head: ctx.getHead().blockRoot,
+            confirmedRoot: this.store.confirmedRoot,
+          },
+          err as Error
+        );
+      }
+    });
+
+    return true;
+  }
+
+  private updateConfirmedRoot(ctx: FastConfirmationContext): FastConfirmationResult {
     const currentSlot = ctx.getCurrentSlot();
     const previousConfirmedRoot = this.store.confirmedRoot;
 
@@ -94,8 +149,31 @@ export class FastConfirmationRule implements IFastConfirmationRule {
 
     this.store.confirmedRoot = confirmedRoot;
     this.updateFastConfirmationMetrics(ctx, {confirmedRoot, didReset, didReorg, didFallback, didRestart});
+    this.notifyConfirmedRoot(ctx);
 
     return {confirmedRoot, didReset};
+  }
+
+  private pinConfirmedRootToFinalized(ctx: FastConfirmationContext): void {
+    this.store.confirmedRoot = ctx.getFinalizedCheckpoint().rootHex;
+    try {
+      this.notifyConfirmedRoot(ctx);
+    } catch (err) {
+      this.logger?.debug("Fast confirmation notify failed", {slot: ctx.getCurrentSlot()}, err as Error);
+    }
+  }
+
+  private notifyConfirmedRoot(ctx: FastConfirmationContext): void {
+    const confirmedRoot = this.store.confirmedRoot;
+    const confirmedBlock = ctx.getBlock(confirmedRoot);
+    if (confirmedBlock === null) {
+      throw new Error(`Fast confirmation produced root not in protoArray: ${confirmedRoot}`);
+    }
+    this.store.notifyFastConfirmation?.({
+      block: confirmedRoot,
+      slot: confirmedBlock.slot,
+      currentSlot: ctx.getCurrentSlot(),
+    });
   }
 
   private updateFastConfirmationVariables(ctx: FastConfirmationContext): void {

--- a/packages/fork-choice/src/forkChoice/fastConfirmation/types.ts
+++ b/packages/fork-choice/src/forkChoice/fastConfirmation/types.ts
@@ -29,6 +29,7 @@ type IFastConfirmationAuxStore = {
   currentEpochObservedJustifiedBalances: EffectiveBalanceIncrements;
   previousEpochGreatestUnrealizedBalances: EffectiveBalanceIncrements;
   stateGetter: ForkChoiceStateGetter;
+  notifyFastConfirmation?(data: {block: RootHex; slot: Slot; currentSlot: Slot}): void;
 };
 
 export type IFastConfirmationStore = IFastConfirmationSpecStore & IFastConfirmationAuxStore;
@@ -126,6 +127,7 @@ export type FastConfirmationContext = {
   getCurrentSlot(): Slot;
   getHead(): ProtoBlock;
   getBlock(root: RootHex): ProtoBlock | null;
+  hasBlock(root: RootHex): boolean;
   getAncestor(root: RootHex, slot: Slot): RootHex;
   isDescendant(ancestor: RootHex, descendant: RootHex): boolean;
   getLatestMessage(validatorIndex: ValidatorIndex): {root: RootHex; epoch: Epoch} | null;
@@ -137,5 +139,8 @@ export type FastConfirmationContext = {
 
 export interface IFastConfirmationRule {
   getConfirmedRoot(): RootHex;
-  onSlotStartAfterPastAttestationsApplied(ctx: FastConfirmationContext): FastConfirmationResult;
+  pause(ctx: FastConfirmationContext): void;
+  resume(ctx: FastConfirmationContext): void;
+  onForkChoiceUpdated(ctx: FastConfirmationContext): void;
+  onSlotStartAfterPastAttestationsApplied(ctx: FastConfirmationContext, updateHead: () => void): boolean;
 }

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -31,7 +31,7 @@ import {
   phase0,
   ssz,
 } from "@lodestar/types";
-import {Logger, MapDef, fromHex, toRootHex, withObservedDuration} from "@lodestar/utils";
+import {Logger, MapDef, fromHex, toRootHex} from "@lodestar/utils";
 import {ForkChoiceMetrics} from "../metrics.js";
 import {computeDeltas} from "../protoArray/computeDeltas.js";
 import {ProtoArrayError, ProtoArrayErrorCode} from "../protoArray/errors.js";
@@ -53,7 +53,6 @@ import {ForkChoiceError, ForkChoiceErrorCode, InvalidAttestationCode, InvalidBlo
 import {
   type FastConfirmationContext,
   FastConfirmationRule,
-  FastConfirmationSteps,
   type IFastConfirmationRule,
   type IFastConfirmationSpecStore,
 } from "./fastConfirmation/fastConfirmationRule.js";
@@ -161,7 +160,6 @@ export class ForkChoice implements IForkChoice {
   /** Optional fast confirmation rule implementation */
   private readonly fastConfirmationRule?: IFastConfirmationRule;
   private readonly fastConfirmationContext?: FastConfirmationContext;
-  private fastConfirmationPaused = false;
   /**
    * Instantiates a Fork Choice from some existing components
    *
@@ -190,7 +188,6 @@ export class ForkChoice implements IForkChoice {
     if (this.opts?.fastConfirmation) {
       this.fastConfirmationRule = new FastConfirmationRule(this.fcStore, metrics, this.logger);
       this.fastConfirmationContext = this.createFastConfirmationContext();
-      metrics?.fastConfirmation.paused.set(0);
     }
 
     metrics?.forkChoice.votes.addCollect(() => {
@@ -253,44 +250,11 @@ export class ForkChoice implements IForkChoice {
   }
 
   resumeFastConfirmation(): void {
-    this.toggleFastConfirmation(false);
+    if (this.fastConfirmationContext) this.fastConfirmationRule?.resume(this.fastConfirmationContext);
   }
 
   pauseFastConfirmation(): void {
-    this.toggleFastConfirmation(true);
-  }
-
-  private toggleFastConfirmation(paused: boolean): void {
-    if (!this.fastConfirmationRule) return;
-    if (paused === this.fastConfirmationPaused) return;
-    this.fastConfirmationPaused = paused;
-    if (paused) {
-      // Pin immediately: block imports report the safe block hash to the EL before the next slot tick
-      this.fcStore.confirmedRoot = this.fcStore.finalizedCheckpoint.rootHex;
-      try {
-        this.notifyConfirmedRoot();
-      } catch (err) {
-        // Callers run in clock/network handler context with no catch above
-        this.logger?.debug("Fast confirmation notify failed", {slot: this.fcStore.currentSlot}, err as Error);
-      }
-    }
-    this.metrics?.fastConfirmation.paused.set(paused ? 1 : 0);
-    this.logger?.info(paused ? "Paused fast confirmation" : "Resumed fast confirmation", {
-      slot: this.fcStore.currentSlot,
-    });
-  }
-
-  private notifyConfirmedRoot(): void {
-    const confirmedRoot = this.fcStore.confirmedRoot;
-    const confirmedBlock = this.getBlockHexDefaultStatus(confirmedRoot);
-    if (confirmedBlock === null) {
-      throw new Error(`Fast confirmation produced root not in protoArray: ${confirmedRoot}`);
-    }
-    this.fcStore.notifyFastConfirmation?.({
-      block: confirmedRoot,
-      slot: confirmedBlock.slot,
-      currentSlot: this.fcStore.currentSlot,
-    });
+    if (this.fastConfirmationContext) this.fastConfirmationRule?.pause(this.fastConfirmationContext);
   }
 
   /**
@@ -671,6 +635,7 @@ export class ForkChoice implements IForkChoice {
     const head = this.protoArray.findHead(this.fcStore.justified.checkpoint.rootHex, currentSlot);
 
     this.head = head;
+    if (this.fastConfirmationContext) this.fastConfirmationRule?.onForkChoiceUpdated(this.fastConfirmationContext);
     return this.head;
   }
 
@@ -2298,40 +2263,9 @@ export class ForkChoice implements IForkChoice {
     const fastConfirmationContext = this.fastConfirmationContext;
     if (!fastConfirmationRule || !fastConfirmationContext) return false;
 
-    if (this.fastConfirmationPaused) {
-      // Keep consumers on a safe, available root while the rule is paused
-      this.fcStore.confirmedRoot = this.fcStore.finalizedCheckpoint.rootHex;
-      try {
-        this.notifyConfirmedRoot();
-      } catch (err) {
-        // Runs outside the timed try/catch below; a throw would escape to the clock listener
-        this.logger?.debug("Fast confirmation notify failed", {slot: this.fcStore.currentSlot}, err as Error);
-      }
-      return false;
-    }
-
-    withObservedDuration(this.metrics?.fastConfirmation.totalDuration.startTimer(), () => {
-      try {
-        withObservedDuration(
-          this.metrics?.fastConfirmation.stepsDuration.startTimer({
-            step: FastConfirmationSteps.updateHead,
-          }),
-          () => this.updateHead()
-        );
-
-        const result = fastConfirmationRule.onSlotStartAfterPastAttestationsApplied(fastConfirmationContext);
-        this.fcStore.confirmedRoot = result.confirmedRoot;
-        this.notifyConfirmedRoot();
-      } catch (err) {
-        this.logger?.debug(
-          "Fast confirmation failed",
-          {slot: this.fcStore.currentSlot, head: this.head.blockRoot, confirmedRoot: this.fcStore.confirmedRoot},
-          err as Error
-        );
-      }
-    });
-
-    return true;
+    return fastConfirmationRule.onSlotStartAfterPastAttestationsApplied(fastConfirmationContext, () =>
+      this.updateHead()
+    );
   }
 
   private createFastConfirmationContext(): FastConfirmationContext {
@@ -2348,6 +2282,7 @@ export class ForkChoice implements IForkChoice {
       getCurrentSlot: () => this.fcStore.currentSlot,
       getHead: () => this.head,
       getBlock: (root: RootHex) => this.getBlockHexDefaultStatus(root),
+      hasBlock: (root: RootHex) => this.hasBlockHexUnsafe(root),
       getAncestor: (root: RootHex, slot: Slot) => this.getAncestor(root, slot).blockRoot,
       isDescendant: (ancestor: RootHex, descendant: RootHex) => {
         const ancestorStatus = this.protoArray.getDefaultVariant(ancestor);

--- a/packages/fork-choice/src/forkChoice/store.ts
+++ b/packages/fork-choice/src/forkChoice/store.ts
@@ -45,7 +45,6 @@ export interface IForkChoiceStore extends IFastConfirmationStore {
   unrealizedFinalizedCheckpoint: CheckpointWithHex;
   justifiedBalancesGetter: JustifiedBalancesGetter;
   equivocatingIndices: Set<ValidatorIndex>;
-  notifyFastConfirmation?(data: {block: RootHex; slot: Slot; currentSlot: Slot}): void;
 }
 
 /**

--- a/packages/fork-choice/test/unit/forkChoice/fastConfirmation.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/fastConfirmation.test.ts
@@ -706,7 +706,7 @@ describe("fast confirmation", () => {
       unrealizedBalances
     );
 
-    new FastConfirmationRule(store, null).onSlotStartAfterPastAttestationsApplied(ctx);
+    new FastConfirmationRule(store, null).onSlotStartAfterPastAttestationsApplied(ctx, () => {});
 
     expect(store.previousEpochGreatestUnrealizedCheckpoint.rootHex).toBe(greatestUnrealizedRoot);
     expect(store.previousEpochGreatestUnrealizedCheckpoint.epoch).toBe(0);
@@ -738,7 +738,7 @@ describe("fast confirmation", () => {
       []
     );
 
-    new FastConfirmationRule(store, null).onSlotStartAfterPastAttestationsApplied(ctx);
+    new FastConfirmationRule(store, null).onSlotStartAfterPastAttestationsApplied(ctx, () => {});
 
     expect(store.previousEpochObservedJustifiedCheckpoint.rootHex).toBe(currentObservedRoot);
     expect(store.currentEpochObservedJustifiedCheckpoint.rootHex).toBe(greatestUnrealizedRoot);

--- a/packages/fork-choice/test/unit/forkChoice/fastConfirmationFinalization.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/fastConfirmationFinalization.test.ts
@@ -1,0 +1,182 @@
+import {describe, expect, it, vi} from "vitest";
+import {fromHexString} from "@chainsafe/ssz";
+import {config} from "@lodestar/config/default";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
+import {RootHex, Slot} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
+import {CheckpointWithHex} from "../../../src/forkChoice/store.js";
+import {
+  ExecutionStatus,
+  ForkChoice,
+  IForkChoiceStore,
+  PayloadStatus,
+  ProtoArray,
+  ProtoBlock,
+} from "../../../src/index.js";
+import {getBlockRoot, getStateRoot} from "../../utils/index.js";
+
+/**
+ * The rule moves the confirmed root on the slot tick, finality advances on every `on_block`. Once finality
+ * passes the confirmed root it drops out of the finalized subtree and `getBlockHex()` reads it as `null`,
+ * which is what `updateHead()` has to repair, well before the archiver prunes anything.
+ */
+describe("fast confirmation on finalization", () => {
+  const genesisSlot = 0;
+  const genesisEpoch = 0;
+  const genesisRoot = "0x0000000000000000000000000000000000000000000000000000000000000000";
+  const anchorRoot = getBlockRoot(genesisSlot);
+  const parentRoot = toHex(Buffer.alloc(32, 0xff));
+  const validatorCount = 100;
+
+  // A block on each of the first two epoch boundaries, plus one right after the last
+  const epoch1Slot = SLOTS_PER_EPOCH;
+  const epoch2Slot = 2 * SLOTS_PER_EPOCH;
+  const parentSlotBySlot = new Map<Slot, Slot>([
+    [epoch1Slot, genesisSlot],
+    [epoch2Slot, epoch1Slot],
+    [epoch2Slot + 1, epoch2Slot],
+  ]);
+
+  function makeChainBlock(slot: Slot): ProtoBlock {
+    return {
+      slot,
+      stateRoot: getStateRoot(slot),
+      parentRoot: getBlockRoot(parentSlotBySlot.get(slot) as Slot),
+      blockRoot: getBlockRoot(slot),
+      targetRoot: anchorRoot,
+
+      justifiedEpoch: genesisEpoch,
+      justifiedRoot: genesisRoot,
+      finalizedEpoch: genesisEpoch,
+      finalizedRoot: genesisRoot,
+      unrealizedJustifiedEpoch: genesisEpoch,
+      unrealizedJustifiedRoot: genesisRoot,
+      unrealizedFinalizedEpoch: genesisEpoch,
+      unrealizedFinalizedRoot: genesisRoot,
+
+      executionPayloadBlockHash: null,
+      executionStatus: ExecutionStatus.PreMerge,
+      dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+
+      parentBlockHash: null,
+      payloadStatus: PayloadStatus.FULL,
+      timeliness: false,
+      importedTimely: false,
+    } as ProtoBlock;
+  }
+
+  function setup(confirmedRoot: RootHex): {
+    forkchoice: ForkChoice;
+    fcStore: IForkChoiceStore;
+    notify: ReturnType<typeof vi.fn>;
+  } {
+    const checkpoint: CheckpointWithHex = {
+      epoch: genesisEpoch,
+      root: fromHexString(anchorRoot),
+      rootHex: anchorRoot,
+    };
+    const balances = new Uint16Array([32]);
+    const notify = vi.fn();
+
+    const fcStore = {
+      currentSlot: epoch2Slot,
+      justified: {checkpoint, balances, totalBalance: 32},
+      unrealizedJustified: {checkpoint, balances},
+      finalizedCheckpoint: checkpoint,
+      unrealizedFinalizedCheckpoint: checkpoint,
+      justifiedBalancesGetter: () => balances,
+      equivocatingIndices: new Set(),
+      confirmedRoot: anchorRoot,
+      previousEpochObservedJustifiedCheckpoint: checkpoint,
+      currentEpochObservedJustifiedCheckpoint: checkpoint,
+      previousEpochGreatestUnrealizedCheckpoint: checkpoint,
+      previousEpochObservedJustifiedBalances: balances,
+      currentEpochObservedJustifiedBalances: balances,
+      previousEpochGreatestUnrealizedBalances: balances,
+      previousSlotHead: anchorRoot,
+      currentSlotHead: anchorRoot,
+      stateGetter: () => null,
+      notifyFastConfirmation: notify,
+    } as unknown as IForkChoiceStore;
+
+    const protoArr = ProtoArray.initialize(
+      {
+        slot: genesisSlot,
+        stateRoot: getStateRoot(genesisSlot),
+        parentRoot,
+        blockRoot: anchorRoot,
+
+        justifiedEpoch: genesisEpoch,
+        justifiedRoot: genesisRoot,
+        finalizedEpoch: genesisEpoch,
+        finalizedRoot: genesisRoot,
+        unrealizedJustifiedEpoch: genesisEpoch,
+        unrealizedJustifiedRoot: genesisRoot,
+        unrealizedFinalizedEpoch: genesisEpoch,
+        unrealizedFinalizedRoot: genesisRoot,
+
+        executionPayloadBlockHash: null,
+        executionStatus: ExecutionStatus.PreMerge,
+        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+
+        parentBlockHash: null,
+        payloadStatus: PayloadStatus.FULL,
+        timeliness: false,
+        importedTimely: false,
+      } as Omit<ProtoBlock, "targetRoot">,
+      genesisSlot
+    );
+    for (const slot of [epoch1Slot, epoch2Slot, epoch2Slot + 1]) {
+      protoArr.onBlock(makeChainBlock(slot), slot, null);
+    }
+
+    const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null, {fastConfirmation: true});
+    fcStore.confirmedRoot = confirmedRoot;
+    notify.mockClear();
+
+    // on_block advanced finality past the epoch the confirmed root sits in, nothing pruned yet
+    fcStore.finalizedCheckpoint = {
+      epoch: 2,
+      root: fromHexString(getBlockRoot(epoch2Slot)),
+      rootHex: getBlockRoot(epoch2Slot),
+    };
+
+    return {forkchoice, fcStore, notify};
+  }
+
+  it("re-pins the confirmed root that finality moved past", () => {
+    const {forkchoice, fcStore, notify} = setup(getBlockRoot(epoch1Slot));
+
+    // What importBlock does right after on_block, via recomputeForkChoiceHead()
+    forkchoice.updateHead();
+
+    expect(fcStore.confirmedRoot).toBe(getBlockRoot(epoch2Slot));
+    expect(forkchoice.getConfirmedBlock()?.blockRoot).toBe(getBlockRoot(epoch2Slot));
+    expect(notify).toHaveBeenCalledExactlyOnceWith({
+      block: getBlockRoot(epoch2Slot),
+      slot: epoch2Slot,
+      currentSlot: epoch2Slot,
+    });
+  });
+
+  it("leaves a confirmed root that finality has not passed alone", () => {
+    const {forkchoice, fcStore, notify} = setup(getBlockRoot(epoch2Slot + 1));
+
+    forkchoice.updateHead();
+
+    expect(fcStore.confirmedRoot).toBe(getBlockRoot(epoch2Slot + 1));
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("leaves an unknown confirmed root for the caller to surface", () => {
+    const unknownRoot = `0x${"12".repeat(32)}`;
+    const {forkchoice, fcStore, notify} = setup(unknownRoot);
+
+    forkchoice.updateHead();
+
+    expect(fcStore.confirmedRoot).toBe(unknownRoot);
+    expect(forkchoice.getConfirmedBlock()).toBeNull();
+    expect(notify).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fork-choice/test/unit/forkChoice/fastConfirmationTestUtils.ts
+++ b/packages/fork-choice/test/unit/forkChoice/fastConfirmationTestUtils.ts
@@ -170,6 +170,7 @@ export function makeContext(
     getCurrentSlot: () => currentSlot,
     getHead: () => blocksByRoot.get(headRoot) ?? nullBlock(headRoot),
     getBlock: (root: RootHex) => blocksByRoot.get(root) ?? null,
+    hasBlock: (root: RootHex) => blocksByRoot.has(root),
     getAncestor: (root: RootHex, slot: Slot) => {
       let current = blocksByRoot.get(root);
       while (current && current.slot > slot) {


### PR DESCRIPTION
## Motivation

Fast-confirmation lifecycle behavior is split between `ForkChoice` and `FastConfirmationRule`. That makes ownership of the confirmed root, pause state, notification, metrics, and finality recovery difficult to reason about.

## Description

- Move pause and resume state into `FastConfirmationRule`.
- Move confirmed-root mutation, notification, metrics, and finality recovery into the FCR module.
- Keep `ForkChoice` responsible for providing fork-choice context and invoking lifecycle hooks.
- Expose one slot entry point, `onSlotStartAfterPastAttestationsApplied`, with the root update kept private.
- Repair roots that became unavailable after finality advanced while preserving unknown roots for callers to surface.

This is the structural follow-up to #10027. That PR uses a shallow finalized-block fallback to unblock the current failure. Once #10027 lands on `unstable`, this draft will remove that temporary fallback before merge.

## Validation

- `pnpm --filter @lodestar/fork-choice check-types`
- `pnpm --filter @lodestar/fork-choice lint`
- Targeted fork-choice unit tests: 45 passed
- Fulu fast-confirmation spec tests: 182 passed, 2 skipped

## AI assistance disclosure

> This PR was written with Codex. The design and resulting changes were reviewed and verified locally.
