### PR TITLE
chore: improve log on REJECTED blocks, columns, payloads

### DIFF
--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -120,9 +120,9 @@ export type BlockErrorType =
   | {code: BlockErrorCode.ALREADY_KNOWN; root: RootHex}
   | {code: BlockErrorCode.REPEAT_PROPOSAL; proposerIndex: ValidatorIndex; root: RootHex}
   | {code: BlockErrorCode.BLOCK_SLOT_LIMIT_REACHED}
-  | {code: BlockErrorCode.INCORRECT_PROPOSER; proposerIndex: ValidatorIndex}
-  | {code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID; blockSlot: Slot}
-  | {code: BlockErrorCode.UNKNOWN_PROPOSER; proposerIndex: ValidatorIndex}
+  | {code: BlockErrorCode.INCORRECT_PROPOSER; slot: Slot; root: RootHex; proposerIndex: ValidatorIndex}
+  | {code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID; slot: Slot; root: RootHex}
+  | {code: BlockErrorCode.UNKNOWN_PROPOSER; slot: Slot; root: RootHex; proposerIndex: ValidatorIndex}
   | {code: BlockErrorCode.INVALID_SIGNATURE; state: IBeaconStateView}
   | {
       code: BlockErrorCode.INVALID_STATE_ROOT;
@@ -132,7 +132,7 @@ export type BlockErrorType =
       postState: IBeaconStateView;
     }
   | {code: BlockErrorCode.NOT_FINALIZED_DESCENDANT; parentRoot: RootHex}
-  | {code: BlockErrorCode.NOT_LATER_THAN_PARENT; parentSlot: Slot; slot: Slot}
+  | {code: BlockErrorCode.NOT_LATER_THAN_PARENT; slot: Slot; root: RootHex; parentSlot: Slot}
   | {code: BlockErrorCode.NON_LINEAR_PARENT_ROOTS}
   | {code: BlockErrorCode.NON_LINEAR_SLOTS}
   | {code: BlockErrorCode.ENVELOPE_BLOCK_ROOT_MISMATCH; envelopeBlockRoot: RootHex; blockRoot: RootHex}
@@ -140,7 +140,7 @@ export type BlockErrorType =
   | {code: BlockErrorCode.BEACON_CHAIN_ERROR; error: Error}
   | {code: BlockErrorCode.KNOWN_BAD_BLOCK}
   | {code: BlockErrorCode.BLACKLISTED_BLOCK}
-  | {code: BlockErrorCode.INCORRECT_TIMESTAMP; timestamp: number; expectedTimestamp: number}
+  | {code: BlockErrorCode.INCORRECT_TIMESTAMP; slot: Slot; root: RootHex; timestamp: number; expectedTimestamp: number}
   | {code: BlockErrorCode.TOO_MUCH_GAS_USED; gasUsed: number; gasLimit: number}
   | {code: BlockErrorCode.SAME_PARENT_HASH; blockHash: RootHex}
   | {code: BlockErrorCode.TRANSACTIONS_TOO_BIG; size: number; max: number}
@@ -151,9 +151,21 @@ export type BlockErrorType =
       errorMessage: string;
     }
   | {code: BlockErrorCode.DATA_UNAVAILABLE}
-  | {code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS; blobKzgCommitmentsLen: number; commitmentLimit: number}
-  | {code: BlockErrorCode.BID_PARENT_ROOT_MISMATCH; bidParentRoot: RootHex; blockParentRoot: RootHex}
-  | {code: BlockErrorCode.NON_ZERO_DEPOSITS; count: number}
+  | {
+      code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS;
+      slot: Slot;
+      root: RootHex;
+      blobKzgCommitmentsLen: number;
+      commitmentLimit: number;
+    }
+  | {
+      code: BlockErrorCode.BID_PARENT_ROOT_MISMATCH;
+      slot: Slot;
+      root: RootHex;
+      bidParentRoot: RootHex;
+      blockParentRoot: RootHex;
+    }
+  | {code: BlockErrorCode.NON_ZERO_DEPOSITS; slot: Slot; root: RootHex; count: number}
   | {code: BlockErrorCode.PARENT_EXECUTION_INVALID; parentRoot: RootHex}
   | {code: BlockErrorCode.PARENT_PAYLOAD_UNKNOWN; parentRoot: RootHex; parentBlockHash: RootHex}
   | {code: BlockErrorCode.NON_LINEAR_PAYLOAD_ROOTS; parentBlockHash: RootHex; expectedBlockHash: RootHex};

