### PR TITLE
fix: batch verify payload attestation signatures in blocks

### DIFF
--- a/packages/state-transition/src/signatureSets/index.ts
+++ b/packages/state-transition/src/signatureSets/index.ts
@@ -1,13 +1,14 @@
 import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq} from "@lodestar/params";
-import {IndexedAttestation, SignedBeaconBlock, altair, capella} from "@lodestar/types";
+import {IndexedAttestation, SignedBeaconBlock, altair, capella, gloas} from "@lodestar/types";
 import {getSyncCommitteeSignatureSet} from "../block/processSyncCommittee.js";
 import {SyncCommitteeCache} from "../cache/syncCommitteeCache.js";
-import {IBeaconStateView} from "../stateView/interface.js";
-import {ISignatureSet} from "../util/index.js";
+import {IBeaconStateView, IBeaconStateViewGloas} from "../stateView/interface.js";
+import {ISignatureSet, createAggregateSignatureSetFromComponents} from "../util/index.js";
 import {getAttesterSlashingsSignatureSets} from "./attesterSlashings.js";
 import {getBlsToExecutionChangeSignatureSets} from "./blsToExecutionChange.js";
 import {getAttestationsSignatureSets} from "./indexedAttestation.js";
+import {getPayloadAttestationDataSigningRoot} from "./indexedPayloadAttestation.js";
 import {getBlockProposerSignatureSet} from "./proposer.js";
 import {getProposerSlashingsSignatureSets} from "./proposerSlashings.js";
 import {getRandaoRevealSignatureSet} from "./randao.js";
@@ -76,6 +77,19 @@ export function getBlockSignatureSets(
     );
     if (blsToExecutionChangeSignatureSets.length > 0) {
       signatureSets.push(...blsToExecutionChangeSignatureSets);
+    }
+  }
+
+  if (fork >= ForkSeq.gloas) {
+    for (const payloadAttestation of (signedBlock as gloas.SignedBeaconBlock).message.body.payloadAttestations) {
+      const ptc = (state as IBeaconStateViewGloas).getPayloadTimelinessCommittee(payloadAttestation.data.slot);
+      signatureSets.push(
+        createAggregateSignatureSetFromComponents(
+          payloadAttestation.aggregationBits.intersectValues(ptc),
+          getPayloadAttestationDataSigningRoot(config, payloadAttestation.data),
+          payloadAttestation.signature
+        )
+      );
     }
   }
 

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -456,6 +456,18 @@ export class BeaconStateView implements IBeaconStateViewLatestFork {
     }
     throw new Error(`PTC committees are not available for epoch=${epoch}`);
   }
