### PR TITLE
refactor: compute payload attributes once in `prepareForNextSlot`

### DIFF
--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -25,6 +25,7 @@ import {Bytes32, Slot, ValidatorIndex} from "@lodestar/types";
 import {Logger, fromHex, isErrorAborted, sleep} from "@lodestar/utils";
 import {GENESIS_SLOT} from "../constants/constants.js";
 import {BuilderStatus} from "../execution/builder/http.js";
+import {PayloadAttributes} from "../execution/index.js";
 import {Metrics} from "../metrics/index.js";
 import {ClockEvent} from "../util/clock.js";
 import {isQueueErrorAborted} from "../util/queue/index.js";
@@ -243,6 +244,7 @@ export class PrepareNextSlotScheduler {
           parentBlockHash = preparedState.latestExecutionPayloadHeader.blockHash;
         }
 
+        let payloadAttributes: PayloadAttributes | undefined;
         // If emitPayloadAttributes is true emit a SSE payloadAttributes event for
         // every slot. Without the flag, only emit the event if we are proposing in the next slot.
         if (
@@ -257,6 +259,7 @@ export class PrepareNextSlotScheduler {
             feeRecipient: feeRecipient ?? "0x0000000000000000000000000000000000000000",
           });
           this.chain.emitter.emit(routes.events.EventType.payloadAttributes, {data, version: fork});
+          payloadAttributes = data.payloadAttributes;
         }
 
         if (feeRecipient) {
@@ -279,7 +282,8 @@ export class PrepareNextSlotScheduler {
             safeBlockHash,
             finalizedBlockHash,
             stateAfterParentPayload,
-            feeRecipient
+            feeRecipient,
+            payloadAttributes
           );
           this.logger.verbose("PrepareNextSlotScheduler prepared new payload", {
             prepareSlot,

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -735,7 +735,9 @@ export async function prepareExecutionPayload(
    * parent execution payload first (see `withParentPayloadApplied`).
    */
   state: IBeaconStateViewBellatrix,
-  suggestedFeeRecipient: string
+  suggestedFeeRecipient: string,
+  /** Attributes already computed for the same state and fee recipient, e.g. for the SSE event */
+  payloadAttributes?: PayloadAttributes
 ): Promise<{prepType: PayloadPreparationType; payloadId: PayloadId}> {
   const timestamp = computeTimeAtSlot(chain.config, state.slot, state.genesisTime);
   const prevRandao = state.getRandaoMix(state.epoch);
@@ -766,13 +768,15 @@ export async function prepareExecutionPayload(
       prepType = PayloadPreparationType.Fresh;
     }
 
-    const attributes: PayloadAttributes = preparePayloadAttributes(fork, chain, {
-      prepareState: state,
-      prepareSlot: state.slot,
-      parentBlockRoot,
-      parentBlockHash,
-      feeRecipient: suggestedFeeRecipient,
-    });
+    const attributes: PayloadAttributes =
+      payloadAttributes ??
+      preparePayloadAttributes(fork, chain, {
+        prepareState: state,
+        prepareSlot: state.slot,
+        parentBlockRoot,
+        parentBlockHash,
+        feeRecipient: suggestedFeeRecipient,
+      });
 
     payloadId = await chain.executionEngine.notifyForkchoiceUpdate(
       fork,

--- a/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
+++ b/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
@@ -169,6 +169,10 @@ describe("PrepareNextSlot scheduler", () => {
       executionEngineStub.notifyForkchoiceUpdate.mock.invocationCallOrder[0]
     );
     expect(spy.mock.invocationCallOrder[0]).toBeLessThan(computeStateHashTreeRoot.mock.invocationCallOrder[0]);
+    // attributes computed for the event are reused for the EL payload preparation
+    expect(executionEngineStub.notifyForkchoiceUpdate.mock.calls[0][4]).toBe(
+      spy.mock.calls[0][0].data.payloadAttributes
+    );
     expect(loggerStub.error).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
When we propose the next slot and a client is subscribed to `payload_attributes`, `prepareForNextSlot` computes the payload attributes twice: once for the SSE event and again in `prepareExecutionPayload` for the `engine_forkchoiceUpdated` call, both from the same state and fee recipient. The second run repeats `getExpectedWithdrawals` (and the target gas limit lookup post-gloas) for nothing.

- `prepareExecutionPayload` accepts precomputed attributes and only builds them itself when none are passed, block production paths are unchanged
- `prepareForNextSlot` passes the attributes of the emitted event to the EL preparation

Cost of the second run, measured as one `getPayloadAttributesForSSE` call on a 250k validator capella state with warm balance and validator caches. The cases differ in how many validators the withdrawals sweep probes before it fills the 16 slots:

| sweep case | probes | per run |
|---|---|---|
| best case, every probe is a withdrawal | 16 | 6.2 us |
| 10% eth1 credentials | 220 | 35 us |
| worst case, bounded sweep without candidates | 16384 | 2.8 ms |

Mainnet is close to the best case, so this saves microseconds per proposal and only when a client is subscribed to the event. It is a cleanup, not a performance improvement.

Follow-up to https://github.com/ChainSafe/lodestar/pull/10037#pullrequestreview-5148972904
