### PR TITLE
feat(api): carry forkchoice hashes on post-gloas payload_attributes events

### DIFF
--- a/packages/api/test/unit/beacon/genericServerTest/events.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/events.test.ts
@@ -2,14 +2,23 @@ import {FastifyInstance} from "fastify";
 import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
 import {config} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
-import {sleep} from "@lodestar/utils";
+import {ssz} from "@lodestar/types";
+import {fromHex, sleep} from "@lodestar/utils";
 import {getClient} from "../../../../src/beacon/client/events.js";
-import {BeaconEvent, Endpoints, EventType, getDefinitions} from "../../../../src/beacon/routes/events.js";
+import {
+  BeaconEvent,
+  Endpoints,
+  EventType,
+  getDefinitions,
+  getEventSerdes,
+} from "../../../../src/beacon/routes/events.js";
 import {getRoutes} from "../../../../src/beacon/server/events.js";
 import {getMockApi, getTestServer} from "../../../utils/utils.js";
 import {eventTestData} from "../testData/events.js";
 
 describe("beacon / events", () => {
+  const safeBlockHash = "0x1111111111111111111111111111111111111111111111111111111111111111";
+  const finalizedBlockHash = "0x2222222222222222222222222222222222222222222222222222222222222222";
   const mockApi = getMockApi<Endpoints>(getDefinitions(config));
   let server: FastifyInstance;
   let baseUrl: string;
@@ -33,6 +42,27 @@ describe("beacon / events", () => {
     controller = new AbortController();
   });
   afterEach(() => controller.abort());
+
+  it.each([ForkName.gloas, ForkName.heze])("Round-trips %s payload attributes with forkchoice hashes", (fork) => {
+    const data =
+      fork === ForkName.gloas
+        ? ssz.gloas.SSEPayloadAttributes.defaultValue()
+        : ssz.heze.SSEPayloadAttributes.defaultValue();
+    data.safeBlockHash = fromHex(safeBlockHash);
+    data.finalizedBlockHash = fromHex(finalizedBlockHash);
+    const message = {version: fork, data};
+    const eventSerdes = getEventSerdes(config);
+    const json = eventSerdes.toJson({type: EventType.payloadAttributes, message});
+
+    expect(json).toMatchObject({
+      version: fork,
+      data: {
+        safe_block_hash: safeBlockHash,
+        finalized_block_hash: finalizedBlockHash,
+      },
+    });
+    expect(eventSerdes.fromJson(EventType.payloadAttributes, json)).toEqual(message);
+  });
 
   it("Receive events", async () => {
     const eventHead1: BeaconEvent = {

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -861,6 +861,12 @@ export function getPayloadAttributesForSSE(
     proposalSlot: prepareSlot,
     parentBlockRoot,
     parentBlockHash,
+    ...(isForkPostGloas(fork)
+      ? {
+          safeBlockHash: fromHex(getSafeExecutionBlockHash(chain.forkChoice)),
+          finalizedBlockHash: fromHex(getFinalizedExecutionBlockHash(chain.forkChoice)),
+        }
+      : {}),
     payloadAttributes,
   } as SSEPayloadAttributes;
 

--- a/packages/beacon-node/test/unit/chain/produceBlock/getPayloadAttributesForSSE.test.ts
+++ b/packages/beacon-node/test/unit/chain/produceBlock/getPayloadAttributesForSSE.test.ts
@@ -1,0 +1,54 @@
+import {describe, expect, it} from "vitest";
+import {getConfig} from "@lodestar/config/test-utils";
+import {ProtoBlock} from "@lodestar/fork-choice";
+import {ForkName, ZERO_HASH_HEX} from "@lodestar/params";
+import {BeaconStateView, isStatePostGloas} from "@lodestar/state-transition";
+import {gloas} from "@lodestar/types";
+import {fromHex, toRootHex} from "@lodestar/utils";
+import {getPayloadAttributesForSSE} from "../../../../src/chain/produceBlock/produceBlockBody.js";
+import {getMockedBeaconChain} from "../../../mocks/mockedBeaconChain.js";
+import {createCachedBeaconStateTest} from "../../../utils/cachedBeaconState.js";
+import {generateState, zeroProtoBlock} from "../../../utils/state.js";
+
+describe("getPayloadAttributesForSSE", () => {
+  it("includes post-Gloas safe and finalized execution block hashes", () => {
+    const config = getConfig(ForkName.gloas);
+    const chain = getMockedBeaconChain();
+    const safeBlockHash = "0x1111111111111111111111111111111111111111111111111111111111111111";
+    const finalizedBlockHash = "0x2222222222222222222222222222222222222222222222222222222222222222";
+    const parentBlockHash = "0x3333333333333333333333333333333333333333333333333333333333333333";
+    const safeBlock = {...zeroProtoBlock, blockRoot: "0xsafe", parentBlockHash: safeBlockHash} as ProtoBlock;
+    const finalizedBlock = {
+      ...zeroProtoBlock,
+      blockRoot: "0xfinalized",
+      parentBlockHash: finalizedBlockHash,
+    } as ProtoBlock;
+    const parentBlock = {
+      ...zeroProtoBlock,
+      executionPayloadBlockHash: parentBlockHash,
+      executionPayloadGasLimit: 30_000_000,
+      parentBlockHash,
+    } as ProtoBlock;
+    chain.forkChoice.getConfirmedRoot.mockReturnValue(safeBlock.blockRoot);
+    chain.forkChoice.getConfirmedBlock.mockReturnValue(safeBlock);
+    chain.forkChoice.getFinalizedBlock.mockReturnValue(finalizedBlock);
+    chain.forkChoice.getBlockHexDefaultStatus.mockReturnValue(null);
+    chain.forkChoice.getBlockHexAndBlockHash.mockReturnValue(parentBlock);
+
+    const state = generateState({}, config, true);
+    const prepareState = new BeaconStateView(createCachedBeaconStateTest(state, config));
+    if (!isStatePostGloas(prepareState)) {
+      throw new Error("Expected Gloas state");
+    }
+    const attributes = getPayloadAttributesForSSE(ForkName.gloas, chain, {
+      prepareState,
+      prepareSlot: 1,
+      parentBlockRoot: fromHex(ZERO_HASH_HEX),
+      parentBlockHash: fromHex(parentBlockHash),
+      feeRecipient: "0x0000000000000000000000000000000000000000",
+    }) as gloas.SSEPayloadAttributes;
+
+    expect(toRootHex(attributes.safeBlockHash)).toBe(safeBlockHash);
+    expect(toRootHex(attributes.finalizedBlockHash)).toBe(finalizedBlockHash);
+  });
+});

--- a/packages/beacon-node/test/unit/chain/produceBlock/getPayloadAttributesForSSE.test.ts
+++ b/packages/beacon-node/test/unit/chain/produceBlock/getPayloadAttributesForSSE.test.ts
@@ -1,54 +1,113 @@
 import {describe, expect, it} from "vitest";
 import {getConfig} from "@lodestar/config/test-utils";
-import {ProtoBlock} from "@lodestar/fork-choice";
+import {ExecutionStatus, PayloadStatus, type ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName, ZERO_HASH_HEX} from "@lodestar/params";
-import {BeaconStateView, isStatePostGloas} from "@lodestar/state-transition";
-import {gloas} from "@lodestar/types";
+import {BeaconStateView, isStatePostBellatrix, isStatePostGloas} from "@lodestar/state-transition";
 import {fromHex, toRootHex} from "@lodestar/utils";
 import {getPayloadAttributesForSSE} from "../../../../src/chain/produceBlock/produceBlockBody.js";
 import {getMockedBeaconChain} from "../../../mocks/mockedBeaconChain.js";
 import {createCachedBeaconStateTest} from "../../../utils/cachedBeaconState.js";
 import {generateState, zeroProtoBlock} from "../../../utils/state.js";
 
-describe("getPayloadAttributesForSSE", () => {
-  it("includes post-Gloas safe and finalized execution block hashes", () => {
-    const config = getConfig(ForkName.gloas);
-    const chain = getMockedBeaconChain();
-    const safeBlockHash = "0x1111111111111111111111111111111111111111111111111111111111111111";
-    const finalizedBlockHash = "0x2222222222222222222222222222222222222222222222222222222222222222";
-    const parentBlockHash = "0x3333333333333333333333333333333333333333333333333333333333333333";
-    const safeBlock = {...zeroProtoBlock, blockRoot: "0xsafe", parentBlockHash: safeBlockHash} as ProtoBlock;
-    const finalizedBlock = {
-      ...zeroProtoBlock,
-      blockRoot: "0xfinalized",
-      parentBlockHash: finalizedBlockHash,
-    } as ProtoBlock;
-    const parentBlock = {
-      ...zeroProtoBlock,
-      executionPayloadBlockHash: parentBlockHash,
-      executionPayloadGasLimit: 30_000_000,
-      parentBlockHash,
-    } as ProtoBlock;
-    chain.forkChoice.getConfirmedRoot.mockReturnValue(safeBlock.blockRoot);
-    chain.forkChoice.getConfirmedBlock.mockReturnValue(safeBlock);
-    chain.forkChoice.getFinalizedBlock.mockReturnValue(finalizedBlock);
-    chain.forkChoice.getBlockHexDefaultStatus.mockReturnValue(null);
-    chain.forkChoice.getBlockHexAndBlockHash.mockReturnValue(parentBlock);
+const safeBlockHash = toRootHex(Buffer.alloc(32, 1));
+const finalizedBlockHash = toRootHex(Buffer.alloc(32, 2));
+const parentBlockHash = toRootHex(Buffer.alloc(32, 3));
 
-    const state = generateState({}, config, true);
-    const prepareState = new BeaconStateView(createCachedBeaconStateTest(state, config));
-    if (!isStatePostGloas(prepareState)) {
-      throw new Error("Expected Gloas state");
-    }
-    const attributes = getPayloadAttributesForSSE(ForkName.gloas, chain, {
+describe("getPayloadAttributesForSSE", () => {
+  for (const fork of [ForkName.gloas, ForkName.heze] as const) {
+    it.each([PayloadStatus.FULL, PayloadStatus.EMPTY])(
+      `includes ${fork} execution hashes when extending %s`,
+      (status) => {
+        const {emit} = setup(fork, status);
+        const attributes = emit();
+        if (!("safeBlockHash" in attributes)) throw Error("Expected post-Gloas attributes");
+
+        expect(toRootHex(attributes.safeBlockHash)).toBe(safeBlockHash);
+        expect(toRootHex(attributes.finalizedBlockHash)).toBe(finalizedBlockHash);
+        expect(toRootHex(attributes.parentBlockHash)).toBe(parentBlockHash);
+      }
+    );
+  }
+
+  it("refreshes the safe hash while finality remains unchanged", () => {
+    const {emit, safeBlock} = setup(ForkName.gloas, PayloadStatus.EMPTY);
+    const first = emit();
+    safeBlock.parentBlockHash = toRootHex(Buffer.alloc(32, 4));
+    const second = emit();
+    if (!("safeBlockHash" in first) || !("safeBlockHash" in second)) throw Error("Expected post-Gloas attributes");
+
+    expect(toRootHex(first.safeBlockHash)).toBe(safeBlockHash);
+    expect(toRootHex(second.safeBlockHash)).toBe(safeBlock.parentBlockHash);
+    expect(toRootHex(second.finalizedBlockHash)).toBe(finalizedBlockHash);
+  });
+
+  it("leaves the pre-Gloas event shape unchanged", () => {
+    const {chain, emit} = setup(ForkName.fulu, PayloadStatus.FULL);
+    const attributes = emit();
+
+    expect(attributes).not.toHaveProperty("safeBlockHash");
+    expect(attributes).not.toHaveProperty("finalizedBlockHash");
+    expect(attributes).toHaveProperty("parentBlockNumber");
+    expect(chain.forkChoice.getConfirmedBlock).not.toHaveBeenCalled();
+    expect(chain.forkChoice.getFinalizedBlock).not.toHaveBeenCalled();
+  });
+});
+
+function setup(fork: ForkName.fulu | ForkName.gloas | ForkName.heze, payloadStatus: PayloadStatus) {
+  const config = getConfig(fork);
+  const chain = getMockedBeaconChain();
+  const safeBlock: ProtoBlock = {
+    ...zeroProtoBlock,
+    executionStatus: ExecutionStatus.Valid,
+    executionPayloadNumber: 1,
+    executionPayloadGasLimit: 30_000_000,
+    slot: 1,
+    blockRoot: toRootHex(Buffer.alloc(32, 5)),
+    executionPayloadBlockHash: toRootHex(Buffer.alloc(32, 6)),
+    parentBlockHash: safeBlockHash,
+    payloadStatus,
+  };
+  const finalizedBlock: ProtoBlock = {
+    ...zeroProtoBlock,
+    executionStatus: ExecutionStatus.Valid,
+    executionPayloadNumber: 1,
+    executionPayloadGasLimit: 30_000_000,
+    slot: 1,
+    blockRoot: toRootHex(Buffer.alloc(32, 7)),
+    executionPayloadBlockHash: toRootHex(Buffer.alloc(32, 8)),
+    parentBlockHash: finalizedBlockHash,
+    payloadStatus,
+  };
+  const parentBlock: ProtoBlock = {
+    ...zeroProtoBlock,
+    executionStatus: ExecutionStatus.Valid,
+    executionPayloadNumber: 1,
+    executionPayloadBlockHash: parentBlockHash,
+    executionPayloadGasLimit: 30_000_000,
+    parentBlockHash,
+    payloadStatus,
+  };
+  chain.forkChoice.getConfirmedRoot.mockReturnValue(safeBlock.blockRoot);
+  chain.forkChoice.getConfirmedBlock.mockReturnValue(safeBlock);
+  chain.forkChoice.getFinalizedBlock.mockReturnValue(finalizedBlock);
+  chain.forkChoice.getBlockHexDefaultStatus.mockReturnValue(null);
+  chain.forkChoice.getBlockHexAndBlockHash.mockReturnValue(parentBlock);
+
+  const state = generateState({}, config, true);
+  if ("latestBlockHash" in state && payloadStatus === PayloadStatus.FULL) {
+    state.latestExecutionPayloadBid.blockHash = fromHex(parentBlockHash);
+    state.latestBlockHash = fromHex(parentBlockHash);
+  }
+  const prepareState = new BeaconStateView(createCachedBeaconStateTest(state, config));
+  if (!isStatePostBellatrix(prepareState)) throw Error("Expected post-Bellatrix state");
+  if (fork !== ForkName.fulu && !isStatePostGloas(prepareState)) throw Error("Expected Gloas state");
+  const emit = () =>
+    getPayloadAttributesForSSE(fork, chain, {
       prepareState,
       prepareSlot: 1,
       parentBlockRoot: fromHex(ZERO_HASH_HEX),
       parentBlockHash: fromHex(parentBlockHash),
       feeRecipient: "0x0000000000000000000000000000000000000000",
-    }) as gloas.SSEPayloadAttributes;
-
-    expect(toRootHex(attributes.safeBlockHash)).toBe(safeBlockHash);
-    expect(toRootHex(attributes.finalizedBlockHash)).toBe(finalizedBlockHash);
-  });
-});
+    });
+  return {chain, emit, safeBlock};
+}

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -648,6 +648,8 @@ export const SSEPayloadAttributes = new ContainerType(
     // parentBlockNumber: UintNum64, // Removed in GLOAS:EIP7732
     parentBlockRoot: Root,
     parentBlockHash: Root,
+    safeBlockHash: Root,
+    finalizedBlockHash: Root,
     payloadAttributes: PayloadAttributes,
   },
   {typeName: "SSEPayloadAttributes", jsonCase: "eth2"}


### PR DESCRIPTION
## Motivation

Post-Gloas the builder issues its own `engine_forkchoiceUpdated` to start a payload build, so it needs the safe and finalized execution block hashes the beacon node would use, not only the head. The standard `payload_attributes` event only carries the parent block hash, and the builder has no good way to derive the other two itself since it isn't running fork choice. Part of the builder sidecar work; the spec-side discussion is ethereum/beacon-APIs#638.

## Description

- `payload_attributes` events emitted post-Gloas carry two optional top-level fields, `safe_block_hash` and `finalized_block_hash`, next to the standard `version` and `data`. They come from the same fork choice lookups (`getSafeExecutionBlockHash` / `getFinalizedExecutionBlockHash`) the beacon node uses for its own `forkchoiceUpdated`, so the builder sees exactly what the node would send.
- The client parses the fields back when present and leaves them out otherwise, so events from beacon nodes that don't send them still parse.
- Pre-Gloas the event shape is unchanged.

I've kept the fields out of the SSZ `SSEPayloadAttributes` container on purpose: required container fields would break parsing of events from other clients, and the shape isn't settled upstream yet. This mirrors what @nflaig has on his builder branch. If beacon-APIs#638 lands with the fields inside `data`, I'll follow it up here.

## Steps to test or reproduce

- `pnpm --filter @lodestar/api test:unit` – new `eventSerdes.test.ts` covers the round trip with and without the hashes, and parsing a post-Gloas event that doesn't carry them.
- `pnpm --filter @lodestar/beacon-node test:unit -- prepareNextSlot` – new Gloas case asserts the emitted event carries the same safe and finalized hashes the node passes to `notifyForkchoiceUpdate`.
- On a Gloas devnet node with `--emitPayloadAttributes`, subscribe to `/eth/v1/events?topics=payload_attributes`; post-fork events include `safe_block_hash` and `finalized_block_hash`.