--- a/packages/beacon-node/src/chain/errors/dataColumnSidecarError.ts
+++ b/packages/beacon-node/src/chain/errors/dataColumnSidecarError.ts
@@ -47,10 +47,12 @@ export enum DataColumnSidecarErrorCode {
 }
 
 export type DataColumnSidecarErrorType =
-  | {code: DataColumnSidecarErrorCode.INVALID_INDEX; slot: Slot; columnIndex: number}
-  | {code: DataColumnSidecarErrorCode.NO_COMMITMENTS; slot: Slot; columnIndex: number}
+  | {code: DataColumnSidecarErrorCode.INVALID_INDEX; slot: Slot; root: RootHex; columnIndex: number}
+  | {code: DataColumnSidecarErrorCode.NO_COMMITMENTS; slot: Slot; root: RootHex; columnIndex: number}
   | {
       code: DataColumnSidecarErrorCode.MISMATCHED_LENGTHS;
+      slot: Slot;
+      root: RootHex;
       columnLength: number;
       commitmentsLength: number;
       proofsLength: number;
@@ -61,10 +63,17 @@ export type DataColumnSidecarErrorType =
       columnIndex: number;
       fork: ForkName;
     }
-  | {code: DataColumnSidecarErrorCode.INVALID_SUBNET; columnIndex: number; gossipSubnet: SubnetID}
+  | {
+      code: DataColumnSidecarErrorCode.INVALID_SUBNET;
+      slot: Slot;
+      root: RootHex;
+      columnIndex: number;
+      gossipSubnet: SubnetID;
+    }
   | {
       code: DataColumnSidecarErrorCode.TOO_MANY_KZG_COMMITMENTS;
       slot: number;
+      root: RootHex;
       columnIndex: number;
       count: number;
       limit: number;
@@ -85,12 +94,12 @@ export type DataColumnSidecarErrorType =
   | {
       code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID;
       slot: Slot;
-      blockRoot: RootHex;
+      root: RootHex;
       index: number;
     }
-  | {code: DataColumnSidecarErrorCode.NOT_LATER_THAN_PARENT; parentSlot: Slot; slot: Slot}
-  | {code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID; slot: Slot; columnIndex: number}
-  | {code: DataColumnSidecarErrorCode.INVALID_KZG_PROOF; slot: Slot; columnIndex: number}
+  | {code: DataColumnSidecarErrorCode.NOT_LATER_THAN_PARENT; slot: Slot; root: RootHex; parentSlot: Slot}
+  | {code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID; slot: Slot; root: RootHex; columnIndex: number}
+  | {code: DataColumnSidecarErrorCode.INVALID_KZG_PROOF; slot: Slot; root: RootHex; columnIndex: number}
   | {code: DataColumnSidecarErrorCode.INCORRECT_SIDECAR_COUNT; slot: number; expected: number; actual: number}
   | {
       code: DataColumnSidecarErrorCode.INCORRECT_BLOCK;
@@ -106,6 +115,7 @@ export type DataColumnSidecarErrorType =
     }
   | {
       code: DataColumnSidecarErrorCode.INCORRECT_SIDECAR_SLOT;
+      root: RootHex;
       columnIndex: number;
       expected: Slot;
       actual: Slot;
@@ -127,7 +137,13 @@ export type DataColumnSidecarErrorType =
       actual: number;
     }
   | {code: DataColumnSidecarErrorCode.INVALID_KZG_PROOF_BATCH; slot: number; reason: string}
-  | {code: DataColumnSidecarErrorCode.INCORRECT_PROPOSER; actualProposerIndex: number; expectedProposerIndex: number}
+  | {
+      code: DataColumnSidecarErrorCode.INCORRECT_PROPOSER;
+      slot: Slot;
+      root: RootHex;
+      actualProposerIndex: number;
+      expectedProposerIndex: number;
+    }
   | {code: DataColumnSidecarErrorCode.PAYLOAD_ENVELOPE_INPUT_MISSING; slot: Slot; blockRoot: RootHex};
 
 export class DataColumnSidecarGossipError extends GossipActionError<DataColumnSidecarErrorType> {}

--- a/packages/beacon-node/src/chain/errors/executionPayloadEnvelope.ts
+++ b/packages/beacon-node/src/chain/errors/executionPayloadEnvelope.ts
@@ -26,23 +26,35 @@ export type ExecutionPayloadEnvelopeErrorType =
       slot: Slot;
     }
   | {code: ExecutionPayloadEnvelopeErrorCode.INVALID_BLOCK; blockRoot: RootHex}
