### PR TITLE
refactor: derive gloas p2p max sizes from ssz types

### DIFF
--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -123,6 +123,9 @@ export class DataTransformSnappy implements DataTransform {
     if (uncompressedDataLength > maxSize) {
       throw Error(`ssz_snappy decoded data length ${uncompressedDataLength} > ${maxSize}`);
     }
+    if (uncompressedDataLength > sszType.maxSize) {
+      throw Error(`ssz_snappy decoded data length ${uncompressedDataLength} > ${sszType.maxSize}`);
+    }
 
     // Only after sanity length checks, we can decompress the data
     // Using Buffer.alloc() instead of Buffer.allocUnsafe() to mitigate high GC pressure observed in some environments
@@ -142,6 +145,9 @@ export class DataTransformSnappy implements DataTransform {
     this.metrics?.dataTransform.outbound.inc({type: topic.type});
     if (data.length > maxSize) {
       throw Error(`ssz_snappy encoded data length ${data.length} > ${maxSize}`);
+    }
+    if (data.length > sszType.maxSize) {
+      throw Error(`ssz_snappy encoded data length ${data.length} > ${sszType.maxSize}`);
     }
 
     // Using Buffer.alloc() instead of Buffer.allocUnsafe() to mitigate high GC pressure observed in some environments

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -123,9 +123,6 @@ export class DataTransformSnappy implements DataTransform {
     if (uncompressedDataLength > maxSize) {
       throw Error(`ssz_snappy decoded data length ${uncompressedDataLength} > ${maxSize}`);
     }
-    if (uncompressedDataLength > sszType.maxSize) {
-      throw Error(`ssz_snappy decoded data length ${uncompressedDataLength} > ${sszType.maxSize}`);
-    }
 
     // Only after sanity length checks, we can decompress the data
     // Using Buffer.alloc() instead of Buffer.allocUnsafe() to mitigate high GC pressure observed in some environments
@@ -145,9 +142,6 @@ export class DataTransformSnappy implements DataTransform {
     this.metrics?.dataTransform.outbound.inc({type: topic.type});
     if (data.length > maxSize) {
       throw Error(`ssz_snappy encoded data length ${data.length} > ${maxSize}`);
-    }
-    if (data.length > sszType.maxSize) {
-      throw Error(`ssz_snappy encoded data length ${data.length} > ${sszType.maxSize}`);
     }
 
     // Using Buffer.alloc() instead of Buffer.allocUnsafe() to mitigate high GC pressure observed in some environments

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -133,17 +133,11 @@ export function getGossipSSZType(topic: GossipTopic) {
 }
 
 /**
- * Return the maximum uncompressed SSZ byte length accepted for a gossip object.
+ * Return the maximum uncompressed SSZ byte length accepted for a gossip object, the SSZ type max size
+ * or MAX_PAYLOAD_SIZE, whichever is smaller.
  */
 export function getGossipSSZMaxSize(topic: GossipTopic, maxPayloadSize: number, sszType?: CompositeTypeAny): number {
-  switch (topic.type) {
-    // Blocks and payload envelopes contain unbounded progressive lists, so their SSZ max size is not a useful bound
-    case GossipType.beacon_block:
-    case GossipType.execution_payload:
-      return maxPayloadSize;
-    default:
-      return (sszType ?? getGossipSSZType(topic)).maxSize;
-  }
+  return Math.min((sszType ?? getGossipSSZType(topic)).maxSize, maxPayloadSize);
 }
 
 /**

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -4,17 +4,11 @@ import {
   ATTESTATION_SUBNET_COUNT,
   ForkName,
   ForkSeq,
-  MAX_ATTESTER_SLASHING_SIZE,
-  MAX_DATA_COLUMN_SIDECAR_SIZE,
-  MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE,
-  MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE,
-  MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE,
   SYNC_COMMITTEE_SUBNET_COUNT,
   isForkPostAltair,
   isForkPostElectra,
   isForkPostFulu,
   isForkPostGloas,
-  isForkPostHeze,
 } from "@lodestar/params";
 import {Attestation, SingleAttestation, ssz, sszTypesFor} from "@lodestar/types";
 import {GossipAction, GossipActionError, GossipErrorCode} from "../../chain/errors/gossipValidation.js";
@@ -142,21 +136,11 @@ export function getGossipSSZType(topic: GossipTopic) {
  * Return the maximum uncompressed SSZ byte length accepted for a gossip object.
  */
 export function getGossipSSZMaxSize(topic: GossipTopic, maxPayloadSize: number, sszType?: CompositeTypeAny): number {
-  const {fork} = topic.boundary;
-  // Gloas progressive containers have broad theoretical SSZ max sizes; use the preset p2p bounds instead.
   switch (topic.type) {
+    // Blocks and payload envelopes contain unbounded progressive lists, so their SSZ max size is not a useful bound
     case GossipType.beacon_block:
-      return maxPayloadSize;
-    case GossipType.beacon_aggregate_and_proof:
-      return isForkPostGloas(fork) ? MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE : (sszType ?? getGossipSSZType(topic)).maxSize;
-    case GossipType.attester_slashing:
-      return isForkPostGloas(fork) ? MAX_ATTESTER_SLASHING_SIZE : (sszType ?? getGossipSSZType(topic)).maxSize;
-    case GossipType.data_column_sidecar:
-      return isForkPostGloas(fork) ? MAX_DATA_COLUMN_SIDECAR_SIZE : (sszType ?? getGossipSSZType(topic)).maxSize;
     case GossipType.execution_payload:
       return maxPayloadSize;
-    case GossipType.execution_payload_bid:
-      return isForkPostHeze(fork) ? MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE : MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE;
     default:
       return (sszType ?? getGossipSSZType(topic)).maxSize;
   }

--- a/packages/beacon-node/src/network/reqresp/protocols.ts
+++ b/packages/beacon-node/src/network/reqresp/protocols.ts
@@ -1,6 +1,6 @@
 import {BeaconConfig} from "@lodestar/config";
-import {ForkName, MAX_DATA_COLUMN_SIDECAR_SIZE, isForkPostGloas} from "@lodestar/params";
-import {ContextBytesFactory, ContextBytesType, Encoding, TypeSizes} from "@lodestar/reqresp";
+import {ForkName} from "@lodestar/params";
+import {ContextBytesFactory, ContextBytesType, Encoding} from "@lodestar/reqresp";
 import {rateLimitQuotas} from "./rateLimit.js";
 import {ProtocolNoHandler, ReqRespMethod, Version, requestSszTypeByMethod, responseSszTypeByMethod} from "./types.js";
 
@@ -151,35 +151,18 @@ function toProtocol(protocol: ProtocolSummary) {
       encoding: Encoding.SSZ_SNAPPY,
       contextBytes: toContextBytes(protocol.contextBytesType, config),
       inboundRateLimits: rateLimitQuotas(fork, config)[protocol.method],
-      requestSizes: requestType === null ? null : clampTypeSizes(requestType, protocol.method, fork, config),
-      responseSizes: (fork) =>
-        clampTypeSizes(responseSszTypeByMethod[protocol.method](fork, protocol.version), protocol.method, fork, config),
+      // Length-prefix must be within the SSZ type bounds or MAX_PAYLOAD_SIZE, whichever is smaller
+      // https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/phase0/p2p-interface.md#encoding-strategies
+      requestSizes:
+        requestType === null
+          ? null
+          : {minSize: requestType.minSize, maxSize: Math.min(requestType.maxSize, config.MAX_PAYLOAD_SIZE)},
+      responseSizes: (fork) => {
+        const responseType = responseSszTypeByMethod[protocol.method](fork, protocol.version);
+        return {minSize: responseType.minSize, maxSize: Math.min(responseType.maxSize, config.MAX_PAYLOAD_SIZE)};
+      },
     };
   };
-}
-
-/**
- * Bound the sizes accepted from the ssz-snappy length-prefix. Gloas progressive containers have broad
- * theoretical SSZ max sizes so the preset p2p bounds must be used instead.
- *
- * The length-prefix must be within the size bounds derived from the payload SSZ type or `MAX_PAYLOAD_SIZE`,
- * whichever is smaller, see
- * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/phase0/p2p-interface.md#encoding-strategies.
- * Type-specific SSZ bounds supersede the bounds derived from the SSZ type, see
- * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/gloas/p2p-interface.md#type-specific-ssz-bounds.
- */
-function clampTypeSizes(type: TypeSizes, method: ReqRespMethod, fork: ForkName, config: BeaconConfig): TypeSizes {
-  let typeSpecificBound = config.MAX_PAYLOAD_SIZE;
-  if (isForkPostGloas(fork)) {
-    switch (method) {
-      case ReqRespMethod.DataColumnSidecarsByRange:
-      case ReqRespMethod.DataColumnSidecarsByRoot:
-        typeSpecificBound = MAX_DATA_COLUMN_SIDECAR_SIZE;
-        break;
-    }
-  }
-
-  return {minSize: type.minSize, maxSize: Math.min(type.maxSize, typeSpecificBound)};
 }
 
 function toContextBytes(type: ContextBytesType, config: BeaconConfig): ContextBytesFactory {

--- a/packages/beacon-node/src/network/reqresp/protocols.ts
+++ b/packages/beacon-node/src/network/reqresp/protocols.ts
@@ -1,6 +1,6 @@
 import {BeaconConfig} from "@lodestar/config";
 import {ForkName} from "@lodestar/params";
-import {ContextBytesFactory, ContextBytesType, Encoding} from "@lodestar/reqresp";
+import {ContextBytesFactory, ContextBytesType, Encoding, TypeSizes} from "@lodestar/reqresp";
 import {rateLimitQuotas} from "./rateLimit.js";
 import {ProtocolNoHandler, ReqRespMethod, Version, requestSszTypeByMethod, responseSszTypeByMethod} from "./types.js";
 
@@ -151,18 +151,18 @@ function toProtocol(protocol: ProtocolSummary) {
       encoding: Encoding.SSZ_SNAPPY,
       contextBytes: toContextBytes(protocol.contextBytesType, config),
       inboundRateLimits: rateLimitQuotas(fork, config)[protocol.method],
-      // Length-prefix must be within the SSZ type bounds or MAX_PAYLOAD_SIZE, whichever is smaller
-      // https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/phase0/p2p-interface.md#encoding-strategies
-      requestSizes:
-        requestType === null
-          ? null
-          : {minSize: requestType.minSize, maxSize: Math.min(requestType.maxSize, config.MAX_PAYLOAD_SIZE)},
-      responseSizes: (fork) => {
-        const responseType = responseSszTypeByMethod[protocol.method](fork, protocol.version);
-        return {minSize: responseType.minSize, maxSize: Math.min(responseType.maxSize, config.MAX_PAYLOAD_SIZE)};
-      },
+      requestSizes: requestType === null ? null : clampTypeSizes(requestType, config),
+      responseSizes: (fork) => clampTypeSizes(responseSszTypeByMethod[protocol.method](fork, protocol.version), config),
     };
   };
+}
+
+/**
+ * Length-prefix must be within the SSZ type bounds or MAX_PAYLOAD_SIZE, whichever is smaller
+ * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/phase0/p2p-interface.md#encoding-strategies
+ */
+function clampTypeSizes(type: TypeSizes, config: BeaconConfig): TypeSizes {
+  return {minSize: type.minSize, maxSize: Math.min(type.maxSize, config.MAX_PAYLOAD_SIZE)};
 }
 
 function toContextBytes(type: ContextBytesType, config: BeaconConfig): ContextBytesFactory {

--- a/packages/beacon-node/test/unit-minimal/network/gossip/topic.test.ts
+++ b/packages/beacon-node/test/unit-minimal/network/gossip/topic.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from "vitest";
+import {config} from "@lodestar/config/default";
+import {
+  ForkName,
+  MAX_ATTESTER_SLASHING_SIZE,
+  MAX_DATA_COLUMN_SIDECAR_SIZE,
+  MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE,
+  MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE,
+  MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE,
+} from "@lodestar/params";
+import {GossipEncoding, GossipType} from "../../../../src/network/gossip/index.js";
+import {getGossipSSZMaxSize} from "../../../../src/network/gossip/topic.js";
+
+describe("network / gossip / topic", () => {
+  const encoding = GossipEncoding.ssz_snappy;
+
+  // Gossip size limits are derived from the ssz types, ensure they match the preset p2p bounds for minimal as well
+  for (const fork of [ForkName.gloas, ForkName.heze]) {
+    it(`should match the preset p2p size bounds for ${fork} progressive objects`, () => {
+      const boundary = {fork, epoch: 0};
+
+      expect({
+        [GossipType.data_column_sidecar]: getGossipSSZMaxSize(
+          {type: GossipType.data_column_sidecar, boundary, subnet: 1, encoding},
+          config.MAX_PAYLOAD_SIZE
+        ),
+        [GossipType.beacon_aggregate_and_proof]: getGossipSSZMaxSize(
+          {type: GossipType.beacon_aggregate_and_proof, boundary, encoding},
+          config.MAX_PAYLOAD_SIZE
+        ),
+        [GossipType.attester_slashing]: getGossipSSZMaxSize(
+          {type: GossipType.attester_slashing, boundary, encoding},
+          config.MAX_PAYLOAD_SIZE
+        ),
+        [GossipType.execution_payload_bid]: getGossipSSZMaxSize(
+          {type: GossipType.execution_payload_bid, boundary, encoding},
+          config.MAX_PAYLOAD_SIZE
+        ),
+      }).toEqual({
+        [GossipType.data_column_sidecar]: MAX_DATA_COLUMN_SIDECAR_SIZE,
+        [GossipType.beacon_aggregate_and_proof]: MAX_SIGNED_AGGREGATE_AND_PROOF_SIZE,
+        [GossipType.attester_slashing]: MAX_ATTESTER_SLASHING_SIZE,
+        [GossipType.execution_payload_bid]:
+          fork === ForkName.heze ? MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE_HEZE : MAX_SIGNED_EXECUTION_PAYLOAD_BID_SIZE,
+      });
+    });
+  }
+});

--- a/packages/beacon-node/test/unit/network/gossip/topic.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/topic.test.ts
@@ -250,7 +250,7 @@ describe("network / gossip / topic", () => {
     }
   });
 
-  it("should use preset-defined gossip size limits for Gloas progressive objects", () => {
+  it("should match the preset p2p size bounds for Gloas progressive objects", () => {
     const boundary = {fork: ForkName.gloas, epoch: config.GLOAS_FORK_EPOCH};
 
     expect({


### PR DESCRIPTION
Since #10042 the gloas progressive lists carry their limits in the ssz types, so the max sizes of `SignedAggregateAndProof`, `AttesterSlashing`, `DataColumnSidecar` and `SignedExecutionPayloadBid` already equal the spec p2p bounds under both presets.

- bound gossip and reqresp objects by the ssz type max size or `MAX_PAYLOAD_SIZE`, whichever is smaller, dropping the gloas special cases in `getGossipSSZMaxSize` and the reqresp size clamp
- remove the ssz type max size checks in gossip encoding, unreachable now that the gossip bound never exceeds the type max size
- add a minimal preset test asserting the derived sizes match the preset p2p bounds for gloas and heze

Follow-up to #10042
