### PR TITLE
fix(api): respect cancellation during event stream setup

### DIFF
--- a/packages/api/src/beacon/client/events.ts
+++ b/packages/api/src/beacon/client/events.ts
@@ -1,4 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
+import {ErrorAborted} from "@lodestar/utils";
 import {getEventSource} from "../../utils/client/eventSource.js";
 import {stringifyQuery, urlJoin} from "../../utils/client/format.js";
 import {ApiClientMethods} from "../../utils/client/method.js";
@@ -26,6 +27,9 @@ export function getClient(config: ChainForkConfig, baseUrl: string): ApiClient {
       const query = stringifyQuery({topics});
       const url = `${urlJoin(baseUrl, definitions.eventstream.url)}?${query}`;
       const EventSource = await getEventSource();
+      if (signal.aborted) {
+        throw new ErrorAborted("eventstream request");
+      }
       const eventSource = new EventSource(url);
 
       const close = (): void => {

--- a/packages/api/test/unit/beacon/genericServerTest/events.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/events.test.ts
@@ -1,8 +1,8 @@
 import {FastifyInstance} from "fastify";
-import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {config} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
-import {sleep} from "@lodestar/utils";
+import {defer, sleep} from "@lodestar/utils";
 import {getClient} from "../../../../src/beacon/client/events.js";
 import {BeaconEvent, Endpoints, EventType, getDefinitions} from "../../../../src/beacon/routes/events.js";
 import {getRoutes} from "../../../../src/beacon/server/events.js";
@@ -33,6 +33,28 @@ describe("beacon / events", () => {
     controller = new AbortController();
   });
   afterEach(() => controller.abort());
+
+  it("Closes the server subscription when the client aborts", async () => {
+    const received = defer<void>();
+    const disconnected = defer<void>();
+    const onClose = vi.fn();
+    mockApi.eventstream.mockImplementation(async ({signal, onEvent}) => {
+      signal.addEventListener("abort", () => disconnected.resolve(), {once: true});
+      onEvent({type: EventType.head, message: eventTestData[EventType.head]});
+    });
+
+    await getClient(config, baseUrl).eventstream({
+      topics: [EventType.head, EventType.proposerPreferences],
+      signal: controller.signal,
+      onEvent: () => received.resolve(),
+      onClose,
+    });
+    await received.promise;
+    controller.abort();
+    await disconnected.promise;
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
 
   it("Receive events", async () => {
     const eventHead1: BeaconEvent = {

--- a/packages/api/test/unit/client/events.test.ts
+++ b/packages/api/test/unit/client/events.test.ts
@@ -1,0 +1,77 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {config} from "@lodestar/config/default";
+import {ErrorAborted, defer} from "@lodestar/utils";
+import {getClient} from "../../../src/beacon/client/events.js";
+import {EventType} from "../../../src/beacon/routes/events.js";
+import {getEventSource} from "../../../src/utils/client/eventSource.js";
+
+vi.mock("../../../src/utils/client/eventSource.js");
+
+describe("event stream cancellation", () => {
+  const close = vi.fn();
+  const addEventListener = vi.fn();
+  const EventSourceMock = vi.fn(
+    class {
+      close = close;
+      addEventListener = addEventListener;
+    }
+  );
+  const EventSourceConstructor = EventSourceMock as unknown as typeof EventSource;
+  const client = getClient(config, "http://127.0.0.1:9596");
+  let controller: AbortController;
+
+  beforeEach(() => {
+    controller = new AbortController();
+    vi.mocked(getEventSource).mockResolvedValue(EventSourceConstructor);
+  });
+
+  afterEach(() => {
+    controller.abort();
+    vi.resetAllMocks();
+  });
+
+  it("does not create a connection with an already aborted signal", async () => {
+    controller.abort();
+
+    await expect(
+      client.eventstream({topics: [EventType.block], signal: controller.signal, onEvent: vi.fn()})
+    ).rejects.toBeInstanceOf(ErrorAborted);
+
+    expect(EventSourceMock).not.toHaveBeenCalled();
+  });
+
+  it("does not create a connection if aborted while loading EventSource", async () => {
+    const loaded = defer<typeof EventSource>();
+    vi.mocked(getEventSource).mockReturnValue(loaded.promise);
+    const setup = client.eventstream({topics: [EventType.block], signal: controller.signal, onEvent: vi.fn()});
+    const rejected = expect(setup).rejects.toBeInstanceOf(ErrorAborted);
+
+    expect(getEventSource).toHaveBeenCalledOnce();
+    controller.abort();
+    loaded.resolve(EventSourceConstructor);
+    await rejected;
+
+    expect(EventSourceMock).not.toHaveBeenCalled();
+  });
+
+  it("closes an established multi-topic subscription once on abort", async () => {
+    const onClose = vi.fn();
+    const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+    await client.eventstream({
+      topics: [EventType.block, EventType.proposerPreferences],
+      signal: controller.signal,
+      onEvent: vi.fn(),
+      onClose,
+    });
+
+    expect(EventSourceMock).toHaveBeenCalledOnce();
+    expect(addEventListener).toHaveBeenCalledTimes(2);
+    expect(close).not.toHaveBeenCalled();
+    controller.abort();
+    controller.abort();
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
+  });
+});


### PR DESCRIPTION
## Motivation

`eventstream()` loads EventSource asynchronously before attaching its abort listener. If the signal is already aborted, or aborts during that await, it still creates a connection and misses the abort event.

I reproduced this while checking Builder shutdown for #10064. It also exists on `unstable`, so this fix is independent of that refactor.

## Description

Check the signal after loading EventSource and before constructing it. Reject cancelled setup with the existing `ErrorAborted`, following the HTTP client's cancellation convention. Established connections keep their existing abort/close behavior.

No reconnect, replay or Builder runtime changes.

## Testing

Base `acdde443d29e59fdbb28f1762b7e2ae6e91faec0`.

- Both cancelled-setup regressions failed before the fix and pass afterward.
- Seven focused tests pass across client cancellation and the existing SSE server suite.
- A real loopback SSE connection confirms client abort releases the server subscription. Existing malformed-event and throwing-consumer tests still pass.
- API type-check, changed-file Biome, build/import and `git diff --check` pass. API dependencies were built in an isolated checkout using the pinned SSZ 1.7.0; the main checkout was untouched.

The setup race is tested deterministically with a mocked EventSource constructor. The loopback test covers established-connection teardown, not a measured live-network leak or the complete Builder lifecycle. Full hosted CI is still pending.

Tracking [REL-01](https://github.com/krisoshea-eth/lodestar/issues/22). This addresses its transport setup cancellation item, not the broader recovery scope.

> This PR was written with OpenAI Codex assistance and manually reviewed and tested with Codex.