-  | {code: ExecutionPayloadEnvelopeErrorCode.SLOT_MISMATCH; envelopeSlot: Slot; blockSlot: Slot}
+  | {
+      code: ExecutionPayloadEnvelopeErrorCode.SLOT_MISMATCH;
+      slot: Slot;
+      root: RootHex;
+      envelopeSlot: Slot;
+      blockSlot: Slot;
+    }
   | {
       code: ExecutionPayloadEnvelopeErrorCode.BUILDER_INDEX_MISMATCH;
+      slot: Slot;
+      root: RootHex;
       envelopeBuilderIndex: BuilderIndex;
       bidBuilderIndex: BuilderIndex | null;
     }
   | {
       code: ExecutionPayloadEnvelopeErrorCode.BLOCK_HASH_MISMATCH;
+      slot: Slot;
+      root: RootHex;
       envelopeBlockHash: RootHex;
       bidBlockHash: RootHex | null;
     }
   | {
       code: ExecutionPayloadEnvelopeErrorCode.EXECUTION_REQUESTS_ROOT_MISMATCH;
+      slot: Slot;
+      root: RootHex;
       envelopeRequestsRoot: RootHex;
       bidRequestsRoot: RootHex;
     }
-  | {code: ExecutionPayloadEnvelopeErrorCode.INVALID_SIGNATURE}
+  | {code: ExecutionPayloadEnvelopeErrorCode.INVALID_SIGNATURE; slot: Slot; root: RootHex}
   | {code: ExecutionPayloadEnvelopeErrorCode.PAYLOAD_ENVELOPE_INPUT_MISSING; blockRoot: RootHex};
 
 export class ExecutionPayloadEnvelopeError extends GossipActionError<ExecutionPayloadEnvelopeErrorType> {}

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -134,8 +134,9 @@ export async function validateGossipBlock(
   if (parentBlock.slot >= blockSlot) {
     throw new BlockGossipError(GossipAction.REJECT, {
       code: BlockErrorCode.NOT_LATER_THAN_PARENT,
-      parentSlot: parentBlock.slot,
       slot: blockSlot,
+      root: blockRoot,
+      parentSlot: parentBlock.slot,
     });
   }
 
@@ -150,6 +151,8 @@ export async function validateGossipBlock(
     if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
       throw new BlockGossipError(GossipAction.REJECT, {
         code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS,
+        slot: blockSlot,
+        root: blockRoot,
         blobKzgCommitmentsLen,
         commitmentLimit: maxBlobsPerBlock,
       });
@@ -167,6 +170,8 @@ export async function validateGossipBlock(
     if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
       throw new BlockGossipError(GossipAction.REJECT, {
         code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS,
+        slot: blockSlot,
+        root: blockRoot,
         blobKzgCommitmentsLen,
         commitmentLimit: maxBlobsPerBlock,
       });
@@ -176,6 +181,8 @@ export async function validateGossipBlock(
     if (!byteArrayEquals(bid.parentBlockRoot, block.parentRoot)) {
       throw new BlockGossipError(GossipAction.REJECT, {
         code: BlockErrorCode.BID_PARENT_ROOT_MISMATCH,
+        slot: blockSlot,
+        root: blockRoot,
         bidParentRoot: toRootHex(bid.parentBlockRoot),
         blockParentRoot: parentRoot,
       });
@@ -185,6 +192,8 @@ export async function validateGossipBlock(
     if (body.deposits.length !== 0) {
       throw new BlockGossipError(GossipAction.REJECT, {
         code: BlockErrorCode.NON_ZERO_DEPOSITS,
+        slot: blockSlot,
+        root: blockRoot,
         count: body.deposits.length,
       });
     }
@@ -249,6 +258,8 @@ export async function validateGossipBlock(
       if (executionPayload.timestamp !== computeTimeAtSlot(config, blockSlot, chain.genesisTime)) {
         throw new BlockGossipError(GossipAction.REJECT, {
           code: BlockErrorCode.INCORRECT_TIMESTAMP,
+          slot: blockSlot,
+          root: blockRoot,
           timestamp: executionPayload.timestamp,
           expectedTimestamp,
         });
@@ -258,7 +269,12 @@ export async function validateGossipBlock(
 
   // [REJECT] The proposer index is a valid validator index
   if (proposerIndex >= state.validatorCount) {
-    throw new BlockGossipError(GossipAction.REJECT, {code: BlockErrorCode.UNKNOWN_PROPOSER, proposerIndex});
+    throw new BlockGossipError(GossipAction.REJECT, {
+      code: BlockErrorCode.UNKNOWN_PROPOSER,
+      slot: blockSlot,
+      root: blockRoot,
+      proposerIndex,
+    });
   }
 
   // [REJECT] The proposer signature, signed_beacon_block.signature, is valid with respect to the proposer_index pubkey.
@@ -270,7 +286,12 @@ export async function validateGossipBlock(
   // shuffling, the block MAY be queued for later processing while proposers for the block's branch are calculated --
   // in such a case do not REJECT, instead IGNORE this message.
   if (state.getBeaconProposer(blockSlot) !== proposerIndex) {
-    throw new BlockGossipError(GossipAction.REJECT, {code: BlockErrorCode.INCORRECT_PROPOSER, proposerIndex});
+    throw new BlockGossipError(GossipAction.REJECT, {
+      code: BlockErrorCode.INCORRECT_PROPOSER,
+      slot: blockSlot,
+      root: blockRoot,
+      proposerIndex,
+    });
   }
 
   // Simple implementation of a pending block queue. Keeping the block here recycles the queue logic, and keeps the
@@ -315,7 +336,8 @@ export async function verifyBlockProposerSignature(
   if (!(await chain.bls.verifySignatureSets([signatureSet], {verifyOnMainThread: opts.verifyOnMainThread ?? true}))) {
     throw new BlockGossipError(GossipAction.REJECT, {
       code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID,
-      blockSlot,
+      slot: blockSlot,
+      root: blockRoot,
     });
   }
 

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -11,7 +11,7 @@ import {
   computeStartSlotAtEpoch,
   getBlockHeaderProposerSignatureSetByHeaderSlot,
 } from "@lodestar/state-transition";
-import {DataColumnSidecar, Root, Slot, SubnetID, ValidatorIndex, fulu, gloas, ssz} from "@lodestar/types";
+import {DataColumnSidecar, Root, RootHex, Slot, SubnetID, ValidatorIndex, fulu, gloas, ssz} from "@lodestar/types";
 import {byteArrayEquals, toRootHex, verifyMerkleBranch} from "@lodestar/utils";
 import {BeaconMetrics} from "../../metrics/metrics/beacon.js";
 import {Metrics} from "../../metrics/metrics.js";
@@ -39,12 +39,14 @@ export async function validateGossipFuluDataColumnSidecar(
   const blockRootHex = toRootHex(ssz.phase0.BeaconBlockHeader.hashTreeRoot(blockHeader));
 
   // 1) [REJECT] The sidecar is valid as verified by verify_data_column_sidecar
-  verifyFuluDataColumnSidecar(chain.config, dataColumnSidecar);
+  verifyFuluDataColumnSidecar(chain.config, dataColumnSidecar, blockRootHex);
 
   // 2) [REJECT] The sidecar is for the correct subnet -- i.e. compute_subnet_for_data_column_sidecar(sidecar.index) == subnet_id
   if (computeSubnetForDataColumnSidecar(chain.config, dataColumnSidecar) !== gossipSubnet) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INVALID_SUBNET,
+      slot: blockHeader.slot,
+      root: blockRootHex,
       columnIndex: dataColumnSidecar.index,
       gossipSubnet: gossipSubnet,
     });
@@ -100,8 +102,9 @@ export async function validateGossipFuluDataColumnSidecar(
   if (parentBlock.slot >= blockHeader.slot) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.NOT_LATER_THAN_PARENT,
-      parentSlot: parentBlock.slot,
       slot: blockHeader.slot,
+      root: blockRootHex,
+      parentSlot: parentBlock.slot,
     });
   }
 
@@ -140,6 +143,8 @@ export async function validateGossipFuluDataColumnSidecar(
   if (proposerIndex !== expectedProposerIndex) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INCORRECT_PROPOSER,
+      slot: blockHeader.slot,
+      root: blockRootHex,
       actualProposerIndex: proposerIndex,
       expectedProposerIndex,
     });
@@ -161,9 +166,9 @@ export async function validateGossipFuluDataColumnSidecar(
     ) {
       throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
         code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
-        blockRoot: blockRootHex,
-        index: dataColumnSidecar.index,
         slot: blockHeader.slot,
+        root: blockRootHex,
+        index: dataColumnSidecar.index,
       });
     }
 
@@ -185,7 +190,8 @@ export async function validateGossipFuluDataColumnSidecar(
   if (!valid) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID,
-      slot: dataColumnSidecar.signedBlockHeader.message.slot,
+      slot: blockHeader.slot,
+      root: blockRootHex,
       columnIndex: dataColumnSidecar.index,
     });
   }
@@ -204,6 +210,7 @@ export async function validateGossipFuluDataColumnSidecar(
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INVALID_KZG_PROOF,
       slot: blockHeader.slot,
+      root: blockRootHex,
       columnIndex: dataColumnSidecar.index,
     });
   } finally {
@@ -240,6 +247,7 @@ export async function validateGossipGloasDataColumnSidecar(
   if (block.slot !== dataColumnSidecar.slot) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INCORRECT_SIDECAR_SLOT,
+      root: blockRootHex,
       columnIndex: dataColumnSidecar.index,
       expected: block.slot,
       actual: dataColumnSidecar.slot,
@@ -248,12 +256,14 @@ export async function validateGossipGloasDataColumnSidecar(
 
   // [REJECT] The sidecar must pass verify_data_column_sidecar against the block commitments
   const kzgCommitments = payloadInput.getBlobKzgCommitments();
-  verifyGloasDataColumnSidecar(dataColumnSidecar, kzgCommitments);
+  verifyGloasDataColumnSidecar(dataColumnSidecar, kzgCommitments, blockRootHex);
 
   // [REJECT] The sidecar must be on the correct subnet
   if (computeSubnetForDataColumnSidecar(chain.config, dataColumnSidecar) !== gossipSubnet) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INVALID_SUBNET,
+      slot: dataColumnSidecar.slot,
+      root: blockRootHex,
       columnIndex: dataColumnSidecar.index,
       gossipSubnet,
     });
@@ -272,6 +282,7 @@ export async function validateGossipGloasDataColumnSidecar(
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INVALID_KZG_PROOF,
       slot: dataColumnSidecar.slot,
+      root: blockRootHex,
       columnIndex: dataColumnSidecar.index,
     });
   } finally {
@@ -283,11 +294,17 @@ export async function validateGossipGloasDataColumnSidecar(
  * SPEC FUNCTION
  * https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.4/specs/fulu/p2p-interface.md#verify_data_column_sidecar
  */
-function verifyFuluDataColumnSidecar(config: ChainForkConfig, dataColumnSidecar: fulu.DataColumnSidecar): void {
+function verifyFuluDataColumnSidecar(
+  config: ChainForkConfig,
+  dataColumnSidecar: fulu.DataColumnSidecar,
+  blockRootHex: RootHex
+): void {
+  const slot = dataColumnSidecar.signedBlockHeader.message.slot;
   if (dataColumnSidecar.index >= NUMBER_OF_COLUMNS) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INVALID_INDEX,
-      slot: dataColumnSidecar.signedBlockHeader.message.slot,
+      slot,
+      root: blockRootHex,
       columnIndex: dataColumnSidecar.index,
     });
   }
@@ -295,18 +312,20 @@ function verifyFuluDataColumnSidecar(config: ChainForkConfig, dataColumnSidecar:
   if (dataColumnSidecar.kzgCommitments.length === 0) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.NO_COMMITMENTS,
-      slot: dataColumnSidecar.signedBlockHeader.message.slot,
+      slot,
+      root: blockRootHex,
       columnIndex: dataColumnSidecar.index,
     });
   }
 
