### PR TITLE
perf: reduce native snappy buffer retention

### DIFF
--- a/packages/beacon-node/src/db/flatFileStore/snappy.ts
+++ b/packages/beacon-node/src/db/flatFileStore/snappy.ts
@@ -1,11 +1,12 @@
 import {compressSync, uncompressSync} from "snappy";
 
+// Copy outputs to avoid deferring native allocation release until the event loop runs finalizers.
 export function compress(data: Uint8Array): Uint8Array {
-  return compressSync(toBuffer(data));
+  return compressSync(toBuffer(data), {copyOutputData: true});
 }
 
 export function uncompress(data: Uint8Array): Uint8Array {
-  const result = uncompressSync(toBuffer(data), {asBuffer: true}) as Buffer;
+  const result = uncompressSync(toBuffer(data), {asBuffer: true, copyOutputData: true}) as Buffer;
   return new Uint8Array(result.buffer, result.byteOffset, result.byteLength);
 }
 

--- a/packages/reqresp/src/utils/snappyCompress.ts
+++ b/packages/reqresp/src/utils/snappyCompress.ts
@@ -1,4 +1,3 @@
-// snappy is better for compression for larger payloads
 import {compressSync} from "snappy";
 import {ChunkType, IDENTIFIER_FRAME, UNCOMPRESSED_CHUNK_SIZE, crc} from "./snappyCommon.js";
 
@@ -8,7 +7,8 @@ export function* encodeSnappy(bytes: Buffer): Generator<Buffer> {
 
   for (let i = 0; i < bytes.length; i += UNCOMPRESSED_CHUNK_SIZE) {
     const chunk = bytes.subarray(i, i + UNCOMPRESSED_CHUNK_SIZE);
-    const compressed = compressSync(chunk);
+    // Copy output to avoid deferring native allocation release until the event loop runs finalizers.
+    const compressed = compressSync(chunk, {copyOutputData: true});
     if (compressed.length < chunk.length) {
       const size = compressed.length + 4;
       yield Buffer.concat([Buffer.from([ChunkType.COMPRESSED, size, size >> 8, size >> 16]), crc(chunk), compressed]);


### PR DESCRIPTION
**TL;DR:** Use Node-owned output buffers for native Snappy calls to reduce allocation retention. This improves memory behavior, with throughput tradeoffs on some workloads.

Enable `copyOutputData: true` for reqresp compression and flat-file compression/decompression. The temporary native allocation is released within the call instead of waiting for an external-buffer finalizer. Storage decoding keeps its plain `Uint8Array` return, and the existing codec, framing and disk format are preserved.

Benchmarks used Node 24.13.0 and Snappy 7.4.3 on an Intel Core i7-1360P, with sequential fresh processes pinned to one CPU. Column fixtures contain synthetic SSZ data. File I/O uses local NVMe storage with eCryptfs and includes the production durability calls.

| Measurement | Default output | Copied output |
| --- | ---: | ---: |
| Reqresp encode, mixed 64 KiB | 63.70 µs | 59.86 µs |
| Reqresp encode, high-entropy 64 KiB | 37.40 µs | 41.21 µs |
| In-memory merge, 8 blobs × 8 columns | 0.354 ms | 0.438 ms |
| In-memory read-all, 21 blobs × 128 columns | 2.354 ms | 3.806 ms |
| Durable merge, 21 blobs × 128 columns | 36.920 ms | 37.611 ms |
| Reqresp mixed 64 KiB allocation trial, sampled peak RSS | 183.4 MiB | 109.1 MiB |
| Durable merge allocation trial, sampled peak RSS growth | 73.0 MiB | 55.4 MiB |

Reqresp timings are medians of six per-process medians. Storage timings are medians of three per-process means, including GC work. Memory figures come from separate equal-work trials: 8,192 reqresp calls in two repetitions, and 16 large storage merges in three repetitions. No forced GC occurs during measured work; reqresp RSS samples also cover cleanup, and storage RSS growth is relative to the post-warmup baseline.

The extra copy has a visible cost in pure decoding and some compression workloads. Durable merge timings overlap between trials; these measurements do not establish a whole-client speedup.

Validation: 284 reqresp/storage tests passed, type checks passed for both affected packages, and Biome and `git diff --check` passed. Byte identity, cross-decoding and output lifetime checks passed. The final diff also passed a separate agent review.

AI assistance: implementation, benchmarks, review and this description were prepared with Codex.
