### PR TITLE
refactor(builder): name the payload store explicitly

### DIFF
--- a/packages/builder/src/builder.ts
+++ b/packages/builder/src/builder.ts
@@ -21,7 +21,7 @@ export type BuilderModules = {
   proposerPreferencesTracker: ProposerPreferencesTracker;
   clock: IClock;
   index: BuilderIndex;
-  store: PayloadStore;
+  payloadStore: PayloadStore;
 };
 
 export type BuilderOptions = {
@@ -48,7 +48,7 @@ export class Builder {
   private readonly index: BuilderIndex;
   private readonly logger: Logger;
   private readonly executionFeeRecipient: ExecutionAddress;
-  private readonly store: PayloadStore;
+  private readonly payloadStore: PayloadStore;
 
   constructor({
     opts,
@@ -58,7 +58,7 @@ export class Builder {
     proposerPreferencesTracker,
     clock,
     index,
-    store,
+    payloadStore,
   }: BuilderModules) {
     this.builderSigner = builderSigner;
     this.blockObserver = blockObserver;
@@ -68,7 +68,7 @@ export class Builder {
     this.controller = opts.abortController;
     this.logger = opts.logger;
     this.index = index;
-    this.store = store;
+    this.payloadStore = payloadStore;
 
     this.executionFeeRecipient = opts.executionFeeRecipient;
 
@@ -116,7 +116,7 @@ export class Builder {
     const blockObserver = new BlockObserver(config, logger, api);
     const proposerPreferencesTracker = new ProposerPreferencesTracker(api, logger);
 
-    const store = new PayloadStore();
+    const payloadStore = new PayloadStore();
 
     return new Builder({
       opts,
@@ -126,12 +126,12 @@ export class Builder {
       proposerPreferencesTracker,
       clock,
       index,
-      store,
+      payloadStore,
     });
   }
 
   private async onSlot(slot: number): Promise<void> {
-    this.store.prune(slot);
+    this.payloadStore.prune(slot);
     this.proposerPreferencesTracker.prune(slot);
   }
 

--- a/packages/builder/test/unit/builder.test.ts
+++ b/packages/builder/test/unit/builder.test.ts
@@ -33,10 +33,10 @@ describe("Builder", () => {
     preferences.message.proposalSlot = 2;
     const dependentRoot = toRootHex(preferences.message.dependentRoot);
     proposerPreferencesTracker.onProposerPreferences(preferences);
-    const store = new PayloadStore();
+    const payloadStore = new PayloadStore();
     const payload = mockBuiltPayload({slot: 0});
     const blockHash = toRootHex(payload.executionPayload.blockHash);
-    store.add({slot: 0, parentBlockRoot: Buffer.alloc(32), blockHash, payload});
+    payloadStore.add({slot: 0, parentBlockRoot: Buffer.alloc(32), blockHash, payload});
     const clockStart = vi.spyOn(clock, "start");
     const observerStart = vi.spyOn(blockObserver, "start").mockImplementation(() => {});
     const preferencesStart = vi.spyOn(proposerPreferencesTracker, "start").mockImplementation(() => {});
@@ -59,7 +59,7 @@ describe("Builder", () => {
       proposerPreferencesTracker,
       clock,
       index: 1,
-      store,
+      payloadStore,
     });
 
     expect(clockStart).toHaveBeenCalledWith(controller.signal);
@@ -69,10 +69,10 @@ describe("Builder", () => {
     expect(clockStart.mock.invocationCallOrder[0]).toBeLessThan(preferencesStart.mock.invocationCallOrder[0]);
     expect(controller.signal.aborted).toBe(false);
 
-    expect(store.has(blockHash)).toBe(true);
+    expect(payloadStore.has(blockHash)).toBe(true);
     expect(proposerPreferencesTracker.get(2, dependentRoot)).toBe(preferences);
     await clock.tickSlotFns(3, controller.signal);
-    expect(store.has(blockHash)).toBe(false);
+    expect(payloadStore.has(blockHash)).toBe(false);
     expect(proposerPreferencesTracker.get(2, dependentRoot)).toBeNull();
 
     await builder.close();

--- a/packages/builder/test/unit/preferenceTracking.test.ts
+++ b/packages/builder/test/unit/preferenceTracking.test.ts
@@ -30,7 +30,7 @@ describe("Builder preference tracking", () => {
     const builderStatusTracker = new BuilderStatusTracker(api, logger, 1, null);
     const blockObserver = new BlockObserver(config, logger, api);
     const proposerPreferencesTracker = new ProposerPreferencesTracker(api, logger);
-    const store = new PayloadStore();
+    const payloadStore = new PayloadStore();
     const opts: BuilderOptions = {
       logger,
       config,
@@ -49,7 +49,7 @@ describe("Builder preference tracking", () => {
       proposerPreferencesTracker,
       clock,
       index: 1,
-      store,
+      payloadStore,
     });
 
     expect(clockStart).toHaveBeenCalledWith(controller.signal);


### PR DESCRIPTION
## Motivation

Follow up on [the naming suggestion in #9976](https://github.com/ChainSafe/lodestar/pull/9976#discussion_r3983752998) so the Builder's payload store is named explicitly.

## Description

Rename `BuilderModules.store` and the corresponding Builder field/local variable to `payloadStore`, including the lifecycle test fixtures. No changes to payload retention, pruning or the `PayloadStore` API.

Tracked in [LOD-89](https://linear.app/kriso/issue/LOD-89) and [the project issue](https://github.com/krisoshea-eth/lodestar/issues/95).

## Testing

- Six focused Builder lifecycle, preference tracking and payload-store tests passed.
- Builder type-check, build/import check, changed-file lint and `git diff --check` passed.

> This PR was written with OpenAI Codex assistance.
