### PR TITLE
fix: align gloas external signer requests with remote signing api

### DIFF
--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -909,7 +909,7 @@ export class ValidatorStore {
     });
 
     const signableMessage: SignableMessage = {
-      type: SignableMessageType.PAYLOAD_ATTESTATION,
+      type: SignableMessageType.PAYLOAD_ATTESTATION_MESSAGE,
       data,
     };
 

--- a/packages/validator/src/util/externalSignerClient.ts
+++ b/packages/validator/src/util/externalSignerClient.ts
@@ -1,6 +1,6 @@
 import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {ForkName, ForkPreBellatrix, ForkSeq, isForkPostDeneb} from "@lodestar/params";
+import {ForkName, ForkPostGloas, ForkPreBellatrix, ForkSeq, isForkPostDeneb} from "@lodestar/params";
 import {blindedOrFullBlockToHeader, computeEpochAtSlot} from "@lodestar/state-transition";
 import {
   AggregateAndProof,
@@ -34,7 +34,7 @@ export enum SignableMessageType {
   SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF = "SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF",
   VALIDATOR_REGISTRATION = "VALIDATOR_REGISTRATION",
   EXECUTION_PAYLOAD_ENVELOPE = "EXECUTION_PAYLOAD_ENVELOPE",
-  PAYLOAD_ATTESTATION = "PAYLOAD_ATTESTATION",
+  PAYLOAD_ATTESTATION_MESSAGE = "PAYLOAD_ATTESTATION_MESSAGE",
   PROPOSER_PREFERENCES = "PROPOSER_PREFERENCES",
   BUILDER_REQUEST_AUTH = "BUILDER_REQUEST_AUTH",
 }
@@ -87,7 +87,7 @@ export type SignableMessage =
   | {type: SignableMessageType.SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF; data: altair.ContributionAndProof}
   | {type: SignableMessageType.VALIDATOR_REGISTRATION; data: ValidatorRegistrationV1}
   | {type: SignableMessageType.EXECUTION_PAYLOAD_ENVELOPE; data: gloas.ExecutionPayloadEnvelope}
-  | {type: SignableMessageType.PAYLOAD_ATTESTATION; data: gloas.PayloadAttestationData}
+  | {type: SignableMessageType.PAYLOAD_ATTESTATION_MESSAGE; data: gloas.PayloadAttestationData}
   | {type: SignableMessageType.PROPOSER_PREFERENCES; data: gloas.ProposerPreferences}
   | {type: SignableMessageType.BUILDER_REQUEST_AUTH; data: gloas.BuilderRequestAuth};
 
@@ -105,7 +105,7 @@ const requiresForkInfo: Record<SignableMessageType, boolean> = {
   [SignableMessageType.SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF]: true,
   [SignableMessageType.VALIDATOR_REGISTRATION]: false,
   [SignableMessageType.EXECUTION_PAYLOAD_ENVELOPE]: true,
-  [SignableMessageType.PAYLOAD_ATTESTATION]: true,
+  [SignableMessageType.PAYLOAD_ATTESTATION_MESSAGE]: true,
   [SignableMessageType.PROPOSER_PREFERENCES]: true,
   [SignableMessageType.BUILDER_REQUEST_AUTH]: false,
 };
@@ -280,17 +280,45 @@ function serializerSignableMessagePayload(config: BeaconConfig, payload: Signabl
     case SignableMessageType.VALIDATOR_REGISTRATION:
       return {validator_registration: ssz.bellatrix.ValidatorRegistrationV1.toJson(payload.data)};
 
-    case SignableMessageType.EXECUTION_PAYLOAD_ENVELOPE:
-      return {execution_payload_envelope: ssz.gloas.ExecutionPayloadEnvelope.toJson(payload.data)};
+    case SignableMessageType.EXECUTION_PAYLOAD_ENVELOPE: {
+      const slot = payload.data.payload.slotNumber;
+      return {
+        execution_payload_envelope: {
+          version: config.getForkName(slot).toUpperCase(),
+          data: config.getForkTypes<ForkPostGloas>(slot).ExecutionPayloadEnvelope.toJson(payload.data),
+        },
+      };
+    }
 
-    case SignableMessageType.PAYLOAD_ATTESTATION:
-      return {payload_attestation: ssz.gloas.PayloadAttestationData.toJson(payload.data)};
+    case SignableMessageType.PAYLOAD_ATTESTATION_MESSAGE: {
+      const slot = payload.data.slot;
+      return {
+        payload_attestation_message: {
+          version: config.getForkName(slot).toUpperCase(),
+          data: config.getForkTypes<ForkPostGloas>(slot).PayloadAttestationData.toJson(payload.data),
+        },
+      };
+    }
 
-    case SignableMessageType.PROPOSER_PREFERENCES:
-      return {proposer_preferences: ssz.gloas.ProposerPreferences.toJson(payload.data)};
+    case SignableMessageType.PROPOSER_PREFERENCES: {
+      const slot = payload.data.proposalSlot;
+      return {
+        proposer_preferences: {
+          version: config.getForkName(slot).toUpperCase(),
+          data: config.getForkTypes<ForkPostGloas>(slot).ProposerPreferences.toJson(payload.data),
+        },
+      };
+    }
 
-    case SignableMessageType.BUILDER_REQUEST_AUTH:
-      return {builder_request_auth: ssz.gloas.BuilderRequestAuth.toJson(payload.data)};
+    case SignableMessageType.BUILDER_REQUEST_AUTH: {
+      const slot = payload.data.slot;
+      return {
+        builder_request_auth: {
+          version: config.getForkName(slot).toUpperCase(),
+          data: config.getForkTypes<ForkPostGloas>(slot).BuilderRequestAuth.toJson(payload.data),
+        },
+      };
+    }
   }
 }
 

