### PR TITLE
docs: document why BuilderPendingPayment.weight is safe as UintNum64

### DIFF
--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -238,6 +238,9 @@ export const BuilderPendingWithdrawal = new ContainerType(
 
 export const BuilderPendingPayment = new ContainerType(
   {
+    // weight accumulates one slot's attesting effective balance in gwei (~total_active_balance /
+    // SLOTS_PER_EPOCH); that stays well under Number.MAX_SAFE_INTEGER (2**53) even far beyond mainnet
+    // stake, so UintNum64 (a JS number) represents it exactly.
     weight: UintNum64,
     withdrawal: BuilderPendingWithdrawal,
     proposerIndex: ValidatorIndex,

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -238,9 +238,9 @@ export const BuilderPendingWithdrawal = new ContainerType(
 
 export const BuilderPendingPayment = new ContainerType(
   {
-    // weight accumulates one slot's attesting effective balance in gwei (~total_active_balance /
-    // SLOTS_PER_EPOCH); that stays well under Number.MAX_SAFE_INTEGER (2**53) even far beyond mainnet
-    // stake, so UintNum64 (a JS number) represents it exactly.
+    // weight sums attesting validators' effective balances, which are multiples of 1e9 Gwei;
+    // such multiples stay exactly representable as JS numbers far beyond any reachable Ethereum
+    // stake, so UintNum64 is safe here.
     weight: UintNum64,
     withdrawal: BuilderPendingWithdrawal,
     proposerIndex: ValidatorIndex,


### PR DESCRIPTION
## What

Keep `BuilderPendingPayment.weight` as `UintNum64` and add a comment explaining why a JS `number` is safe here.

## Why

Per @nflaig's review, this reverts the bigint-domain refactor the PR originally proposed — `num64` is safe, so it was never a correctness fix. `weight` accumulates one slot's attesting effective balance in gwei, bounded by ~`total_active_balance / SLOTS_PER_EPOCH`, which stays well under `Number.MAX_SAFE_INTEGER` (2^53) even far beyond mainnet stake, so a JS number represents it exactly. Matches pk910's [correction on #9350](https://github.com/ChainSafe/lodestar/pull/9350#issuecomment-4415645047).

The bigint-domain coherence refactor, if still wanted, would be a separate PR.

Refs #9350

🤖 Generated with AI assistance