-  const epoch = computeEpochAtSlot(dataColumnSidecar.signedBlockHeader.message.slot);
+  const epoch = computeEpochAtSlot(slot);
   const maxBlobsPerBlock = config.getMaxBlobsPerBlock(epoch);
 
   if (dataColumnSidecar.kzgCommitments.length > maxBlobsPerBlock) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.TOO_MANY_KZG_COMMITMENTS,
-      slot: dataColumnSidecar.signedBlockHeader.message.slot,
+      slot,
+      root: blockRootHex,
       columnIndex: dataColumnSidecar.index,
       count: dataColumnSidecar.kzgCommitments.length,
       limit: maxBlobsPerBlock,
@@ -319,6 +338,8 @@ function verifyFuluDataColumnSidecar(config: ChainForkConfig, dataColumnSidecar:
   ) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.MISMATCHED_LENGTHS,
+      slot,
+      root: blockRootHex,
       columnLength: dataColumnSidecar.column.length,
       commitmentsLength: dataColumnSidecar.kzgCommitments.length,
       proofsLength: dataColumnSidecar.kzgProofs.length,
@@ -330,12 +351,17 @@ function verifyFuluDataColumnSidecar(config: ChainForkConfig, dataColumnSidecar:
  * SPEC FUNCTION
  * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.3/specs/gloas/p2p-interface.md#modified-verify_data_column_sidecar
  */
-function verifyGloasDataColumnSidecar(dataColumnSidecar: gloas.DataColumnSidecar, kzgCommitments: Uint8Array[]): void {
+function verifyGloasDataColumnSidecar(
+  dataColumnSidecar: gloas.DataColumnSidecar,
+  kzgCommitments: Uint8Array[],
+  blockRootHex: RootHex
+): void {
   const slot = getDataColumnSidecarSlot(dataColumnSidecar);
   if (dataColumnSidecar.index >= NUMBER_OF_COLUMNS) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INVALID_INDEX,
       slot,
+      root: blockRootHex,
       columnIndex: dataColumnSidecar.index,
     });
   }