--- a/packages/validator/test/e2e-mainnet/web3signer.test.ts
+++ b/packages/validator/test/e2e-mainnet/web3signer.test.ts
@@ -149,6 +149,62 @@ describe("web3signer signature test", () => {
     await assertSameSignature("signVoluntaryExit", pubkeyBytes, validatorIndex, epoch);
   });
 
+  it("signExecutionPayloadEnvelope", async ({skip}) => {
+    if (ForkSeq.gloas > externalSigner.supportedForkSeq) {
+      skip();
+      return;
+    }
+
+    const slot = computeStartSlotAtEpoch(config.GLOAS_FORK_EPOCH);
+    const envelope = ssz.gloas.ExecutionPayloadEnvelope.defaultValue();
+    envelope.payload.slotNumber = slot;
+
+    await assertSameSignature("signExecutionPayloadEnvelope", pubkeyBytes, envelope, slot);
+  });
+
+  it("signPayloadAttestation", async ({skip}) => {
+    if (ForkSeq.gloas > externalSigner.supportedForkSeq) {
+      skip();
+      return;
+    }
+
+    const slot = computeStartSlotAtEpoch(config.GLOAS_FORK_EPOCH);
+    const data = ssz.gloas.PayloadAttestationData.defaultValue();
+    data.slot = slot;
+
+    await assertSameSignature("signPayloadAttestation", {pubkey: pubkeyBytes, validatorIndex, slot}, data, slot);
+  });
+
+  it("signProposerPreferences", async ({skip}) => {
+    if (ForkSeq.gloas > externalSigner.supportedForkSeq) {
+      skip();
+      return;
+    }
+
+    const slot = computeStartSlotAtEpoch(config.GLOAS_FORK_EPOCH) + 1;
+    const dependentRoot = ssz.phase0.BeaconBlockHeader.defaultValue().bodyRoot;
+
+    await assertSameSignature(
+      "signProposerPreferences",
+      {pubkey: pubkeyBytes, validatorIndex, slot},
+      dependentRoot,
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      30_000_000,
+      slot - 1
+    );
+  });
+
+  it("signBuilderRequestAuth", async ({skip}) => {
+    if (ForkSeq.gloas > externalSigner.supportedForkSeq) {
+      skip();
+      return;
+    }
+
+    const slot = computeStartSlotAtEpoch(config.GLOAS_FORK_EPOCH);
+
+    await assertSameSignature("signBuilderRequestAuth", pubkeyBytes, Buffer.from("https://builder.example.org"), slot);
+  });
+
   // ValidatorRegistration includes a timestamp so it's possible that web3signer instance and local instance
   // sign different messages and this test fails. Disabling unless it can be proven deterministic
   it.skip("signValidatorRegistration", async () => {


### PR DESCRIPTION
Aligns the external signer client with the Glamsterdam additions to the remote signing api (ethereum/remote-signing-api#28). All new gloas payloads are `version`-wrapped like `BLOCK_V2` and `AGGREGATE_AND_PROOF_V2`, and the PTC signing type is named after the message the validator produces, consistent with `ATTESTATION` and `SYNC_COMMITTEE_MESSAGE` which also carry only the signed data.

- rename `PAYLOAD_ATTESTATION` to `PAYLOAD_ATTESTATION_MESSAGE`, body key `payload_attestation_message`
- wrap `execution_payload_envelope`, `payload_attestation_message`, `proposer_preferences` and `builder_request_auth` in `{version, data}`, version is the fork at the message slot
- add web3signer e2e cases for the four signing types, skipped until the test image supports gloas

The same request shapes are implemented in Consensys-Incorporated/web3signer#1192.