+
+  /**
+   * Return the PTC for a slot in the previous, current or next epoch
+   */
+  getPayloadTimelinessCommittee(slot: Slot): Uint32Array {
+    if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
+      throw new Error("PTC committees are not supported before Gloas");
+    }
+
+    return (this.cachedState as CachedBeaconStateGloas).epochCtx.getPayloadTimelinessCommittee(slot);
+  }
+
   /**
    * Return all positions of the validator in the PTC committee for the given slot.
    *

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -285,6 +285,7 @@ export interface IBeaconStateViewGloas extends IBeaconStateViewFulu {
   getBuildersLength(): number;
   canBuilderCoverBid(builderIndex: BuilderIndex, bidAmount: number): boolean;
   getEpochPTCs(epoch: Epoch): Uint32Array[];
+  getPayloadTimelinessCommittee(slot: Slot): Uint32Array;
   getIndicesInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number[];
   /**
    * Clone the state and apply parent execution payload effects.

--- a/packages/state-transition/src/stateView/nativeBeaconStateView.ts
+++ b/packages/state-transition/src/stateView/nativeBeaconStateView.ts
@@ -926,6 +926,10 @@ export class NativeBeaconStateView implements IBeaconStateViewLatestFork {
     return cached;
   }
 
+  getPayloadTimelinessCommittee(slot: Slot): Uint32Array {
+    return this.binding.getPayloadTimelinessCommittee(slot);
+  }
+
   getIndicesInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number[] {
     return this.binding.getIndicesInPayloadTimelinessCommittee(validatorIndex, slot);
   }

--- a/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -3,13 +3,20 @@ import {describe, expect, it} from "vitest";
 import {SecretKey} from "@chainsafe/lodestar-z/blst";
 import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
 import {BitArray} from "@chainsafe/ssz";
+import {createChainForkConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
-import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE} from "@lodestar/params";
-import {BLSSignature, ValidatorIndex, capella, phase0, ssz} from "@lodestar/types";
-import {ZERO_HASH} from "../../../src/constants/index.js";
+import {
+  FAR_FUTURE_EPOCH,
+  MAX_EFFECTIVE_BALANCE,
+  PTC_SIZE,
+  SLOTS_PER_EPOCH,
+  SYNC_COMMITTEE_SIZE,
+} from "@lodestar/params";
+import {BLSSignature, ValidatorIndex, capella, gloas, phase0, ssz} from "@lodestar/types";
+import {G2_POINT_AT_INFINITY, ZERO_HASH} from "../../../src/constants/index.js";
 import {BeaconStateView} from "../../../src/index.js";
-import {getBlockSignatureSets} from "../../../src/signatureSets/index.js";
-import {generateCachedState} from "../../../src/testUtils/state.js";
+import {getBlockSignatureSets, getPayloadAttestationDataSigningRoot} from "../../../src/signatureSets/index.js";
+import {createCachedBeaconStateTest, generateCachedState} from "../../../src/testUtils/state.js";
 import {SignatureSetType, toBlsSignatureSet, verifySignatureSet} from "../../../src/util/signatureSets.js";
 import {generateValidators} from "../../utils/validator.js";
 
@@ -134,6 +141,87 @@ describe("signatureSets", () => {
         // 1 x voluntaryExits
         1
     );
+  });
+
+  it("should include payload attestation signatures from a gloas block", () => {
+    const chainConfig = createChainForkConfig({
+      ALTAIR_FORK_EPOCH: 0,
+      BELLATRIX_FORK_EPOCH: 0,
+      CAPELLA_FORK_EPOCH: 0,
+      DENEB_FORK_EPOCH: 0,
+      ELECTRA_FORK_EPOCH: 0,
+      FULU_FORK_EPOCH: 0,
+      GLOAS_FORK_EPOCH: 0,
+    });
+    // The block is at the first slot of an epoch, so its payload attestation uses the previous epoch's PTC
+    const blockSlot = SLOTS_PER_EPOCH;
+    const stateView = ssz.gloas.BeaconState.defaultViewDU();
+    stateView.slot = blockSlot;
+    const pubkeys: Uint8Array[] = [];
+    for (let i = 0; i < 32; i++) {
+      const validator = ssz.phase0.Validator.defaultViewDU();
+      validator.pubkey = SecretKey.fromKeygen(Buffer.alloc(32, i)).toPublicKey().toBytes();
+      validator.effectiveBalance = MAX_EFFECTIVE_BALANCE;
+      validator.activationEpoch = 0;
+      validator.exitEpoch = FAR_FUTURE_EPOCH;
+      validator.withdrawableEpoch = FAR_FUTURE_EPOCH;
+      pubkeys.push(validator.pubkey);
+      stateView.validators.push(validator);
+      stateView.balances.push(MAX_EFFECTIVE_BALANCE);
+      stateView.previousEpochParticipation.push(0);
+      stateView.currentEpochParticipation.push(0);
+      stateView.inactivityScores.push(0);
+    }
+    const syncCommittee = {
+      pubkeys: Array.from({length: SYNC_COMMITTEE_SIZE}, () => pubkeys[0]),
+      aggregatePubkey: pubkeys[0],
+    };
+    stateView.currentSyncCommittee = ssz.altair.SyncCommittee.toViewDU(syncCommittee);
+    stateView.nextSyncCommittee = ssz.altair.SyncCommittee.toViewDU(syncCommittee);
+    stateView.commit();
+    pubkeyCache.reset();
+    const state = createCachedBeaconStateTest(stateView, chainConfig);
+
+    const data: gloas.PayloadAttestationData = {
+      beaconBlockRoot: ZERO_HASH,
+      slot: blockSlot - 1,
+      payloadPresent: true,
+      blobDataAvailable: true,
+    };
+    const signature = SecretKey.fromKeygen(Buffer.alloc(32, 0))
+      .sign(getPayloadAttestationDataSigningRoot(state.config, data))
+      .toBytes();
+
+    const signedBlock: gloas.SignedBeaconBlock = {
+      message: {
+        slot: blockSlot,
+        proposerIndex: 0,
+        parentRoot: ZERO_HASH,
+        stateRoot: ZERO_HASH,
+        body: {
+          ...ssz.gloas.BeaconBlockBody.defaultValue(),
+          syncAggregate: {
+            syncCommitteeBits: BitArray.fromBitLen(SYNC_COMMITTEE_SIZE),
+            syncCommitteeSignature: G2_POINT_AT_INFINITY,
+          },
+          payloadAttestations: [{aggregationBits: BitArray.fromSingleBit(PTC_SIZE, 0), data, signature}],
+        },
+      },
+      signature: EMPTY_SIGNATURE,
+    };
+
+    const signatureSets = getBlockSignatureSets(
+      state.config,
+      state.epochCtx.currentSyncCommitteeIndexed,
+      new BeaconStateView(state),
+      signedBlock,
+      []
+    );
+    // Randao reveal, block signature and the payload attestation
+    expect(signatureSets.length).toBe(3);
+    // The default ptcWindow is all zeros, so validator 0 fills every PTC position
+    expect(signatureSets[2]).toMatchObject({type: SignatureSetType.aggregate, indices: [0]});
+    expect(verifySignatureSet(signatureSets[2])).toBe(true);
   });
 });
 


### PR DESCRIPTION
Since #9761 `processPayloadAttestation` honors `verifySignatures`, which is false on the default block import path because signatures are expected to be verified in batch. `getBlockSignatureSets` did not include payload attestations, so PTC signatures in blocks were not verified anywhere. A proposer could include a payload attestation with an arbitrary signature and lodestar would import the block while every other client rejects it, see https://github.com/ChainSafe/lodestar/pull/9761#discussion_r3921309021.

- add payload attestation signature sets to `getBlockSignatureSets`
- add slot-based `getPayloadTimelinessCommittee` to the state view, `getEpochPTCs` does not serve the previous epoch which is needed at epoch boundaries

The native state view binding needs to implement the new getter. A spec test harness that catches this class of regression will follow in a separate PR.