@@ -344,6 +370,7 @@ function verifyGloasDataColumnSidecar(dataColumnSidecar: gloas.DataColumnSidecar
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.NO_COMMITMENTS,
       slot,
+      root: blockRootHex,
       columnIndex: dataColumnSidecar.index,
     });
   }
@@ -354,6 +381,8 @@ function verifyGloasDataColumnSidecar(dataColumnSidecar: gloas.DataColumnSidecar
   ) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.MISMATCHED_LENGTHS,
+      slot,
+      root: blockRootHex,
       columnLength: dataColumnSidecar.column.length,
       commitmentsLength: kzgCommitments.length,
       proofsLength: dataColumnSidecar.kzgProofs.length,
@@ -465,8 +494,8 @@ export async function validateFuluBlockDataColumnSidecars(
         ) {
           throw new DataColumnSidecarValidationError({
             code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
-            blockRoot: rootHex,
             slot: blockSlot,
+            root: rootHex,
             index: dataColumnSidecars[0].index,
           });
         }
@@ -499,6 +528,7 @@ export async function validateFuluBlockDataColumnSidecars(
           {
             code: DataColumnSidecarErrorCode.INVALID_INDEX,
             slot: blockSlot,
+            root: toRootHex(blockRoot),
             columnIndex: columnSidecar.index,
           },
           "DataColumnSidecar has invalid index"
@@ -543,6 +573,7 @@ export async function validateFuluBlockDataColumnSidecars(
           {
             code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID,
             slot: blockSlot,
+            root: toRootHex(blockRoot),
             columnIndex: columnSidecar.index,
           },
           "DataColumnSidecar has invalid inclusion proof"
@@ -623,6 +654,7 @@ export async function validateGloasBlockDataColumnSidecars(
       if (columnSidecar.slot !== blockSlot) {
         throw new DataColumnSidecarValidationError({
           code: DataColumnSidecarErrorCode.INCORRECT_SIDECAR_SLOT,
+          root: toRootHex(blockRoot),
           columnIndex: columnSidecar.index,
           expected: blockSlot,
           actual: columnSidecar.slot,
@@ -644,6 +676,7 @@ export async function validateGloasBlockDataColumnSidecars(
           {
             code: DataColumnSidecarErrorCode.INVALID_INDEX,
             slot: blockSlot,
+            root: toRootHex(blockRoot),
             columnIndex: columnSidecar.index,
           },
           "DataColumnSidecar has invalid index"

--- a/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
@@ -82,6 +82,8 @@ async function validateExecutionPayloadEnvelope(
   if (block.slot !== payload.slotNumber) {
     throw new ExecutionPayloadEnvelopeError(GossipAction.REJECT, {
       code: ExecutionPayloadEnvelopeErrorCode.SLOT_MISMATCH,
+      slot: payload.slotNumber,
+      root: blockRootHex,
       envelopeSlot: payload.slotNumber,
       blockSlot: block.slot,
     });
@@ -91,6 +93,8 @@ async function validateExecutionPayloadEnvelope(
   if (envelope.builderIndex !== payloadInput.getBuilderIndex()) {
     throw new ExecutionPayloadEnvelopeError(GossipAction.REJECT, {
       code: ExecutionPayloadEnvelopeErrorCode.BUILDER_INDEX_MISMATCH,
+      slot: payload.slotNumber,
+      root: blockRootHex,
       envelopeBuilderIndex: envelope.builderIndex,
       bidBuilderIndex: payloadInput.getBuilderIndex(),
     });
@@ -100,6 +104,8 @@ async function validateExecutionPayloadEnvelope(
   if (toRootHex(payload.blockHash) !== payloadInput.getBlockHashHex()) {
     throw new ExecutionPayloadEnvelopeError(GossipAction.REJECT, {
       code: ExecutionPayloadEnvelopeErrorCode.BLOCK_HASH_MISMATCH,
+      slot: payload.slotNumber,
+      root: blockRootHex,
       envelopeBlockHash: toRootHex(payload.blockHash),
       bidBlockHash: payloadInput.getBlockHashHex(),
     });
@@ -110,6 +116,8 @@ async function validateExecutionPayloadEnvelope(
   if (!byteArrayEquals(requestsRoot, payloadInput.getBid().executionRequestsRoot)) {
     throw new ExecutionPayloadEnvelopeError(GossipAction.REJECT, {
       code: ExecutionPayloadEnvelopeErrorCode.EXECUTION_REQUESTS_ROOT_MISMATCH,
+      slot: payload.slotNumber,
+      root: blockRootHex,
       envelopeRequestsRoot: toRootHex(requestsRoot),
       bidRequestsRoot: toRootHex(payloadInput.getBid().executionRequestsRoot),
     });
@@ -141,6 +149,8 @@ async function validateExecutionPayloadEnvelope(
   if (!(await chain.bls.verifySignatureSets([signatureSet], {verifyOnMainThread: true}))) {
     throw new ExecutionPayloadEnvelopeError(GossipAction.REJECT, {
       code: ExecutionPayloadEnvelopeErrorCode.INVALID_SIGNATURE,
+      slot: payload.slotNumber,
+      root: blockRootHex,
     });
   }
 }

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -27,7 +27,7 @@ import {
   ssz,
   sszTypesFor,
 } from "@lodestar/types";
-import {LogLevel, Logger, prettyBytes, toHex, toRootHex} from "@lodestar/utils";
+import {LogLevel, Logger, toHex, toRootHex} from "@lodestar/utils";
 import {
   BlockInput,
   BlockInputColumns,
@@ -157,7 +157,6 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
     const slot = signedBlock.message.slot;
     const forkTypes = config.getForkTypes(slot);
     const blockRootHex = toRootHex(forkTypes.BeaconBlock.hashTreeRoot(signedBlock.message));
-    const blockShortHex = prettyBytes(blockRootHex);
     const delaySec = chain.clock.secFromSlot(slot, seenTimestampSec);
     const recvToValLatency = Date.now() / 1000 - seenTimestampSec;
 
@@ -167,6 +166,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
 
     const logCtx = {
       slot,
+      root: blockRootHex,
       currentSlot: chain.clock.currentSlot,
       peerId: peerIdStr,
       delaySec,
@@ -227,7 +227,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       return blockInput;
     } catch (e) {
       if (e instanceof BlockGossipError) {
-        logger.debug("Gossip block has error", {slot, root: blockShortHex, code: e.type.code});
+        logger.debug("Gossip block has error", {slot, root: blockRootHex, code: e.type.code});
         if (
           (e.type.code === BlockErrorCode.PARENT_BLOCK_UNKNOWN ||
             e.type.code === BlockErrorCode.PARENT_PAYLOAD_UNKNOWN) &&
@@ -279,7 +279,6 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
     const slot = blobBlockHeader.slot;
     const fork = config.getForkName(slot);
     const blockRootHex = toRootHex(ssz.phase0.BeaconBlockHeader.hashTreeRoot(blobBlockHeader));
-    const blockShortHex = prettyBytes(blockRootHex);
 
     const delaySec = chain.clock.secFromSlot(slot, seenTimestampSec);
     const recvToValLatency = Date.now() / 1000 - seenTimestampSec;
@@ -332,7 +331,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       if (e instanceof BlobSidecarGossipError) {
         // Don't trigger this yet if full block and blobs haven't arrived yet
         if (e.type.code === BlobSidecarErrorCode.PARENT_UNKNOWN) {
-          logger.debug("Gossip blob has error", {slot, root: blockShortHex, code: e.type.code});
+          logger.debug("Gossip blob has error", {slot, root: blockRootHex, code: e.type.code});
           // no need to trigger `unknownBlockParent` event here, as we already did it in `validateBeaconBlock()`
           //
           // TODO(fulu): is this note above correct? Could have random blob that we see that could trigger
@@ -696,11 +695,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
           logLevel = LogLevel.error;
         }
         metrics?.gossipBlock.processBlockErrors.inc({error: e instanceof BlockError ? e.type.code : "NOT_BLOCK_ERROR"});
-        logger[logLevel](
-          "Error processing block",
-          {slot, peer: peerIdStr, blockRoot: prettyBytes(blockInput.blockRootHex)},
-          e as Error
-        );
+        logger[logLevel]("Error processing block", {slot, root: blockInput.blockRootHex, peer: peerIdStr}, e as Error);
         // TODO(fulu): Revisit when we prune block inputs
         chain.seenBlockInputCache.prune(blockInput.blockRootHex);
       });


### PR DESCRIPTION
**Motivation**

- when there are REJECTED block, the log was not detailed enough, and some log missed block root.
- for example ` Gossip validation beacon_block rejected peerId=16...mJKujG, clientAgent=Lighthouse, clientVersion=Lighthouse/v8.1.3/x86_64-linux, code=BLOCK_ERROR_UNKNOWN_PROPOSER, proposerIndex=2349064`

**Description**

- for REJECTED error code of block/column/payload, always include slot and full root

part of #9925

**AI Assistance Disclosure**

- created with the help of Claude